### PR TITLE
Adding new test cases for noobaa bucket error state improvements

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -597,7 +597,7 @@
         "hashed_secret": "66a36e77fd002579809717841f998f4d21cd5913",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2897,
+        "line_number": 2925,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -637,7 +637,7 @@
         "hashed_secret": "b7e9a6e2e04ed3edbf8b4e21def4beccbb6eb6b1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 230,
+        "line_number": 233,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -645,7 +645,7 @@
         "hashed_secret": "a12337323b638ab044b1166bff4b1a1f83162819",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 833,
+        "line_number": 840,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -653,7 +653,7 @@
         "hashed_secret": "fb947972c92f052c0a08866d182be0075a2b601b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 842,
+        "line_number": 849,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -661,7 +661,7 @@
         "hashed_secret": "03e227627ab8681281fdb8aa3d799b03f782d672",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2035,
+        "line_number": 2052,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -669,7 +669,7 @@
         "hashed_secret": "ef5f3d909f23bd0aa02b4253f98350384f709c86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2142,
+        "line_number": 2159,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -677,7 +677,7 @@
         "hashed_secret": "cb1ae2b504c4615841d8144267a131231d2bd677",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2143,
+        "line_number": 2160,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -685,7 +685,7 @@
         "hashed_secret": "1a1e70e87dd0452c42f33ce9bf74aa28134dba6b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2144,
+        "line_number": 2161,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -693,7 +693,7 @@
         "hashed_secret": "7b1ba2f04f2f1604dc4e3caffcadf9fcbce7df5b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2145,
+        "line_number": 2162,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -701,7 +701,7 @@
         "hashed_secret": "0fa3b21ced80146d752888f2b60ec80e0d4b8925",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2157,
+        "line_number": 2174,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -709,7 +709,7 @@
         "hashed_secret": "f084f2068494b8d1cd06811dd97d02c3d85f40ee",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2172,
+        "line_number": 2189,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -717,7 +717,7 @@
         "hashed_secret": "adfa401a3b0a733d8f00519ac8c6b3893a2e7e8e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2173,
+        "line_number": 2190,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -725,7 +725,7 @@
         "hashed_secret": "898e46bbadc12f87120548bd445eb4210c8407c8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2181,
+        "line_number": 2198,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -733,7 +733,7 @@
         "hashed_secret": "f57ccec6b8f7b12b635ab53d26c3bf7300247341",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2182,
+        "line_number": 2199,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -741,7 +741,7 @@
         "hashed_secret": "77b044ea736f8cbe568d1954424186d901f89db9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2183,
+        "line_number": 2200,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -749,7 +749,7 @@
         "hashed_secret": "d64368f12ca17c69568c6a132f17d44d56e60660",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2184,
+        "line_number": 2201,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -757,7 +757,7 @@
         "hashed_secret": "8f9ca35156c02cb6ba58c5b51230b9bedc38de4f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2185,
+        "line_number": 2202,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -765,7 +765,7 @@
         "hashed_secret": "9ec53cfd9929c70c3f87c210b6a7b77fb6d79d43",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2752,
+        "line_number": 2799,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -773,7 +773,7 @@
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2909,
+        "line_number": 2964,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -781,7 +781,7 @@
         "hashed_secret": "adc1f5c8707f7d7aba3aabe13c15e5ef1151872e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2910,
+        "line_number": 2965,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -789,7 +789,7 @@
         "hashed_secret": "ee46262b2df945e46ea310b925ad087465dbd3f2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3631,
+        "line_number": 3686,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -797,7 +797,7 @@
         "hashed_secret": "f678cad4ab874d71b559a069d5e34a95fe38a480",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3632,
+        "line_number": 3687,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/conf/ocsci/external_rhcs_cluster_ipv6.yaml
+++ b/conf/ocsci/external_rhcs_cluster_ipv6.yaml
@@ -1,0 +1,18 @@
+DEPLOYMENT:
+  external_mode: True
+  force_download_client: True
+  # WA for issue: https://github.com/red-hat-storage/ocs-ci/issues/2861
+  min_noobaa_endpoints: 1
+  ipv6: true
+ENV_DATA:
+  storage_cluster_name: 'ocs-external-storagecluster'
+
+EXTERNAL_MODE:
+  # base64 encoded data of json output
+  # from exporter script
+  # https://github.com/rook/rook/blob/master/cluster/examples/kubernetes/ceph/create-external-cluster-resources.py
+  external_cluster_details: PLACE_HOLDER
+
+REPORTING:
+  polarion:
+    deployment_id: 'OCS-2563'

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -1933,10 +1933,13 @@ class Deployment(object):
             )
             raise
 
-    def deploy_with_external_mode(self):
+    def deploy_with_external_mode(self, image=None):
         """
         This function handles the deployment of OCS on
         external/indpendent RHCS cluster
+
+        Args:
+            image (str): Image of ocs registry.
 
         """
         if config.EXTERNAL_MODE.get("rgw_secure"):
@@ -1950,7 +1953,7 @@ class Deployment(object):
                 logger.info("Creating namespace and operator group.")
                 run_cmd(f"oc apply -f {constants.OLM_YAML}")
             if not live_deployment:
-                create_catalog_source()
+                create_catalog_source(image)
             self.subscribe_ocs()
             operator_selector = get_selector_for_ocs_operator()
             subscription_plan_approval = config.DEPLOYMENT.get(
@@ -2195,7 +2198,7 @@ class Deployment(object):
                 label_nodes(nodes=worker_node_objs, label=constants.OPERATOR_NODE_LABEL)
 
         if config.DEPLOYMENT["external_mode"]:
-            self.deploy_with_external_mode()
+            self.deploy_with_external_mode(image)
         else:
             self.deploy_ocs_via_operator(image)
             if config.ENV_DATA["mcg_only_deployment"]:

--- a/ocs_ci/deployment/helpers/external_cluster_helpers.py
+++ b/ocs_ci/deployment/helpers/external_cluster_helpers.py
@@ -1486,9 +1486,10 @@ def get_rgw_endpoint():
             if config.EXTERNAL_MODE.get("use_fqdn_rgw_endpoint"):
                 logger.info("using FQDN as rgw endpoint")
                 rgw_endpoint = each["hostname"]
-            elif config.EXTERNAL_MODE.get("use_ipv6_rgw_endpoint"):
+            elif config.DEPLOYMENT.get("ipv6"):
                 logger.info("using IPv6 as rgw endpoint")
-                rgw_endpoint = each["ipv6_address"]
+                # This is a workaround for DFBUGS-5859 till 4.22 rgw must use hostname in ipv6
+                rgw_endpoint = each["hostname"]
             else:
                 logger.info("using IPv4 as rgw endpoint")
                 rgw_endpoint = each["ip_address"]

--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -5077,7 +5077,7 @@ def verify_storagecluster_nodetopology():
     ocs_node_names = []
     for node_obj in ocs_node_objs:
         ocs_node_names.append(node_obj.name)
-    return ocs_node_names.sort() == nodes_storage_cluster.sort()
+    return sorted(ocs_node_names) == sorted(nodes_storage_cluster)
 
 
 def get_noobaa_metrics_token_from_secret():

--- a/ocs_ci/ocs/bucket_utils.py
+++ b/ocs_ci/ocs/bucket_utils.py
@@ -3651,6 +3651,76 @@ def get_noobaa_bucket_replication_metrics_in_prometheus(
         )
 
 
+def get_bucket_mode(mcg_obj, bucket_name):
+    """
+    Get the current mode of a bucket from NooBaa.
+
+    Args:
+        mcg_obj (MCG): MCG object
+        bucket_name (str): Name of the bucket
+
+    Returns:
+        str: The bucket mode (e.g. "OPTIMAL", "EXCEEDING_QUOTA")
+    """
+    bucket_info = mcg_obj.get_bucket_info(bucket_name)
+    if bucket_info:
+        logger.debug(f"Bucket info for {bucket_name}: {bucket_info}")
+        return bucket_info.get("mode", "UNKNOWN")
+    logger.warning(f"Bucket {bucket_name} not found in NooBaa system")
+    return "UNKNOWN"
+
+
+def wait_for_bucket_mode(mcg_obj, bucket_name, expected_mode, timeout=600, sleep=15):
+    """
+    Poll NooBaa until the bucket enters the expected mode or timeout.
+
+    Args:
+        mcg_obj (MCG): MCG object
+        bucket_name (str): Name of the bucket
+        expected_mode (str): Expected bucket mode (e.g. "EXCEEDING_QUOTA")
+            or "!OPTIMAL" to wait for any non-OPTIMAL mode
+            (UNKNOWN is excluded to avoid false positives on lookup failures)
+        timeout (int): Timeout in seconds (default: 600)
+        sleep (int): Poll interval in seconds (default: 15)
+
+    Returns:
+        str: The actual bucket mode once matched
+
+    Raises:
+        AssertionError: If the bucket does not reach the expected mode
+            within the timeout
+    """
+    check_not_optimal = expected_mode == "!OPTIMAL"
+    last_mode = "UNKNOWN"
+
+    try:
+        for mode in TimeoutSampler(
+            timeout=timeout,
+            sleep=sleep,
+            func=get_bucket_mode,
+            mcg_obj=mcg_obj,
+            bucket_name=bucket_name,
+        ):
+            last_mode = mode
+            if check_not_optimal and mode not in ("OPTIMAL", "UNKNOWN"):
+                logger.info(f"Bucket {bucket_name} entered non-OPTIMAL mode: {mode}")
+                return mode
+            elif not check_not_optimal and mode == expected_mode:
+                logger.info(f"Bucket {bucket_name} entered expected mode: {mode}")
+                return mode
+    except TimeoutExpiredError:
+        if check_not_optimal:
+            assert False, (
+                f"Bucket {bucket_name} is still OPTIMAL after "
+                f"{timeout}s (last mode: {last_mode})"
+            )
+        else:
+            assert False, (
+                f"Expected bucket mode {expected_mode} for {bucket_name}, "
+                f"got {last_mode} after {timeout}s"
+            )
+
+
 def get_bucket_status_value(mcg_obj, bucket_name, key):
     """
     Helper function returning specific bucket status value by key

--- a/ocs_ci/ocs/ocs_upgrade.py
+++ b/ocs_ci/ocs/ocs_upgrade.py
@@ -568,6 +568,10 @@ class OCSUpgrade(object):
         csv_list = get_csvs_start_with_prefix(resource_name, namespace=self.namespace)
         for csv in csv_list:
             if resource_name in csv.get("metadata").get("name"):
+                logger.info(
+                    "searching for pre-upgrade csv with version: "
+                    f"{config.PREUPGRADE_CONFIG.get('ENV_DATA').get('ocs_version')}"
+                )
                 if config.PREUPGRADE_CONFIG.get("ENV_DATA").get(
                     "ocs_version"
                 ) in csv.get("metadata").get("name"):

--- a/ocs_ci/ocs/provider_client_upgrade.py
+++ b/ocs_ci/ocs/provider_client_upgrade.py
@@ -193,6 +193,9 @@ class ProviderClusterOperatorUpgrade(ProviderUpgrade):
 
     """
 
+    def __init__(self):
+        super().__init__(namespace=config.ENV_DATA["cluster_namespace"])
+
     def run_provider_upgrade(self):
         """
         This method is for running the upgrade of ocs, metallb, acm and cnv opertaors

--- a/ocs_ci/ocs/resources/csi_addons.py
+++ b/ocs_ci/ocs/resources/csi_addons.py
@@ -22,14 +22,17 @@ from ocs_ci.utility.utils import TimeoutSampler
 logger = logging.getLogger(__name__)
 
 
-def _restart_csi_addons_controller(namespace: str) -> None:
+def restart_csi_addons_controller(namespace: str = "") -> None:
     """
     Restart the CSI Addons controller manager and wait for it to be Ready.
 
     Args:
         namespace (str): The namespace where the controller runs.
+            Defaults to the cluster namespace from config.
 
     """
+    if not namespace:
+        namespace = config.ENV_DATA.get("cluster_namespace", "openshift-storage")
     logger.info("Restarting CSI Addons controller manager pods...")
     pod.restart_pods_having_label(
         label=constants.CSI_ADDONS_CONTROLLER_MANAGER_LABEL,
@@ -50,10 +53,12 @@ def _restart_csi_addons_controller(namespace: str) -> None:
             break
 
 
-def update_csi_addons_config(key: str, value: str) -> None:
+def update_csi_addons_config(key: str, value: str, *, restart: bool = True) -> None:
     """
-    Create or update a key in the 'csi-addons-config' ConfigMap and restart
-    the CSI Addons controller manager so the change is picked up.
+    Create or update a key in the 'csi-addons-config' ConfigMap.
+
+    Optionally restarts the CSI Addons controller manager so the change
+    is picked up immediately.
 
     Handles both cases: ConfigMap exists / does not exist.
     Uses JSON merge patch to preserve existing keys.
@@ -61,6 +66,8 @@ def update_csi_addons_config(key: str, value: str) -> None:
     Args:
         key (str): The ConfigMap data key to set (e.g. 'cronjob-stagger-window').
         value (str): The value to assign to the key.
+        restart (bool): Whether to restart the controller after updating.
+            Defaults to True.
 
     Raises:
         CommandFailed: If the ConfigMap patch or create operation fails.
@@ -110,7 +117,10 @@ def update_csi_addons_config(key: str, value: str) -> None:
                 pass
 
     logger.info("ConfigMap '%s' updated: %s=%s", configmap_name, key, value)
-    _restart_csi_addons_controller(namespace)
+    if restart:
+        restart_csi_addons_controller(namespace)
+    else:
+        logger.info("Skipping controller restart (restart=False)")
 
 
 def remove_csi_addons_config_key(key: str) -> None:
@@ -163,7 +173,7 @@ def remove_csi_addons_config_key(key: str) -> None:
     )
 
     logger.info("Key '%s' removed from ConfigMap '%s'", key, configmap_name)
-    _restart_csi_addons_controller(namespace)
+    restart_csi_addons_controller(namespace)
 
 
 def get_csi_addons_config_value(key: str, default: str = "") -> str:

--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -238,11 +238,19 @@ def patch_storageclass_ocs_external_label(resource_name):
         f"{constants.OCS_EXTERNAL_STORAGECLASS_LABEL}="
         f"{constants.OCS_EXTERNAL_STORAGECLASS_LABEL_VALUE}"
     )
-    sc_ocp.patch(
-        resource_name=resource_name,
-        params=json.dumps(_storageclass_ocs_external_label_patch()),
-        format_type="merge",
-    )
+    try:
+        sc_ocp.patch(
+            resource_name=resource_name,
+            params=json.dumps(_storageclass_ocs_external_label_patch()),
+            format_type="merge",
+        )
+    except CommandFailed as ex:
+        if "NotFound" in str(ex):
+            log.warning(
+                f"StorageClass {resource_name} disappeared before patch; skipping"
+            )
+        else:
+            raise
 
 
 def _delete_storageclass_ignore_not_found(sc_ocp, sc_name):

--- a/ocs_ci/utility/ibmcloud.py
+++ b/ocs_ci/utility/ibmcloud.py
@@ -1399,7 +1399,21 @@ def configure_ingress_load_balancer_security_group():
             namespace="openshift-ingress",
             resource_name="router-default",
         )
-        service_data = ocp_obj.get()
+
+        # Retry getting service data as it may not be immediately available
+        logger.debug(
+            "Attempting to retrieve router-default service data with retry logic"
+        )
+        service_data = None
+        try:
+            for sample in TimeoutSampler(timeout=900, sleep=30, func=ocp_obj.get):
+                if sample:
+                    service_data = sample
+                    logger.debug("Successfully retrieved router-default service data")
+                    break
+        except Exception as e:
+            logger.warning(f"Failed to retrieve router-default service data: {e}")
+            return
 
         # Extract load balancer hostname
         lb_ingress = (

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -4958,6 +4958,10 @@ def mirror_image(image, cluster_config=None):
             mirror_base = f"{mirror_registry}/{mirror_registry_path}"
 
         mirrored_image = mirror_base + re.sub(r"^[^/]*", "", orig_image_full)
+        # remove the sha256 hash from the mirrored image (if present) and replace it by temporary custom tag:
+        if "@sha256" in mirrored_image:
+            mirrored_image = mirrored_image.split("@")[0]
+            mirrored_image += f":odf-qe-temp-tag-{get_random_str(10)}"
         # mirror the image
         log.info(
             f"Mirroring image '{image}' ('{orig_image_full}') to '{mirrored_image}'"

--- a/tests/cross_functional/system_test/test_cluster_wide_key_rotation_systemtest.py
+++ b/tests/cross_functional/system_test/test_cluster_wide_key_rotation_systemtest.py
@@ -6,6 +6,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     magenta_squad,
     ignore_leftovers,
     encryption_at_rest_required,
+    jira,
 )
 from ocs_ci.framework.testlib import E2ETest
 from ocs_ci.helpers.keyrotation_helper import (
@@ -25,6 +26,7 @@ log = logging.getLogger(__name__)
 @system_test
 @ignore_leftovers
 @encryption_at_rest_required
+@jira("DFBUGS-5769")
 class TestKeyRotationWithClusterFull(E2ETest):
     @pytest.fixture(autouse=True)
     def init_sanity(self):

--- a/tests/cross_functional/system_test/test_mcg_replication_with_disruptions.py
+++ b/tests/cross_functional/system_test/test_mcg_replication_with_disruptions.py
@@ -270,7 +270,6 @@ class TestMCGReplicationWithDisruptions(E2ETest):
 
 @system_test
 @magenta_squad
-@skipif_vsphere_ipi
 class TestLogBasedReplicationWithDisruptions:
     @retry(Exception, tries=10, delay=5)
     def delete_objs_in_batch(self, objs_to_delete, mockup_logger, source_bucket):

--- a/tests/functional/monitoring/prometheus/alerts/test_noobaa_bucket_error_state_mode.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_noobaa_bucket_error_state_mode.py
@@ -141,8 +141,9 @@ class TestNooBaaBucketErrorStateMode:
         Steps:
             1. Create a data bucket with a 2Gi quota
             2. Upload ~2.5GB to exceed the quota
-            3. Verify bucket mode is EXCEEDING_QUOTA via NooBaa
-            4. Clean up
+            3. Wait for bucket mode to propagate
+            4. Verify bucket mode is EXCEEDING_QUOTA via NooBaa
+            5. Clean up
 
         Args:
             mcg_obj (MCG): MCG object with S3 connection credentials
@@ -161,6 +162,10 @@ class TestNooBaaBucketErrorStateMode:
                 f"(quota 2Gi) to trigger EXCEEDING_QUOTA"
             )
 
+            run_time = 60 * 7
+            log.info(f"Waiting {run_time}s for bucket mode to propagate")
+            time.sleep(run_time)
+
             expected_mode = "EXCEEDING_QUOTA"
             bucket_mode = _get_bucket_mode(mcg_obj, bucket_name)
             assert bucket_mode == expected_mode, (
@@ -171,7 +176,9 @@ class TestNooBaaBucketErrorStateMode:
             bucket.delete()
 
     @polarion_id("OCS-XXXXX")
-    def test_data_bucket_resource_error_mode(self, mcg_obj, bucket_factory, cld_mgr):
+    def test_data_bucket_resource_error_mode(
+        self, mcg_obj, bucket_factory, cld_mgr, request
+    ):
         """
         Trigger a resource-related bucket mode on a data bucket and
         verify the bucket enters a non-OPTIMAL error mode.
@@ -187,6 +194,7 @@ class TestNooBaaBucketErrorStateMode:
             mcg_obj (MCG): MCG object with S3 connection credentials
             bucket_factory (func): Factory for creating MCG buckets
             cld_mgr (CloudManager): Cloud manager for cloud operations
+            request: Pytest request object for finalizer registration
         """
         bucketclass_dict = {
             "interface": "OC",
@@ -197,9 +205,17 @@ class TestNooBaaBucketErrorStateMode:
             interface=bucketclass_dict["interface"],
             bucketclass=bucketclass_dict,
         )[0]
+        backingstore = bucket.bucketclass.backingstores[0]
+
+        def cleanup():
+            bucket.delete()
+            bucket.bucketclass.delete()
+            backingstore.delete()
+
+        request.addfinalizer(cleanup)
+
         log.info(f"Created data bucket {bucket.name} with AWS backing store")
 
-        backingstore = bucket.bucketclass.backingstores[0]
         target_uls_name = backingstore.uls_name
         log.info(
             f"Backing store {backingstore.name} uses "
@@ -221,13 +237,11 @@ class TestNooBaaBucketErrorStateMode:
             f"deleting backing store target"
         )
 
-        bucket.delete()
-        bucket.bucketclass.delete()
-        backingstore.delete()
-
     @skipif_mcg_only
     @polarion_id("OCS-XXXXX")
-    def test_data_bucket_capacity_error_mode(self, mcg_obj, awscli_pod, bucket_factory):
+    def test_data_bucket_capacity_error_mode(
+        self, mcg_obj, awscli_pod, bucket_factory, request
+    ):
         """
         Trigger a capacity-related bucket mode on a data bucket and
         verify the bucket enters a non-OPTIMAL error mode.
@@ -244,6 +258,7 @@ class TestNooBaaBucketErrorStateMode:
             mcg_obj (MCG): MCG object with S3 connection credentials
             awscli_pod (Pod): Pod running the AWSCLI tools
             bucket_factory (func): Factory for creating MCG buckets
+            request: Pytest request object for finalizer registration
         """
         bucketclass_dict = {
             "interface": "OC",
@@ -255,6 +270,14 @@ class TestNooBaaBucketErrorStateMode:
             bucketclass=bucketclass_dict,
         )[0]
         backingstore = bucket.bucketclass.backingstores[0]
+
+        def cleanup():
+            bucket.delete()
+            bucket.bucketclass.delete()
+            backingstore.delete()
+
+        request.addfinalizer(cleanup)
+
         log.info(
             f"Created data bucket {bucket.name} with "
             f"2Gi PV pool backing store {backingstore.name}"
@@ -276,10 +299,6 @@ class TestNooBaaBucketErrorStateMode:
             f"exceeding PV pool capacity"
         )
 
-        bucket.delete()
-        bucket.bucketclass.delete()
-        backingstore.delete()
-
     # ------------------------------------------------------------------
     # Namespace bucket tests
     # ------------------------------------------------------------------
@@ -291,6 +310,7 @@ class TestNooBaaBucketErrorStateMode:
         bucket_factory,
         namespace_store_factory,
         cld_mgr,
+        request,
     ):
         """
         Trigger a resource-related bucket mode on a namespace bucket
@@ -309,10 +329,10 @@ class TestNooBaaBucketErrorStateMode:
             bucket_factory (func): Factory for creating MCG buckets
             namespace_store_factory (func): Factory for creating namespace stores
             cld_mgr (CloudManager): Cloud manager for cloud operations
+            request: Pytest request object for finalizer registration
         """
         nss_tup = ("oc", {"aws": [(2, "us-east-2")]})
         ns_stores = namespace_store_factory(*nss_tup)
-        log.info(f"Created namespace stores: " f"{[ns.name for ns in ns_stores]}")
 
         bucketclass_dict = {
             "interface": "OC",
@@ -326,7 +346,17 @@ class TestNooBaaBucketErrorStateMode:
             interface=bucketclass_dict["interface"],
             bucketclass=bucketclass_dict,
         )[0]
-        log.info(f"Created namespace bucket {ns_bucket.name} " f"with Multi policy")
+
+        def cleanup():
+            ns_bucket.delete()
+            ns_bucket.bucketclass.delete()
+            for ns_store in ns_stores:
+                ns_store.delete()
+
+        request.addfinalizer(cleanup)
+
+        log.info(f"Created namespace stores: {[ns.name for ns in ns_stores]}")
+        log.info(f"Created namespace bucket {ns_bucket.name} with Multi policy")
 
         target_uls_name = ns_stores[0].uls_name
         log.info(
@@ -345,10 +375,6 @@ class TestNooBaaBucketErrorStateMode:
             f"after deleting namespace store target"
         )
 
-        ns_bucket.delete()
-        ns_bucket.bucketclass.delete()
-        ns_stores[0].delete()
-
     @polarion_id("OCS-XXXXX")
     def test_ns_bucket_quota_error_mode(
         self,
@@ -356,6 +382,7 @@ class TestNooBaaBucketErrorStateMode:
         awscli_pod,
         bucket_factory,
         namespace_store_factory,
+        request,
     ):
         """
         Trigger a quota-related bucket mode on a namespace bucket and
@@ -367,18 +394,19 @@ class TestNooBaaBucketErrorStateMode:
                namespace store
             3. Set a 100Mi quota on the namespace bucket
             4. Upload data exceeding the quota
-            5. Verify bucket mode is EXCEEDING_QUOTA via NooBaa
-            6. Clean up
+            5. Wait for bucket mode to propagate
+            6. Verify bucket mode is EXCEEDING_QUOTA via NooBaa
+            7. Clean up
 
         Args:
             mcg_obj (MCG): MCG object with S3 connection credentials
             awscli_pod (Pod): Pod running the AWSCLI tools
             bucket_factory (func): Factory for creating MCG buckets
             namespace_store_factory (func): Factory for creating namespace stores
+            request: Pytest request object for finalizer registration
         """
         nss_tup = ("oc", {"aws": [(1, "us-east-2")]})
         ns_stores = namespace_store_factory(*nss_tup)
-        log.info(f"Created namespace store: {ns_stores[0].name}")
 
         bucketclass_dict = {
             "interface": "OC",
@@ -392,6 +420,15 @@ class TestNooBaaBucketErrorStateMode:
             interface=bucketclass_dict["interface"],
             bucketclass=bucketclass_dict,
         )[0]
+
+        def cleanup():
+            ns_bucket.delete()
+            ns_bucket.bucketclass.delete()
+            ns_stores[0].delete()
+
+        request.addfinalizer(cleanup)
+
+        log.info(f"Created namespace store: {ns_stores[0].name}")
         log.info(f"Created namespace bucket {ns_bucket.name} (Single policy)")
 
         mcg_obj.exec_mcg_cmd(
@@ -407,15 +444,15 @@ class TestNooBaaBucketErrorStateMode:
             f"(quota 100Mi) to trigger EXCEEDING_QUOTA"
         )
 
+        run_time = 60 * 7
+        log.info(f"Waiting {run_time}s for bucket mode to propagate")
+        time.sleep(run_time)
+
         expected_mode = "EXCEEDING_QUOTA"
         bucket_mode = _get_bucket_mode(mcg_obj, ns_bucket.name)
         assert (
             bucket_mode == expected_mode
         ), f"Expected bucket mode {expected_mode}, got {bucket_mode}"
-
-        ns_bucket.delete()
-        ns_bucket.bucketclass.delete()
-        ns_stores[0].delete()
 
     @skipif_mcg_only
     @polarion_id("OCS-XXXXX")
@@ -426,6 +463,7 @@ class TestNooBaaBucketErrorStateMode:
         bucket_factory,
         backingstore_factory,
         namespace_store_factory,
+        request,
     ):
         """
         Trigger a capacity-related bucket mode on a namespace bucket
@@ -452,18 +490,14 @@ class TestNooBaaBucketErrorStateMode:
             bucket_factory (func): Factory for creating MCG buckets
             backingstore_factory (func): Factory for creating backing stores
             namespace_store_factory (func): Factory for creating namespace stores
+            request: Pytest request object for finalizer registration
         """
         pv_backingstore = backingstore_factory(
             "oc", {"pv": [(1, 2, constants.DEFAULT_STORAGECLASS_RBD)]}
         )[0]
-        log.info(
-            f"Created PV pool backing store {pv_backingstore.name} "
-            f"(2Gi) for cache layer"
-        )
 
         nss_tup = ("oc", {"aws": [(1, "us-east-2")]})
         ns_stores = namespace_store_factory(*nss_tup)
-        log.info(f"Created namespace store (hub): {ns_stores[0].name}")
 
         cache_bucketclass = {
             "interface": "OC",
@@ -479,9 +513,21 @@ class TestNooBaaBucketErrorStateMode:
             interface=cache_bucketclass["interface"],
             bucketclass=cache_bucketclass,
         )[0]
+
+        def cleanup():
+            ns_bucket.delete()
+            ns_bucket.bucketclass.delete()
+            pv_backingstore.delete()
+            ns_stores[0].delete()
+
+        request.addfinalizer(cleanup)
+
         log.info(
-            f"Created Cache namespace bucket {ns_bucket.name} " f"with PV pool cache"
+            f"Created PV pool backing store {pv_backingstore.name} "
+            f"(2Gi) for cache layer"
         )
+        log.info(f"Created namespace store (hub): {ns_stores[0].name}")
+        log.info(f"Created Cache namespace bucket {ns_bucket.name} with PV pool cache")
 
         _upload_data_to_bucket(awscli_pod, ns_bucket.name, mcg_obj, 4, 700)
         log.info(
@@ -499,11 +545,6 @@ class TestNooBaaBucketErrorStateMode:
             f"after exceeding cache PV pool capacity"
         )
 
-        ns_bucket.delete()
-        ns_bucket.bucketclass.delete()
-        pv_backingstore.delete()
-        ns_stores[0].delete()
-
 
 def setup_module(module):
     ocs_obj = OCP()
@@ -511,5 +552,6 @@ def setup_module(module):
 
 
 def teardown_module(module):
-    ocs_obj = OCP()
-    ocs_obj.login_as_user(module.original_user)
+    if hasattr(module, "original_user"):
+        ocs_obj = OCP()
+        ocs_obj.login_as_user(module.original_user)

--- a/tests/functional/monitoring/prometheus/alerts/test_noobaa_bucket_error_state_mode.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_noobaa_bucket_error_state_mode.py
@@ -1,0 +1,515 @@
+import logging
+import time
+
+from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import (
+    red_squad,
+    skipif_ocs_version,
+    skipif_mcg_only,
+)
+from ocs_ci.framework.testlib import (
+    polarion_id,
+    runs_on_provider,
+    skipif_aws_creds_are_missing,
+    skipif_disconnected_cluster,
+    skipif_managed_service,
+    tier2,
+    mcg,
+)
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.bucket_utils import craft_s3_command
+from ocs_ci.ocs.ocp import OCP
+from ocs_ci.ocs.resources.objectbucket import MCGCLIBucket
+from ocs_ci.helpers.helpers import create_unique_resource_name
+
+log = logging.getLogger(__name__)
+
+
+def _get_bucket_mode(mcg_obj, bucket_name):
+    """
+    Get the current mode of a bucket from NooBaa.
+
+    Args:
+        mcg_obj: MCG object
+        bucket_name (str): Name of the bucket
+
+    Returns:
+        str: The bucket mode (e.g. "OPTIMAL", "EXCEEDING_QUOTA")
+    """
+    bucket_info = mcg_obj.get_bucket_info(bucket_name)
+    if bucket_info:
+        log.info(f"Full bucket info for {bucket_name}: {bucket_info}")
+        return bucket_info.get("mode", "UNKNOWN")
+    log.warning(f"Bucket {bucket_name} not found in NooBaa system")
+    return "UNKNOWN"
+
+
+def _upload_data_to_bucket(awscli_pod, bucket_name, mcg_obj, file_count, file_size_mb):
+    """
+    Upload data files to a bucket via S3.
+
+    Args:
+        awscli_pod: Pod with awscli tools
+        bucket_name (str): Target bucket name
+        mcg_obj: MCG object with S3 credentials
+        file_count (int): Number of files to upload
+        file_size_mb (int): Size of each file in MB
+    """
+    awscli_pod.exec_cmd_on_pod(
+        f"dd if=/dev/zero of=/tmp/testfile bs=1M count={file_size_mb}"
+    )
+    for i in range(1, file_count + 1):
+        try:
+            awscli_pod.exec_cmd_on_pod(
+                craft_s3_command(
+                    f"cp /tmp/testfile s3://{bucket_name}/testfile{i}",
+                    mcg_obj,
+                ),
+                out_yaml_format=False,
+                secrets=[
+                    mcg_obj.access_key_id,
+                    mcg_obj.access_key,
+                    mcg_obj.s3_endpoint,
+                ],
+            )
+        except Exception:
+            log.warning(
+                f"Upload of testfile{i} to {bucket_name} failed "
+                f"(expected when exceeding capacity/quota)"
+            )
+
+
+def _delete_data_from_bucket(awscli_pod, bucket_name, mcg_obj, file_count):
+    """
+    Delete data files from a bucket via S3.
+
+    Args:
+        awscli_pod: Pod with awscli tools
+        bucket_name (str): Target bucket name
+        mcg_obj: MCG object with S3 credentials
+        file_count (int): Number of files to delete
+    """
+    for i in range(1, file_count + 1):
+        try:
+            awscli_pod.exec_cmd_on_pod(
+                craft_s3_command(f"rm s3://{bucket_name}/testfile{i}", mcg_obj),
+                out_yaml_format=False,
+                secrets=[
+                    mcg_obj.access_key_id,
+                    mcg_obj.access_key,
+                    mcg_obj.s3_endpoint,
+                ],
+            )
+        except Exception:
+            log.warning(f"Failed to delete testfile{i} from {bucket_name}")
+
+
+@mcg
+@red_squad
+@tier2
+@runs_on_provider
+@skipif_managed_service
+@skipif_disconnected_cluster
+@skipif_aws_creds_are_missing
+@skipif_ocs_version("<4.22")
+class TestNooBaaBucketErrorStateMode:
+    """
+    Tests for RHSTOR-7732: verify that NooBaa buckets enter the
+    expected error modes (bucket_mode) when specific failure
+    conditions are triggered.
+
+    Each test triggers an error condition on a bucket, then verifies
+    via NooBaa's get_bucket_info that the bucket enters the expected
+    error mode.
+
+    Covers three error categories for both data and namespace buckets:
+    - Quota-related modes (e.g. EXCEEDING_QUOTA)
+    - Resource-related modes (e.g. NO_RESOURCES, ALL_TIERS_HAVE_ISSUES)
+    - Capacity-related modes (e.g. NO_CAPACITY, LOW_CAPACITY)
+    """
+
+    # ------------------------------------------------------------------
+    # Data bucket tests
+    # ------------------------------------------------------------------
+
+    @polarion_id("OCS-XXXXX")
+    def test_data_bucket_quota_error_mode(self, mcg_obj, awscli_pod):
+        """
+        Trigger a quota-related bucket mode on a data bucket and verify
+        the bucket enters EXCEEDING_QUOTA mode.
+
+        Steps:
+            1. Create a data bucket with a 2Gi quota
+            2. Upload ~2.5GB to exceed the quota
+            3. Verify bucket mode is EXCEEDING_QUOTA via NooBaa
+            4. Clean up
+
+        Args:
+            mcg_obj (MCG): MCG object with S3 connection credentials
+            awscli_pod (Pod): Pod running the AWSCLI tools
+        """
+        bucket_name = create_unique_resource_name(
+            resource_description="bucket", resource_type="quota"
+        )
+        bucket = MCGCLIBucket(bucket_name, mcg=mcg_obj, quota="2Gi")
+        log.info(f"Created bucket {bucket_name} with 2Gi quota")
+
+        try:
+            _upload_data_to_bucket(awscli_pod, bucket_name, mcg_obj, 5, 500)
+            log.info(
+                f"Uploaded ~2.5GB to bucket {bucket_name} "
+                f"(quota 2Gi) to trigger EXCEEDING_QUOTA"
+            )
+
+            expected_mode = "EXCEEDING_QUOTA"
+            bucket_mode = _get_bucket_mode(mcg_obj, bucket_name)
+            assert bucket_mode == expected_mode, (
+                f"Expected bucket mode {expected_mode}, " f"got {bucket_mode}"
+            )
+        finally:
+            _delete_data_from_bucket(awscli_pod, bucket_name, mcg_obj, 5)
+            bucket.delete()
+
+    @polarion_id("OCS-XXXXX")
+    def test_data_bucket_resource_error_mode(self, mcg_obj, bucket_factory, cld_mgr):
+        """
+        Trigger a resource-related bucket mode on a data bucket and
+        verify the bucket enters a non-OPTIMAL error mode.
+
+        Steps:
+            1. Create a data bucket with an AWS-backed backing store
+            2. Delete the AWS target bucket of the backing store
+            3. Wait for bucket to detect the resource error
+            4. Verify bucket mode is not OPTIMAL via NooBaa
+            5. Clean up
+
+        Args:
+            mcg_obj (MCG): MCG object with S3 connection credentials
+            bucket_factory (func): Factory for creating MCG buckets
+            cld_mgr (CloudManager): Cloud manager for cloud operations
+        """
+        bucketclass_dict = {
+            "interface": "OC",
+            "backingstore_dict": {"aws": [(1, "us-east-2")]},
+        }
+        bucket = bucket_factory(
+            amount=1,
+            interface=bucketclass_dict["interface"],
+            bucketclass=bucketclass_dict,
+        )[0]
+        log.info(f"Created data bucket {bucket.name} with AWS backing store")
+
+        backingstore = bucket.bucketclass.backingstores[0]
+        target_uls_name = backingstore.uls_name
+        log.info(
+            f"Backing store {backingstore.name} uses "
+            f"target bucket {target_uls_name}"
+        )
+
+        cld_mgr.aws_client.delete_uls(target_uls_name)
+        log.info(
+            f"Deleted target bucket {target_uls_name} " f"to trigger resource error"
+        )
+
+        run_time = 60 * 7
+        log.info(f"Waiting {run_time}s for bucket to enter error state")
+        time.sleep(run_time)
+
+        bucket_mode = _get_bucket_mode(mcg_obj, bucket.name)
+        assert bucket_mode != "OPTIMAL", (
+            f"Bucket {bucket.name} is still OPTIMAL after "
+            f"deleting backing store target"
+        )
+
+        bucket.delete()
+        bucket.bucketclass.delete()
+        backingstore.delete()
+
+    @skipif_mcg_only
+    @polarion_id("OCS-XXXXX")
+    def test_data_bucket_capacity_error_mode(self, mcg_obj, awscli_pod, bucket_factory):
+        """
+        Trigger a capacity-related bucket mode on a data bucket and
+        verify the bucket enters a non-OPTIMAL error mode.
+
+        Steps:
+            1. Create a data bucket backed by a small PV pool (2Gi)
+            2. Upload data exceeding PV pool capacity
+            3. Wait for bucket to detect the capacity exhaustion
+            4. Verify bucket mode is not OPTIMAL via NooBaa
+               (e.g. NO_CAPACITY, LOW_CAPACITY)
+            5. Clean up
+
+        Args:
+            mcg_obj (MCG): MCG object with S3 connection credentials
+            awscli_pod (Pod): Pod running the AWSCLI tools
+            bucket_factory (func): Factory for creating MCG buckets
+        """
+        bucketclass_dict = {
+            "interface": "OC",
+            "backingstore_dict": {"pv": [(1, 2, constants.DEFAULT_STORAGECLASS_RBD)]},
+        }
+        bucket = bucket_factory(
+            amount=1,
+            interface=bucketclass_dict["interface"],
+            bucketclass=bucketclass_dict,
+        )[0]
+        backingstore = bucket.bucketclass.backingstores[0]
+        log.info(
+            f"Created data bucket {bucket.name} with "
+            f"2Gi PV pool backing store {backingstore.name}"
+        )
+
+        _upload_data_to_bucket(awscli_pod, bucket.name, mcg_obj, 4, 700)
+        log.info(
+            f"Uploaded ~2.8GB to bucket {bucket.name} "
+            f"(PV pool capacity 2Gi) to trigger capacity error"
+        )
+
+        run_time = 60 * 7
+        log.info(f"Waiting {run_time}s for bucket to enter capacity error state")
+        time.sleep(run_time)
+
+        bucket_mode = _get_bucket_mode(mcg_obj, bucket.name)
+        assert bucket_mode != "OPTIMAL", (
+            f"Bucket {bucket.name} is still OPTIMAL after "
+            f"exceeding PV pool capacity"
+        )
+
+        bucket.delete()
+        bucket.bucketclass.delete()
+        backingstore.delete()
+
+    # ------------------------------------------------------------------
+    # Namespace bucket tests
+    # ------------------------------------------------------------------
+
+    @polarion_id("OCS-XXXXX")
+    def test_ns_bucket_resource_error_mode(
+        self,
+        mcg_obj,
+        bucket_factory,
+        namespace_store_factory,
+        cld_mgr,
+    ):
+        """
+        Trigger a resource-related bucket mode on a namespace bucket
+        and verify the bucket enters a non-OPTIMAL error mode.
+
+        Steps:
+            1. Create 2 namespace stores backed by AWS target buckets
+            2. Create a namespace bucket using Multi policy
+            3. Delete the target bucket of one namespace store
+            4. Wait for bucket to detect the resource error
+            5. Verify bucket mode is not OPTIMAL via NooBaa
+            6. Clean up
+
+        Args:
+            mcg_obj (MCG): MCG object with S3 connection credentials
+            bucket_factory (func): Factory for creating MCG buckets
+            namespace_store_factory (func): Factory for creating namespace stores
+            cld_mgr (CloudManager): Cloud manager for cloud operations
+        """
+        nss_tup = ("oc", {"aws": [(2, "us-east-2")]})
+        ns_stores = namespace_store_factory(*nss_tup)
+        log.info(f"Created namespace stores: " f"{[ns.name for ns in ns_stores]}")
+
+        bucketclass_dict = {
+            "interface": "OC",
+            "namespace_policy_dict": {
+                "type": "Multi",
+                "namespacestores": ns_stores,
+            },
+        }
+        ns_bucket = bucket_factory(
+            amount=1,
+            interface=bucketclass_dict["interface"],
+            bucketclass=bucketclass_dict,
+        )[0]
+        log.info(f"Created namespace bucket {ns_bucket.name} " f"with Multi policy")
+
+        target_uls_name = ns_stores[0].uls_name
+        log.info(
+            f"Deleting target bucket {target_uls_name} of "
+            f"namespace store {ns_stores[0].name}"
+        )
+        cld_mgr.aws_client.delete_uls(target_uls_name)
+
+        run_time = 60 * 7
+        log.info(f"Waiting {run_time}s for namespace bucket to enter error state")
+        time.sleep(run_time)
+
+        bucket_mode = _get_bucket_mode(mcg_obj, ns_bucket.name)
+        assert bucket_mode != "OPTIMAL", (
+            f"Namespace bucket {ns_bucket.name} is still OPTIMAL "
+            f"after deleting namespace store target"
+        )
+
+        ns_bucket.delete()
+        ns_bucket.bucketclass.delete()
+        ns_stores[0].delete()
+
+    @polarion_id("OCS-XXXXX")
+    def test_ns_bucket_quota_error_mode(
+        self,
+        mcg_obj,
+        awscli_pod,
+        bucket_factory,
+        namespace_store_factory,
+    ):
+        """
+        Trigger a quota-related bucket mode on a namespace bucket and
+        verify the bucket enters EXCEEDING_QUOTA mode.
+
+        Steps:
+            1. Create an AWS-backed namespace store
+            2. Create a namespace bucket (Single policy) using the
+               namespace store
+            3. Set a 100Mi quota on the namespace bucket
+            4. Upload data exceeding the quota
+            5. Verify bucket mode is EXCEEDING_QUOTA via NooBaa
+            6. Clean up
+
+        Args:
+            mcg_obj (MCG): MCG object with S3 connection credentials
+            awscli_pod (Pod): Pod running the AWSCLI tools
+            bucket_factory (func): Factory for creating MCG buckets
+            namespace_store_factory (func): Factory for creating namespace stores
+        """
+        nss_tup = ("oc", {"aws": [(1, "us-east-2")]})
+        ns_stores = namespace_store_factory(*nss_tup)
+        log.info(f"Created namespace store: {ns_stores[0].name}")
+
+        bucketclass_dict = {
+            "interface": "OC",
+            "namespace_policy_dict": {
+                "type": "Single",
+                "namespacestores": ns_stores,
+            },
+        }
+        ns_bucket = bucket_factory(
+            amount=1,
+            interface=bucketclass_dict["interface"],
+            bucketclass=bucketclass_dict,
+        )[0]
+        log.info(f"Created namespace bucket {ns_bucket.name} (Single policy)")
+
+        mcg_obj.exec_mcg_cmd(
+            cmd=f"bucket update --max-size=100Mi {ns_bucket.name}",
+            namespace=config.ENV_DATA["cluster_namespace"],
+            use_yes=True,
+        )
+        log.info(f"Set 100Mi quota on namespace bucket {ns_bucket.name}")
+
+        _upload_data_to_bucket(awscli_pod, ns_bucket.name, mcg_obj, 3, 50)
+        log.info(
+            f"Uploaded ~150MB to namespace bucket {ns_bucket.name} "
+            f"(quota 100Mi) to trigger EXCEEDING_QUOTA"
+        )
+
+        expected_mode = "EXCEEDING_QUOTA"
+        bucket_mode = _get_bucket_mode(mcg_obj, ns_bucket.name)
+        assert (
+            bucket_mode == expected_mode
+        ), f"Expected bucket mode {expected_mode}, got {bucket_mode}"
+
+        ns_bucket.delete()
+        ns_bucket.bucketclass.delete()
+        ns_stores[0].delete()
+
+    @skipif_mcg_only
+    @polarion_id("OCS-XXXXX")
+    def test_ns_bucket_capacity_error_mode(
+        self,
+        mcg_obj,
+        awscli_pod,
+        bucket_factory,
+        backingstore_factory,
+        namespace_store_factory,
+    ):
+        """
+        Trigger a capacity-related bucket mode on a namespace bucket
+        and verify the bucket enters a non-OPTIMAL error mode.
+
+        Uses a Cache namespace bucket where the cache layer is a small
+        PV pool backing store (2Gi). Filling the cache beyond its
+        capacity triggers a capacity error mode.
+
+        Steps:
+            1. Create a PV pool backing store (2Gi) for the cache layer
+            2. Create an AWS-backed namespace store for the hub
+            3. Create a Cache namespace bucket with the AWS hub and
+               PV pool cache
+            4. Upload data exceeding PV pool capacity
+            5. Wait for bucket to detect the capacity exhaustion
+            6. Verify bucket mode is not OPTIMAL via NooBaa
+               (e.g. NO_CAPACITY, LOW_CAPACITY)
+            7. Clean up
+
+        Args:
+            mcg_obj (MCG): MCG object with S3 connection credentials
+            awscli_pod (Pod): Pod running the AWSCLI tools
+            bucket_factory (func): Factory for creating MCG buckets
+            backingstore_factory (func): Factory for creating backing stores
+            namespace_store_factory (func): Factory for creating namespace stores
+        """
+        pv_backingstore = backingstore_factory(
+            "oc", {"pv": [(1, 2, constants.DEFAULT_STORAGECLASS_RBD)]}
+        )[0]
+        log.info(
+            f"Created PV pool backing store {pv_backingstore.name} "
+            f"(2Gi) for cache layer"
+        )
+
+        nss_tup = ("oc", {"aws": [(1, "us-east-2")]})
+        ns_stores = namespace_store_factory(*nss_tup)
+        log.info(f"Created namespace store (hub): {ns_stores[0].name}")
+
+        cache_bucketclass = {
+            "interface": "OC",
+            "namespace_policy_dict": {
+                "type": "Cache",
+                "ttl": 300000,
+                "namespacestores": ns_stores,
+            },
+            "placement_policy": {"tiers": [{"backingStores": [pv_backingstore.name]}]},
+        }
+        ns_bucket = bucket_factory(
+            amount=1,
+            interface=cache_bucketclass["interface"],
+            bucketclass=cache_bucketclass,
+        )[0]
+        log.info(
+            f"Created Cache namespace bucket {ns_bucket.name} " f"with PV pool cache"
+        )
+
+        _upload_data_to_bucket(awscli_pod, ns_bucket.name, mcg_obj, 4, 700)
+        log.info(
+            f"Uploaded ~2.8GB to cache namespace bucket {ns_bucket.name} "
+            f"(cache PV pool 2Gi) to trigger capacity error"
+        )
+
+        run_time = 60 * 7
+        log.info(f"Waiting {run_time}s for namespace bucket to enter error state")
+        time.sleep(run_time)
+
+        bucket_mode = _get_bucket_mode(mcg_obj, ns_bucket.name)
+        assert bucket_mode != "OPTIMAL", (
+            f"Namespace bucket {ns_bucket.name} is still OPTIMAL "
+            f"after exceeding cache PV pool capacity"
+        )
+
+        ns_bucket.delete()
+        ns_bucket.bucketclass.delete()
+        pv_backingstore.delete()
+        ns_stores[0].delete()
+
+
+def setup_module(module):
+    ocs_obj = OCP()
+    module.original_user = ocs_obj.get_user_name()
+
+
+def teardown_module(module):
+    ocs_obj = OCP()
+    ocs_obj.login_as_user(module.original_user)

--- a/tests/functional/monitoring/prometheus/alerts/test_noobaa_bucket_error_state_mode.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_noobaa_bucket_error_state_mode.py
@@ -1,5 +1,4 @@
 import logging
-import time
 
 from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import (
@@ -21,8 +20,61 @@ from ocs_ci.ocs.bucket_utils import craft_s3_command
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.resources.objectbucket import MCGCLIBucket
 from ocs_ci.helpers.helpers import create_unique_resource_name
+from ocs_ci.ocs.exceptions import TimeoutExpiredError
+from ocs_ci.utility.utils import TimeoutSampler
 
 log = logging.getLogger(__name__)
+
+BUCKET_MODE_TIMEOUT = 60 * 10
+BUCKET_MODE_POLL_INTERVAL = 15
+
+
+def _wait_for_bucket_mode(mcg_obj, bucket_name, expected_mode):
+    """
+    Poll NooBaa until the bucket enters the expected mode or timeout.
+
+    Args:
+        mcg_obj: MCG object
+        bucket_name (str): Name of the bucket
+        expected_mode (str): Expected bucket mode (e.g. "EXCEEDING_QUOTA")
+            or "!OPTIMAL" to wait for any non-OPTIMAL mode
+
+    Returns:
+        str: The actual bucket mode once matched
+
+    Raises:
+        AssertionError: If the bucket does not reach the expected mode
+            within the timeout
+    """
+    check_not_optimal = expected_mode == "!OPTIMAL"
+    last_mode = "UNKNOWN"
+
+    try:
+        for mode in TimeoutSampler(
+            timeout=BUCKET_MODE_TIMEOUT,
+            sleep=BUCKET_MODE_POLL_INTERVAL,
+            func=_get_bucket_mode,
+            mcg_obj=mcg_obj,
+            bucket_name=bucket_name,
+        ):
+            last_mode = mode
+            if check_not_optimal and mode != "OPTIMAL":
+                log.info(f"Bucket {bucket_name} entered non-OPTIMAL mode: {mode}")
+                return mode
+            elif not check_not_optimal and mode == expected_mode:
+                log.info(f"Bucket {bucket_name} entered expected mode: {mode}")
+                return mode
+    except TimeoutExpiredError:
+        if check_not_optimal:
+            assert False, (
+                f"Bucket {bucket_name} is still OPTIMAL after "
+                f"{BUCKET_MODE_TIMEOUT}s (last mode: {last_mode})"
+            )
+        else:
+            assert False, (
+                f"Expected bucket mode {expected_mode} for {bucket_name}, "
+                f"got {last_mode} after {BUCKET_MODE_TIMEOUT}s"
+            )
 
 
 def _get_bucket_mode(mcg_obj, bucket_name):
@@ -162,15 +214,7 @@ class TestNooBaaBucketErrorStateMode:
                 f"(quota 2Gi) to trigger EXCEEDING_QUOTA"
             )
 
-            run_time = 60 * 7
-            log.info(f"Waiting {run_time}s for bucket mode to propagate")
-            time.sleep(run_time)
-
-            expected_mode = "EXCEEDING_QUOTA"
-            bucket_mode = _get_bucket_mode(mcg_obj, bucket_name)
-            assert bucket_mode == expected_mode, (
-                f"Expected bucket mode {expected_mode}, " f"got {bucket_mode}"
-            )
+            _wait_for_bucket_mode(mcg_obj, bucket_name, "EXCEEDING_QUOTA")
         finally:
             _delete_data_from_bucket(awscli_pod, bucket_name, mcg_obj, 5)
             bucket.delete()
@@ -227,15 +271,7 @@ class TestNooBaaBucketErrorStateMode:
             f"Deleted target bucket {target_uls_name} " f"to trigger resource error"
         )
 
-        run_time = 60 * 7
-        log.info(f"Waiting {run_time}s for bucket to enter error state")
-        time.sleep(run_time)
-
-        bucket_mode = _get_bucket_mode(mcg_obj, bucket.name)
-        assert bucket_mode != "OPTIMAL", (
-            f"Bucket {bucket.name} is still OPTIMAL after "
-            f"deleting backing store target"
-        )
+        _wait_for_bucket_mode(mcg_obj, bucket.name, "!OPTIMAL")
 
     @skipif_mcg_only
     @polarion_id("OCS-XXXXX")
@@ -289,15 +325,7 @@ class TestNooBaaBucketErrorStateMode:
             f"(PV pool capacity 2Gi) to trigger capacity error"
         )
 
-        run_time = 60 * 7
-        log.info(f"Waiting {run_time}s for bucket to enter capacity error state")
-        time.sleep(run_time)
-
-        bucket_mode = _get_bucket_mode(mcg_obj, bucket.name)
-        assert bucket_mode != "OPTIMAL", (
-            f"Bucket {bucket.name} is still OPTIMAL after "
-            f"exceeding PV pool capacity"
-        )
+        _wait_for_bucket_mode(mcg_obj, bucket.name, "!OPTIMAL")
 
     # ------------------------------------------------------------------
     # Namespace bucket tests
@@ -365,15 +393,7 @@ class TestNooBaaBucketErrorStateMode:
         )
         cld_mgr.aws_client.delete_uls(target_uls_name)
 
-        run_time = 60 * 7
-        log.info(f"Waiting {run_time}s for namespace bucket to enter error state")
-        time.sleep(run_time)
-
-        bucket_mode = _get_bucket_mode(mcg_obj, ns_bucket.name)
-        assert bucket_mode != "OPTIMAL", (
-            f"Namespace bucket {ns_bucket.name} is still OPTIMAL "
-            f"after deleting namespace store target"
-        )
+        _wait_for_bucket_mode(mcg_obj, ns_bucket.name, "!OPTIMAL")
 
     @polarion_id("OCS-XXXXX")
     def test_ns_bucket_quota_error_mode(
@@ -444,15 +464,7 @@ class TestNooBaaBucketErrorStateMode:
             f"(quota 100Mi) to trigger EXCEEDING_QUOTA"
         )
 
-        run_time = 60 * 7
-        log.info(f"Waiting {run_time}s for bucket mode to propagate")
-        time.sleep(run_time)
-
-        expected_mode = "EXCEEDING_QUOTA"
-        bucket_mode = _get_bucket_mode(mcg_obj, ns_bucket.name)
-        assert (
-            bucket_mode == expected_mode
-        ), f"Expected bucket mode {expected_mode}, got {bucket_mode}"
+        _wait_for_bucket_mode(mcg_obj, ns_bucket.name, "EXCEEDING_QUOTA")
 
     @skipif_mcg_only
     @polarion_id("OCS-XXXXX")
@@ -535,15 +547,7 @@ class TestNooBaaBucketErrorStateMode:
             f"(cache PV pool 2Gi) to trigger capacity error"
         )
 
-        run_time = 60 * 7
-        log.info(f"Waiting {run_time}s for namespace bucket to enter error state")
-        time.sleep(run_time)
-
-        bucket_mode = _get_bucket_mode(mcg_obj, ns_bucket.name)
-        assert bucket_mode != "OPTIMAL", (
-            f"Namespace bucket {ns_bucket.name} is still OPTIMAL "
-            f"after exceeding cache PV pool capacity"
-        )
+        _wait_for_bucket_mode(mcg_obj, ns_bucket.name, "!OPTIMAL")
 
 
 def setup_module(module):

--- a/tests/functional/monitoring/prometheus/alerts/test_noobaa_bucket_error_state_mode.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_noobaa_bucket_error_state_mode.py
@@ -136,7 +136,7 @@ class TestNooBaaBucketErrorStateMode:
     def test_data_bucket_quota_error_mode(self, mcg_obj, awscli_pod):
         """
         Trigger a quota-related bucket mode on a data bucket and verify
-        the bucket enters EXCEEDING_QUOTA mode.
+        that the bucket enters EXCEEDING_QUOTA mode.
 
         Steps:
             1. Create a data bucket with a 2Gi quota

--- a/tests/functional/object/mcg/test_noobaa_bucket_error_state_mode.py
+++ b/tests/functional/object/mcg/test_noobaa_bucket_error_state_mode.py
@@ -39,6 +39,7 @@ def _wait_for_bucket_mode(mcg_obj, bucket_name, expected_mode, timeout=None):
         bucket_name (str): Name of the bucket
         expected_mode (str): Expected bucket mode (e.g. "EXCEEDING_QUOTA")
             or "!OPTIMAL" to wait for any non-OPTIMAL mode
+            (UNKNOWN is excluded to avoid false positives on lookup failures)
         timeout (int): Timeout in seconds (default: BUCKET_MODE_TIMEOUT)
 
     Returns:
@@ -62,7 +63,7 @@ def _wait_for_bucket_mode(mcg_obj, bucket_name, expected_mode, timeout=None):
             bucket_name=bucket_name,
         ):
             last_mode = mode
-            if check_not_optimal and mode != "OPTIMAL":
+            if check_not_optimal and mode not in ("OPTIMAL", "UNKNOWN"):
                 log.info(f"Bucket {bucket_name} entered non-OPTIMAL mode: {mode}")
                 return mode
             elif not check_not_optimal and mode == expected_mode:

--- a/tests/functional/object/mcg/test_noobaa_bucket_error_state_mode.py
+++ b/tests/functional/object/mcg/test_noobaa_bucket_error_state_mode.py
@@ -7,7 +7,6 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_mcg_only,
 )
 from ocs_ci.framework.testlib import (
-    polarion_id,
     runs_on_provider,
     skipif_aws_creds_are_missing,
     skipif_disconnected_cluster,
@@ -17,7 +16,6 @@ from ocs_ci.framework.testlib import (
 )
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.bucket_utils import craft_s3_command
-from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.resources.objectbucket import MCGCLIBucket
 from ocs_ci.helpers.helpers import create_unique_resource_name
 from ocs_ci.ocs.exceptions import TimeoutExpiredError
@@ -160,9 +158,7 @@ def _delete_data_from_bucket(awscli_pod, bucket_name, mcg_obj, file_count):
 @red_squad
 @tier2
 @runs_on_provider
-@skipif_managed_service
 @skipif_disconnected_cluster
-@skipif_aws_creds_are_missing
 @skipif_ocs_version("<4.22")
 class TestNooBaaBucketErrorStateMode:
     """
@@ -184,7 +180,8 @@ class TestNooBaaBucketErrorStateMode:
     # Data bucket tests
     # ------------------------------------------------------------------
 
-    @polarion_id("OCS-XXXXX")
+    # TODO: Replace with actual Polarion ID
+    # @polarion_id("OCS-XXXXX")
     def test_data_bucket_quota_error_mode(self, mcg_obj, awscli_pod):
         """
         Trigger a quota-related bucket mode on a data bucket and verify
@@ -219,7 +216,10 @@ class TestNooBaaBucketErrorStateMode:
             _delete_data_from_bucket(awscli_pod, bucket_name, mcg_obj, 5)
             bucket.delete()
 
-    @polarion_id("OCS-XXXXX")
+    @skipif_managed_service
+    @skipif_aws_creds_are_missing
+    # TODO: Replace with actual Polarion ID
+    # @polarion_id("OCS-XXXXX")
     def test_data_bucket_resource_error_mode(
         self, mcg_obj, bucket_factory, cld_mgr, request
     ):
@@ -274,7 +274,8 @@ class TestNooBaaBucketErrorStateMode:
         _wait_for_bucket_mode(mcg_obj, bucket.name, "!OPTIMAL")
 
     @skipif_mcg_only
-    @polarion_id("OCS-XXXXX")
+    # TODO: Replace with actual Polarion ID
+    # @polarion_id("OCS-XXXXX")
     def test_data_bucket_capacity_error_mode(
         self, mcg_obj, awscli_pod, bucket_factory, request
     ):
@@ -331,7 +332,10 @@ class TestNooBaaBucketErrorStateMode:
     # Namespace bucket tests
     # ------------------------------------------------------------------
 
-    @polarion_id("OCS-XXXXX")
+    @skipif_managed_service
+    @skipif_aws_creds_are_missing
+    # TODO: Replace with actual Polarion ID
+    # @polarion_id("OCS-XXXXX")
     def test_ns_bucket_resource_error_mode(
         self,
         mcg_obj,
@@ -395,7 +399,10 @@ class TestNooBaaBucketErrorStateMode:
 
         _wait_for_bucket_mode(mcg_obj, ns_bucket.name, "!OPTIMAL")
 
-    @polarion_id("OCS-XXXXX")
+    @skipif_managed_service
+    @skipif_aws_creds_are_missing
+    # TODO: Replace with actual Polarion ID
+    # @polarion_id("OCS-XXXXX")
     def test_ns_bucket_quota_error_mode(
         self,
         mcg_obj,
@@ -467,7 +474,10 @@ class TestNooBaaBucketErrorStateMode:
         _wait_for_bucket_mode(mcg_obj, ns_bucket.name, "EXCEEDING_QUOTA")
 
     @skipif_mcg_only
-    @polarion_id("OCS-XXXXX")
+    @skipif_managed_service
+    @skipif_aws_creds_are_missing
+    # TODO: Replace with actual Polarion ID
+    # @polarion_id("OCS-XXXXX")
     def test_ns_bucket_capacity_error_mode(
         self,
         mcg_obj,
@@ -548,14 +558,3 @@ class TestNooBaaBucketErrorStateMode:
         )
 
         _wait_for_bucket_mode(mcg_obj, ns_bucket.name, "!OPTIMAL")
-
-
-def setup_module(module):
-    ocs_obj = OCP()
-    module.original_user = ocs_obj.get_user_name()
-
-
-def teardown_module(module):
-    if hasattr(module, "original_user"):
-        ocs_obj = OCP()
-        ocs_obj.login_as_user(module.original_user)

--- a/tests/functional/object/mcg/test_noobaa_bucket_error_state_mode.py
+++ b/tests/functional/object/mcg/test_noobaa_bucket_error_state_mode.py
@@ -1,5 +1,7 @@
+import json
 import logging
 
+from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import (
     post_upgrade,
     red_squad,
@@ -23,6 +25,7 @@ from ocs_ci.ocs.bucket_utils import (
     write_random_test_objects_to_bucket,
 )
 from ocs_ci.ocs.exceptions import CommandFailed
+from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.resources.objectbucket import MCGCLIBucket
 from ocs_ci.helpers.helpers import create_unique_resource_name
 from ocs_ci.utility.prometheus import PrometheusAPI, wait_for_alert_firing
@@ -123,19 +126,19 @@ class TestNooBaaBucketErrorStateMode:
     # TODO: Replace with actual Polarion ID
     # @polarion_id("OCS-XXXXX")
     def test_data_bucket_resource_error_mode(
-        self, mcg_obj, awscli_pod, bucket_factory, cld_mgr
+        self, mcg_obj, awscli_pod, bucket_factory
     ):
         """
         Trigger a resource-related bucket mode on a data bucket and
         verify the bucket enters NOT_ENOUGH_HEALTHY_RESOURCES mode.
 
-        Uses an AWS cloud backing store and deletes its target bucket
-        to simulate a resource failure.
+        Corrupts the AWS credentials secret of the backing store so
+        that NooBaa can no longer access the underlying cloud storage.
 
         Steps:
             1. Create a data bucket with an AWS cloud backing store
             2. Upload data so NooBaa tracks objects against the store
-            3. Delete the target bucket of the backing store
+            3. Patch the backing store's secret with invalid credentials
             4. Wait for bucket to detect the resource error
             5. Verify bucket mode is NOT_ENOUGH_HEALTHY_RESOURCES
             6. Clean up
@@ -144,7 +147,6 @@ class TestNooBaaBucketErrorStateMode:
             mcg_obj (MCG): MCG object with S3 connection credentials
             awscli_pod (Pod): Pod running the AWSCLI tools
             bucket_factory (func): Factory for creating MCG buckets
-            cld_mgr (CloudManager): Cloud manager for cloud operations
         """
         bucketclass_dict = {
             "interface": "OC",
@@ -175,12 +177,25 @@ class TestNooBaaBucketErrorStateMode:
             f"so NooBaa tracks objects against the backing store"
         )
 
-        target_uls_name = backingstore.uls_name
+        bs_ocp = OCP(
+            namespace=config.ENV_DATA["cluster_namespace"],
+            kind="backingstore",
+        ).get(resource_name=backingstore.name)
+        secret_name = bs_ocp["spec"]["awsS3"]["secret"]["name"]
         logger.info(
-            f"Deleting target bucket {target_uls_name} of "
-            f"backing store {backingstore.name}"
+            f"Patching secret {secret_name} with invalid AWS credentials "
+            f"to make backing store {backingstore.name} unhealthy"
         )
-        cld_mgr.aws_client.delete_uls(target_uls_name)
+        OCP(
+            namespace=config.ENV_DATA["cluster_namespace"],
+            kind="secret",
+        ).patch(
+            resource_name=secret_name,
+            params=json.dumps(
+                {"data": {"AWS_ACCESS_KEY_ID": "d3JvbmdhY2Nlc3NrZXk="}}
+            ),
+            format_type="merge",
+        )
 
         wait_for_bucket_mode(mcg_obj, bucket.name, "NOT_ENOUGH_HEALTHY_RESOURCES")
 

--- a/tests/functional/object/mcg/test_noobaa_bucket_error_state_mode.py
+++ b/tests/functional/object/mcg/test_noobaa_bucket_error_state_mode.py
@@ -1,8 +1,5 @@
 import logging
 
-import pytest
-
-from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import (
     post_upgrade,
     red_squad,
@@ -225,85 +222,6 @@ class TestNooBaaBucketErrorStateMode:
         finally:
             _delete_data_from_bucket(awscli_pod, bucket_name, mcg_obj, 5)
             bucket.delete()
-
-    @pytest.mark.skip(
-        reason="NS buckets don't keep metadata and act as a proxy — "
-        "quota is not supported for namespace buckets. "
-        "Confirmed by Eran Tamir on RHSTOR-7732."
-    )
-    @skipif_managed_service
-    @skipif_aws_creds_are_missing
-    # TODO: Replace with actual Polarion ID
-    # @polarion_id("OCS-XXXXX")
-    def test_ns_bucket_quota_error_mode(
-        self,
-        mcg_obj,
-        awscli_pod,
-        bucket_factory,
-        namespace_store_factory,
-        request,
-    ):
-        """
-        Trigger a quota-related bucket mode on a namespace bucket and
-        verify the bucket enters EXCEEDING_QUOTA mode.
-
-        Steps:
-            1. Create an AWS-backed namespace store
-            2. Create a namespace bucket (Single policy) using the
-               namespace store
-            3. Set a 1Gi quota on the namespace bucket
-            4. Upload data exceeding the quota
-            5. Wait for bucket mode to propagate
-            6. Verify bucket mode is EXCEEDING_QUOTA via NooBaa
-            7. Clean up
-
-        Args:
-            mcg_obj (MCG): MCG object with S3 connection credentials
-            awscli_pod (Pod): Pod running the AWSCLI tools
-            bucket_factory (func): Factory for creating MCG buckets
-            namespace_store_factory (func): Factory for creating namespace stores
-            request: Pytest request object for finalizer registration
-        """
-        nss_tup = ("oc", {"aws": [(1, "us-east-2")]})
-        ns_stores = namespace_store_factory(*nss_tup)
-
-        bucketclass_dict = {
-            "interface": "OC",
-            "namespace_policy_dict": {
-                "type": "Single",
-                "namespacestores": ns_stores,
-            },
-        }
-        ns_bucket = bucket_factory(
-            amount=1,
-            interface=bucketclass_dict["interface"],
-            bucketclass=bucketclass_dict,
-        )[0]
-
-        def cleanup():
-            ns_bucket.delete()
-            ns_bucket.bucketclass.delete()
-            ns_stores[0].delete()
-
-        request.addfinalizer(cleanup)
-
-        log.info(f"Created namespace store: {ns_stores[0].name}")
-        log.info(f"Created namespace bucket {ns_bucket.name} (Single policy)")
-
-        mcg_obj.exec_mcg_cmd(
-            cmd=f"bucket update --max-size=1Gi {ns_bucket.name}",
-            namespace=config.ENV_DATA["cluster_namespace"],
-            use_yes=True,
-        )
-        log.info(f"Set 1Gi quota on namespace bucket {ns_bucket.name}")
-
-        _upload_data_to_bucket(awscli_pod, ns_bucket.name, mcg_obj, 3, 500)
-        log.info(
-            f"Uploaded ~1.5GB to namespace bucket {ns_bucket.name} "
-            f"(quota 1Gi) to trigger EXCEEDING_QUOTA"
-        )
-
-        _wait_for_bucket_mode(mcg_obj, ns_bucket.name, "EXCEEDING_QUOTA")
 
     # ------------------------------------------------------------------
     # Resource error mode tests (NOT_ENOUGH_HEALTHY_RESOURCES)
@@ -584,96 +502,6 @@ class TestNooBaaBucketErrorStateMode:
         assert (
             final_mode in capacity_error_modes
         ), f"Expected one of {capacity_error_modes}, got {final_mode}"
-
-    @pytest.mark.skip(
-        reason="NS buckets don't keep metadata and act as a proxy — "
-        "capacity tracking is not supported for namespace buckets. "
-        "Confirmed by Eran Tamir on RHSTOR-7732."
-    )
-    @skipif_mcg_only
-    @skipif_managed_service
-    @skipif_aws_creds_are_missing
-    # TODO: Replace with actual Polarion ID
-    # @polarion_id("OCS-XXXXX")
-    def test_ns_bucket_capacity_error_mode(
-        self,
-        mcg_obj,
-        awscli_pod,
-        bucket_factory,
-        backingstore_factory,
-        namespace_store_factory,
-        request,
-    ):
-        """
-        Trigger a capacity-related bucket mode on a namespace bucket
-        and verify the bucket enters NOT_ENOUGH_HEALTHY_RESOURCES mode.
-
-        Uses a Cache namespace bucket where the cache layer is a small
-        PV pool backing store (17Gi). Filling the cache beyond its
-        capacity triggers a capacity error mode.
-
-        Steps:
-            1. Create a PV pool backing store (17Gi) for the cache layer
-            2. Create an AWS-backed namespace store for the hub
-            3. Create a Cache namespace bucket with the AWS hub and
-               PV pool cache
-            4. Upload data exceeding PV pool capacity
-            5. Wait for bucket to detect the capacity exhaustion
-            6. Verify bucket mode is NOT_ENOUGH_HEALTHY_RESOURCES
-            7. Clean up
-
-        Args:
-            mcg_obj (MCG): MCG object with S3 connection credentials
-            awscli_pod (Pod): Pod running the AWSCLI tools
-            bucket_factory (func): Factory for creating MCG buckets
-            backingstore_factory (func): Factory for creating backing stores
-            namespace_store_factory (func): Factory for creating namespace stores
-            request: Pytest request object for finalizer registration
-        """
-        pv_backingstore = backingstore_factory(
-            "oc", {"pv": [(1, 17, constants.DEFAULT_STORAGECLASS_RBD)]}
-        )[0]
-
-        nss_tup = ("oc", {"aws": [(1, "us-east-2")]})
-        ns_stores = namespace_store_factory(*nss_tup)
-
-        cache_bucketclass = {
-            "interface": "OC",
-            "namespace_policy_dict": {
-                "type": "Cache",
-                "ttl": 300000,
-                "namespacestores": ns_stores,
-            },
-            "placement_policy": {"tiers": [{"backingStores": [pv_backingstore.name]}]},
-        }
-        ns_bucket = bucket_factory(
-            amount=1,
-            interface=cache_bucketclass["interface"],
-            bucketclass=cache_bucketclass,
-        )[0]
-
-        def cleanup():
-            ns_bucket.delete()
-            ns_bucket.bucketclass.delete()
-            pv_backingstore.delete()
-            ns_stores[0].delete()
-
-        request.addfinalizer(cleanup)
-
-        log.info(
-            f"Created PV pool backing store {pv_backingstore.name} "
-            f"(17Gi) for cache layer"
-        )
-        log.info(f"Created namespace store (hub): {ns_stores[0].name}")
-        log.info(f"Created Cache namespace bucket {ns_bucket.name} with PV pool cache")
-
-        _upload_data_to_bucket(awscli_pod, ns_bucket.name, mcg_obj, 4, 5000)
-        log.info(
-            f"Uploaded ~20GB to cache namespace bucket {ns_bucket.name} "
-            f"(cache PV pool 17Gi) to trigger capacity error"
-        )
-
-        _wait_for_bucket_mode(mcg_obj, ns_bucket.name, "NOT_ENOUGH_HEALTHY_RESOURCES")
 
     # ------------------------------------------------------------------
     # Alert verification test

--- a/tests/functional/object/mcg/test_noobaa_bucket_error_state_mode.py
+++ b/tests/functional/object/mcg/test_noobaa_bucket_error_state_mode.py
@@ -4,6 +4,7 @@ import pytest
 
 from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import (
+    post_upgrade,
     red_squad,
     skipif_ocs_version,
     skipif_mcg_only,
@@ -164,6 +165,7 @@ def _delete_data_from_bucket(awscli_pod, bucket_name, mcg_obj, file_count):
 @mcg
 @red_squad
 @tier2
+@post_upgrade
 @runs_on_provider
 @skipif_disconnected_cluster
 @skipif_ocs_version("<4.22")

--- a/tests/functional/object/mcg/test_noobaa_bucket_error_state_mode.py
+++ b/tests/functional/object/mcg/test_noobaa_bucket_error_state_mode.py
@@ -238,9 +238,7 @@ class TestNooBaaBucketErrorStateMode:
     @skipif_mcg_only
     # TODO: Replace with actual Polarion ID
     # @polarion_id("OCS-XXXXX")
-    def test_data_bucket_resource_error_mode(
-        self, mcg_obj, awscli_pod, bucket_factory, request
-    ):
+    def test_data_bucket_resource_error_mode(self, mcg_obj, awscli_pod, bucket_factory):
         """
         Trigger a resource-related bucket mode on a data bucket and
         verify the bucket enters NOT_ENOUGH_HEALTHY_RESOURCES mode.
@@ -260,7 +258,6 @@ class TestNooBaaBucketErrorStateMode:
             mcg_obj (MCG): MCG object with S3 connection credentials
             awscli_pod (Pod): Pod running the AWSCLI tools
             bucket_factory (func): Factory for creating MCG buckets
-            request: Pytest request object for finalizer registration
         """
         bucketclass_dict = {
             "interface": "OC",
@@ -272,13 +269,6 @@ class TestNooBaaBucketErrorStateMode:
             bucketclass=bucketclass_dict,
         )[0]
         backingstore = bucket.bucketclass.backingstores[0]
-
-        def cleanup():
-            bucket.delete()
-            bucket.bucketclass.delete()
-            backingstore.delete()
-
-        request.addfinalizer(cleanup)
 
         log.info(
             f"Created data bucket {bucket.name} with "
@@ -313,7 +303,6 @@ class TestNooBaaBucketErrorStateMode:
         bucket_factory,
         namespace_store_factory,
         cld_mgr,
-        request,
     ):
         """
         Trigger a resource-related bucket mode on a namespace bucket
@@ -334,7 +323,6 @@ class TestNooBaaBucketErrorStateMode:
             bucket_factory (func): Factory for creating MCG buckets
             namespace_store_factory (func): Factory for creating namespace stores
             cld_mgr (CloudManager): Cloud manager for cloud operations
-            request: Pytest request object for finalizer registration
         """
         nss_tup = ("oc", {"aws": [(2, "us-east-2")]})
         ns_stores = namespace_store_factory(*nss_tup)
@@ -351,14 +339,6 @@ class TestNooBaaBucketErrorStateMode:
             interface=bucketclass_dict["interface"],
             bucketclass=bucketclass_dict,
         )[0]
-
-        def cleanup():
-            ns_bucket.delete()
-            ns_bucket.bucketclass.delete()
-            for ns_store in ns_stores:
-                ns_store.delete()
-
-        request.addfinalizer(cleanup)
 
         log.info(f"Created namespace stores: {[ns.name for ns in ns_stores]}")
         log.info(f"Created namespace bucket {ns_bucket.name} with Multi policy")
@@ -385,9 +365,7 @@ class TestNooBaaBucketErrorStateMode:
     @skipif_mcg_only
     # TODO: Replace with actual Polarion ID
     # @polarion_id("OCS-XXXXX")
-    def test_data_bucket_capacity_error_mode(
-        self, mcg_obj, awscli_pod, bucket_factory, request
-    ):
+    def test_data_bucket_capacity_error_mode(self, mcg_obj, awscli_pod, bucket_factory):
         """
         Gradually fill a data bucket's PV pool backing store and track
         bucket mode transitions through capacity error states.
@@ -407,7 +385,6 @@ class TestNooBaaBucketErrorStateMode:
             mcg_obj (MCG): MCG object with S3 connection credentials
             awscli_pod (Pod): Pod running the AWSCLI tools
             bucket_factory (func): Factory for creating MCG buckets
-            request: Pytest request object for finalizer registration
         """
         capacity_error_modes = {
             "LOW_CAPACITY",
@@ -431,13 +408,6 @@ class TestNooBaaBucketErrorStateMode:
             bucketclass=bucketclass_dict,
         )[0]
         backingstore = bucket.bucketclass.backingstores[0]
-
-        def cleanup():
-            bucket.delete()
-            bucket.bucketclass.delete()
-            backingstore.delete()
-
-        request.addfinalizer(cleanup)
 
         log.info(
             f"Created data bucket {bucket.name} with "

--- a/tests/functional/object/mcg/test_noobaa_bucket_error_state_mode.py
+++ b/tests/functional/object/mcg/test_noobaa_bucket_error_state_mode.py
@@ -23,6 +23,7 @@ from ocs_ci.ocs.resources.objectbucket import MCGCLIBucket
 from ocs_ci.ocs.resources.pod import get_noobaa_pvpool_pods
 from ocs_ci.helpers.helpers import create_unique_resource_name
 from ocs_ci.ocs.exceptions import TimeoutExpiredError
+from ocs_ci.utility.prometheus import PrometheusAPI, wait_for_alert_firing
 from ocs_ci.utility.utils import TimeoutSampler
 
 log = logging.getLogger(__name__)
@@ -673,3 +674,78 @@ class TestNooBaaBucketErrorStateMode:
         )
 
         _wait_for_bucket_mode(mcg_obj, ns_bucket.name, "NOT_ENOUGH_HEALTHY_RESOURCES")
+
+    # ------------------------------------------------------------------
+    # Alert verification test
+    # ------------------------------------------------------------------
+
+    # TODO: Replace with actual Polarion ID
+    # @polarion_id("OCS-XXXXX")
+    def test_bucket_error_state_alert(self, mcg_obj, awscli_pod, threading_lock):
+        """
+        Verify that the NooBaaBucketErrorState Prometheus alert fires
+        with the correct bucket_mode label when a bucket enters an
+        error state.
+
+        Uses a quota-exceeded scenario (fastest to trigger) and waits
+        for the alert to fire after 5+ minutes.
+
+        Steps:
+            1. Create a data bucket with a 2Gi quota
+            2. Upload ~2.5GB to exceed the quota
+            3. Verify bucket enters EXCEEDING_QUOTA mode
+            4. Wait for NooBaaBucketErrorState alert to fire (~5 min)
+            5. Verify alert contains bucket_mode=EXCEEDING_QUOTA
+            6. Clean up
+
+        Args:
+            mcg_obj (MCG): MCG object with S3 connection credentials
+            awscli_pod (Pod): Pod running the AWSCLI tools
+            threading_lock: Threading lock for Prometheus API
+        """
+        bucket_name = create_unique_resource_name(
+            resource_description="bucket", resource_type="alert-quota"
+        )
+        bucket = MCGCLIBucket(bucket_name, mcg=mcg_obj, quota="2Gi")
+        log.info(f"Created bucket {bucket_name} with 2Gi quota")
+
+        try:
+            _upload_data_to_bucket(awscli_pod, bucket_name, mcg_obj, 5, 500)
+            log.info(
+                f"Uploaded ~2.5GB to bucket {bucket_name} "
+                f"(quota 2Gi) to trigger EXCEEDING_QUOTA"
+            )
+
+            _wait_for_bucket_mode(mcg_obj, bucket_name, "EXCEEDING_QUOTA")
+            log.info(
+                f"Bucket {bucket_name} is in EXCEEDING_QUOTA mode, "
+                f"waiting for Prometheus alert to fire (5+ minutes)"
+            )
+
+            prometheus_api = PrometheusAPI(threading_lock=threading_lock)
+            alert_name = "NooBaaBucketErrorState"
+            alerts = wait_for_alert_firing(
+                api=prometheus_api,
+                alert_name=alert_name,
+                timeout=600,
+                expected_message_substr="EXCEEDING_QUOTA",
+            )
+
+            alert_labels = alerts[0]["labels"]
+            log.info(f"Alert {alert_name} fired with labels: {alert_labels}")
+            assert alert_labels.get("bucket_mode") == "EXCEEDING_QUOTA", (
+                f"Expected bucket_mode=EXCEEDING_QUOTA in alert labels, "
+                f"got bucket_mode={alert_labels.get('bucket_mode')}"
+            )
+            assert alert_labels.get("bucket_name") == bucket_name, (
+                f"Expected bucket_name={bucket_name} in alert labels, "
+                f"got bucket_name={alert_labels.get('bucket_name')}"
+            )
+            log.info(
+                f"Alert {alert_name} verified: "
+                f"bucket_name={alert_labels.get('bucket_name')}, "
+                f"bucket_mode={alert_labels.get('bucket_mode')}"
+            )
+        finally:
+            _delete_data_from_bucket(awscli_pod, bucket_name, mcg_obj, 5)
+            bucket.delete()

--- a/tests/functional/object/mcg/test_noobaa_bucket_error_state_mode.py
+++ b/tests/functional/object/mcg/test_noobaa_bucket_error_state_mode.py
@@ -1,7 +1,5 @@
-import json
 import logging
 
-from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import (
     post_upgrade,
     red_squad,
@@ -25,8 +23,8 @@ from ocs_ci.ocs.bucket_utils import (
     write_random_test_objects_to_bucket,
 )
 from ocs_ci.ocs.exceptions import CommandFailed
-from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.resources.objectbucket import MCGCLIBucket
+from ocs_ci.ocs.resources.pod import get_noobaa_pvpool_pods
 from ocs_ci.helpers.helpers import create_unique_resource_name
 from ocs_ci.utility.prometheus import PrometheusAPI, wait_for_alert_firing
 
@@ -121,24 +119,21 @@ class TestNooBaaBucketErrorStateMode:
     # Resource error mode tests (NOT_ENOUGH_HEALTHY_RESOURCES)
     # ------------------------------------------------------------------
 
-    @skipif_managed_service
-    @skipif_aws_creds_are_missing
+    @skipif_mcg_only
     # TODO: Replace with actual Polarion ID
     # @polarion_id("OCS-XXXXX")
-    def test_data_bucket_resource_error_mode(
-        self, mcg_obj, awscli_pod, bucket_factory
-    ):
+    def test_data_bucket_resource_error_mode(self, mcg_obj, awscli_pod, bucket_factory):
         """
         Trigger a resource-related bucket mode on a data bucket and
         verify the bucket enters NOT_ENOUGH_HEALTHY_RESOURCES mode.
 
-        Corrupts the AWS credentials secret of the backing store so
-        that NooBaa can no longer access the underlying cloud storage.
+        Uses a PV pool backing store and force-deletes its pool pod
+        to simulate a resource failure.
 
         Steps:
-            1. Create a data bucket with an AWS cloud backing store
+            1. Create a data bucket with a PV pool backing store (17Gi)
             2. Upload data so NooBaa tracks objects against the store
-            3. Patch the backing store's secret with invalid credentials
+            3. Force-delete the PV pool pod to trigger resource error
             4. Wait for bucket to detect the resource error
             5. Verify bucket mode is NOT_ENOUGH_HEALTHY_RESOURCES
             6. Clean up
@@ -150,7 +145,7 @@ class TestNooBaaBucketErrorStateMode:
         """
         bucketclass_dict = {
             "interface": "OC",
-            "backingstore_dict": {"aws": [(1, "us-east-2")]},
+            "backingstore_dict": {"pv": [(1, 17, constants.DEFAULT_STORAGECLASS_RBD)]},
         }
         bucket = bucket_factory(
             amount=1,
@@ -161,7 +156,7 @@ class TestNooBaaBucketErrorStateMode:
 
         logger.info(
             f"Created data bucket {bucket.name} with "
-            f"AWS backing store {backingstore.name}"
+            f"PV pool backing store {backingstore.name}"
         )
 
         write_random_test_objects_to_bucket(
@@ -177,25 +172,14 @@ class TestNooBaaBucketErrorStateMode:
             f"so NooBaa tracks objects against the backing store"
         )
 
-        bs_ocp = OCP(
-            namespace=config.ENV_DATA["cluster_namespace"],
-            kind="backingstore",
-        ).get(resource_name=backingstore.name)
-        secret_name = bs_ocp["spec"]["awsS3"]["secret"]["name"]
-        logger.info(
-            f"Patching secret {secret_name} with invalid AWS credentials "
-            f"to make backing store {backingstore.name} unhealthy"
-        )
-        OCP(
-            namespace=config.ENV_DATA["cluster_namespace"],
-            kind="secret",
-        ).patch(
-            resource_name=secret_name,
-            params=json.dumps(
-                {"data": {"AWS_ACCESS_KEY_ID": "d3JvbmdhY2Nlc3NrZXk="}}
-            ),
-            format_type="merge",
-        )
+        pool_pods = get_noobaa_pvpool_pods(backingstore.name)
+        assert pool_pods, f"No pool pods found for backing store {backingstore.name}"
+        for pod in pool_pods:
+            logger.info(
+                f"Deleting pool pod {pod.name} of backing store "
+                f"{backingstore.name} to trigger resource error"
+            )
+            pod.delete(force=True)
 
         wait_for_bucket_mode(mcg_obj, bucket.name, "NOT_ENOUGH_HEALTHY_RESOURCES")
 

--- a/tests/functional/object/mcg/test_noobaa_bucket_error_state_mode.py
+++ b/tests/functional/object/mcg/test_noobaa_bucket_error_state_mode.py
@@ -14,8 +14,10 @@ from ocs_ci.framework.testlib import (
     tier2,
     mcg,
 )
+from ocs_ci.framework import config
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.bucket_utils import craft_s3_command
+from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.resources.objectbucket import MCGCLIBucket
 
 from ocs_ci.helpers.helpers import create_unique_resource_name
@@ -286,7 +288,10 @@ class TestNooBaaBucketErrorStateMode:
             f"to trigger resource error"
         )
         params = '{"spec":{"pvPool":{"numVolumes":0}}}'
-        backingstore.ocp.patch(
+        OCP(
+            kind="BackingStore",
+            namespace=config.ENV_DATA["cluster_namespace"],
+        ).patch(
             resource_name=backingstore.name,
             params=params,
             format_type="merge",

--- a/tests/functional/object/mcg/test_noobaa_bucket_error_state_mode.py
+++ b/tests/functional/object/mcg/test_noobaa_bucket_error_state_mode.py
@@ -14,7 +14,6 @@ from ocs_ci.framework.testlib import (
     tier2,
     mcg,
 )
-from ocs_ci.framework import config
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.bucket_utils import (
     copy_objects,
@@ -24,7 +23,6 @@ from ocs_ci.ocs.bucket_utils import (
     write_random_test_objects_to_bucket,
 )
 from ocs_ci.ocs.exceptions import CommandFailed
-from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.resources.objectbucket import MCGCLIBucket
 from ocs_ci.helpers.helpers import create_unique_resource_name
 from ocs_ci.utility.prometheus import PrometheusAPI, wait_for_alert_firing
@@ -120,21 +118,24 @@ class TestNooBaaBucketErrorStateMode:
     # Resource error mode tests (NOT_ENOUGH_HEALTHY_RESOURCES)
     # ------------------------------------------------------------------
 
-    @skipif_mcg_only
+    @skipif_managed_service
+    @skipif_aws_creds_are_missing
     # TODO: Replace with actual Polarion ID
     # @polarion_id("OCS-XXXXX")
-    def test_data_bucket_resource_error_mode(self, mcg_obj, awscli_pod, bucket_factory):
+    def test_data_bucket_resource_error_mode(
+        self, mcg_obj, awscli_pod, bucket_factory, cld_mgr
+    ):
         """
         Trigger a resource-related bucket mode on a data bucket and
         verify the bucket enters NOT_ENOUGH_HEALTHY_RESOURCES mode.
 
-        Uses a PV pool backing store and scales its StatefulSet to 0
-        replicas to simulate a resource failure.
+        Uses an AWS cloud backing store and deletes its target bucket
+        to simulate a resource failure.
 
         Steps:
-            1. Create a data bucket with a PV pool backing store (17Gi)
+            1. Create a data bucket with an AWS cloud backing store
             2. Upload data so NooBaa tracks objects against the store
-            3. Scale the PV pool StatefulSet to 0 replicas
+            3. Delete the target bucket of the backing store
             4. Wait for bucket to detect the resource error
             5. Verify bucket mode is NOT_ENOUGH_HEALTHY_RESOURCES
             6. Clean up
@@ -143,10 +144,11 @@ class TestNooBaaBucketErrorStateMode:
             mcg_obj (MCG): MCG object with S3 connection credentials
             awscli_pod (Pod): Pod running the AWSCLI tools
             bucket_factory (func): Factory for creating MCG buckets
+            cld_mgr (CloudManager): Cloud manager for cloud operations
         """
         bucketclass_dict = {
             "interface": "OC",
-            "backingstore_dict": {"pv": [(1, 17, constants.DEFAULT_STORAGECLASS_RBD)]},
+            "backingstore_dict": {"aws": [(1, "us-east-2")]},
         }
         bucket = bucket_factory(
             amount=1,
@@ -157,7 +159,7 @@ class TestNooBaaBucketErrorStateMode:
 
         logger.info(
             f"Created data bucket {bucket.name} with "
-            f"PV pool backing store {backingstore.name}"
+            f"AWS backing store {backingstore.name}"
         )
 
         write_random_test_objects_to_bucket(
@@ -173,15 +175,12 @@ class TestNooBaaBucketErrorStateMode:
             f"so NooBaa tracks objects against the backing store"
         )
 
-        sts_name = f"noobaa-pod-agent-{backingstore.name}"
+        target_uls_name = backingstore.uls_name
         logger.info(
-            f"Scaling StatefulSet {sts_name} to 0 replicas "
-            f"to trigger resource error"
+            f"Deleting target bucket {target_uls_name} of "
+            f"backing store {backingstore.name}"
         )
-        OCP(
-            kind="StatefulSet",
-            namespace=config.ENV_DATA["cluster_namespace"],
-        ).exec_oc_cmd(f"scale statefulset {sts_name} --replicas=0")
+        cld_mgr.aws_client.delete_uls(target_uls_name)
 
         wait_for_bucket_mode(mcg_obj, bucket.name, "NOT_ENOUGH_HEALTHY_RESOURCES")
 

--- a/tests/functional/object/mcg/test_noobaa_bucket_error_state_mode.py
+++ b/tests/functional/object/mcg/test_noobaa_bucket_error_state_mode.py
@@ -17,7 +17,7 @@ from ocs_ci.framework.testlib import (
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.bucket_utils import craft_s3_command
 from ocs_ci.ocs.resources.objectbucket import MCGCLIBucket
-from ocs_ci.ocs.resources.pod import get_noobaa_pvpool_pods
+
 from ocs_ci.helpers.helpers import create_unique_resource_name
 from ocs_ci.ocs.exceptions import TimeoutExpiredError
 from ocs_ci.utility.prometheus import PrometheusAPI, wait_for_alert_firing
@@ -243,13 +243,13 @@ class TestNooBaaBucketErrorStateMode:
         Trigger a resource-related bucket mode on a data bucket and
         verify the bucket enters NOT_ENOUGH_HEALTHY_RESOURCES mode.
 
-        Uses a PV pool backing store and deletes its pool pod
+        Uses a PV pool backing store and scales it down to 0 volumes
         to simulate a resource failure.
 
         Steps:
             1. Create a data bucket with a PV pool backing store (17Gi)
             2. Upload data so NooBaa tracks objects against the store
-            3. Delete the PV pool pod to trigger resource error
+            3. Scale the backing store to 0 volumes to trigger resource error
             4. Wait for bucket to detect the resource error
             5. Verify bucket mode is NOT_ENOUGH_HEALTHY_RESOURCES
             6. Clean up
@@ -281,14 +281,16 @@ class TestNooBaaBucketErrorStateMode:
             f"so NooBaa tracks objects against the backing store"
         )
 
-        pool_pods = get_noobaa_pvpool_pods(backingstore.name)
-        assert pool_pods, f"No pool pods found for backing store {backingstore.name}"
-        for pod in pool_pods:
-            log.info(
-                f"Deleting pool pod {pod.name} of backing store "
-                f"{backingstore.name} to trigger resource error"
-            )
-            pod.delete(force=True)
+        log.info(
+            f"Scaling PV pool backing store {backingstore.name} to 0 volumes "
+            f"to trigger resource error"
+        )
+        params = '{"spec":{"pvPool":{"numVolumes":0}}}'
+        backingstore.ocp.patch(
+            resource_name=backingstore.name,
+            params=params,
+            format_type="merge",
+        )
 
         _wait_for_bucket_mode(mcg_obj, bucket.name, "NOT_ENOUGH_HEALTHY_RESOURCES")
 

--- a/tests/functional/object/mcg/test_noobaa_bucket_error_state_mode.py
+++ b/tests/functional/object/mcg/test_noobaa_bucket_error_state_mode.py
@@ -177,10 +177,18 @@ class TestNooBaaBucketErrorStateMode:
     via NooBaa's get_bucket_info that the bucket enters the expected
     error mode.
 
-    Covers three error categories for both data and namespace buckets:
-    - Quota-related: EXCEEDING_QUOTA
-    - Resource-related: NOT_ENOUGH_HEALTHY_RESOURCES
-    - Capacity-related: NOT_ENOUGH_HEALTHY_RESOURCES
+    Covers three error categories:
+    - Quota-related (data buckets): EXCEEDING_QUOTA
+    - Resource-related (data and namespace buckets):
+      NOT_ENOUGH_HEALTHY_RESOURCES
+    - Capacity-related (data buckets): capacity exhaustion modes
+
+    Also verifies that the NooBaaBucketErrorState Prometheus alert
+    fires with the correct bucket_mode label.
+
+    Note: Namespace buckets are only tested for resource errors,
+    as they act as proxies and do not enforce quota or track
+    capacity internally.
     """
 
     # ------------------------------------------------------------------

--- a/tests/functional/object/mcg/test_noobaa_bucket_error_state_mode.py
+++ b/tests/functional/object/mcg/test_noobaa_bucket_error_state_mode.py
@@ -31,8 +31,6 @@ from ocs_ci.utility.prometheus import PrometheusAPI, wait_for_alert_firing
 
 logger = logging.getLogger(__name__)
 
-UPLOAD_DIR = "/tmp/bucket_error_test"
-
 
 @mcg
 @red_squad
@@ -98,7 +96,7 @@ class TestNooBaaBucketErrorStateMode:
                 write_random_test_objects_to_bucket(
                     io_pod=awscli_pod,
                     bucket_to_write=bucket_name,
-                    file_dir=UPLOAD_DIR,
+                    file_dir=f"/tmp/{bucket_name}",
                     amount=5,
                     bs="500M",
                     mcg_obj=mcg_obj,
@@ -165,7 +163,7 @@ class TestNooBaaBucketErrorStateMode:
         write_random_test_objects_to_bucket(
             io_pod=awscli_pod,
             bucket_to_write=bucket.name,
-            file_dir=UPLOAD_DIR,
+            file_dir=f"/tmp/{bucket.name}",
             amount=2,
             bs="50M",
             mcg_obj=mcg_obj,
@@ -245,7 +243,7 @@ class TestNooBaaBucketErrorStateMode:
         write_random_test_objects_to_bucket(
             io_pod=awscli_pod,
             bucket_to_write=ns_bucket.name,
-            file_dir=UPLOAD_DIR,
+            file_dir=f"/tmp/{ns_bucket.name}",
             amount=2,
             bs="50M",
             mcg_obj=mcg_obj,
@@ -420,7 +418,7 @@ class TestNooBaaBucketErrorStateMode:
                 write_random_test_objects_to_bucket(
                     io_pod=awscli_pod,
                     bucket_to_write=bucket_name,
-                    file_dir=UPLOAD_DIR,
+                    file_dir=f"/tmp/{bucket_name}",
                     amount=5,
                     bs="500M",
                     mcg_obj=mcg_obj,

--- a/tests/functional/object/mcg/test_noobaa_bucket_error_state_mode.py
+++ b/tests/functional/object/mcg/test_noobaa_bucket_error_state_mode.py
@@ -128,13 +128,13 @@ class TestNooBaaBucketErrorStateMode:
         Trigger a resource-related bucket mode on a data bucket and
         verify the bucket enters NOT_ENOUGH_HEALTHY_RESOURCES mode.
 
-        Uses a PV pool backing store and scales it down to 0 volumes
-        to simulate a resource failure.
+        Uses a PV pool backing store and scales its StatefulSet to 0
+        replicas to simulate a resource failure.
 
         Steps:
             1. Create a data bucket with a PV pool backing store (17Gi)
             2. Upload data so NooBaa tracks objects against the store
-            3. Scale the backing store to 0 volumes to trigger resource error
+            3. Scale the PV pool StatefulSet to 0 replicas
             4. Wait for bucket to detect the resource error
             5. Verify bucket mode is NOT_ENOUGH_HEALTHY_RESOURCES
             6. Clean up
@@ -173,19 +173,15 @@ class TestNooBaaBucketErrorStateMode:
             f"so NooBaa tracks objects against the backing store"
         )
 
+        sts_name = f"noobaa-pod-agent-{backingstore.name}"
         logger.info(
-            f"Scaling PV pool backing store {backingstore.name} to 0 volumes "
+            f"Scaling StatefulSet {sts_name} to 0 replicas "
             f"to trigger resource error"
         )
-        params = '{"spec":{"pvPool":{"numVolumes":0}}}'
         OCP(
-            kind="BackingStore",
+            kind="StatefulSet",
             namespace=config.ENV_DATA["cluster_namespace"],
-        ).patch(
-            resource_name=backingstore.name,
-            params=params,
-            format_type="merge",
-        )
+        ).exec_oc_cmd(f"scale statefulset {sts_name} --replicas=0")
 
         wait_for_bucket_mode(mcg_obj, bucket.name, "NOT_ENOUGH_HEALTHY_RESOURCES")
 

--- a/tests/functional/object/mcg/test_noobaa_bucket_error_state_mode.py
+++ b/tests/functional/object/mcg/test_noobaa_bucket_error_state_mode.py
@@ -1,5 +1,7 @@
 import logging
 
+import pytest
+
 from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import (
     red_squad,
@@ -17,6 +19,7 @@ from ocs_ci.framework.testlib import (
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.bucket_utils import craft_s3_command
 from ocs_ci.ocs.resources.objectbucket import MCGCLIBucket
+from ocs_ci.ocs.resources.pod import get_noobaa_pvpool_pods
 from ocs_ci.helpers.helpers import create_unique_resource_name
 from ocs_ci.ocs.exceptions import TimeoutExpiredError
 from ocs_ci.utility.utils import TimeoutSampler
@@ -27,7 +30,7 @@ BUCKET_MODE_TIMEOUT = 60 * 10
 BUCKET_MODE_POLL_INTERVAL = 15
 
 
-def _wait_for_bucket_mode(mcg_obj, bucket_name, expected_mode):
+def _wait_for_bucket_mode(mcg_obj, bucket_name, expected_mode, timeout=None):
     """
     Poll NooBaa until the bucket enters the expected mode or timeout.
 
@@ -36,6 +39,7 @@ def _wait_for_bucket_mode(mcg_obj, bucket_name, expected_mode):
         bucket_name (str): Name of the bucket
         expected_mode (str): Expected bucket mode (e.g. "EXCEEDING_QUOTA")
             or "!OPTIMAL" to wait for any non-OPTIMAL mode
+        timeout (int): Timeout in seconds (default: BUCKET_MODE_TIMEOUT)
 
     Returns:
         str: The actual bucket mode once matched
@@ -44,12 +48,14 @@ def _wait_for_bucket_mode(mcg_obj, bucket_name, expected_mode):
         AssertionError: If the bucket does not reach the expected mode
             within the timeout
     """
+    if timeout is None:
+        timeout = BUCKET_MODE_TIMEOUT
     check_not_optimal = expected_mode == "!OPTIMAL"
     last_mode = "UNKNOWN"
 
     try:
         for mode in TimeoutSampler(
-            timeout=BUCKET_MODE_TIMEOUT,
+            timeout=timeout,
             sleep=BUCKET_MODE_POLL_INTERVAL,
             func=_get_bucket_mode,
             mcg_obj=mcg_obj,
@@ -66,12 +72,12 @@ def _wait_for_bucket_mode(mcg_obj, bucket_name, expected_mode):
         if check_not_optimal:
             assert False, (
                 f"Bucket {bucket_name} is still OPTIMAL after "
-                f"{BUCKET_MODE_TIMEOUT}s (last mode: {last_mode})"
+                f"{timeout}s (last mode: {last_mode})"
             )
         else:
             assert False, (
                 f"Expected bucket mode {expected_mode} for {bucket_name}, "
-                f"got {last_mode} after {BUCKET_MODE_TIMEOUT}s"
+                f"got {last_mode} after {timeout}s"
             )
 
 
@@ -171,13 +177,13 @@ class TestNooBaaBucketErrorStateMode:
     error mode.
 
     Covers three error categories for both data and namespace buckets:
-    - Quota-related modes (e.g. EXCEEDING_QUOTA)
-    - Resource-related modes (e.g. NO_RESOURCES, ALL_TIERS_HAVE_ISSUES)
-    - Capacity-related modes (e.g. NO_CAPACITY, LOW_CAPACITY)
+    - Quota-related: EXCEEDING_QUOTA
+    - Resource-related: NOT_ENOUGH_HEALTHY_RESOURCES
+    - Capacity-related: NOT_ENOUGH_HEALTHY_RESOURCES
     """
 
     # ------------------------------------------------------------------
-    # Data bucket tests
+    # Quota error mode tests (EXCEEDING_QUOTA)
     # ------------------------------------------------------------------
 
     # TODO: Replace with actual Polarion ID
@@ -216,189 +222,11 @@ class TestNooBaaBucketErrorStateMode:
             _delete_data_from_bucket(awscli_pod, bucket_name, mcg_obj, 5)
             bucket.delete()
 
-    @skipif_managed_service
-    @skipif_aws_creds_are_missing
-    # TODO: Replace with actual Polarion ID
-    # @polarion_id("OCS-XXXXX")
-    def test_data_bucket_resource_error_mode(
-        self, mcg_obj, bucket_factory, cld_mgr, request
-    ):
-        """
-        Trigger a resource-related bucket mode on a data bucket and
-        verify the bucket enters a non-OPTIMAL error mode.
-
-        Steps:
-            1. Create a data bucket with an AWS-backed backing store
-            2. Delete the AWS target bucket of the backing store
-            3. Wait for bucket to detect the resource error
-            4. Verify bucket mode is not OPTIMAL via NooBaa
-            5. Clean up
-
-        Args:
-            mcg_obj (MCG): MCG object with S3 connection credentials
-            bucket_factory (func): Factory for creating MCG buckets
-            cld_mgr (CloudManager): Cloud manager for cloud operations
-            request: Pytest request object for finalizer registration
-        """
-        bucketclass_dict = {
-            "interface": "OC",
-            "backingstore_dict": {"aws": [(1, "us-east-2")]},
-        }
-        bucket = bucket_factory(
-            amount=1,
-            interface=bucketclass_dict["interface"],
-            bucketclass=bucketclass_dict,
-        )[0]
-        backingstore = bucket.bucketclass.backingstores[0]
-
-        def cleanup():
-            bucket.delete()
-            bucket.bucketclass.delete()
-            backingstore.delete()
-
-        request.addfinalizer(cleanup)
-
-        log.info(f"Created data bucket {bucket.name} with AWS backing store")
-
-        target_uls_name = backingstore.uls_name
-        log.info(
-            f"Backing store {backingstore.name} uses "
-            f"target bucket {target_uls_name}"
-        )
-
-        cld_mgr.aws_client.delete_uls(target_uls_name)
-        log.info(
-            f"Deleted target bucket {target_uls_name} " f"to trigger resource error"
-        )
-
-        _wait_for_bucket_mode(mcg_obj, bucket.name, "!OPTIMAL")
-
-    @skipif_mcg_only
-    # TODO: Replace with actual Polarion ID
-    # @polarion_id("OCS-XXXXX")
-    def test_data_bucket_capacity_error_mode(
-        self, mcg_obj, awscli_pod, bucket_factory, request
-    ):
-        """
-        Trigger a capacity-related bucket mode on a data bucket and
-        verify the bucket enters a non-OPTIMAL error mode.
-
-        Steps:
-            1. Create a data bucket backed by a small PV pool (2Gi)
-            2. Upload data exceeding PV pool capacity
-            3. Wait for bucket to detect the capacity exhaustion
-            4. Verify bucket mode is not OPTIMAL via NooBaa
-               (e.g. NO_CAPACITY, LOW_CAPACITY)
-            5. Clean up
-
-        Args:
-            mcg_obj (MCG): MCG object with S3 connection credentials
-            awscli_pod (Pod): Pod running the AWSCLI tools
-            bucket_factory (func): Factory for creating MCG buckets
-            request: Pytest request object for finalizer registration
-        """
-        bucketclass_dict = {
-            "interface": "OC",
-            "backingstore_dict": {"pv": [(1, 2, constants.DEFAULT_STORAGECLASS_RBD)]},
-        }
-        bucket = bucket_factory(
-            amount=1,
-            interface=bucketclass_dict["interface"],
-            bucketclass=bucketclass_dict,
-        )[0]
-        backingstore = bucket.bucketclass.backingstores[0]
-
-        def cleanup():
-            bucket.delete()
-            bucket.bucketclass.delete()
-            backingstore.delete()
-
-        request.addfinalizer(cleanup)
-
-        log.info(
-            f"Created data bucket {bucket.name} with "
-            f"2Gi PV pool backing store {backingstore.name}"
-        )
-
-        _upload_data_to_bucket(awscli_pod, bucket.name, mcg_obj, 4, 700)
-        log.info(
-            f"Uploaded ~2.8GB to bucket {bucket.name} "
-            f"(PV pool capacity 2Gi) to trigger capacity error"
-        )
-
-        _wait_for_bucket_mode(mcg_obj, bucket.name, "!OPTIMAL")
-
-    # ------------------------------------------------------------------
-    # Namespace bucket tests
-    # ------------------------------------------------------------------
-
-    @skipif_managed_service
-    @skipif_aws_creds_are_missing
-    # TODO: Replace with actual Polarion ID
-    # @polarion_id("OCS-XXXXX")
-    def test_ns_bucket_resource_error_mode(
-        self,
-        mcg_obj,
-        bucket_factory,
-        namespace_store_factory,
-        cld_mgr,
-        request,
-    ):
-        """
-        Trigger a resource-related bucket mode on a namespace bucket
-        and verify the bucket enters a non-OPTIMAL error mode.
-
-        Steps:
-            1. Create 2 namespace stores backed by AWS target buckets
-            2. Create a namespace bucket using Multi policy
-            3. Delete the target bucket of one namespace store
-            4. Wait for bucket to detect the resource error
-            5. Verify bucket mode is not OPTIMAL via NooBaa
-            6. Clean up
-
-        Args:
-            mcg_obj (MCG): MCG object with S3 connection credentials
-            bucket_factory (func): Factory for creating MCG buckets
-            namespace_store_factory (func): Factory for creating namespace stores
-            cld_mgr (CloudManager): Cloud manager for cloud operations
-            request: Pytest request object for finalizer registration
-        """
-        nss_tup = ("oc", {"aws": [(2, "us-east-2")]})
-        ns_stores = namespace_store_factory(*nss_tup)
-
-        bucketclass_dict = {
-            "interface": "OC",
-            "namespace_policy_dict": {
-                "type": "Multi",
-                "namespacestores": ns_stores,
-            },
-        }
-        ns_bucket = bucket_factory(
-            amount=1,
-            interface=bucketclass_dict["interface"],
-            bucketclass=bucketclass_dict,
-        )[0]
-
-        def cleanup():
-            ns_bucket.delete()
-            ns_bucket.bucketclass.delete()
-            for ns_store in ns_stores:
-                ns_store.delete()
-
-        request.addfinalizer(cleanup)
-
-        log.info(f"Created namespace stores: {[ns.name for ns in ns_stores]}")
-        log.info(f"Created namespace bucket {ns_bucket.name} with Multi policy")
-
-        target_uls_name = ns_stores[0].uls_name
-        log.info(
-            f"Deleting target bucket {target_uls_name} of "
-            f"namespace store {ns_stores[0].name}"
-        )
-        cld_mgr.aws_client.delete_uls(target_uls_name)
-
-        _wait_for_bucket_mode(mcg_obj, ns_bucket.name, "!OPTIMAL")
-
+    @pytest.mark.skip(
+        reason="NS buckets don't keep metadata and act as a proxy — "
+        "quota is not supported for namespace buckets. "
+        "Confirmed by Eran Tamir on RHSTOR-7732."
+    )
     @skipif_managed_service
     @skipif_aws_creds_are_missing
     # TODO: Replace with actual Polarion ID
@@ -419,7 +247,7 @@ class TestNooBaaBucketErrorStateMode:
             1. Create an AWS-backed namespace store
             2. Create a namespace bucket (Single policy) using the
                namespace store
-            3. Set a 100Mi quota on the namespace bucket
+            3. Set a 1Gi quota on the namespace bucket
             4. Upload data exceeding the quota
             5. Wait for bucket mode to propagate
             6. Verify bucket mode is EXCEEDING_QUOTA via NooBaa
@@ -459,20 +287,305 @@ class TestNooBaaBucketErrorStateMode:
         log.info(f"Created namespace bucket {ns_bucket.name} (Single policy)")
 
         mcg_obj.exec_mcg_cmd(
-            cmd=f"bucket update --max-size=100Mi {ns_bucket.name}",
+            cmd=f"bucket update --max-size=1Gi {ns_bucket.name}",
             namespace=config.ENV_DATA["cluster_namespace"],
             use_yes=True,
         )
-        log.info(f"Set 100Mi quota on namespace bucket {ns_bucket.name}")
+        log.info(f"Set 1Gi quota on namespace bucket {ns_bucket.name}")
 
-        _upload_data_to_bucket(awscli_pod, ns_bucket.name, mcg_obj, 3, 50)
+        _upload_data_to_bucket(awscli_pod, ns_bucket.name, mcg_obj, 3, 500)
         log.info(
-            f"Uploaded ~150MB to namespace bucket {ns_bucket.name} "
-            f"(quota 100Mi) to trigger EXCEEDING_QUOTA"
+            f"Uploaded ~1.5GB to namespace bucket {ns_bucket.name} "
+            f"(quota 1Gi) to trigger EXCEEDING_QUOTA"
         )
 
         _wait_for_bucket_mode(mcg_obj, ns_bucket.name, "EXCEEDING_QUOTA")
 
+    # ------------------------------------------------------------------
+    # Resource error mode tests (NOT_ENOUGH_HEALTHY_RESOURCES)
+    # ------------------------------------------------------------------
+
+    @skipif_mcg_only
+    # TODO: Replace with actual Polarion ID
+    # @polarion_id("OCS-XXXXX")
+    def test_data_bucket_resource_error_mode(
+        self, mcg_obj, awscli_pod, bucket_factory, request
+    ):
+        """
+        Trigger a resource-related bucket mode on a data bucket and
+        verify the bucket enters NOT_ENOUGH_HEALTHY_RESOURCES mode.
+
+        Uses a PV pool backing store and deletes its pool pod
+        to simulate a resource failure.
+
+        Steps:
+            1. Create a data bucket with a PV pool backing store (17Gi)
+            2. Upload data so NooBaa tracks objects against the store
+            3. Delete the PV pool pod to trigger resource error
+            4. Wait for bucket to detect the resource error
+            5. Verify bucket mode is NOT_ENOUGH_HEALTHY_RESOURCES
+            6. Clean up
+
+        Args:
+            mcg_obj (MCG): MCG object with S3 connection credentials
+            awscli_pod (Pod): Pod running the AWSCLI tools
+            bucket_factory (func): Factory for creating MCG buckets
+            request: Pytest request object for finalizer registration
+        """
+        bucketclass_dict = {
+            "interface": "OC",
+            "backingstore_dict": {"pv": [(1, 17, constants.DEFAULT_STORAGECLASS_RBD)]},
+        }
+        bucket = bucket_factory(
+            amount=1,
+            interface=bucketclass_dict["interface"],
+            bucketclass=bucketclass_dict,
+        )[0]
+        backingstore = bucket.bucketclass.backingstores[0]
+
+        def cleanup():
+            bucket.delete()
+            bucket.bucketclass.delete()
+            backingstore.delete()
+
+        request.addfinalizer(cleanup)
+
+        log.info(
+            f"Created data bucket {bucket.name} with "
+            f"PV pool backing store {backingstore.name}"
+        )
+
+        _upload_data_to_bucket(awscli_pod, bucket.name, mcg_obj, 2, 50)
+        log.info(
+            f"Uploaded ~100MB to bucket {bucket.name} "
+            f"so NooBaa tracks objects against the backing store"
+        )
+
+        pool_pods = get_noobaa_pvpool_pods(backingstore.name)
+        assert pool_pods, f"No pool pods found for backing store {backingstore.name}"
+        for pod in pool_pods:
+            log.info(
+                f"Deleting pool pod {pod.name} of backing store "
+                f"{backingstore.name} to trigger resource error"
+            )
+            pod.delete(force=True)
+
+        _wait_for_bucket_mode(mcg_obj, bucket.name, "NOT_ENOUGH_HEALTHY_RESOURCES")
+
+    @skipif_managed_service
+    @skipif_aws_creds_are_missing
+    # TODO: Replace with actual Polarion ID
+    # @polarion_id("OCS-XXXXX")
+    def test_ns_bucket_resource_error_mode(
+        self,
+        mcg_obj,
+        awscli_pod,
+        bucket_factory,
+        namespace_store_factory,
+        cld_mgr,
+        request,
+    ):
+        """
+        Trigger a resource-related bucket mode on a namespace bucket
+        and verify the bucket enters NOT_ENOUGH_HEALTHY_RESOURCES mode.
+
+        Steps:
+            1. Create 2 namespace stores backed by AWS target buckets
+            2. Create a namespace bucket using Multi policy
+            3. Upload data so NooBaa tracks objects against the stores
+            4. Delete the target bucket of one namespace store
+            5. Wait for bucket to detect the resource error
+            6. Verify bucket mode is NOT_ENOUGH_HEALTHY_RESOURCES
+            7. Clean up
+
+        Args:
+            mcg_obj (MCG): MCG object with S3 connection credentials
+            awscli_pod (Pod): Pod running the AWSCLI tools
+            bucket_factory (func): Factory for creating MCG buckets
+            namespace_store_factory (func): Factory for creating namespace stores
+            cld_mgr (CloudManager): Cloud manager for cloud operations
+            request: Pytest request object for finalizer registration
+        """
+        nss_tup = ("oc", {"aws": [(2, "us-east-2")]})
+        ns_stores = namespace_store_factory(*nss_tup)
+
+        bucketclass_dict = {
+            "interface": "OC",
+            "namespace_policy_dict": {
+                "type": "Multi",
+                "namespacestores": ns_stores,
+            },
+        }
+        ns_bucket = bucket_factory(
+            amount=1,
+            interface=bucketclass_dict["interface"],
+            bucketclass=bucketclass_dict,
+        )[0]
+
+        def cleanup():
+            ns_bucket.delete()
+            ns_bucket.bucketclass.delete()
+            for ns_store in ns_stores:
+                ns_store.delete()
+
+        request.addfinalizer(cleanup)
+
+        log.info(f"Created namespace stores: {[ns.name for ns in ns_stores]}")
+        log.info(f"Created namespace bucket {ns_bucket.name} with Multi policy")
+
+        _upload_data_to_bucket(awscli_pod, ns_bucket.name, mcg_obj, 2, 50)
+        log.info(
+            f"Uploaded ~100MB to namespace bucket {ns_bucket.name} "
+            f"so NooBaa tracks objects against the namespace stores"
+        )
+
+        target_uls_name = ns_stores[0].uls_name
+        log.info(
+            f"Deleting target bucket {target_uls_name} of "
+            f"namespace store {ns_stores[0].name}"
+        )
+        cld_mgr.aws_client.delete_uls(target_uls_name)
+
+        _wait_for_bucket_mode(mcg_obj, ns_bucket.name, "NOT_ENOUGH_HEALTHY_RESOURCES")
+
+    # ------------------------------------------------------------------
+    # Capacity error mode tests
+    # ------------------------------------------------------------------
+
+    @skipif_mcg_only
+    # TODO: Replace with actual Polarion ID
+    # @polarion_id("OCS-XXXXX")
+    def test_data_bucket_capacity_error_mode(
+        self, mcg_obj, awscli_pod, bucket_factory, request
+    ):
+        """
+        Gradually fill a data bucket's PV pool backing store and track
+        bucket mode transitions through capacity error states.
+
+        Uploads data in 4GB increments, checking the bucket mode after
+        each upload to capture intermediate modes (e.g. LOW_CAPACITY,
+        NO_CAPACITY) before the final NOT_ENOUGH_HEALTHY_RESOURCES.
+
+        Steps:
+            1. Create a data bucket backed by a small PV pool (17Gi)
+            2. Upload data in 4GB increments, checking mode after each
+            3. Log all observed mode transitions
+            4. Verify bucket reaches a capacity error mode
+            5. Clean up
+
+        Args:
+            mcg_obj (MCG): MCG object with S3 connection credentials
+            awscli_pod (Pod): Pod running the AWSCLI tools
+            bucket_factory (func): Factory for creating MCG buckets
+            request: Pytest request object for finalizer registration
+        """
+        capacity_error_modes = {
+            "LOW_CAPACITY",
+            "TIER_LOW_CAPACITY",
+            "NO_CAPACITY",
+            "TIER_NO_CAPACITY",
+            "NOT_ENOUGH_HEALTHY_RESOURCES",
+            "TIER_NOT_ENOUGH_HEALTHY_RESOURCES",
+            "NOT_ENOUGH_RESOURCES",
+            "TIER_NOT_ENOUGH_RESOURCES",
+            "NO_RESOURCES",
+        }
+
+        bucketclass_dict = {
+            "interface": "OC",
+            "backingstore_dict": {"pv": [(1, 17, constants.DEFAULT_STORAGECLASS_RBD)]},
+        }
+        bucket = bucket_factory(
+            amount=1,
+            interface=bucketclass_dict["interface"],
+            bucketclass=bucketclass_dict,
+        )[0]
+        backingstore = bucket.bucketclass.backingstores[0]
+
+        def cleanup():
+            bucket.delete()
+            bucket.bucketclass.delete()
+            backingstore.delete()
+
+        request.addfinalizer(cleanup)
+
+        log.info(
+            f"Created data bucket {bucket.name} with "
+            f"17Gi PV pool backing store {backingstore.name}"
+        )
+
+        observed_modes = []
+        file_num = 0
+        final_mode = None
+
+        awscli_pod.exec_cmd_on_pod("dd if=/dev/zero of=/tmp/testfile bs=1M count=4000")
+        log.info("Created 4GB test file for gradual upload")
+
+        for chunk in range(1, 7):
+            file_num += 1
+            log.info(
+                f"Uploading chunk {chunk}/6 (~4GB) to bucket {bucket.name} "
+                f"(total so far: ~{chunk * 4}GB, PV pool: 17Gi)"
+            )
+            try:
+                awscli_pod.exec_cmd_on_pod(
+                    craft_s3_command(
+                        f"cp /tmp/testfile s3://{bucket.name}/testfile{file_num}",
+                        mcg_obj,
+                    ),
+                    out_yaml_format=False,
+                    secrets=[
+                        mcg_obj.access_key_id,
+                        mcg_obj.access_key,
+                        mcg_obj.s3_endpoint,
+                    ],
+                )
+            except Exception:
+                log.warning(
+                    f"Upload of chunk {chunk} failed "
+                    f"(expected when exceeding capacity)"
+                )
+
+            mode = _get_bucket_mode(mcg_obj, bucket.name)
+            log.info(
+                f"After chunk {chunk}: bucket mode = {mode} "
+                f"(uploaded ~{chunk * 4}GB / 17Gi)"
+            )
+
+            if mode != "OPTIMAL" and mode not in observed_modes:
+                observed_modes.append(mode)
+                log.info(f"New non-OPTIMAL mode observed: {mode}")
+
+            if mode in capacity_error_modes:
+                final_mode = mode
+                log.info(f"Bucket {bucket.name} entered capacity error mode: {mode}")
+                break
+
+        if not final_mode:
+            log.info(
+                "Bucket still OPTIMAL after all uploads, "
+                "waiting for mode to propagate"
+            )
+            final_mode = _wait_for_bucket_mode(
+                mcg_obj, bucket.name, "NOT_ENOUGH_HEALTHY_RESOURCES"
+            )
+            if final_mode and final_mode not in observed_modes:
+                observed_modes.append(final_mode)
+
+        log.info(
+            f"Capacity test complete. "
+            f"Observed mode transitions: {observed_modes}. "
+            f"Final mode: {final_mode}"
+        )
+        assert (
+            final_mode in capacity_error_modes
+        ), f"Expected one of {capacity_error_modes}, got {final_mode}"
+
+    @pytest.mark.skip(
+        reason="NS buckets don't keep metadata and act as a proxy — "
+        "capacity tracking is not supported for namespace buckets. "
+        "Confirmed by Eran Tamir on RHSTOR-7732."
+    )
     @skipif_mcg_only
     @skipif_managed_service
     @skipif_aws_creds_are_missing
@@ -489,21 +602,20 @@ class TestNooBaaBucketErrorStateMode:
     ):
         """
         Trigger a capacity-related bucket mode on a namespace bucket
-        and verify the bucket enters a non-OPTIMAL error mode.
+        and verify the bucket enters NOT_ENOUGH_HEALTHY_RESOURCES mode.
 
         Uses a Cache namespace bucket where the cache layer is a small
-        PV pool backing store (2Gi). Filling the cache beyond its
+        PV pool backing store (17Gi). Filling the cache beyond its
         capacity triggers a capacity error mode.
 
         Steps:
-            1. Create a PV pool backing store (2Gi) for the cache layer
+            1. Create a PV pool backing store (17Gi) for the cache layer
             2. Create an AWS-backed namespace store for the hub
             3. Create a Cache namespace bucket with the AWS hub and
                PV pool cache
             4. Upload data exceeding PV pool capacity
             5. Wait for bucket to detect the capacity exhaustion
-            6. Verify bucket mode is not OPTIMAL via NooBaa
-               (e.g. NO_CAPACITY, LOW_CAPACITY)
+            6. Verify bucket mode is NOT_ENOUGH_HEALTHY_RESOURCES
             7. Clean up
 
         Args:
@@ -515,7 +627,7 @@ class TestNooBaaBucketErrorStateMode:
             request: Pytest request object for finalizer registration
         """
         pv_backingstore = backingstore_factory(
-            "oc", {"pv": [(1, 2, constants.DEFAULT_STORAGECLASS_RBD)]}
+            "oc", {"pv": [(1, 17, constants.DEFAULT_STORAGECLASS_RBD)]}
         )[0]
 
         nss_tup = ("oc", {"aws": [(1, "us-east-2")]})
@@ -546,15 +658,15 @@ class TestNooBaaBucketErrorStateMode:
 
         log.info(
             f"Created PV pool backing store {pv_backingstore.name} "
-            f"(2Gi) for cache layer"
+            f"(17Gi) for cache layer"
         )
         log.info(f"Created namespace store (hub): {ns_stores[0].name}")
         log.info(f"Created Cache namespace bucket {ns_bucket.name} with PV pool cache")
 
-        _upload_data_to_bucket(awscli_pod, ns_bucket.name, mcg_obj, 4, 700)
+        _upload_data_to_bucket(awscli_pod, ns_bucket.name, mcg_obj, 4, 5000)
         log.info(
-            f"Uploaded ~2.8GB to cache namespace bucket {ns_bucket.name} "
-            f"(cache PV pool 2Gi) to trigger capacity error"
+            f"Uploaded ~20GB to cache namespace bucket {ns_bucket.name} "
+            f"(cache PV pool 17Gi) to trigger capacity error"
         )
 
-        _wait_for_bucket_mode(mcg_obj, ns_bucket.name, "!OPTIMAL")
+        _wait_for_bucket_mode(mcg_obj, ns_bucket.name, "NOT_ENOUGH_HEALTHY_RESOURCES")

--- a/tests/functional/object/mcg/test_noobaa_bucket_error_state_mode.py
+++ b/tests/functional/object/mcg/test_noobaa_bucket_error_state_mode.py
@@ -16,150 +16,22 @@ from ocs_ci.framework.testlib import (
 )
 from ocs_ci.framework import config
 from ocs_ci.ocs import constants
-from ocs_ci.ocs.bucket_utils import craft_s3_command
+from ocs_ci.ocs.bucket_utils import (
+    copy_objects,
+    get_bucket_mode,
+    rm_object_recursive,
+    wait_for_bucket_mode,
+    write_random_test_objects_to_bucket,
+)
+from ocs_ci.ocs.exceptions import CommandFailed
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.resources.objectbucket import MCGCLIBucket
-
 from ocs_ci.helpers.helpers import create_unique_resource_name
-from ocs_ci.ocs.exceptions import TimeoutExpiredError
 from ocs_ci.utility.prometheus import PrometheusAPI, wait_for_alert_firing
-from ocs_ci.utility.utils import TimeoutSampler
 
-log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
-BUCKET_MODE_TIMEOUT = 60 * 10
-BUCKET_MODE_POLL_INTERVAL = 15
-
-
-def _wait_for_bucket_mode(mcg_obj, bucket_name, expected_mode, timeout=None):
-    """
-    Poll NooBaa until the bucket enters the expected mode or timeout.
-
-    Args:
-        mcg_obj: MCG object
-        bucket_name (str): Name of the bucket
-        expected_mode (str): Expected bucket mode (e.g. "EXCEEDING_QUOTA")
-            or "!OPTIMAL" to wait for any non-OPTIMAL mode
-            (UNKNOWN is excluded to avoid false positives on lookup failures)
-        timeout (int): Timeout in seconds (default: BUCKET_MODE_TIMEOUT)
-
-    Returns:
-        str: The actual bucket mode once matched
-
-    Raises:
-        AssertionError: If the bucket does not reach the expected mode
-            within the timeout
-    """
-    if timeout is None:
-        timeout = BUCKET_MODE_TIMEOUT
-    check_not_optimal = expected_mode == "!OPTIMAL"
-    last_mode = "UNKNOWN"
-
-    try:
-        for mode in TimeoutSampler(
-            timeout=timeout,
-            sleep=BUCKET_MODE_POLL_INTERVAL,
-            func=_get_bucket_mode,
-            mcg_obj=mcg_obj,
-            bucket_name=bucket_name,
-        ):
-            last_mode = mode
-            if check_not_optimal and mode not in ("OPTIMAL", "UNKNOWN"):
-                log.info(f"Bucket {bucket_name} entered non-OPTIMAL mode: {mode}")
-                return mode
-            elif not check_not_optimal and mode == expected_mode:
-                log.info(f"Bucket {bucket_name} entered expected mode: {mode}")
-                return mode
-    except TimeoutExpiredError:
-        if check_not_optimal:
-            assert False, (
-                f"Bucket {bucket_name} is still OPTIMAL after "
-                f"{timeout}s (last mode: {last_mode})"
-            )
-        else:
-            assert False, (
-                f"Expected bucket mode {expected_mode} for {bucket_name}, "
-                f"got {last_mode} after {timeout}s"
-            )
-
-
-def _get_bucket_mode(mcg_obj, bucket_name):
-    """
-    Get the current mode of a bucket from NooBaa.
-
-    Args:
-        mcg_obj: MCG object
-        bucket_name (str): Name of the bucket
-
-    Returns:
-        str: The bucket mode (e.g. "OPTIMAL", "EXCEEDING_QUOTA")
-    """
-    bucket_info = mcg_obj.get_bucket_info(bucket_name)
-    if bucket_info:
-        log.info(f"Full bucket info for {bucket_name}: {bucket_info}")
-        return bucket_info.get("mode", "UNKNOWN")
-    log.warning(f"Bucket {bucket_name} not found in NooBaa system")
-    return "UNKNOWN"
-
-
-def _upload_data_to_bucket(awscli_pod, bucket_name, mcg_obj, file_count, file_size_mb):
-    """
-    Upload data files to a bucket via S3.
-
-    Args:
-        awscli_pod: Pod with awscli tools
-        bucket_name (str): Target bucket name
-        mcg_obj: MCG object with S3 credentials
-        file_count (int): Number of files to upload
-        file_size_mb (int): Size of each file in MB
-    """
-    awscli_pod.exec_cmd_on_pod(
-        f"dd if=/dev/zero of=/tmp/testfile bs=1M count={file_size_mb}"
-    )
-    for i in range(1, file_count + 1):
-        try:
-            awscli_pod.exec_cmd_on_pod(
-                craft_s3_command(
-                    f"cp /tmp/testfile s3://{bucket_name}/testfile{i}",
-                    mcg_obj,
-                ),
-                out_yaml_format=False,
-                secrets=[
-                    mcg_obj.access_key_id,
-                    mcg_obj.access_key,
-                    mcg_obj.s3_endpoint,
-                ],
-            )
-        except Exception:
-            log.warning(
-                f"Upload of testfile{i} to {bucket_name} failed "
-                f"(expected when exceeding capacity/quota)"
-            )
-
-
-def _delete_data_from_bucket(awscli_pod, bucket_name, mcg_obj, file_count):
-    """
-    Delete data files from a bucket via S3.
-
-    Args:
-        awscli_pod: Pod with awscli tools
-        bucket_name (str): Target bucket name
-        mcg_obj: MCG object with S3 credentials
-        file_count (int): Number of files to delete
-    """
-    for i in range(1, file_count + 1):
-        try:
-            awscli_pod.exec_cmd_on_pod(
-                craft_s3_command(f"rm s3://{bucket_name}/testfile{i}", mcg_obj),
-                out_yaml_format=False,
-                secrets=[
-                    mcg_obj.access_key_id,
-                    mcg_obj.access_key,
-                    mcg_obj.s3_endpoint,
-                ],
-            )
-        except Exception:
-            log.warning(f"Failed to delete testfile{i} from {bucket_name}")
+UPLOAD_DIR = "/tmp/bucket_error_test"
 
 
 @mcg
@@ -219,18 +91,31 @@ class TestNooBaaBucketErrorStateMode:
             resource_description="bucket", resource_type="quota"
         )
         bucket = MCGCLIBucket(bucket_name, mcg=mcg_obj, quota="2Gi")
-        log.info(f"Created bucket {bucket_name} with 2Gi quota")
+        logger.info(f"Created bucket {bucket_name} with 2Gi quota")
 
         try:
-            _upload_data_to_bucket(awscli_pod, bucket_name, mcg_obj, 5, 500)
-            log.info(
-                f"Uploaded ~2.5GB to bucket {bucket_name} "
+            try:
+                write_random_test_objects_to_bucket(
+                    io_pod=awscli_pod,
+                    bucket_to_write=bucket_name,
+                    file_dir=UPLOAD_DIR,
+                    amount=5,
+                    bs="500M",
+                    mcg_obj=mcg_obj,
+                )
+            except CommandFailed:
+                logger.warning("Some uploads failed as expected when exceeding quota")
+            logger.info(
+                f"Uploaded data to bucket {bucket_name} "
                 f"(quota 2Gi) to trigger EXCEEDING_QUOTA"
             )
 
-            _wait_for_bucket_mode(mcg_obj, bucket_name, "EXCEEDING_QUOTA")
+            wait_for_bucket_mode(mcg_obj, bucket_name, "EXCEEDING_QUOTA")
         finally:
-            _delete_data_from_bucket(awscli_pod, bucket_name, mcg_obj, 5)
+            try:
+                rm_object_recursive(awscli_pod, bucket_name, mcg_obj)
+            except CommandFailed:
+                logger.warning(f"Cleanup of bucket {bucket_name} objects failed")
             bucket.delete()
 
     # ------------------------------------------------------------------
@@ -272,18 +157,25 @@ class TestNooBaaBucketErrorStateMode:
         )[0]
         backingstore = bucket.bucketclass.backingstores[0]
 
-        log.info(
+        logger.info(
             f"Created data bucket {bucket.name} with "
             f"PV pool backing store {backingstore.name}"
         )
 
-        _upload_data_to_bucket(awscli_pod, bucket.name, mcg_obj, 2, 50)
-        log.info(
+        write_random_test_objects_to_bucket(
+            io_pod=awscli_pod,
+            bucket_to_write=bucket.name,
+            file_dir=UPLOAD_DIR,
+            amount=2,
+            bs="50M",
+            mcg_obj=mcg_obj,
+        )
+        logger.info(
             f"Uploaded ~100MB to bucket {bucket.name} "
             f"so NooBaa tracks objects against the backing store"
         )
 
-        log.info(
+        logger.info(
             f"Scaling PV pool backing store {backingstore.name} to 0 volumes "
             f"to trigger resource error"
         )
@@ -297,7 +189,7 @@ class TestNooBaaBucketErrorStateMode:
             format_type="merge",
         )
 
-        _wait_for_bucket_mode(mcg_obj, bucket.name, "NOT_ENOUGH_HEALTHY_RESOURCES")
+        wait_for_bucket_mode(mcg_obj, bucket.name, "NOT_ENOUGH_HEALTHY_RESOURCES")
 
     @skipif_managed_service
     @skipif_aws_creds_are_missing
@@ -347,23 +239,30 @@ class TestNooBaaBucketErrorStateMode:
             bucketclass=bucketclass_dict,
         )[0]
 
-        log.info(f"Created namespace stores: {[ns.name for ns in ns_stores]}")
-        log.info(f"Created namespace bucket {ns_bucket.name} with Multi policy")
+        logger.info(f"Created namespace stores: {[ns.name for ns in ns_stores]}")
+        logger.info(f"Created namespace bucket {ns_bucket.name} with Multi policy")
 
-        _upload_data_to_bucket(awscli_pod, ns_bucket.name, mcg_obj, 2, 50)
-        log.info(
+        write_random_test_objects_to_bucket(
+            io_pod=awscli_pod,
+            bucket_to_write=ns_bucket.name,
+            file_dir=UPLOAD_DIR,
+            amount=2,
+            bs="50M",
+            mcg_obj=mcg_obj,
+        )
+        logger.info(
             f"Uploaded ~100MB to namespace bucket {ns_bucket.name} "
             f"so NooBaa tracks objects against the namespace stores"
         )
 
         target_uls_name = ns_stores[0].uls_name
-        log.info(
+        logger.info(
             f"Deleting target bucket {target_uls_name} of "
             f"namespace store {ns_stores[0].name}"
         )
         cld_mgr.aws_client.delete_uls(target_uls_name)
 
-        _wait_for_bucket_mode(mcg_obj, ns_bucket.name, "NOT_ENOUGH_HEALTHY_RESOURCES")
+        wait_for_bucket_mode(mcg_obj, ns_bucket.name, "NOT_ENOUGH_HEALTHY_RESOURCES")
 
     # ------------------------------------------------------------------
     # Capacity error mode tests
@@ -416,7 +315,7 @@ class TestNooBaaBucketErrorStateMode:
         )[0]
         backingstore = bucket.bucketclass.backingstores[0]
 
-        log.info(
+        logger.info(
             f"Created data bucket {bucket.name} with "
             f"17Gi PV pool backing store {backingstore.name}"
         )
@@ -426,60 +325,54 @@ class TestNooBaaBucketErrorStateMode:
         final_mode = None
 
         awscli_pod.exec_cmd_on_pod("dd if=/dev/zero of=/tmp/testfile bs=1M count=4000")
-        log.info("Created 4GB test file for gradual upload")
+        logger.info("Created 4GB test file for gradual upload")
 
         for chunk in range(1, 7):
             file_num += 1
-            log.info(
+            logger.info(
                 f"Uploading chunk {chunk}/6 (~4GB) to bucket {bucket.name} "
                 f"(total so far: ~{chunk * 4}GB, PV pool: 17Gi)"
             )
             try:
-                awscli_pod.exec_cmd_on_pod(
-                    craft_s3_command(
-                        f"cp /tmp/testfile s3://{bucket.name}/testfile{file_num}",
-                        mcg_obj,
-                    ),
-                    out_yaml_format=False,
-                    secrets=[
-                        mcg_obj.access_key_id,
-                        mcg_obj.access_key,
-                        mcg_obj.s3_endpoint,
-                    ],
+                copy_objects(
+                    awscli_pod,
+                    "/tmp/testfile",
+                    f"s3://{bucket.name}/testfile{file_num}",
+                    s3_obj=mcg_obj,
                 )
-            except Exception:
-                log.warning(
+            except CommandFailed:
+                logger.warning(
                     f"Upload of chunk {chunk} failed "
                     f"(expected when exceeding capacity)"
                 )
 
-            mode = _get_bucket_mode(mcg_obj, bucket.name)
-            log.info(
+            mode = get_bucket_mode(mcg_obj, bucket.name)
+            logger.info(
                 f"After chunk {chunk}: bucket mode = {mode} "
                 f"(uploaded ~{chunk * 4}GB / 17Gi)"
             )
 
             if mode != "OPTIMAL" and mode not in observed_modes:
                 observed_modes.append(mode)
-                log.info(f"New non-OPTIMAL mode observed: {mode}")
+                logger.info(f"New non-OPTIMAL mode observed: {mode}")
 
             if mode in capacity_error_modes:
                 final_mode = mode
-                log.info(f"Bucket {bucket.name} entered capacity error mode: {mode}")
+                logger.info(f"Bucket {bucket.name} entered capacity error mode: {mode}")
                 break
 
         if not final_mode:
-            log.info(
+            logger.info(
                 "Bucket still OPTIMAL after all uploads, "
                 "waiting for mode to propagate"
             )
-            final_mode = _wait_for_bucket_mode(
+            final_mode = wait_for_bucket_mode(
                 mcg_obj, bucket.name, "NOT_ENOUGH_HEALTHY_RESOURCES"
             )
             if final_mode and final_mode not in observed_modes:
                 observed_modes.append(final_mode)
 
-        log.info(
+        logger.info(
             f"Capacity test complete. "
             f"Observed mode transitions: {observed_modes}. "
             f"Final mode: {final_mode}"
@@ -520,17 +413,27 @@ class TestNooBaaBucketErrorStateMode:
             resource_description="bucket", resource_type="alert-quota"
         )
         bucket = MCGCLIBucket(bucket_name, mcg=mcg_obj, quota="2Gi")
-        log.info(f"Created bucket {bucket_name} with 2Gi quota")
+        logger.info(f"Created bucket {bucket_name} with 2Gi quota")
 
         try:
-            _upload_data_to_bucket(awscli_pod, bucket_name, mcg_obj, 5, 500)
-            log.info(
-                f"Uploaded ~2.5GB to bucket {bucket_name} "
+            try:
+                write_random_test_objects_to_bucket(
+                    io_pod=awscli_pod,
+                    bucket_to_write=bucket_name,
+                    file_dir=UPLOAD_DIR,
+                    amount=5,
+                    bs="500M",
+                    mcg_obj=mcg_obj,
+                )
+            except CommandFailed:
+                logger.warning("Some uploads failed as expected when exceeding quota")
+            logger.info(
+                f"Uploaded data to bucket {bucket_name} "
                 f"(quota 2Gi) to trigger EXCEEDING_QUOTA"
             )
 
-            _wait_for_bucket_mode(mcg_obj, bucket_name, "EXCEEDING_QUOTA")
-            log.info(
+            wait_for_bucket_mode(mcg_obj, bucket_name, "EXCEEDING_QUOTA")
+            logger.info(
                 f"Bucket {bucket_name} is in EXCEEDING_QUOTA mode, "
                 f"waiting for Prometheus alert to fire (5+ minutes)"
             )
@@ -545,7 +448,7 @@ class TestNooBaaBucketErrorStateMode:
             )
 
             alert_labels = alerts[0]["labels"]
-            log.info(f"Alert {alert_name} fired with labels: {alert_labels}")
+            logger.info(f"Alert {alert_name} fired with labels: {alert_labels}")
             assert alert_labels.get("bucket_mode") == "EXCEEDING_QUOTA", (
                 f"Expected bucket_mode=EXCEEDING_QUOTA in alert labels, "
                 f"got bucket_mode={alert_labels.get('bucket_mode')}"
@@ -554,11 +457,14 @@ class TestNooBaaBucketErrorStateMode:
                 f"Expected bucket_name={bucket_name} in alert labels, "
                 f"got bucket_name={alert_labels.get('bucket_name')}"
             )
-            log.info(
+            logger.info(
                 f"Alert {alert_name} verified: "
                 f"bucket_name={alert_labels.get('bucket_name')}, "
                 f"bucket_mode={alert_labels.get('bucket_mode')}"
             )
         finally:
-            _delete_data_from_bucket(awscli_pod, bucket_name, mcg_obj, 5)
+            try:
+                rm_object_recursive(awscli_pod, bucket_name, mcg_obj)
+            except CommandFailed:
+                logger.warning(f"Cleanup of bucket {bucket_name} objects failed")
             bucket.delete()

--- a/tests/functional/object/mcg/test_provider_client.py
+++ b/tests/functional/object/mcg/test_provider_client.py
@@ -8,6 +8,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     run_on_all_clients_push_missing_configs,
     runs_on_provider,
     mcg,
+    pc_or_ms_provider_required,
     provider_client_ms_platform_required,
 )
 from ocs_ci.ocs import constants
@@ -32,7 +33,7 @@ def return_to_original_context():
 @mcg
 @red_squad
 @runs_on_provider
-@provider_client_ms_platform_required
+@pc_or_ms_provider_required
 @tier1
 @polarion_id("OCS-5415")
 def test_verify_backingstore_uses_rgw(mcg_obj_session):

--- a/tests/functional/pv/space_reclaim/test_staggered_cronjob_scheduling.py
+++ b/tests/functional/pv/space_reclaim/test_staggered_cronjob_scheduling.py
@@ -8,18 +8,24 @@ Upstream PR: https://github.com/csi-addons/kubernetes-csi-addons/pull/949
 """
 
 import logging
-from datetime import datetime
+import time
+from datetime import datetime, timezone
 
 import pytest
 
-from ocs_ci.framework.pytest_customization.marks import green_squad, skipif_ocs_version
-from ocs_ci.framework.testlib import ManageTest, tier2
+from ocs_ci.framework.pytest_customization.marks import (
+    green_squad,
+    jira,
+    skipif_ocs_version,
+)
+from ocs_ci.framework.testlib import ManageTest, tier2, tier3
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.exceptions import TimeoutExpiredError
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.resources.csi_addons import (
     get_csi_addons_config_value,
     remove_csi_addons_config_key,
+    restart_csi_addons_controller,
     update_csi_addons_config,
 )
 from ocs_ci.utility.utils import TimeoutSampler
@@ -35,8 +41,16 @@ NUM_PVCS = 3
 PVC_SIZE_GIB = 5
 SHORT_SCHEDULE = "*/3 * * * *"
 CRONJOB_CREATION_TIMEOUT = 180
-JOB_CREATION_TIMEOUT = 360
+JOB_CREATION_TIMEOUT = 420
 MIN_STAGGER_SPREAD_SECONDS = 5
+CUSTOM_STAGGER_WINDOW_HOURS = "1"
+INVALID_STAGGER_WINDOW = "abc"
+NUM_PVCS_LARGE = 10
+SECOND_ROUND_TIMEOUT = 720
+OFFSET_TOLERANCE_SECONDS = 10
+JOB_IMMEDIATE_THRESHOLD_SECONDS = 120
+SUSPEND_WAIT_SECONDS = 210
+LARGE_SCALE_JOB_TIMEOUT = 600
 
 
 @green_squad
@@ -272,7 +286,10 @@ class TestStaggeredCronjobScheduling(ManageTest):
         return timestamps
 
     def _collect_job_timestamps(
-        self, namespace: str, cronjob_names: list[str]
+        self,
+        namespace: str,
+        cronjob_names: list[str],
+        timeout: int = JOB_CREATION_TIMEOUT,
     ) -> dict[str, datetime]:
         """
         Wait for at least one ReclaimSpaceJob per CronJob and return their
@@ -281,6 +298,7 @@ class TestStaggeredCronjobScheduling(ManageTest):
         Args:
             namespace (str): Namespace where Jobs are created.
             cronjob_names (list[str]): CronJob names to match Jobs against.
+            timeout (int): Maximum wait time in seconds.
 
         Returns:
             dict[str, datetime]: Mapping of CronJob name to earliest Job creation datetime.
@@ -292,7 +310,7 @@ class TestStaggeredCronjobScheduling(ManageTest):
         ocp_jobs = OCP(kind=constants.RECLAIMSPACEJOBS, namespace=namespace)
 
         for timestamps in TimeoutSampler(
-            timeout=JOB_CREATION_TIMEOUT,
+            timeout=timeout,
             sleep=15,
             func=self._get_earliest_job_timestamps,
             ocp_jobs=ocp_jobs,
@@ -302,6 +320,7 @@ class TestStaggeredCronjobScheduling(ManageTest):
                 for cj_name, ts in timestamps.items():
                     logger.info("Job timestamp for CronJob '%s': %s", cj_name, ts)
                 return timestamps
+        raise TimeoutExpiredError(f"Jobs not found for all CronJobs within {timeout}s")
 
     def _assert_stagger_spread(self, timestamps: dict) -> None:
         """
@@ -316,6 +335,9 @@ class TestStaggeredCronjobScheduling(ManageTest):
 
         """
         ts_values = list(timestamps.values())
+        assert (
+            len(ts_values) >= 2
+        ), f"Need at least 2 timestamps to measure spread, got {len(ts_values)}"
         max_spread = max(
             abs((a - b).total_seconds())
             for i, a in enumerate(ts_values)
@@ -327,4 +349,786 @@ class TestStaggeredCronjobScheduling(ManageTest):
             f"All Job timestamps within {MIN_STAGGER_SPREAD_SECONDS}s of each other "
             f"(spread={max_spread:.1f}s). Stagger may not be active. "
             f"Timestamps: {timestamps}"
+        )
+
+    def _create_pvcs_and_wait_for_cronjobs(
+        self,
+        storageclass_factory,
+        multi_pvc_factory,
+        pod_factory,
+        num_pvcs: int = NUM_PVCS,
+        schedule: str = SHORT_SCHEDULE,
+    ) -> tuple[list, dict[str, OCP]]:
+        """
+        Create StorageClass with ReclaimSpace schedule, PVCs, pods, and
+        wait for ReclaimSpaceCronJob creation for each PVC.
+
+        Args:
+            storageclass_factory: Fixture for creating StorageClasses.
+            multi_pvc_factory: Fixture for creating multiple PVCs.
+            pod_factory: Fixture for creating pods.
+            num_pvcs (int): Number of PVCs to create.
+            schedule (str): Cron schedule for ReclaimSpace.
+
+        Returns:
+            tuple[list, dict[str, OCP]]: (pvc_objs, cronjob_map) where
+                cronjob_map maps PVC name to CronJob OCP object.
+
+        """
+        logger.info("Creating StorageClass with schedule: %s", schedule)
+        sc_obj = storageclass_factory(
+            interface=constants.CEPHBLOCKPOOL,
+            annotations={
+                constants.RECLAIMSPACE_SCHEDULE_ANNOTATION: schedule,
+            },
+        )
+
+        logger.info("Creating %d RBD PVCs (size=%dGiB)", num_pvcs, PVC_SIZE_GIB)
+        pvc_objs = multi_pvc_factory(
+            size=PVC_SIZE_GIB,
+            num_of_pvc=num_pvcs,
+            storageclass=sc_obj,
+            access_modes=[f"{constants.ACCESS_MODE_RWO}-Block"],
+            wait_each=True,
+        )
+
+        logger.info("Creating pods for %d PVCs", num_pvcs)
+        for pvc_obj in pvc_objs:
+            pod_factory(
+                interface=constants.CEPHBLOCKPOOL,
+                pvc=pvc_obj,
+                status=constants.STATUS_RUNNING,
+                raw_block_pv=True,
+            )
+
+        logger.info("Waiting for ReclaimSpaceCronJob creation")
+        cronjob_map = {}
+        for pvc_obj in pvc_objs:
+            cronjob_obj = self._wait_for_cronjob(pvc_obj)
+            cronjob_map[pvc_obj.name] = cronjob_obj
+
+        return pvc_objs, cronjob_map
+
+    def _get_nth_job_timestamps(
+        self,
+        ocp_jobs: OCP,
+        cronjob_names: list[str],
+        round_number: int,
+    ) -> dict[str, datetime] | None:
+        """
+        Check whether each CronJob has at least *round_number* Jobs and
+        return the Nth Job's creation timestamp.
+
+        Args:
+            ocp_jobs (OCP): OCP client for ReclaimSpaceJobs.
+            cronjob_names (list[str]): CronJob names to match against.
+            round_number (int): Which round to collect (1-based).
+
+        Returns:
+            dict[str, datetime] | None: Timestamps if all have enough Jobs, else None.
+
+        """
+        all_jobs = ocp_jobs.get().get("items", [])
+        timestamps = {}
+        for cj_name in cronjob_names:
+            prefix = f"{cj_name}-"
+            matching = sorted(
+                [j for j in all_jobs if j["metadata"]["name"].startswith(prefix)],
+                key=lambda j: j["metadata"]["creationTimestamp"],
+            )
+            if len(matching) < round_number:
+                return None
+            ts_str = matching[round_number - 1]["metadata"]["creationTimestamp"]
+            timestamps[cj_name] = datetime.strptime(ts_str, "%Y-%m-%dT%H:%M:%SZ")
+        return timestamps
+
+    def _collect_nth_round_job_timestamps(
+        self,
+        namespace: str,
+        cronjob_names: list[str],
+        round_number: int,
+    ) -> dict[str, datetime]:
+        """
+        Wait for the Nth round of ReclaimSpaceJobs per CronJob and return
+        their creation timestamps.
+
+        Args:
+            namespace (str): Namespace where Jobs are created.
+            cronjob_names (list[str]): CronJob names to match against.
+            round_number (int): Which round to collect (1-based).
+
+        Returns:
+            dict[str, datetime]: Mapping of CronJob name to Nth Job timestamp.
+
+        Raises:
+            TimeoutExpiredError: If not all CronJobs have enough Jobs in time.
+
+        """
+        ocp_jobs = OCP(kind=constants.RECLAIMSPACEJOBS, namespace=namespace)
+
+        for timestamps in TimeoutSampler(
+            timeout=SECOND_ROUND_TIMEOUT,
+            sleep=15,
+            func=self._get_nth_job_timestamps,
+            ocp_jobs=ocp_jobs,
+            cronjob_names=cronjob_names,
+            round_number=round_number,
+        ):
+            if timestamps:
+                for cj_name, ts in timestamps.items():
+                    logger.info(
+                        "Round %d timestamp for CronJob '%s': %s",
+                        round_number,
+                        cj_name,
+                        ts,
+                    )
+                return timestamps
+        raise TimeoutExpiredError(
+            f"Round {round_number} Jobs not found for all CronJobs "
+            f"within {SECOND_ROUND_TIMEOUT}s"
+        )
+
+    def _calculate_stagger_offsets(
+        self,
+        timestamps: dict[str, datetime],
+        interval_minutes: int,
+    ) -> dict[str, float]:
+        """
+        Calculate the stagger offset for each CronJob by computing how far
+        its Job creation time is from the nearest schedule boundary.
+
+        Uses modular arithmetic: offset = seconds_since_epoch % interval.
+
+        Args:
+            timestamps (dict[str, datetime]): CronJob name to Job creation time.
+            interval_minutes (int): Schedule interval in minutes.
+
+        Returns:
+            dict[str, float]: CronJob name to offset in seconds within the interval.
+
+        """
+        interval_seconds = interval_minutes * 60
+        offsets = {}
+        for cj_name, ts in timestamps.items():
+            epoch_seconds = int(ts.timestamp())
+            offset = epoch_seconds % interval_seconds
+            offsets[cj_name] = float(offset)
+            logger.info(
+                "CronJob '%s': timestamp=%s, offset=%.1fs (within %ds interval)",
+                cj_name,
+                ts,
+                offset,
+                interval_seconds,
+            )
+        return offsets
+
+    def _assert_offsets_match(
+        self,
+        offsets_round1: dict[str, float],
+        offsets_round2: dict[str, float],
+        interval_seconds: int,
+        tolerance: float = OFFSET_TOLERANCE_SECONDS,
+    ) -> None:
+        """
+        Assert that stagger offsets from two rounds match within tolerance
+        for each CronJob, using circular distance to handle wrap-around
+        at the interval boundary.
+
+        Args:
+            offsets_round1 (dict[str, float]): Offsets from first round.
+            offsets_round2 (dict[str, float]): Offsets from second round.
+            interval_seconds (int): Schedule interval in seconds for
+                circular distance calculation.
+            tolerance (float): Maximum allowed difference in seconds.
+
+        Raises:
+            AssertionError: If any CronJob's offset differs beyond tolerance,
+                or if the two rounds have different CronJob sets.
+
+        """
+        assert offsets_round1.keys() == offsets_round2.keys(), (
+            f"CronJob sets differ between rounds: "
+            f"round1={set(offsets_round1.keys())}, "
+            f"round2={set(offsets_round2.keys())}"
+        )
+        for cj_name in offsets_round1:
+            o1 = offsets_round1[cj_name]
+            o2 = offsets_round2[cj_name]
+            linear_diff = abs(o1 - o2)
+            diff = min(linear_diff, interval_seconds - linear_diff)
+            logger.info(
+                "CronJob '%s': round1_offset=%.1fs, round2_offset=%.1fs, "
+                "diff=%.1fs (circular)",
+                cj_name,
+                o1,
+                o2,
+                diff,
+            )
+            assert diff <= tolerance, (
+                f"CronJob '{cj_name}' offset changed between rounds: "
+                f"{o1:.1f}s vs {o2:.1f}s (diff={diff:.1f}s, tolerance={tolerance}s)"
+            )
+
+    def _assert_stagger_within_window(
+        self,
+        timestamps: dict[str, datetime],
+        window_seconds: float,
+    ) -> None:
+        """
+        Assert that the maximum spread between any two Job timestamps
+        does not exceed the given stagger window.
+
+        Args:
+            timestamps (dict[str, datetime]): CronJob name to creation time.
+            window_seconds (float): Maximum allowed spread in seconds.
+
+        Raises:
+            AssertionError: If max spread exceeds the window.
+
+        """
+        ts_values = list(timestamps.values())
+        assert (
+            len(ts_values) >= 2
+        ), f"Need at least 2 timestamps to measure spread, got {len(ts_values)}"
+        max_spread = max(
+            abs((a - b).total_seconds())
+            for i, a in enumerate(ts_values)
+            for b in ts_values[i + 1 :]
+        )
+        logger.info(
+            "Stagger spread: %.1fs (window limit: %.1fs)",
+            max_spread,
+            window_seconds,
+        )
+        assert max_spread <= window_seconds, (
+            f"Job timestamps spread ({max_spread:.1f}s) exceeds stagger window "
+            f"({window_seconds:.1f}s). Timestamps: {timestamps}"
+        )
+
+    def suspend_cronjob(self, cronjob_ocp: OCP) -> None:
+        """
+        Suspend a ReclaimSpaceCronJob by patching spec.suspend=true.
+
+        Uses direct CronJob patching instead of the PVC-annotation-based
+        helper, which is not available in ODF 4.22+.
+
+        Args:
+            cronjob_ocp (OCP): The CronJob OCP object to suspend.
+
+        """
+        patch = '[{"op": "add", "path": "/spec/suspend", "value": true}]'
+        cronjob_ocp.patch(params=patch, format_type="json")
+        logger.info("Suspended CronJob '%s'", cronjob_ocp.resource_name)
+
+    def resume_cronjob(self, cronjob_ocp: OCP) -> None:
+        """
+        Resume a suspended ReclaimSpaceCronJob by patching spec.suspend=false.
+
+        Args:
+            cronjob_ocp (OCP): The CronJob OCP object to resume.
+
+        """
+        patch = '[{"op": "replace", "path": "/spec/suspend", "value": false}]'
+        cronjob_ocp.patch(params=patch, format_type="json")
+        logger.info("Resumed CronJob '%s'", cronjob_ocp.resource_name)
+
+    @tier2
+    @pytest.mark.polarion_id("OCS-7982")
+    @jira("DFBUGS-6991")
+    def test_invalid_stagger_window_blocks_cronjob_creation(
+        self,
+        storageclass_factory,
+        multi_pvc_factory,
+        pod_factory,
+    ):
+        """
+        Verify controller behavior when cronjob-stagger-window contains
+        an invalid (non-numeric) value.
+
+        Known bug (DFBUGS-6991): The controller uses strconv.Atoi to
+        parse the window value. When parsing fails, the error blocks
+        CronJob reconciliation entirely instead of falling back to the
+        default window (2h). Once the bug is fixed, this test should be
+        updated to assert that CronJobs ARE created with default fallback.
+
+        Steps:
+            1. Set cronjob-stagger-window to a non-numeric value.
+            2. Create PVCs with a short-interval schedule.
+            3. Verify CronJobs are NOT created (blocked by parse error).
+
+        """
+        logger.info(
+            "Setting invalid stagger window: %s",
+            INVALID_STAGGER_WINDOW,
+        )
+        update_csi_addons_config(
+            CRONJOB_STAGGER_WINDOW_KEY,
+            INVALID_STAGGER_WINDOW,
+        )
+
+        readback = get_csi_addons_config_value(
+            CRONJOB_STAGGER_WINDOW_KEY,
+            default=CRONJOB_STAGGER_WINDOW_DEFAULT,
+        )
+        assert (
+            readback == INVALID_STAGGER_WINDOW
+        ), f"ConfigMap should contain '{INVALID_STAGGER_WINDOW}', got '{readback}'"
+
+        logger.info("Creating StorageClass with schedule: %s", SHORT_SCHEDULE)
+        sc_obj = storageclass_factory(
+            interface=constants.CEPHBLOCKPOOL,
+            annotations={
+                constants.RECLAIMSPACE_SCHEDULE_ANNOTATION: SHORT_SCHEDULE,
+            },
+        )
+
+        logger.info("Creating %d RBD PVCs (size=%dGiB)", NUM_PVCS, PVC_SIZE_GIB)
+        pvc_objs = multi_pvc_factory(
+            size=PVC_SIZE_GIB,
+            num_of_pvc=NUM_PVCS,
+            storageclass=sc_obj,
+            access_modes=[f"{constants.ACCESS_MODE_RWO}-Block"],
+            wait_each=True,
+        )
+
+        logger.info("Creating pods for PVCs")
+        for pvc_obj in pvc_objs:
+            pod_factory(
+                interface=constants.CEPHBLOCKPOOL,
+                pvc=pvc_obj,
+                status=constants.STATUS_RUNNING,
+                raw_block_pv=True,
+            )
+
+        expected_name = f"{pvc_objs[0].name}-reclaimspace"
+        cronjob_ocp = OCP(
+            kind=constants.RECLAIMSPACECRONJOB,
+            namespace=pvc_objs[0].namespace,
+            resource_name=expected_name,
+        )
+        found = cronjob_ocp.check_resource_existence(
+            should_exist=True, timeout=CRONJOB_CREATION_TIMEOUT
+        )
+        assert not found, (
+            f"CronJob '{expected_name}' was created despite invalid "
+            f"stagger window '{INVALID_STAGGER_WINDOW}'. If the controller "
+            f"now falls back to default, DFBUGS-6991 is fixed — update "
+            f"this test to verify fallback behavior."
+        )
+
+    @tier2
+    @pytest.mark.polarion_id("OCS-7983")
+    def test_configmap_update_requires_controller_restart(
+        self,
+        storageclass_factory,
+        multi_pvc_factory,
+        pod_factory,
+    ):
+        """
+        Verify that ConfigMap changes only take effect after the controller
+        is restarted — the controller caches values at startup.
+
+        Steps:
+            1. Create PVCs and wait for staggered Jobs (round 1).
+            2. Patch ConfigMap window=0 WITHOUT restarting the controller.
+            3. Wait for round 2 Jobs — stagger should STILL be active.
+            4. Restart the controller.
+            5. Wait for round 3 Jobs — stagger should now be DISABLED.
+
+        """
+        pvc_objs, cronjob_map = self._create_pvcs_and_wait_for_cronjobs(
+            storageclass_factory,
+            multi_pvc_factory,
+            pod_factory,
+        )
+        pvc_namespace = pvc_objs[0].namespace
+        cronjob_names = [cj.resource_name for cj in cronjob_map.values()]
+
+        logger.info("Waiting for round 1 Jobs (stagger active)")
+        ts_round1 = self._collect_job_timestamps(pvc_namespace, cronjob_names)
+        self._assert_stagger_spread(ts_round1)
+
+        logger.info("Patching ConfigMap window=0 WITHOUT controller restart")
+        update_csi_addons_config(
+            CRONJOB_STAGGER_WINDOW_KEY,
+            "0",
+            restart=False,
+        )
+        readback = get_csi_addons_config_value(
+            CRONJOB_STAGGER_WINDOW_KEY,
+            default=CRONJOB_STAGGER_WINDOW_DEFAULT,
+        )
+        assert (
+            readback == "0"
+        ), f"ConfigMap should read '0' after patch, got '{readback}'"
+
+        logger.info("Waiting for round 2 Jobs (controller NOT restarted)")
+        ts_round2 = self._collect_nth_round_job_timestamps(
+            pvc_namespace,
+            cronjob_names,
+            round_number=2,
+        )
+        self._assert_stagger_spread(ts_round2)
+        logger.info("Round 2 still shows stagger — old value cached")
+
+        logger.info("Restarting controller to pick up window=0")
+        restart_csi_addons_controller()
+
+        logger.info("Waiting for round 3 Jobs (stagger should be disabled)")
+        ts_round3 = self._collect_nth_round_job_timestamps(
+            pvc_namespace,
+            cronjob_names,
+            round_number=3,
+        )
+        ts_values = list(ts_round3.values())
+        max_spread = max(
+            abs((a - b).total_seconds())
+            for i, a in enumerate(ts_values)
+            for b in ts_values[i + 1 :]
+        )
+        logger.info(
+            "Round 3 spread: %.1fs (expecting < %ds)",
+            max_spread,
+            MIN_STAGGER_SPREAD_SECONDS,
+        )
+        assert max_spread < MIN_STAGGER_SPREAD_SECONDS, (
+            f"After restart with window=0, Jobs should fire together but "
+            f"spread is {max_spread:.1f}s. Timestamps: {ts_round3}"
+        )
+
+    @tier2
+    @pytest.mark.polarion_id("OCS-7984")
+    def test_short_interval_shrinks_stagger_window(
+        self,
+        storageclass_factory,
+        multi_pvc_factory,
+        pod_factory,
+    ):
+        """
+        Verify that when the schedule interval is shorter than the configured
+        stagger window, the effective window shrinks to match the interval.
+
+        With */3 schedule and default 2h window: min(3min, 2h) = 3min.
+        Jobs must be staggered but within a 3-minute window.
+
+        Steps:
+            1. Ensure default stagger window (2h).
+            2. Create PVCs with */3 schedule.
+            3. Wait for Jobs and verify stagger is active.
+            4. Verify all timestamps fall within 3 minutes of each other.
+
+        """
+        pvc_objs, cronjob_map = self._create_pvcs_and_wait_for_cronjobs(
+            storageclass_factory,
+            multi_pvc_factory,
+            pod_factory,
+        )
+        pvc_namespace = pvc_objs[0].namespace
+        cronjob_names = [cj.resource_name for cj in cronjob_map.values()]
+
+        timestamps = self._collect_job_timestamps(pvc_namespace, cronjob_names)
+        self._assert_stagger_spread(timestamps)
+        self._assert_stagger_within_window(timestamps, window_seconds=180)
+
+    @tier2
+    @pytest.mark.polarion_id("OCS-7985")
+    def test_same_uid_produces_same_offset(
+        self,
+        storageclass_factory,
+        multi_pvc_factory,
+        pod_factory,
+    ):
+        """
+        Verify that the stagger offset is deterministic — the same CronJob
+        UID always produces the same offset across consecutive Job rounds.
+
+        Steps:
+            1. Create 1 PVC with */3 schedule, wait for CronJob.
+            2. Wait for round 1 Job, calculate offset.
+            3. Wait for round 2 Job, calculate offset.
+            4. Assert offsets match within tolerance.
+
+        """
+        pvc_objs, cronjob_map = self._create_pvcs_and_wait_for_cronjobs(
+            storageclass_factory,
+            multi_pvc_factory,
+            pod_factory,
+            num_pvcs=1,
+        )
+        pvc_namespace = pvc_objs[0].namespace
+        cronjob_names = [cj.resource_name for cj in cronjob_map.values()]
+
+        logger.info("Waiting for round 1 Job")
+        ts_round1 = self._collect_job_timestamps(pvc_namespace, cronjob_names)
+        offsets_round1 = self._calculate_stagger_offsets(ts_round1, interval_minutes=3)
+
+        logger.info("Waiting for round 2 Job")
+        ts_round2 = self._collect_nth_round_job_timestamps(
+            pvc_namespace,
+            cronjob_names,
+            round_number=2,
+        )
+        offsets_round2 = self._calculate_stagger_offsets(ts_round2, interval_minutes=3)
+
+        self._assert_offsets_match(offsets_round1, offsets_round2, interval_seconds=180)
+
+    @tier3
+    @pytest.mark.polarion_id("OCS-7986")
+    def test_missed_run_bypasses_stagger(
+        self,
+        storageclass_factory,
+        multi_pvc_factory,
+        pod_factory,
+    ):
+        """
+        Verify that a CronJob that missed its scheduled run while suspended
+        fires immediately upon resume, without waiting for the stagger offset.
+
+        Steps:
+            1. Create 1 PVC with */3 schedule, wait for CronJob + first Job.
+            2. Suspend the CronJob.
+            3. Wait past the schedule interval so a run is missed.
+            4. Resume the CronJob and record the resume timestamp.
+            5. Wait for the next Job and assert it was created promptly.
+
+        """
+        pvc_objs, cronjob_map = self._create_pvcs_and_wait_for_cronjobs(
+            storageclass_factory,
+            multi_pvc_factory,
+            pod_factory,
+            num_pvcs=1,
+        )
+        pvc_namespace = pvc_objs[0].namespace
+        cj_name = list(cronjob_map.keys())[0]
+        cj_obj = cronjob_map[cj_name]
+
+        logger.info("Waiting for first Job to confirm scheduling works")
+        self._collect_job_timestamps(pvc_namespace, [cj_obj.resource_name])
+
+        logger.info("Suspending CronJob '%s'", cj_obj.resource_name)
+        self.suspend_cronjob(cj_obj)
+
+        cj_data = cj_obj.get()
+        assert (
+            cj_data["spec"].get("suspend") is True
+        ), f"CronJob '{cj_obj.resource_name}' should be suspended"
+
+        logger.info(
+            "Waiting %ds for at least one scheduled run to be missed",
+            SUSPEND_WAIT_SECONDS,
+        )
+        time.sleep(SUSPEND_WAIT_SECONDS)
+
+        ocp_jobs = OCP(kind=constants.RECLAIMSPACEJOBS, namespace=pvc_namespace)
+        jobs_before = ocp_jobs.get().get("items", [])
+        jobs_before_count = len(
+            [
+                j
+                for j in jobs_before
+                if j["metadata"]["name"].startswith(f"{cj_obj.resource_name}-")
+            ]
+        )
+
+        logger.info("Resuming CronJob '%s'", cj_obj.resource_name)
+        resume_time = datetime.now(timezone.utc).replace(tzinfo=None)
+        self.resume_cronjob(cj_obj)
+
+        logger.info("Waiting for post-resume Job")
+        for sample in TimeoutSampler(
+            timeout=JOB_IMMEDIATE_THRESHOLD_SECONDS,
+            sleep=5,
+            func=ocp_jobs.get,
+        ):
+            all_jobs = sample.get("items", [])
+            matching = [
+                j
+                for j in all_jobs
+                if j["metadata"]["name"].startswith(f"{cj_obj.resource_name}-")
+            ]
+            if len(matching) > jobs_before_count:
+                newest = max(
+                    matching,
+                    key=lambda j: j["metadata"]["creationTimestamp"],
+                )
+                ts_str = newest["metadata"]["creationTimestamp"]
+                job_time = datetime.strptime(ts_str, "%Y-%m-%dT%H:%M:%SZ")
+                delay = (job_time - resume_time).total_seconds()
+                logger.info(
+                    "Post-resume Job created %.1fs after resume",
+                    delay,
+                )
+                assert delay < JOB_IMMEDIATE_THRESHOLD_SECONDS, (
+                    f"Missed-run Job took {delay:.1f}s after resume, "
+                    f"expected within {JOB_IMMEDIATE_THRESHOLD_SECONDS}s"
+                )
+                break
+
+    @tier3
+    @pytest.mark.polarion_id("OCS-7987")
+    def test_offset_survives_controller_restart(
+        self,
+        storageclass_factory,
+        multi_pvc_factory,
+        pod_factory,
+    ):
+        """
+        Verify that stagger offsets remain the same after a controller
+        restart, since the offset is derived from the CronJob UID which
+        does not change.
+
+        Steps:
+            1. Create PVCs, wait for CronJobs and round 1 Jobs.
+            2. Calculate stagger offsets for round 1.
+            3. Verify CronJob UIDs before restart.
+            4. Restart the controller.
+            5. Wait for round 3 Jobs (skip round 2 catch-up), calculate offsets.
+            6. Assert UIDs unchanged and offsets match.
+
+        """
+        pvc_objs, cronjob_map = self._create_pvcs_and_wait_for_cronjobs(
+            storageclass_factory,
+            multi_pvc_factory,
+            pod_factory,
+        )
+        pvc_namespace = pvc_objs[0].namespace
+        cronjob_names = [cj.resource_name for cj in cronjob_map.values()]
+
+        logger.info("Collecting round 1 timestamps")
+        ts_round1 = self._collect_job_timestamps(pvc_namespace, cronjob_names)
+        offsets_round1 = self._calculate_stagger_offsets(ts_round1, interval_minutes=3)
+
+        uids_before = {}
+        for pvc_name, cj_obj in cronjob_map.items():
+            uids_before[pvc_name] = cj_obj.get()["metadata"]["uid"]
+
+        logger.info("Restarting CSI Addons controller")
+        restart_csi_addons_controller()
+
+        uids_after = {}
+        for pvc_name, cj_obj in cronjob_map.items():
+            uids_after[pvc_name] = cj_obj.get()["metadata"]["uid"]
+        assert uids_before == uids_after, (
+            f"CronJob UIDs changed after controller restart: "
+            f"before={uids_before}, after={uids_after}"
+        )
+
+        logger.info(
+            "Collecting round 3 timestamps (post-restart, skipping catch-up round)"
+        )
+        ts_round3 = self._collect_nth_round_job_timestamps(
+            pvc_namespace,
+            cronjob_names,
+            round_number=3,
+        )
+        offsets_round3 = self._calculate_stagger_offsets(ts_round3, interval_minutes=3)
+
+        self._assert_offsets_match(offsets_round1, offsets_round3, interval_seconds=180)
+        logger.info("Stagger offsets survived controller restart")
+
+    @tier3
+    @pytest.mark.polarion_id("OCS-7988")
+    def test_custom_stagger_window(
+        self,
+        storageclass_factory,
+        multi_pvc_factory,
+        pod_factory,
+    ):
+        """
+        Verify that a custom stagger window value is accepted by the
+        controller and stagger remains active.
+
+        Sets window=1 (1 hour) and uses */3 schedule. Since the interval
+        (3min) is shorter than the window (1h), the effective stagger is
+        min(3min, 1h) = 3min. This test verifies the controller accepts
+        the custom value and continues to stagger Jobs.
+
+        Note: Testing window-as-the-limiting-factor requires interval >
+        window, which needs @hourly or longer schedules (impractical for
+        CI). The controller only accepts integer hours (strconv.Atoi).
+
+        Steps:
+            1. Set custom stagger window to 1h.
+            2. Create PVCs with */3 schedule.
+            3. Wait for Jobs.
+            4. Verify stagger is active.
+
+        """
+        logger.info(
+            "Setting custom stagger window: %sh",
+            CUSTOM_STAGGER_WINDOW_HOURS,
+        )
+        update_csi_addons_config(
+            CRONJOB_STAGGER_WINDOW_KEY,
+            CUSTOM_STAGGER_WINDOW_HOURS,
+        )
+
+        pvc_objs, cronjob_map = self._create_pvcs_and_wait_for_cronjobs(
+            storageclass_factory,
+            multi_pvc_factory,
+            pod_factory,
+        )
+        pvc_namespace = pvc_objs[0].namespace
+        cronjob_names = [cj.resource_name for cj in cronjob_map.values()]
+
+        timestamps = self._collect_job_timestamps(pvc_namespace, cronjob_names)
+        self._assert_stagger_spread(timestamps)
+
+    @tier3
+    @pytest.mark.polarion_id("OCS-7989")
+    def test_many_pvcs_spread_uniformly(
+        self,
+        storageclass_factory,
+        multi_pvc_factory,
+        pod_factory,
+    ):
+        """
+        Verify that staggered scheduling prevents thundering herd with
+        many PVCs sharing the same schedule.
+
+        Steps:
+            1. Create 10 PVCs with */3 schedule.
+            2. Wait for 10 CronJobs, verify unique UIDs.
+            3. Wait for 10 Jobs.
+            4. Verify stagger spread and no timestamp clustering.
+
+        """
+        pvc_objs, cronjob_map = self._create_pvcs_and_wait_for_cronjobs(
+            storageclass_factory,
+            multi_pvc_factory,
+            pod_factory,
+            num_pvcs=NUM_PVCS_LARGE,
+        )
+
+        uids = set()
+        for cj_obj in cronjob_map.values():
+            uid = cj_obj.get()["metadata"]["uid"]
+            uids.add(uid)
+        assert len(uids) == NUM_PVCS_LARGE, (
+            f"Expected {NUM_PVCS_LARGE} unique CronJob UIDs, "
+            f"got {len(uids)}: {uids}"
+        )
+
+        pvc_namespace = pvc_objs[0].namespace
+        cronjob_names = [cj.resource_name for cj in cronjob_map.values()]
+
+        timestamps = self._collect_job_timestamps(
+            pvc_namespace, cronjob_names, timeout=LARGE_SCALE_JOB_TIMEOUT
+        )
+        self._assert_stagger_spread(timestamps)
+
+        ts_sorted = sorted(timestamps.values())
+        clustered = 0
+        for i in range(len(ts_sorted) - 1):
+            if abs((ts_sorted[i + 1] - ts_sorted[i]).total_seconds()) < 2:
+                clustered += 1
+        max_clustered = NUM_PVCS_LARGE // 3
+        logger.info(
+            "Adjacent pairs within 2s: %d (max allowed: %d)",
+            clustered,
+            max_clustered,
+        )
+        assert clustered <= max_clustered, (
+            f"Too many Jobs clustered together ({clustered} pairs within 2s, "
+            f"max {max_clustered}). Thundering herd not prevented. "
+            f"Timestamps: {dict(sorted(timestamps.items(), key=lambda x: x[1]))}"
         )

--- a/tests/functional/z_cluster/nodes/test_node_replacement_proactive.py
+++ b/tests/functional/z_cluster/nodes/test_node_replacement_proactive.py
@@ -30,7 +30,7 @@ from ocs_ci.helpers.helpers import (
 )
 from ocs_ci.helpers.sanity_helpers import Sanity
 
-log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def select_osd_node_name():
@@ -43,7 +43,7 @@ def select_osd_node_name():
     """
     osd_node_names = node.get_osd_running_nodes()
     osd_node_name = random.choice(osd_node_names)
-    log.info(f"Selected OSD is {osd_node_name}")
+    logger.info(f"Selected OSD is {osd_node_name}")
     return osd_node_name
 
 
@@ -69,7 +69,7 @@ def check_node_replacement_verification_steps(
     num_of_old_ocs_nodes = len(ocs_nodes)
 
     if num_of_old_osd_nodes <= min_osd_nodes:
-        log.info(
+        logger.info(
             f"We have {num_of_old_osd_nodes} osd nodes in the cluster - which is the minimum number "
             f"of osd nodes. Wait for the new created worker node to appear in the osd nodes"
         )
@@ -86,39 +86,44 @@ def check_node_replacement_verification_steps(
                 new_osd_node_name = new_node_name
         else:
             new_osd_node_name = node.wait_for_new_osd_node(old_osd_node_names, timeout)
-        log.info(f"Newly created OSD name: {new_osd_node_name}")
+        logger.info(f"Newly created OSD name: {new_osd_node_name}")
+        logger.assertion(f"New OSD node found: {bool(new_osd_node_name)}")
         assert new_osd_node_name, (
             f"New osd node not found after the node replacement process "
             f"while waiting for {timeout} seconds"
         )
     elif num_of_old_osd_nodes < num_of_old_ocs_nodes:
         num_of_extra_old_ocs_nodes = num_of_old_ocs_nodes - num_of_old_osd_nodes
-        log.info(
+        logger.info(
             f"We have {num_of_extra_old_ocs_nodes} existing extra OCS worker nodes in the cluster"
             f"Wait for one of the existing OCS nodes to appear in the osd nodes"
         )
         timeout = 600
         new_osd_node_name = node.wait_for_new_osd_node(old_osd_node_names, timeout)
+        logger.assertion(f"New OSD node found: {bool(new_osd_node_name)}")
         assert new_osd_node_name, (
             f"New osd node not found after the node replacement process "
             f"while waiting for {timeout} seconds"
         )
     else:
-        log.info(
+        logger.info(
             f"We have more than {min_osd_nodes} osd nodes in the cluster, and also we don't have "
             f"an existing extra OCS worker nodes in the cluster. Don't wait for the new osd node"
         )
         new_osd_node_name = None
 
+    logger.assertion("Running ceph-side node replacement verification steps")
     assert node.node_replacement_verification_steps_ceph_side(
         old_node_name, new_node_name, new_osd_node_name
     )
+    logger.assertion("Running user-side node replacement verification steps")
     assert node.node_replacement_verification_steps_user_side(
         old_node_name, new_node_name, new_osd_node_name, old_osd_ids
     )
 
     # If the cluster is an MS provider cluster, and we also have MS consumer clusters in the run
     if is_ms_provider_cluster() and config.is_consumer_exist():
+        logger.assertion("Consumer verification after provider node replacement")
         assert node.consumers_verification_steps_after_provider_node_replacement()
 
 
@@ -173,18 +178,26 @@ def delete_and_create_osd_node(osd_node_name):
                 new_node_name = node.delete_and_create_osd_node_vsphere_upi(
                     osd_node_name, use_existing_node=use_existing_node
                 )
+        else:
+            msg_invalid_platform = (
+                "ocs-ci config 'platform' value "
+                f"'{config.ENV_DATA['platform']}' is not supported for UPI "
+                f"deployment, results of this test run are all invalid."
+            )
+            logger.error(msg_invalid_platform)
+            pytest.fail(msg_invalid_platform)
     elif dt == constants.MANAGED_CP_DEPL_TYPE:
         new_node_name = node.delete_and_create_osd_node_managed_cp(osd_node_name)
     else:
-        log.error(msg_invalid)
+        logger.error(msg_invalid)
         pytest.fail(msg_invalid)
 
-    log.info("Start node replacement verification steps...")
+    logger.info("Start node replacement verification steps...")
     check_node_replacement_verification_steps(
         osd_node_name, new_node_name, old_osd_node_names, old_osd_ids
     )
 
-    log.info("Clear crash warnings and osd removal leftovers")
+    logger.info("Clear crash warnings and osd removal leftovers")
     clear_crash_warning_and_osd_removal_leftovers()
 
 
@@ -203,9 +216,12 @@ class TestNodeReplacementWithIO(ManageTest):
     """
 
     @pytest.fixture(autouse=True)
-    def teardown(self):
-        log.info("Clear crash warnings and osd removal leftovers")
-        clear_crash_warning_and_osd_removal_leftovers()
+    def teardown(self, request):
+        def finalizer():
+            logger.info("Clear crash warnings and osd removal leftovers")
+            clear_crash_warning_and_osd_removal_leftovers()
+
+        request.addfinalizer(finalizer)
 
     @pytest.fixture(autouse=True)
     def init_sanity(self):
@@ -228,42 +244,43 @@ class TestNodeReplacementWithIO(ManageTest):
 
         """
 
-        # Get worker nodes
+        logger.test_step("Get worker nodes and select OSD node for replacement")
         worker_node_list = node.get_worker_nodes()
-        log.info(f"Current available worker nodes are {worker_node_list}")
+        logger.info(f"Current available worker nodes are {worker_node_list}")
 
         osd_node_name = select_osd_node_name()
 
-        log.info("Creating dc pod backed with rbd pvc and running io in bg")
+        logger.test_step("Create RBD and CephFS DC pods with background IO")
+        logger.info("Creating dc pod backed with rbd pvc and running io in bg")
         rbd_dc_pod = deployment_pod_factory(interface=constants.CEPHBLOCKPOOL, size=20)
         pod.run_io_in_bg(rbd_dc_pod, expect_to_fail=False, fedora_dc=True)
 
-        log.info("Creating dc pod backed with cephfs pvc and running io in bg")
+        logger.info("Creating dc pod backed with cephfs pvc and running io in bg")
         cephfs_dc_pod = deployment_pod_factory(
             interface=constants.CEPHFILESYSTEM, size=20
         )
         pod.run_io_in_bg(cephfs_dc_pod, expect_to_fail=False, fedora_dc=True)
 
+        logger.test_step("Delete and create OSD node")
         delete_and_create_osd_node(osd_node_name)
 
-        # Creating Resources
-        log.info("Creating Resources using sanity helpers")
+        logger.test_step("Create and delete sanity resources")
+        logger.info("Creating Resources using sanity helpers")
         self.sanity_helpers.create_resources(
             pvc_factory, pod_factory, bucket_factory, rgw_bucket_factory
         )
-        # Deleting Resources
         self.sanity_helpers.delete_resources()
 
-        # Verify everything running fine
-        log.info("Verifying All resources are Running and matches expected result")
+        logger.test_step("Verify cluster health and StorageCluster topology")
+        logger.info("Verifying All resources are Running and matches expected result")
         self.sanity_helpers.health_check(tries=120)
 
-        # Verify OSD is encrypted
         if config.ENV_DATA.get("encryption_at_rest"):
             osd_encryption_verification()
 
+        logger.assertion("Verifying StorageCluster node topology is valid")
         assert (
-            verify_storagecluster_nodetopology
+            verify_storagecluster_nodetopology()
         ), "Storagecluster node topology is having an entry of non ocs node(s) - Not expected"
 
 
@@ -283,7 +300,7 @@ class TestNodeReplacement(ManageTest):
     @pytest.fixture(autouse=True)
     def teardown(self, request):
         def finalizer():
-            log.info("Clear crash warnings and osd removal leftovers")
+            logger.info("Clear crash warnings and osd removal leftovers")
             clear_crash_warning_and_osd_removal_leftovers()
 
         request.addfinalizer(finalizer)
@@ -302,24 +319,26 @@ class TestNodeReplacement(ManageTest):
         Knip-894 Node Replacement proactive(without IO running)
 
         """
+        logger.test_step("Select OSD node and perform node replacement")
         osd_node_name = select_osd_node_name()
         delete_and_create_osd_node(osd_node_name)
 
-        # Verify everything running fine
-        log.info("Verifying All resources are Running and matches expected result")
+        logger.test_step("Verify cluster health and data rebalance")
+        logger.info("Verifying All resources are Running and matches expected result")
         self.sanity_helpers.health_check(tries=120)
 
-        # Verify OSD encrypted
         if config.ENV_DATA.get("encryption_at_rest"):
             osd_encryption_verification()
 
         ceph_cluster_obj = CephCluster()
+        logger.assertion("Verifying Ceph data rebalance completes within 1800s")
         assert ceph_cluster_obj.wait_for_rebalance(
             timeout=1800
         ), "Data re-balance failed to complete"
 
+        logger.assertion("Verifying StorageCluster node topology is valid")
         assert (
-            verify_storagecluster_nodetopology
+            verify_storagecluster_nodetopology()
         ), "Storagecluster node topology is having an entry of non ocs node(s) - Not expected"
 
 
@@ -345,25 +364,36 @@ class TestNodeReplacementTwice(ManageTest):
 
     @pytest.fixture(autouse=True)
     def teardown(self, request):
-        log.info("Clear crash warnings and osd removal leftovers")
-        clear_crash_warning_and_osd_removal_leftovers()
+        def finalizer():
+            logger.info("Clear crash warnings and osd removal leftovers")
+            clear_crash_warning_and_osd_removal_leftovers()
+
+        request.addfinalizer(finalizer)
 
     @skipif_ibm_cloud_managed
     def test_nodereplacement_twice(self):
         for i in range(2):
-            # Get random node name for replacement
+            logger.info(f"=== Node replacement iteration {i + 1}/2 ===")
+
+            logger.test_step("Select OSD node and perform node replacement")
             node_name_to_delete = select_osd_node_name()
-            log.info(f"Selected node for replacement: {node_name_to_delete}")
+            logger.info(f"Selected node for replacement: {node_name_to_delete}")
             delete_and_create_osd_node(node_name_to_delete)
+
+            logger.test_step("Verify deleted node is removed from ceph osd tree")
             ct_pod = pod.get_ceph_tools_pod()
             tree_output = ct_pod.exec_ceph_cmd(ceph_cmd="ceph osd tree")
-            log.info("ceph osd tree output:")
-            log.info(tree_output)
+            logger.info("ceph osd tree output:")
+            logger.info(tree_output)
 
-            assert not (
-                node_name_to_delete in str(tree_output)
+            logger.assertion(
+                f"Deleted node '{node_name_to_delete}' not in ceph osd tree"
+            )
+            assert node_name_to_delete not in str(
+                tree_output
             ), f"Deleted host {node_name_to_delete} still exist in ceph osd tree after node replacement"
 
+            logger.assertion("Verifying StorageCluster node topology is valid")
             assert (
                 verify_storagecluster_nodetopology
             ), "Storagecluster node topology is having an entry of non ocs node(s) - Not expected"


### PR DESCRIPTION
**Summary**
  
  Add 5 tests verifying that NooBaa data buckets and namespace buckets enter the expected error modes (bucket_mode) when specific failure conditions are triggered, and that the  NooBaaBucketErrorState Prometheus alert fires with the correct bucket_mode label.

   Related epic: [RHSTOR-7732](https://redhat.atlassian.net/browse/RHSTOR-7732)

  **Background**

  The NooBaaBucketErrorState alert was improved to include bucket_mode in its message and description, making the alert actionable by indicating the reason for the error. These tests verify that buckets correctly transition to the expected error modes when quota, resource, or capacity failures occur, and that the Prometheus alert propagates the bucket_mode correctly.

Test Cases:

1. test_data_bucket_quota_error_mode (Data Bucket) — EXCEEDING_QUOTA

Flow:
  1. Create a data bucket with a 2Gi quota
  2. Upload ~2.5GB (5 files x 500MB) to exceed the quota
  3. Poll bucket mode via NooBaa's get_bucket_info
  4. Verify bucket enters EXCEEDING_QUOTA mode
  
How to trigger: Uploading data beyond the bucket's configured quota causes NooBaa to flag the bucket as EXCEEDING_QUOTA.

2. test_data_bucket_resource_error_mode (Data Bucket) — NOT_ENOUGH_HEALTHY_RESOURCES

Flow:
  1. Create a data bucket with a PV pool backing store (17Gi)
  2. Upload ~100MB so NooBaa tracks objects against the backing store
  3. Force-delete the PV pool pod to make the resource unavailable
  4. Poll bucket mode via NooBaa's get_bucket_info
  5. Verify bucket enters NOT_ENOUGH_HEALTHY_RESOURCES mode

How to trigger: Killing the PV pool pod removes the backing store's agent. NooBaa detects the missing pool node and marks the bucket as NOT_ENOUGH_HEALTHY_RESOURCES.

3. test_ns_bucket_resource_error_mode (Namespace Bucket) — NOT_ENOUGH_HEALTHY_RESOURCES

Flow:
  1. Create 2 AWS-backed namespace stores
  2. Create a namespace bucket with Multi policy using both stores
  3. Upload ~100MB so NooBaa tracks objects against the namespace stores
  4. Delete the underlying AWS target bucket of one namespace store
  5. Poll bucket mode via NooBaa's get_bucket_info
  6. Verify bucket enters NOT_ENOUGH_HEALTHY_RESOURCES mode

How to trigger: Deleting the AWS target bucket makes one namespace store unavailable. NooBaa detects the missing resource and marks the bucket as NOT_ENOUGH_HEALTHY_RESOURCES.

4. test_data_bucket_capacity_error_mode (Data Bucket) — NOT_ENOUGH_HEALTHY_RESOURCES

Flow:
  1. Create a data bucket with a PV pool backing store (17Gi)
  2. Upload data gradually in 4GB chunks, checking bucket mode after each chunk
  3. Log all observed mode transitions (to capture any intermediate modes like LOW_CAPACITY or NO_CAPACITY)
  4. Verify bucket enters a capacity error mode (any of: LOW_CAPACITY, NO_CAPACITY, NOT_ENOUGH_HEALTHY_RESOURCES, etc.)

How to trigger: Filling the PV pool beyond its capacity exhausts the storage. NooBaa detects the backing store has no free space and marks the bucket as NOT_ENOUGH_HEALTHY_RESOURCES.

5. test_bucket_error_state_alert — Prometheus Alert Verification

Flow:
  1. Create a data bucket with a 2Gi quota
  2. Upload ~2.5GB to exceed the quota
  3. Wait for bucket to enter EXCEEDING_QUOTA mode
  4. Wait for the NooBaaBucketErrorState Prometheus alert to fire (~5 min delay)
  5. Verify the alert's labels contain bucket_mode=EXCEEDING_QUOTA and the correct bucket_name
  6. Clean up
  
How to trigger: Uses the quota-exceeded scenario (fastest to trigger) and verifies that the improved alert propagates the bucket_mode into the Prometheus alert labels.

  Note: Namespace bucket quota and capacity tests were intentionally excluded — NS buckets act as proxies and don't keep metadata internally, so quota is never enforced and capacity exhaustion cannot be triggered. Confirmed by Eran Tamir on [RHSTOR-7732](https://redhat.atlassian.net/browse/RHSTOR-7732).

Validation:

  Each test verifies via NooBaa's get_bucket_info that the bucket enters the expected error mode after the failure condition is triggered. The alert test additionally validates the Prometheus alert labels. Full bucket info is logged before assertions to aid debugging if mode values change.

Markers:

  - @tier2, @mcg, @red_squad, @runs_on_provider
  - @skipif_disconnected_cluster, @skipif_ocs_version("&lt;4.22")
  - AWS-dependent tests additionally have @skipif_managed_service, @skipif_aws_creds_are_missing
  - PV pool tests additionally have @skipif_mcg_only

=======================================================================================

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive functional tests validating NooBaa bucket mode transitions for data and namespace buckets across quota-exceeded, resource-unavailable, and capacity-exceeded scenarios.
  * Six targeted tests cover data and namespace buckets, including quota, resource, and capacity failures.
  * Tests include resilient object upload/cleanup and wait/poll checks to assert expected or non-optimal bucket modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->