### PR TITLE
Add ODF 4.23 config file

### DIFF
--- a/ocs_ci/framework/conf/ocs_version/ocs-4.23.yaml
+++ b/ocs_ci/framework/conf/ocs_version/ocs-4.23.yaml
@@ -1,0 +1,15 @@
+---
+DEPLOYMENT:
+  # TODO: Change to latest-stable-4.23 once we have stable build
+  default_ocs_registry_image: "quay.io/rhceph-dev/ocs-registry:latest-4.23"
+  default_latest_tag: 'latest-4.23'
+  ocs_csv_channel: "stable-4.23"
+  default_ocp_version: '4.22'
+  konflux_build: true
+ENV_DATA:
+  ocs_version: '4.23'
+REPORTING:
+  default_ocs_must_gather_latest_tag: 'v4.23'
+  default_ocs_must_gather_image: "quay.io/rhceph-dev/odf4-odf-must-gather-rhel9"
+UPGRADE:
+  default_latest_stable_upgrade_tag: 'latest-stable-upgrade-4.23'

--- a/ocs_ci/utility/framework/initialization.py
+++ b/ocs_ci/utility/framework/initialization.py
@@ -167,6 +167,7 @@ def process_ocsci_conf(arguments):
             "4.20",
             "4.21",
             "4.22",
+            "4.23",
         ],
     )
     parser.add_argument("--ocs-registry-image")


### PR DESCRIPTION
Signed-off-by: vavuthu [vavuthu@redhat.com](mailto:vavuthu@redhat.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added full support for OCS version 4.23 with comprehensive default configuration
  * Set default OCP compatibility to version 4.22
  * Configured registry image and stable CSV channel defaults for the 4.23 release
  * Established must-gather defaults and upgrade path configuration for 4.23
  * OCS version 4.23 can now be selected and configured via CLI options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->