### PR TITLE
fix test_reclaim_space_cronjob_with_annotation 422-419

### DIFF
--- a/tests/functional/pv/space_reclaim/test_rbd_reclaimspace_cronjob.py
+++ b/tests/functional/pv/space_reclaim/test_rbd_reclaimspace_cronjob.py
@@ -185,15 +185,15 @@ class TestRbdSpaceReclaim(ManageTest):
         pvc_factory,
     ):
         """
-        Test case to check that reclaim space job is created for rbd pvc with reclaim space annotation
+        Test case to check that reclaim space cronjob is created for rbd pvc
+        when the StorageClass carries the reclaimspace schedule annotation.
 
         Steps:
         1. Create a project
         2. Create a storage class with reclaim policy as delete
-        3. Create a pvc with above storage class
-        4. Run IO on the pod
-        5. Add reclaim space annotation to the pvc
-        6. Validate the reclaim space cronjob
+        3. Annotate the storage class with reclaimspace schedule
+        4. Create a pvc with above storage class
+        5. Validate the reclaim space cronjob is auto-created
         """
 
         # get random size for pvc
@@ -219,6 +219,14 @@ class TestRbdSpaceReclaim(ManageTest):
             pool_name="test-pool-cronjob",
         )
 
+        log.info(
+            f"Annotating StorageClass {sc_obj.name} with "
+            f"reclaimspace.csiaddons.openshift.io/schedule=@{schedule}"
+        )
+        OCP(kind=constants.STORAGECLASS).annotate(
+            f"reclaimspace.csiaddons.openshift.io/schedule=@{schedule}", sc_obj.name
+        )
+
         pvc_obj = pvc_factory(
             interface=constants.CEPHBLOCKPOOL,
             project=project_obj,
@@ -231,30 +239,19 @@ class TestRbdSpaceReclaim(ManageTest):
 
         helpers.wait_for_resource_state(pvc_obj, pvc_status)
 
-        log.info("add reclaimspace.csiaddons.openshift.io/schedule label to PVC ")
-        OCP(kind=constants.PVC, namespace=self.namespace).annotate(
-            f"reclaimspace.csiaddons.openshift.io/schedule=@{schedule}", pvc_obj.name
-        )
-
         pvc_to_chron_job_dict = self.wait_for_cronjobs(True, 60)
         assert pvc_to_chron_job_dict, "Reclaim space cron job does not exist"
 
-        chron_job_name = (
-            pvc_obj.get()
-            .get("metadata")
-            .get("annotations")
-            .get("reclaimspace.csiaddons.openshift.io/cronjob")
+        expected_cronjob_name = f"{pvc_obj.name}-reclaimspace"
+        expected_schedule = f"@{schedule}"
+        assert expected_cronjob_name in pvc_to_chron_job_dict, (
+            f"Expected cronjob {expected_cronjob_name} not found. "
+            f"Found: {list(pvc_to_chron_job_dict.keys())}"
         )
-        chron_job_schedule = (
-            pvc_obj.get()
-            .get("metadata")
-            .get("annotations")
-            .get(constants.RECLAIMSPACE_SCHEDULE_ANNOTATION)
+        assert pvc_to_chron_job_dict[expected_cronjob_name] == expected_schedule, (
+            f"Cronjob schedule mismatch: expected {expected_schedule}, "
+            f"got {pvc_to_chron_job_dict[expected_cronjob_name]}"
         )
-
-        assert (
-            pvc_to_chron_job_dict[chron_job_name] == chron_job_schedule
-        ), "Reclaim space cron job does not exist, or schedule is not correct"
 
     def wait_for_cronjobs(self, cronjobs_exist, timeout=60):
         """


### PR DESCRIPTION
Fix #15300

Wit this PR we address a longstanding issue with updated behavior of the test `test_reclaim_space_cronjob_with_annotation`

  1. Created the custom EC StorageClass
  2. Annotated the SC with reclaimspace.csiaddons.openshift.io/schedule
  3. Created a PVC
  4. Verified the ReclaimSpaceCronJob was auto-created with the correct name and schedule
  
  Verified: 
[run-ci-reclaim-cronjob.log](https://github.com/user-attachments/files/28602014/run-ci-reclaim-cronjob.log)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated reclaimspace scheduling tests to reflect annotation configuration at the StorageClass level instead of PVC level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->