### PR TITLE
is_ec_pool_supported - safety check to prevent err on client cl

### DIFF
--- a/ocs_ci/ocs/cluster.py
+++ b/ocs_ci/ocs/cluster.py
@@ -2407,14 +2407,22 @@ def is_ec_pool_supported():
     from ocs_ci.helpers.helpers import get_failure_domin
     from ocs_ci.ocs.resources import pod
 
+    cluster_type = config.ENV_DATA.get("cluster_type", "").lower()
+    if cluster_type == "provider":
+        return False
+
     platform = config.ENV_DATA["platform"].lower()
     if platform not in constants.ON_PREM_PLATFORMS:
         return False
     if not is_lso_cluster():
         return False
-    if get_failure_domin() != "host":
-        return False
-    if len(pod.get_osd_pods()) < 3:
+    try:
+        if get_failure_domin() != "host":
+            return False
+        if len(pod.get_osd_pods()) < 3:
+            return False
+    except Exception:
+        logger.debug("is_ec_pool_supported: cluster not ready, returning False")
         return False
     return True
 


### PR DESCRIPTION
Fix the problem on multi-cluster builds, when checking the StorageCluster specs on clients or not deployed yet clusters
```
2026-06-08 14:55:23  07:55:23 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig patch storagecluster ocs-storagecluster -n openshift-storage --type json --patch '[{ "op": "replace", "path": "/spec/enableCephTools", "value": true }]'
2026-06-08 14:55:24  07:55:23 - MainThread - ocs_ci.utility.utils - WARNING  - Command stderr: error: the server doesn't have a resource type "storagecluster"
2026-06-08 14:55:24  
2026-06-08 14:55:24  
2026-06-08 14:55:24  _ tests/functional/pv/pv_services/test_verify_new_cbp_creation_not_blocked_by_invalid_cbp.py _
2026-06-08 14:55:24  tests/functional/pv/pv_services/test_verify_new_cbp_creation_not_blocked_by_invalid_cbp.py:32: in <module>
2026-06-08 14:55:24      not is_ec_pool_supported(),
2026-06-08 14:55:24  ocs_ci/ocs/cluster.py:2415: in is_ec_pool_supported
2026-06-08 14:55:24      if get_failure_domin() != "host":
2026-06-08 14:55:24  ocs_ci/helpers/helpers.py:2946: in get_failure_domin
2026-06-08 14:55:24      ct_pod = pod.get_ceph_tools_pod()
2026-06-08 14:55:24  ocs_ci/ocs/resources/pod.py:896: in get_ceph_tools_pod
2026-06-08 14:55:24      setup_ceph_toolbox()
2026-06-08 14:55:24  ocs_ci/ocs/utils.py:892: in setup_ceph_toolbox
2026-06-08 14:55:24      run_cmd(cmd)
2026-06-08 14:55:24  ocs_ci/utility/utils.py:630: in run_cmd
2026-06-08 14:55:24      completed_process = exec_cmd(
2026-06-08 14:55:24  ocs_ci/utility/retry.py:79: in f_retry
2026-06-08 14:55:24      return f(*args, **kwargs)
2026-06-08 14:55:24  ocs_ci/utility/utils.py:880: in exec_cmd
2026-06-08 14:55:24      raise CommandFailed(
2026-06-08 14:55:24  E   ocs_ci.ocs.exceptions.CommandFailed: Error during execution of command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig patch storagecluster ocs-storagecluster -n openshift-storage --type json --patch '[{ "op": "replace", "path": "/spec/enableCephTools", "value": true }]'.
2026-06-08 14:55:24  E   Error is error: the server doesn't have a resource type "storagecluster"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during Erasure Code pool support validation across various cluster configurations.
  * Enhanced robustness of pool readiness and failure domain checks to gracefully handle transient cluster states.
  * Added cluster type-specific validation for improved support detection, including specific handling for provider clusters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->