### PR TITLE
Allow Block only deployment

### DIFF
--- a/conf/README.md
+++ b/conf/README.md
@@ -567,6 +567,7 @@ Configurations specific to disable/enable OCS components
 * `disable_noobaa` - Disable noobaa component deployment (Default: False)
 * `disable_cephfs` - Disable cephfs component deployment (Default: False)
 * `disable_blockpools` - Disable blockpools (rbd) component deployment (Default: False)
+* `disable_cephobjectstoreusers` - Disable cephObjectStoreUsers, this should be disabled together with RGW! (Default: False)
 
 ## Example of accessing config/default data
 

--- a/ocs_ci/ocs/cluster.py
+++ b/ocs_ci/ocs/cluster.py
@@ -1428,11 +1428,17 @@ def validate_pdb_creation():
             pdb_count = constants.PDB_COUNT_ARBITER_VSPHERE
             pdb_required.append(constants.RGW_PDB)
 
-    if odf_running_version >= version.VERSION_4_19:
+    if odf_running_version >= version.VERSION_4_19 and not config.COMPONENTS.get(
+        "disable_noobaa", False
+    ):
         pdb_count += 1
         pdb_required.append(constants.NOOBAA_DB_PG_PDB)
     else:
         logger.info(f"Required PDB count is {pdb_count}")
+
+    if config.COMPONENTS.get("disable_cephfs", False):
+        pdb_required.remove(constants.MDS_PDB)
+        pdb_count -= 1
 
     if len(item_list) != pdb_count:
         raise PDBNotCreatedException(

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -3199,6 +3199,7 @@ OCS_COMPONENTS_MAP = {
     "noobaa": "multiCloudGateway",
     "blockpools": "cephBlockPools",
     "cephnonresilentpools": "cephNonResilientPools",
+    "cephobjectstoreusers": "cephObjectStoreUsers",
 }
 
 DEFAULT_PAXOS_SERVICE_TRIM_MIN = 250

--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -555,9 +555,11 @@ def ocs_install_verification(
                 or disable_rgw
             ):
                 continue
-        if "noobaa" in label and (disable_noobaa or managed_service or client_cluster):
+        if ("noobaa" in label or label is constants.NOOBAA_CNPG_POD_LABEL) and (
+            disable_noobaa or managed_service or client_cluster
+        ):
             continue
-        if "mds" in label and disable_cephfs:
+        if ("mds" in label or "cephfs" in label) and disable_cephfs:
             continue
         if label == constants.MANAGED_CONTROLLER_LABEL:
             if fusion_aas_provider:
@@ -671,7 +673,12 @@ def ocs_install_verification(
                 f"{namespace}.rbd.csi.ceph.com",
             }.issubset(csi_drivers)
         else:
-            assert defaults.CSI_PROVISIONERS.issubset(csi_drivers)
+            csi_provisioners = set(defaults.CSI_PROVISIONERS)
+            if disable_cephfs:
+                csi_provisioners.discard(defaults.CEPHFS_PROVISIONER)
+            if disable_blockpools:
+                csi_provisioners.discard(defaults.RBD_PROVISIONER)
+            assert csi_provisioners.issubset(csi_drivers)
 
     # Verify node and provisioner secret names in storage class
     log.info("Verifying node and provisioner secret names in storage class.")
@@ -1074,24 +1081,36 @@ def ocs_install_verification(
         else constants.ROOK_CEPH_OPERATOR
     )
     if odf_running_version >= version.VERSION_4_19 or hci_cluster:
-        provisioner_deployment_and_owner_names = {
-            f"{constants.CEPHFS_PROVISIONER}-ctrlplugin": constants.CEPHFS_PROVISIONER,
-            f"{constants.RBD_PROVISIONER}-ctrlplugin": constants.RBD_PROVISIONER,
-        }
-        nodeplugin_daemonset_and_owner_names = {
-            f"{constants.CEPHFS_PROVISIONER}-nodeplugin": constants.CEPHFS_PROVISIONER,
-            f"{constants.RBD_PROVISIONER}-nodeplugin": constants.RBD_PROVISIONER,
-        }
+        provisioner_deployment_and_owner_names = {}
+        nodeplugin_daemonset_and_owner_names = {}
+        if not disable_cephfs:
+            provisioner_deployment_and_owner_names[
+                f"{constants.CEPHFS_PROVISIONER}-ctrlplugin"
+            ] = constants.CEPHFS_PROVISIONER
+            nodeplugin_daemonset_and_owner_names[
+                f"{constants.CEPHFS_PROVISIONER}-nodeplugin"
+            ] = constants.CEPHFS_PROVISIONER
+        if not disable_blockpools:
+            provisioner_deployment_and_owner_names[
+                f"{constants.RBD_PROVISIONER}-ctrlplugin"
+            ] = constants.RBD_PROVISIONER
+            nodeplugin_daemonset_and_owner_names[
+                f"{constants.RBD_PROVISIONER}-nodeplugin"
+            ] = constants.RBD_PROVISIONER
         csi_owner_kind = constants.DRIVER
     else:
-        provisioner_deployment_and_owner_names = {
-            "csi-cephfsplugin-provisioner": csi_owner_name,
-            "csi-rbdplugin-provisioner": csi_owner_name,
-        }
-        nodeplugin_daemonset_and_owner_names = {
-            "csi-cephfsplugin": csi_owner_name,
-            "csi-rbdplugin": csi_owner_name,
-        }
+        provisioner_deployment_and_owner_names = {}
+        nodeplugin_daemonset_and_owner_names = {}
+        if not disable_cephfs:
+            provisioner_deployment_and_owner_names["csi-cephfsplugin-provisioner"] = (
+                csi_owner_name
+            )
+            nodeplugin_daemonset_and_owner_names["csi-cephfsplugin"] = csi_owner_name
+        if not disable_blockpools:
+            provisioner_deployment_and_owner_names["csi-rbdplugin-provisioner"] = (
+                csi_owner_name
+            )
+            nodeplugin_daemonset_and_owner_names["csi-rbdplugin"] = csi_owner_name
         csi_owner_kind = constants.CONFIGMAP if hci_cluster else constants.DEPLOYMENT
 
     deployment_kind = OCP(kind=constants.DEPLOYMENT, namespace=namespace)
@@ -1142,7 +1161,11 @@ def ocs_install_verification(
         ), "Host network is not set to False for cephObjectStores when spec.hostNetwork is True"
     log.info("Verified the providerAPIServerServiceType setting in StorageCluster")
     log.info("Verifying the csi driver ownership")
-    csi_driver_list = [constants.RBD_PROVISIONER, constants.CEPHFS_PROVISIONER]
+    csi_driver_list = []
+    if not disable_blockpools:
+        csi_driver_list.append(constants.RBD_PROVISIONER)
+    if not disable_cephfs:
+        csi_driver_list.append(constants.CEPHFS_PROVISIONER)
     if odf_running_version >= version.VERSION_4_19 or hci_cluster:
         csi_driver_obj = OCP(kind=constants.DRIVER, namespace=namespace)
         for driver in csi_driver_list:

--- a/ocs_ci/ocs/resources/storageconsumer.py
+++ b/ocs_ci/ocs/resources/storageconsumer.py
@@ -892,6 +892,26 @@ def verify_consumer_configmap(
         )
 
         _handle_converged_client_ceph_names(ceph_data, ceph_data_on_consumer_match)
+    elif internal_consumer and disable_cephfs and not disable_blockpools:
+        """
+        Handle internal consumer with CephFS disabled.
+        Only verify RBD-related configuration.
+        """
+        # Only check RBD configuration
+        ceph_data_on_consumer_match["rbd-rados-ns"] = (
+            ceph_data.get("rbd-rados-ns", "") == "<implicit>"
+        )
+        ceph_data_on_consumer_match["csi-rbd-node-ceph-user"] = (
+            ceph_data.get("csi-rbd-node-ceph-user", "") == "rook-csi-rbd-node"
+        )
+        ceph_data_on_consumer_match["csi-rbd-provisioner-ceph-user"] = (
+            ceph_data.get("csi-rbd-provisioner-ceph-user", "")
+            == "rook-csi-rbd-provisioner"
+        )
+        ceph_data_on_consumer_match["csiop-rbd-client-profile"] = (
+            ceph_data.get("csiop-rbd-client-profile", "")
+            == config.cluster_ctx.ENV_DATA["cluster_namespace"]
+        )
     elif (
         not internal_consumer
         and not (disable_blockpools or disable_cephfs)

--- a/ocs_ci/ocs/resources/storageconsumer.py
+++ b/ocs_ci/ocs/resources/storageconsumer.py
@@ -635,8 +635,20 @@ def verify_storage_consumer_resources(
         storage_class_names_on_cluster = [
             item["metadata"]["name"] for item in storage_classes_ocp["items"]
         ]
+
+        disable_cephfs = config.COMPONENTS["disable_cephfs"]
+
         for storage_class in storage_classes_on_consumer:
             if storage_class not in storage_class_names_on_cluster:
+                # Workaround for DFBUGS-7417: StorageConsumer lists CephFS StorageClass even when disabled
+                # Skip CephFS StorageClass verification if CephFS is disabled (DFBUGS-7417)
+                if disable_cephfs and "cephfs" in storage_class:
+                    log.warning(
+                        f"Skipping verification of StorageClass {storage_class} "
+                        f"(CephFS is disabled, workaround for DFBUGS-7417)"
+                    )
+                    continue
+
                 raise AssertionError(
                     f"StorageClass {storage_class} is not available on the cluster "
                     f"but listed in storage consumer {consumer_name}."
@@ -673,6 +685,15 @@ def verify_storage_consumer_resources(
         ]
         for volume_snapshot_class in volume_snapshot_classes_on_consumer or []:
             if volume_snapshot_class not in volume_snapshot_class_names_on_cluster:
+                # Workaround for DFBUGS-7417: StorageConsumer lists CephFS even when disabled
+                # Skip CephFS VolumeSnapshotClass verification if CephFS is disabled (DFBUGS-7417)
+                if disable_cephfs and "cephfs" in volume_snapshot_class:
+                    log.warning(
+                        f"Skipping verification of VolumeSnapshotClass {volume_snapshot_class} "
+                        f"(CephFS is disabled, workaround for DFBUGS-7417)"
+                    )
+                    continue
+
                 raise AssertionError(
                     f"VolumeSnapshotClass {volume_snapshot_class} is not available on the cluster "
                     f"but listed in storage consumer {consumer_name}."


### PR DESCRIPTION
Allow block-only deployment:
* add related config file
* fix `validate_pdb_creation` function to consider enabled/disabled components

if noobaa or cephfs component is disabled, the respective PDBs are missing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new configuration option to disable the CephObjectStoreUsers component (`disable_cephobjectstoreusers`).

* **Improvements**
  * Updated storage installation verification to account for disabled optional components (NooBaa, CephFS, and BlockPools), including CSI and resource checks so validations match the enabled feature set.

* **Tests**
  * Added component-aware test skipping to prevent failures when required components are disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->