### PR TITLE
odf-cli: extract cross-platform binaries from amd64 image

### DIFF
--- a/ocs_ci/helpers/odf_cli.py
+++ b/ocs_ci/helpers/odf_cli.py
@@ -139,6 +139,7 @@ class ODFCLIRetriever:
 
         exec_cmd(
             f"oc image extract --registry-config {pull_secret_path} "
+            f"--filter-by-os=linux/amd64 "
             f"{image} --confirm "
             f"--path {remote_path}:{local_cli_dir}"
         )


### PR DESCRIPTION
ODF CLI v4.22 stores cross-platform binaries under
/usr/share/odf only in the amd64 image variant.

On ppc64le and s390x images, /usr/share/odf is not
present, causing ODF CLI extraction to fail with
FileNotFoundError.

Add an amd64 image override during extraction so
architecture-specific binaries can be extracted
consistently across platforms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced ODF CLI binary extraction process to filter downloads more accurately based on operating system and architecture specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->