### PR TITLE
added test test_disable_alerts_and_verify_health_score 

### DIFF
--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -8,6 +8,7 @@ import logging
 import re
 import tempfile
 import json
+import time
 
 from jsonschema import validate
 from jsonschema.exceptions import ValidationError
@@ -3802,8 +3803,6 @@ def trigger_storage_cluster_reconciliation(storage_cluster_name=None, namespace=
         bool: True if annotation was successfully applied
 
     """
-    import time
-
     if storage_cluster_name is None:
         storage_cluster_name = config.ENV_DATA.get(
             "storage_cluster_name", constants.DEFAULT_CLUSTERNAME

--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -3785,3 +3785,54 @@ def get_storage_client():
             or constants.STORAGE_CLIENT_NAME
         ),
     )
+
+
+def trigger_storage_cluster_reconciliation(storage_cluster_name=None, namespace=None):
+    """
+    Trigger StorageCluster operator reconciliation by adding a timestamp annotation.
+    This forces the operator to reconcile the StorageCluster resource.
+
+    Args:
+        storage_cluster_name (str): Name of the StorageCluster resource.
+            If None, uses the default from config.
+        namespace (str): Namespace of the StorageCluster resource.
+            If None, uses the default from config.
+
+    Returns:
+        bool: True if annotation was successfully applied
+
+    """
+    import time
+
+    if storage_cluster_name is None:
+        storage_cluster_name = config.ENV_DATA.get(
+            "storage_cluster_name", constants.DEFAULT_CLUSTERNAME
+        )
+    if namespace is None:
+        namespace = config.ENV_DATA.get(
+            "cluster_namespace", constants.OPENSHIFT_STORAGE_NAMESPACE
+        )
+    log.info(
+        f"Triggering reconciliation for StorageCluster '{storage_cluster_name}' "
+        f"in namespace '{namespace}'"
+    )
+    sc_obj = OCP(kind=constants.STORAGECLUSTER, namespace=namespace)
+    timestamp = str(int(time.time()))
+    annotation_cmd = (
+        f"annotate storagecluster {storage_cluster_name} "
+        f"-n {namespace} "
+        f'reconcile-trigger="{timestamp}" --overwrite'
+    )
+    try:
+        sc_obj.exec_oc_cmd(annotation_cmd)
+        log.info(
+            f"Successfully triggered reconciliation for StorageCluster "
+            f"'{storage_cluster_name}' with timestamp {timestamp}"
+        )
+        return True
+    except CommandFailed as e:
+        log.error(
+            f"Failed to trigger reconciliation for StorageCluster "
+            f"'{storage_cluster_name}': {e}"
+        )
+        raise

--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -3816,7 +3816,7 @@ def trigger_storage_cluster_reconciliation(storage_cluster_name=None, namespace=
         f"in namespace '{namespace}'"
     )
     sc_obj = OCP(kind=constants.STORAGECLUSTER, namespace=namespace)
-    timestamp = str(int(time.time()))
+    timestamp = str(time.time_ns())
     annotation_cmd = (
         f"annotate storagecluster {storage_cluster_name} "
         f"-n {namespace} "

--- a/ocs_ci/ocs/ui/page_objects/infra_health.py
+++ b/ocs_ci/ocs/ui/page_objects/infra_health.py
@@ -328,6 +328,51 @@ class InfraHealthOverview(PageNavigator):
         self.take_screenshot("unsilence_alerts_page")
         self.do_click(self.validation_loc["unsilence_alerts"])
 
+    def silence_alerts_indefinitely(self):
+        """
+        This method is necessary to disable alerts.
+        """
+        radio_button = self.find_an_element_by_xpath(
+            self.validation_loc["silence_type_indefinite_radio"][0]
+        )
+        if not radio_button.is_selected():
+            self.do_click(
+                self.validation_loc["silence_type_indefinite_radio"],
+                enable_screenshot=True,
+            )
+            logger.info("Selected 'Indefinite' silence type")
+        else:
+            logger.info("'Indefinite' silence type already selected")
+        logger.info("Clicking silence button")
+        self.take_screenshot("silence_alerts_indefinitely_page")
+        self.do_click(self.validation_loc["silence_popup_button"])
+
+    def disable_alert_by_name(self, alert_check_name):
+        """
+        Disable a single alert by silencing it indefinitely.
+
+        Args:
+            alert_check_name (str): Name of the alert check to disable
+        """
+        logger.info(f"Disabling alert: {alert_check_name}")
+        alerts = self.filter_by_name_or_details(alert_check_name)
+        count = 0
+        for alert in alerts:
+            if alert.check == alert_check_name and alert.end_time is None:
+                self.do_click(
+                    format_locator(self.validation_loc["select_alert"], str(count))
+                )
+            count += 1
+        time.sleep(2)
+        self.take_screenshot(f"selected_alert_{alert_check_name}")
+        logger.info("Clicking 'Silence' button")
+        self.do_click(self.validation_loc["silence_alerts"], enable_screenshot=True)
+        self.wait_for_element_to_be_visible(
+            self.validation_loc["silence_popup"], timeout=10
+        )
+        logger.info("Selecting 'Indefinitely' silence type to disable alert")
+        self.silence_alerts_indefinitely()
+
     def unsilence_all_alerts(self):
         """
         Unsilence all alerts
@@ -352,6 +397,29 @@ class InfraHealthOverview(PageNavigator):
         self.do_send_keys(self.validation_loc["filter_by_details"], alert_name)
         self.select_all_alerts()
         self.take_screenshot(f"unsilence_alert_{alert_name}")
+        self.unsilence_alerts()
+
+    def unsilence_alert_by_type_indefinite(self):
+        """
+        Unsilence alerts filtered by 'Indefinite' silence type.
+        """
+        logger.info("Unsilencing alerts filtered by silence type 'Indefinite'")
+        self.click_silenced_alerts()
+        self.do_click(self.validation_loc["all_checks"])
+        time.sleep(1)
+        indefinite_checkbox = self.validation_loc["filter_indefinite_checkbox"]
+        checkbox_element = self.find_an_element_by_xpath(indefinite_checkbox[0])
+        is_checked = checkbox_element.is_selected()
+        if not is_checked:
+            logger.info("Indefinite checkbox not checked, clicking it")
+            self.do_click(indefinite_checkbox)
+        else:
+            logger.info("Indefinite checkbox already checked")
+        self.do_click(self.validation_loc["all_checks"])
+        time.sleep(1)
+        logger.info("Selecting all indefinitely silenced alerts")
+        self.select_all_alerts()
+        self.take_screenshot(f"all_alert_{indefinite_checkbox}")
         self.unsilence_alerts()
 
     def silence_all_alerts(self, silent_duration: int):

--- a/ocs_ci/ocs/ui/page_objects/infra_health.py
+++ b/ocs_ci/ocs/ui/page_objects/infra_health.py
@@ -404,7 +404,9 @@ class InfraHealthOverview(PageNavigator):
         logger.info("Unsilencing alerts filtered by silence type 'Indefinite'")
         self.click_silenced_alerts()
         self.do_click(self.validation_loc["all_checks"])
-        time.sleep(1)
+        self.wait_for_element_to_be_visible(
+            self.validation_loc["checks_list"], timeout=10
+        )
         indefinite_checkbox = self.validation_loc["filter_indefinite_checkbox"]
         checkbox_element = self.find_an_element_by_xpath(indefinite_checkbox[0])
         is_checked = checkbox_element.is_selected()
@@ -414,7 +416,6 @@ class InfraHealthOverview(PageNavigator):
         else:
             logger.info("Indefinite checkbox already checked")
         self.do_click(self.validation_loc["all_checks"])
-        time.sleep(1)
         logger.info("Selecting all indefinitely silenced alerts")
         self.select_all_alerts()
         self.take_screenshot(f"all_alert_{indefinite_checkbox}")

--- a/ocs_ci/ocs/ui/page_objects/infra_health.py
+++ b/ocs_ci/ocs/ui/page_objects/infra_health.py
@@ -418,7 +418,7 @@ class InfraHealthOverview(PageNavigator):
         self.do_click(self.validation_loc["all_checks"])
         logger.info("Selecting all indefinitely silenced alerts")
         self.select_all_alerts()
-        self.take_screenshot(f"all_alert_{indefinite_checkbox}")
+        self.take_screenshot("all_alerts_indefinite_filter")
         self.unsilence_alerts()
 
     def silence_all_alerts(self, silent_duration: int):

--- a/ocs_ci/ocs/ui/page_objects/infra_health.py
+++ b/ocs_ci/ocs/ui/page_objects/infra_health.py
@@ -356,13 +356,11 @@ class InfraHealthOverview(PageNavigator):
         """
         logger.info(f"Disabling alert: {alert_check_name}")
         alerts = self.filter_by_name_or_details(alert_check_name)
-        count = 0
-        for alert in alerts:
+        for count, alert in enumerate(alerts):
             if alert.check == alert_check_name and alert.end_time is None:
                 self.do_click(
                     format_locator(self.validation_loc["select_alert"], str(count))
                 )
-            count += 1
         time.sleep(2)
         self.take_screenshot(f"selected_alert_{alert_check_name}")
         logger.info("Clicking 'Silence' button")

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -2486,6 +2486,10 @@ validation_4_21 = {
         "//button[.//span[normalize-space()='All checks']]",
         By.XPATH,
     ),
+    "checks_list": (
+        "//div[contains(@class,'c-menu__content')]",
+        By.XPATH,
+    ),
     "select_alert": (
         "//input[@name='checkrow{}']",
         By.XPATH,

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -2483,7 +2483,7 @@ validation_4_21 = {
         By.XPATH,
     ),
     "all_checks": (
-        "//span[normalize-space()='All checks']",
+        "//button[.//span[normalize-space()='All checks']]",
         By.XPATH,
     ),
     "select_alert": (

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -2482,6 +2482,10 @@ validation_4_21 = {
         " and normalize-space()='Indefinite']/ancestor::label//input[@type='checkbox']",
         By.XPATH,
     ),
+    "all_checks": (
+        "//span[normalize-space()='All checks']",
+        By.XPATH,
+    ),
     "select_alert": (
         "//input[@name='checkrow{}']",
         By.XPATH,

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -2473,6 +2473,19 @@ validation_4_21 = {
         "//span[contains(text(),'Silence alert')]",
         By.XPATH,
     ),
+    "silence_type_indefinite_radio": (
+        "//input[@id='silence-type-indefinite']",
+        By.XPATH,
+    ),
+    "filter_indefinite_checkbox": (
+        "//span[contains(@class,'c-menu__item-text')"
+        " and normalize-space()='Indefinite']/ancestor::label//input[@type='checkbox']",
+        By.XPATH,
+    ),
+    "select_alert": (
+        "//input[@name='checkrow{}']",
+        By.XPATH,
+    ),
     "duration_input": (
         "//input[@name='duration']",
         By.XPATH,

--- a/tests/functional/ui/test_health_overview.py
+++ b/tests/functional/ui/test_health_overview.py
@@ -19,6 +19,10 @@ from ocs_ci.framework.pytest_customization.marks import (
     tier2,
     tier1,
 )
+from ocs_ci.ocs.resources.storage_cluster import (
+    get_default_storagecluster,
+    trigger_storage_cluster_reconciliation,
+)
 from ocs_ci.ocs import constants
 from ocs_ci.helpers.helpers import create_resource
 from ocs_ci.framework.testlib import ManageTest
@@ -156,6 +160,9 @@ class TestHealthOverview(ManageTest):
         yield  # Test runs here
 
         # Teardown phase (after test completes)
+        if not getattr(self, "alerts_silenced", True):
+            logger.info("Teardown: Alerts already unsilenced, skipping cleanup")
+            return
         logger.info("Teardown: Un-silencing all alerts")
         try:
             df_overview = PageNavigator().nav_storage_data_foundation_overview_page()
@@ -369,6 +376,100 @@ class TestHealthOverview(ManageTest):
                     logger.warning(f"Failed to scale mon during cleanup: {ex}")
 
         request.addfinalizer(finalizer)
+
+    def mock_alerts(
+        self, alert_name, alert_yaml, threading_lock, timeout=120, sleep=60
+    ):
+        """
+        Apply a custom alert rule and wait for the alert to reach firing state.
+
+        Args:
+            alert_name (str): Name of the alert to mock (e.g., constants.ALERT_ODF_NODE_LATENCY_HIGH_OSD_NODES)
+            alert_yaml (str): Filename of the alert rule YAML (e.g., "custom-odf-latency-rule.yaml")
+            threading_lock: Threading lock for PrometheusAPI
+            timeout (int): Maximum time to wait for alert to fire (default: 120 seconds)
+            sleep (int): Sleep interval between checks (default: 60 seconds)
+
+        Returns:
+            list: List of fired alerts
+
+        """
+        logger.info(f"Mocking alert: {alert_name} using rule file: {alert_yaml}")
+        alert_yaml_path = os.path.join(constants.HEALTHALERTS_DIR, alert_yaml)
+        logger.info(f"Loading alert rule from: {alert_yaml_path}")
+        alert_yaml_load = load_yaml(alert_yaml_path)
+        self.rule = create_resource(**alert_yaml_load)
+        logger.info(f"Alert rule created successfully: {self.rule.name}")
+        logger.info(f"Waiting {timeout} seconds for alert to trigger...")
+        time.sleep(timeout)
+        api = PrometheusAPI(threading_lock=threading_lock)
+        api.refresh_connection()
+        logger.info(f"Checking if alert '{alert_name}' is in firing state...")
+        alerts = api.wait_for_alert(
+            name=alert_name, state="firing", timeout=timeout, sleep=sleep
+        )
+        if alerts:
+            logger.info(
+                f"Alert '{alert_name}' successfully reached firing state. Found {len(alerts)} alert(s)"
+            )
+        else:
+            logger.warning(f"No alerts found in firing state for '{alert_name}'")
+        return alerts
+
+    def verify_alert_in_excluded_alerts(self, alert_name):
+        """
+        Verify that the alert name is present in storagecluster spec.monitoring.excludedAlerts
+
+        Args:
+            alert_name (str): Name of the alert to verify
+
+        Returns:
+            bool: True if alert is in excludedAlerts, False otherwise
+        """
+        logger.info(f"Verifying alert '{alert_name}' in storagecluster excludedAlerts")
+        sc_obj = get_default_storagecluster()
+        sc_data = sc_obj.get()
+        excluded_alerts = (
+            sc_data.get("spec", {}).get("monitoring", {}).get("excludedAlerts", [])
+        )
+        alert_names = [
+            a.get("alertName") for a in excluded_alerts if isinstance(a, dict)
+        ]
+        return alert_name in alert_names
+
+    def verify_health_score_after_alert_change(self, alert, idx, score_before):
+        """
+        Helper method to verify health score changes after alert is disabled.
+
+        Args:
+            alert: Alert object that was disabled
+            idx: Current alert index (1-based)
+            score_before: Health score before disabling the alert
+
+        Returns:
+            int: Health score from UI after the alert change
+        """
+        logger.info("Verifying health score after alert change")
+        severity = SEVERITY_BY_CHECK.get(alert)
+        expected_drop = SEVERITY_DROP_MAP.get(severity, 2)
+        logger.info(
+            f"Alert '{alert}' has severity={severity}, "
+            f"expected health score recovery by {expected_drop}%"
+        )
+        PageNavigator().nav_storage_data_foundation_overview_page()
+        logger.info("Waiting for health score to update...")
+        expected_score = expected_drop + score_before
+        self.wait_for_health_score_recovery(expected_score)
+        score_after_ui = self.get_health_score_ui()
+        assert (
+            score_after_ui == expected_score
+        ), f"Score {score_after_ui}% didn't reach expected {expected_score}%"
+        PageNavigator().take_screenshot(f"health_score_after_disable_{idx}")
+        logger.info(
+            f"Alert {idx} disabled successfully. "
+            f"Score change: {score_before}% -> {score_after_ui}% "
+        )
+        return score_after_ui
 
     @tier1
     @polarion_id("OCS-7475")
@@ -658,3 +759,128 @@ class TestHealthOverview(ManageTest):
         assert (
             baseline_score == health_score_after_scale_up
         ), f"Baseline: {baseline_score}%, Current: {health_score_after_scale_up}%"
+
+    @tier2
+    @polarion_id("OCS-7993")
+    @skipif_ocs_version("<4.22")
+    def test_disable_alerts_and_verify_health_score(
+        self,
+        setup_ui_class,
+        threading_lock,
+        alert_rule_teardown,
+        unsilence_alerts_teardown,
+    ):
+        """
+        Test to disable (silence indefinitely)  alerts one by one and verify health score updates.
+
+        Test Steps:
+        1. Navigate to view infra score page from ODF Health Overview page
+        2. Verify alert is shown in "Active Alerts" section
+        3. Select any one of active alert and click on silence
+        4. Confirm disable action (select indefinitely)
+        5. Check that the healthscore in UI is updated and same is reflected in ocs_health_score metric
+        6. Repeat the above steps for disabling all alerts
+        7. Triggering StorageCluster reconciliation
+        8. Verifying excluded alerts are maintained after reconciliation
+        9. Unsilencing all alerts with indefinite filter
+        10. Score is reflected based on active alerts
+        """
+        page_nav = PageNavigator()
+        df_overview = page_nav.nav_storage_data_foundation_overview_page()
+        baseline_score = self.get_health_score_ui()
+        logger.info(f"Baseline health score from overview: {baseline_score}")
+        page_nav.take_screenshot("initial_health_overview")
+        infra_health_overview = df_overview.nav_health_view_checks()
+        logger.info("Verifying alerts in Active Alerts section")
+        infra_health_overview.click_last_24_hours_alerts()
+        all_alerts = infra_health_overview.get_all_checks()
+        unique_alert_types = list(
+            set(alert.check for alert in all_alerts if alert.end_time is None)
+        )
+        logger.info(
+            f"Found {len(unique_alert_types)} unique active alert types in Active Alerts section"
+        )
+        logger.info(f"Active alert types: {unique_alert_types}")
+
+        if not unique_alert_types:
+            logger.warning("No alerts found in Active Alerts section")
+            logger.info("Test will verify the disable functionality with mock scenario")
+            self.mock_alerts(
+                constants.ALERT_ODF_NODE_LATENCY_HIGH_OSD_NODES,
+                "custom-odf-latency-rule.yaml",
+                threading_lock,
+            )
+            unique_alert_types = [constants.ALERT_ODF_NODE_LATENCY_HIGH_OSD_NODES]
+            logger.info(f"Using mocked alert: {unique_alert_types}")
+
+        alerts_to_disable = []
+        self.update_alert_map(threading_lock)
+        for alert in unique_alert_types:
+            if ALERT_MAP[alert] > 0:
+                alerts_to_disable.append(alert)
+        if not alerts_to_disable:
+            pytest.skip("No active alerts available to test disable functionality")
+
+        current_score = baseline_score
+        for idx, alert in enumerate(alerts_to_disable, 1):
+            logger.info(f"Processing alert {idx}/{len(alerts_to_disable)}: {alert}")
+            if idx > 1:
+                infra_health_overview = (
+                    page_nav.nav_storage_data_foundation_overview_page().nav_health_view_checks()
+                )
+                infra_health_overview.click_last_24_hours_alerts()
+
+            infra_health_overview.disable_alert_by_name(alert)
+            current_score = self.verify_health_score_after_alert_change(
+                alert, idx, current_score
+            )
+
+            logger.info("Verifying alert in storagecluster excludedAlerts")
+            assert self.verify_alert_in_excluded_alerts(
+                alert
+            ), f"Alert '{alert}' not found in storagecluster spec.monitoring.excludedAlerts"
+        logger.info("All selected alerts have been disabled")
+
+        page_nav.take_screenshot("final_health_overview_all_disabled")
+
+        assert (
+            current_score == 100
+        ), f"Final health score after disabling all alerts: {current_score}%"
+
+        logger.info("Triggering StorageCluster reconciliation")
+        trigger_storage_cluster_reconciliation()
+        time.sleep(2)
+
+        logger.info("Verifying excluded alerts are maintained after reconciliation")
+        for alert in alerts_to_disable:
+            assert self.verify_alert_in_excluded_alerts(alert), (
+                f"Alert '{alert}' was removed from excludedAlerts after reconciliation! "
+                "This indicates the reconciliation did not preserve the excluded alerts."
+            )
+        logger.info(
+            f"SUCCESS: All {len(alerts_to_disable)} disabled alerts are still present "
+            "in excludedAlerts after StorageCluster reconciliation"
+        )
+        logger.info("Unsilencing all alerts with indefinite filter")
+        df_overview = page_nav.nav_storage_data_foundation_overview_page()
+        infra_health_overview = df_overview.nav_health_view_checks()
+        page_nav.take_screenshot("before_unsilence_indefinite")
+        infra_health_overview.unsilence_alert_by_type_indefinite()
+        self.alerts_silenced = False
+        logger.info("Successfully unsilenced all indefinitely silenced alerts")
+        logger.info("Waiting for alerts to trigger")
+        time.sleep(30)
+        logger.info("Verifying health score reflects active alerts after unsilencing")
+        self.update_alert_map(threading_lock)
+        expected_score_drop = 0
+        for alert in ALERT_MAP.keys():
+            if ALERT_MAP[alert] > 0:
+                severity = SEVERITY_BY_CHECK.get(alert)
+                expected_score_drop += SEVERITY_DROP_MAP.get(severity, 0)
+        expected_score = 100 - expected_score_drop
+        logger.info(
+            f"Expected health score based on active alerts: {expected_score}% "
+            f"(drop of {expected_score_drop}%)"
+        )
+        self.wait_for_health_score_recovery(expected_score)
+        logger.info("SUCCESS: Health score correctly reflects active alerts.")

--- a/tests/functional/ui/test_health_overview.py
+++ b/tests/functional/ui/test_health_overview.py
@@ -854,7 +854,11 @@ class TestHealthOverview(ManageTest):
 
         logger.info("Triggering StorageCluster reconciliation")
         trigger_storage_cluster_reconciliation()
-        time.sleep(2)
+        sc_obj = get_default_storagecluster()
+        for sample in TimeoutSampler(120, 10, sc_obj.get):
+            if sample.get("status", {}).get("phase") == "Ready":
+                logger.info("StorageCluster reconciliation complete")
+                break
 
         logger.info("Verifying excluded alerts are maintained after reconciliation")
         for alert in alerts_to_disable:
@@ -883,9 +887,10 @@ class TestHealthOverview(ManageTest):
                 severity = SEVERITY_BY_CHECK.get(alert)
                 expected_score_drop += SEVERITY_DROP_MAP.get(severity, 0)
         expected_score = 100 - expected_score_drop
-        logger.info(
-            f"Expected health score based on active alerts: {expected_score}% "
-            f"(drop of {expected_score_drop}%)"
+        self.wait_for_health_score_change(
+            expected_delta=expected_score_drop, baseline=100
         )
-        self.wait_for_health_score_recovery(expected_score)
+        assert (
+            current_score == expected_score
+        ), f"Expected health score {expected_score}%, got {current_score}%"
         logger.info("SUCCESS: Health score correctly reflects active alerts.")

--- a/tests/functional/ui/test_health_overview.py
+++ b/tests/functional/ui/test_health_overview.py
@@ -392,7 +392,6 @@ class TestHealthOverview(ManageTest):
 
         Returns:
             list: List of fired alerts
-
         """
         logger.info(f"Mocking alert: {alert_name} using rule file: {alert_yaml}")
         alert_yaml_path = os.path.join(constants.HEALTHALERTS_DIR, alert_yaml)
@@ -791,11 +790,12 @@ class TestHealthOverview(ManageTest):
         logger.info(f"Baseline health score from overview: {baseline_score}")
         page_nav.take_screenshot("initial_health_overview")
         infra_health_overview = df_overview.nav_health_view_checks()
+        mock_alerts = False
         logger.info("Verifying alerts in Active Alerts section")
         infra_health_overview.click_last_24_hours_alerts()
         all_alerts = infra_health_overview.get_all_checks()
         unique_alert_types = list(
-            set(alert.check for alert in all_alerts if alert.end_time is None)
+            {alert.check for alert in all_alerts if alert.end_time is None}
         )
         logger.info(
             f"Found {len(unique_alert_types)} unique active alert types in Active Alerts section"
@@ -805,6 +805,7 @@ class TestHealthOverview(ManageTest):
         if not unique_alert_types:
             logger.warning("No alerts found in Active Alerts section")
             logger.info("Test will verify the disable functionality with mock scenario")
+            mock_alerts = True
             self.mock_alerts(
                 constants.ALERT_ODF_NODE_LATENCY_HIGH_OSD_NODES,
                 "custom-odf-latency-rule.yaml",
@@ -812,6 +813,11 @@ class TestHealthOverview(ManageTest):
             )
             unique_alert_types = [constants.ALERT_ODF_NODE_LATENCY_HIGH_OSD_NODES]
             logger.info(f"Using mocked alert: {unique_alert_types}")
+            self.wait_for_health_score_change(
+                expected_delta=10, baseline=baseline_score
+            )
+            baseline_score = self.get_health_score_ui()
+            logger.info(f"Updated baseline after mock alert: {baseline_score}%")
 
         alerts_to_disable = []
         self.update_alert_map(threading_lock)
@@ -824,7 +830,7 @@ class TestHealthOverview(ManageTest):
         current_score = baseline_score
         for idx, alert in enumerate(alerts_to_disable, 1):
             logger.info(f"Processing alert {idx}/{len(alerts_to_disable)}: {alert}")
-            if idx > 1:
+            if idx > 1 or mock_alerts:
                 infra_health_overview = (
                     page_nav.nav_storage_data_foundation_overview_page().nav_health_view_checks()
                 )
@@ -840,7 +846,6 @@ class TestHealthOverview(ManageTest):
                 alert
             ), f"Alert '{alert}' not found in storagecluster spec.monitoring.excludedAlerts"
         logger.info("All selected alerts have been disabled")
-
         page_nav.take_screenshot("final_health_overview_all_disabled")
 
         assert (


### PR DESCRIPTION
As part of HealthOverview part 2([RHSTOR-8145](https://redhat.atlassian.net/browse/RHSTOR-8145)) , added a new test case to silence alerts indefinitely which includes :
1. Disabling alerts (silence alerts indefinitely) and checking health score recovery
2. Verify spec.monitoring.excludedAlerts contains disabled alert list
3. Unsilence alerts indefinitely and check health score is decreased according to active alerts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Indefinite alert silencing and unsilencing via the UI, including bulk selection and filter controls.
  * Disable and persistently exclude specific alerts from monitoring; storage-cluster reconciliation can be triggered to validate persistence.
  * UI captures screenshots during key alert workflows for diagnostics.

* **Tests**
  * New UI functional tests and helpers covering alert disabling, excluded-alert persistence, triggering reconciliation, and health-score verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->