### PR TITLE
422 provider multicluster updage fix - csv issue

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -543,7 +543,7 @@
         "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7091,
+        "line_number": 7140,
         "type": "Private Key",
         "verified_result": null
       }

--- a/ocs_ci/ocs/ocs_upgrade.py
+++ b/ocs_ci/ocs/ocs_upgrade.py
@@ -568,6 +568,10 @@ class OCSUpgrade(object):
         csv_list = get_csvs_start_with_prefix(resource_name, namespace=self.namespace)
         for csv in csv_list:
             if resource_name in csv.get("metadata").get("name"):
+                logger.info(
+                    "searching for pre-upgrade csv with version: "
+                    f"{config.PREUPGRADE_CONFIG.get('ENV_DATA').get('ocs_version')}"
+                )
                 if config.PREUPGRADE_CONFIG.get("ENV_DATA").get(
                     "ocs_version"
                 ) in csv.get("metadata").get("name"):

--- a/ocs_ci/ocs/provider_client_upgrade.py
+++ b/ocs_ci/ocs/provider_client_upgrade.py
@@ -193,6 +193,9 @@ class ProviderClusterOperatorUpgrade(ProviderUpgrade):
 
     """
 
+    def __init__(self):
+        super().__init__(namespace=config.ENV_DATA["cluster_namespace"])
+
     def run_provider_upgrade(self):
         """
         This method is for running the upgrade of ocs, metallb, acm and cnv opertaors


### PR DESCRIPTION
Resolve CSVNotFound issue during multicluster Provider upgrade

Fix #15298

```
2026-06-04 12:28:31  05:28:31 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig -n openshift-storage get csv -n openshift-storage -o yaml
2026-06-04 12:28:33  05:28:33 - MainThread - ocs_ci.ocs.provider_client_upgrade - ERROR  - Operator upgrade failed: No preupgrade CSV found for ocs-operator
2026-06-04 12:28:33  05:28:33 - MainThread - ocs_ci.framework.pytest_customization.reports - INFO  - duration reported by tests/functional/upgrade/test_upgrade.py::test_provider_cluster_upgrade immediately after test execution: 34.54
2026-06-04 12:28:34  FAILED
2026-06-04 12:28:34  ________________________ test_provider_cluster_upgrade _________________________
2026-06-04 12:28:34  
2026-06-04 12:28:34  zone_rank = None, role_rank = None, config_index = None
2026-06-04 12:28:34  
2026-06-04 12:28:34      @yellow_squad
2026-06-04 12:28:34      @provider_operator_upgrade
2026-06-04 12:28:34      @runs_on_provider
2026-06-04 12:28:34      def test_provider_cluster_upgrade(zone_rank, role_rank, config_index):
2026-06-04 12:28:34          """
2026-06-04 12:28:34          Test upgrade for provider cluster
2026-06-04 12:28:34      
2026-06-04 12:28:34          """
2026-06-04 12:28:34          provider_cluster_upgrade_obj = ProviderClusterOperatorUpgrade()
2026-06-04 12:28:34  >       provider_cluster_upgrade_obj.run_provider_upgrade()
2026-06-04 12:28:34  
2026-06-04 12:28:34  tests/functional/upgrade/test_upgrade.py:180: 
2026-06-04 12:28:34  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2026-06-04 12:28:34  ocs_ci/ocs/provider_client_upgrade.py:207: in run_provider_upgrade
2026-06-04 12:28:34      ocs_upgrade.run_ocs_upgrade()
2026-06-04 12:28:34  ocs_ci/ocs/ocs_upgrade.py:871: in run_ocs_upgrade
2026-06-04 12:28:34      csv_name_pre_upgrade = upgrade_ocs.get_csv_name_pre_upgrade()
2026-06-04 12:28:34  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2026-06-04 12:28:34  
2026-06-04 12:28:34  self = <ocs_ci.ocs.ocs_upgrade.OCSUpgrade object at 0x7f5837a55f50>
2026-06-04 12:28:34  resource_name = 'ocs-operator'
2026-06-04 12:28:34  
2026-06-04 12:28:34      def get_csv_name_pre_upgrade(self, resource_name=OCS_OPERATOR_NAME):
2026-06-04 12:28:34          """
2026-06-04 12:28:34          Get pre-upgrade CSV name
2026-06-04 12:28:34      
2026-06-04 12:28:34          Ealier we used to depend on packagemanifest to find the pre-upgrade
2026-06-04 12:28:34          csv name. Due to issues in catalogsource where csv names were not shown properly once
2026-06-04 12:28:34          catalogsource for upgrade version has been created, we are taking new approach of
2026-06-04 12:28:34          finding csv name from csv list and also look for pre-upgrade ocs version for finding out
2026-06-04 12:28:34          the actual csv
2026-06-04 12:28:34      
2026-06-04 12:28:34          """
2026-06-04 12:28:34          csv_name = None
2026-06-04 12:28:34          csv_list = get_csvs_start_with_prefix(resource_name, namespace=self.namespace)
2026-06-04 12:28:34          for csv in csv_list:
2026-06-04 12:28:34              if resource_name in csv.get("metadata").get("name"):
2026-06-04 12:28:34                  if config.PREUPGRADE_CONFIG.get("ENV_DATA").get(
2026-06-04 12:28:34                      "ocs_version"
2026-06-04 12:28:34                  ) in csv.get("metadata").get("name"):
2026-06-04 12:28:34                      csv_name = csv.get("metadata").get("name")
2026-06-04 12:28:34                      return csv_name
2026-06-04 12:28:34  >       raise CSVNotFound(f"No preupgrade CSV found for {resource_name}")
2026-06-04 12:28:34  E       ocs_ci.ocs.exceptions.CSVNotFound: No preupgrade CSV found for ocs-operator
2026-06-04 12:28:34  
2026-06-04 12:28:34  ocs_ci/ocs/ocs_upgrade.py:576: CSVNotFound
```


change is surgical:                                                                                                                                                             
                                                                  
  - ProviderClusterOperatorUpgrade — ODF-specific class — now explicitly passes cluster_namespace to the parent, overriding the openshift-operators default                           
  - OperatorUpgrade — MetalLB/CNV/ACM/LSO — still calls super().__init__() with no arguments → still gets openshift-operators ✓                                                       
  - KubevirtClusterUpgrade — still gets openshift-operators ✓                                                                                                                         
  - DRUpgrade hierarchy — completely unaffected, has its own __init__ ✓                                                                                                               
  - ProviderUpgrade itself — default unchanged ✓ 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgrade initialization now runs using the configured cluster namespace for upgrade operations.
* **Improvements**
  * Enhanced logging during pre-upgrade CSV scanning: info messages now report the pre-upgrade OCS version being examined, improving scan visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Verification run: https://url.corp.redhat.com/fb0f5d8