### PR TITLE
Fix test_verify_backingstore_uses_rgw failing on client clusters

### DIFF
--- a/tests/functional/object/mcg/test_provider_client.py
+++ b/tests/functional/object/mcg/test_provider_client.py
@@ -8,6 +8,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     run_on_all_clients_push_missing_configs,
     runs_on_provider,
     mcg,
+    pc_or_ms_provider_required,
     provider_client_ms_platform_required,
 )
 from ocs_ci.ocs import constants
@@ -32,7 +33,7 @@ def return_to_original_context():
 @mcg
 @red_squad
 @runs_on_provider
-@provider_client_ms_platform_required
+@pc_or_ms_provider_required
 @tier1
 @polarion_id("OCS-5415")
 def test_verify_backingstore_uses_rgw(mcg_obj_session):


### PR DESCRIPTION
Description:

  The test was using `provider_client_ms_platform_required` which only checks the platform type (HCI/MS) but not the cluster type (provider vs client).
  This caused the test to run on client clusters where CephObjectStore does not exist, resulting in a NotFound error and very low pass rate.

  Replaced with `pc_or_ms_provider_required` which checks both platform type AND cluster type, so the test is properly skipped on client clusters. 

  Fixes https://github.com/red-hat-storage/ocs-ci/issues/12679

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test configuration to use a revised marker for platform provider requirements, improving test categorization and execution across different provider types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->