### PR TITLE
EC config file

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -543,7 +543,7 @@
         "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7091,
+        "line_number": 7140,
         "type": "Private Key",
         "verified_result": null
       }
@@ -597,7 +597,7 @@
         "hashed_secret": "66a36e77fd002579809717841f998f4d21cd5913",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2924,
+        "line_number": 2897,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -765,7 +765,7 @@
         "hashed_secret": "9ec53cfd9929c70c3f87c210b6a7b77fb6d79d43",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2778,
+        "line_number": 2752,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -773,7 +773,7 @@
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2935,
+        "line_number": 2909,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -781,7 +781,7 @@
         "hashed_secret": "adc1f5c8707f7d7aba3aabe13c15e5ef1151872e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2936,
+        "line_number": 2910,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -789,7 +789,7 @@
         "hashed_secret": "ee46262b2df945e46ea310b925ad087465dbd3f2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3657,
+        "line_number": 3631,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -797,7 +797,7 @@
         "hashed_secret": "f678cad4ab874d71b559a069d5e34a95fe38a480",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3658,
+        "line_number": 3632,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -1015,7 +1015,7 @@
         "hashed_secret": "f0e2d8610edefa0c02b673dcac7964b02ce3e890",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 746,
+        "line_number": 748,
         "type": "Basic Auth Credentials",
         "verified_result": null
       }

--- a/conf/deployment/vsphere/ipi_1az_rhcos_vsan_lso_vmdk_3m_6w_ec.yaml
+++ b/conf/deployment/vsphere/ipi_1az_rhcos_vsan_lso_vmdk_3m_6w_ec.yaml
@@ -1,0 +1,25 @@
+---
+# This config is suppose to work on most of DCs we have.
+DEPLOYMENT:
+  allow_lower_instance_requirements: false
+  ocs_operator_nodes_to_label: 6
+  local_storage: true
+  type: 'VMDK'
+  provision_type: 'thick'
+  ec_default_pools: true
+  ec_data_chunks: 4
+  ec_coding_chunks: 2
+  ec_failure_domain: host
+ENV_DATA:
+  platform: 'vsphere'
+  deployment_type: 'ipi'
+  worker_replicas: 6
+  master_replicas: 3
+  worker_num_cpus: '16'
+  master_num_cpus: '4'
+  master_memory: '16384'
+  compute_memory: '65536'
+  fio_storageutilization_min_mbps: 10.0
+REPORTING:
+  polarion:
+    deployment_id: 'OCS-2363'

--- a/conf/deployment/vsphere/upi_1az_rhcos_vsan_lso_vmdk_3m_6w_ec.yaml
+++ b/conf/deployment/vsphere/upi_1az_rhcos_vsan_lso_vmdk_3m_6w_ec.yaml
@@ -1,0 +1,22 @@
+---
+# This config is suppose to work on most of DCs we have.
+DEPLOYMENT:
+  allow_lower_instance_requirements: false
+  ocs_operator_nodes_to_label: 6
+  local_storage: true
+  type: 'VMDK'
+  provision_type: 'thick'
+  ec_default_pools: true
+  ec_data_chunks: 4
+  ec_coding_chunks: 2
+  ec_failure_domain: host
+ENV_DATA:
+  platform: 'vsphere'
+  deployment_type: 'upi'
+  worker_replicas: 6
+  master_replicas: 3
+  worker_num_cpus: '16'
+  master_num_cpus: '4'
+  master_memory: '16384'
+  compute_memory: '65536'
+  fio_storageutilization_min_mbps: 10.0

--- a/ocs_ci/utility/storage_cluster_setup.py
+++ b/ocs_ci/utility/storage_cluster_setup.py
@@ -145,7 +145,9 @@ class StorageClusterSetup(object):
         ):
             cluster_data["spec"]["flexibleScaling"] = True
             # https://bugzilla.redhat.com/show_bug.cgi?id=1921023
-            cluster_data["spec"]["storageDeviceSets"][0]["count"] = 3
+            cluster_data["spec"]["storageDeviceSets"][0]["count"] = (
+                config.DEPLOYMENT.get("ocs_operator_nodes_to_label", 3)
+            )
             cluster_data["spec"]["storageDeviceSets"][0]["replica"] = 1
         elif (
             self.platform.lower() == constants.FYRE_PLATFORM


### PR DESCRIPTION
Signed-off-by: vavuthu [vavuthu@redhat.com](mailto:vavuthu@redhat.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added vSphere UPI and IPI deployment profiles for RHCOS enabling vSAN local storage (VMDK) with thick provisioning and erasure-coding defaults (host-level failure domains).
  * Included default replica counts (3 masters, 6 workers), CPU/memory sizing, a storage-utilization benchmarking threshold, and deployment reporting metadata.
  * Storage scaling now respects configurable device-set counts instead of a fixed value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->