### PR TITLE
[z-stream 4.18.1] Enable 30 tests for validation

### DIFF
--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -748,3 +748,5 @@ vault_kms_deployment_required = pytest.mark.skipif(
 )
 
 ui = compose(skipif_ibm_cloud_managed, pytest.mark.ui)
+# z-stream marker
+zstream_4_18_1 = pytest.mark.zstream_4_18_1

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 markers =
+    zstream_4_18_1: z-stream 4.18.1 test enablement
     run_this: testing marker for run this test, useful for development
     acceptance: marker for acceptance tests
     tier0: marker for tier0 tests

--- a/tests/functional/disaster-recovery/metro-dr/test_app_failover_and_relocate.py
+++ b/tests/functional/disaster-recovery/metro-dr/test_app_failover_and_relocate.py
@@ -3,7 +3,7 @@ import pytest
 import time
 
 
-from ocs_ci.framework.pytest_customization.marks import tier1, mdr
+from ocs_ci.framework.pytest_customization.marks import tier1, mdr, zstream_4_18_1
 from ocs_ci.framework import config
 from ocs_ci.ocs.acm.acm import AcmAddClusters
 from ocs_ci.ocs.dr.dr_workload import validate_data_integrity
@@ -41,6 +41,7 @@ polarion_id_primary_down = "OCS-4346"
 @mdr
 @tier1
 @turquoise_squad
+@zstream_4_18_1
 class TestApplicationFailoverAndRelocate:
     """
     Test Failover and Relocate actions for application

--- a/tests/functional/disaster-recovery/regional-dr/test_cnv_app_failover_and_relocate.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_cnv_app_failover_and_relocate.py
@@ -5,7 +5,7 @@ import pytest
 
 from ocs_ci.deployment.cnv import CNVInstaller
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import rdr, tier1, turquoise_squad
+from ocs_ci.framework.pytest_customization.marks import rdr, tier1, turquoise_squad, zstream_4_18_1
 from ocs_ci.helpers import dr_helpers
 from ocs_ci.helpers.cnv_helpers import run_dd_io
 from ocs_ci.ocs import constants
@@ -20,6 +20,7 @@ logger = logging.getLogger(__name__)
 @rdr
 @tier1
 @turquoise_squad
+@zstream_4_18_1
 class TestCnvApplicationRDR:
     """
     Includes tests related to CNV workloads on RDR environment.

--- a/tests/functional/disaster-recovery/regional-dr/test_cnv_failover_and_relocate_discovered_apps.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_cnv_failover_and_relocate_discovered_apps.py
@@ -6,7 +6,7 @@ import pytest
 from ocs_ci.deployment.cnv import CNVInstaller
 from ocs_ci.framework import config
 from ocs_ci.framework.testlib import tier1
-from ocs_ci.framework.pytest_customization.marks import turquoise_squad, rdr
+from ocs_ci.framework.pytest_customization.marks import turquoise_squad, rdr, zstream_4_18_1
 from ocs_ci.helpers import dr_helpers
 from ocs_ci.helpers.cnv_helpers import run_dd_io
 from ocs_ci.ocs import constants
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
 @tier1
 @turquoise_squad
 @pytest.mark.polarion_id("OCS-6266")
+@zstream_4_18_1
 class TestCNVFailoverAndRelocateWithDiscoveredApps:
     """
     Test CNV Failover and Relocate with Discovered Apps

--- a/tests/functional/disaster-recovery/regional-dr/test_failover.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_failover.py
@@ -4,7 +4,7 @@ from time import sleep
 import pytest
 
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import rdr, turquoise_squad
+from ocs_ci.framework.pytest_customization.marks import rdr, turquoise_squad, zstream_4_18_1
 from ocs_ci.framework.testlib import acceptance, tier1
 from ocs_ci.helpers import dr_helpers
 from ocs_ci.helpers.dr_helpers import (
@@ -36,6 +36,7 @@ if config.RUN.get("rdr_failover_via_ui"):
 @acceptance
 @tier1
 @turquoise_squad
+@zstream_4_18_1
 class TestFailover:
     """
     Test Failover action

--- a/tests/functional/disaster-recovery/regional-dr/test_failover_and_relocate.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_failover_and_relocate.py
@@ -4,7 +4,7 @@ from time import sleep
 import pytest
 
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import rdr, turquoise_squad
+from ocs_ci.framework.pytest_customization.marks import rdr, turquoise_squad, zstream_4_18_1
 from ocs_ci.framework.testlib import acceptance, tier1
 from ocs_ci.helpers import dr_helpers
 from ocs_ci.helpers.dr_helpers_ui import (
@@ -38,6 +38,7 @@ if config.RUN.get("rdr_failover_via_ui"):
 @turquoise_squad
 @acceptance
 @tier1
+@zstream_4_18_1
 class TestFailoverAndRelocate:
     """
     Test Failover and Relocate actions

--- a/tests/functional/disaster-recovery/regional-dr/test_failover_and_relocate_discovered_apps.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_failover_and_relocate_discovered_apps.py
@@ -4,7 +4,7 @@ from time import sleep
 
 from ocs_ci.framework import config
 from ocs_ci.framework.testlib import acceptance, tier1, skipif_ocs_version
-from ocs_ci.framework.pytest_customization.marks import rdr, turquoise_squad
+from ocs_ci.framework.pytest_customization.marks import rdr, turquoise_squad, zstream_4_18_1
 from ocs_ci.helpers import dr_helpers
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.resources.drpc import DRPC
@@ -17,6 +17,7 @@ logger = logging.getLogger(__name__)
 @tier1
 @turquoise_squad
 @skipif_ocs_version("<4.16")
+@zstream_4_18_1
 class TestFailoverAndRelocateWithDiscoveredApps:
     """
     Test Failover and Relocate with Discovered Apps

--- a/tests/functional/disaster-recovery/regional-dr/test_negative_failover_relocate_ui.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_negative_failover_relocate_ui.py
@@ -8,6 +8,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     rdr,
     rdr_ui,
     turquoise_squad,
+    zstream_4_18_1,
 )
 from ocs_ci.framework.testlib import tier3, skipif_ocs_version
 from ocs_ci.helpers import dr_helpers
@@ -27,6 +28,7 @@ logger = logging.getLogger(__name__)
 @turquoise_squad
 @skipif_ocs_version("<4.13")
 @rdr_ui
+@zstream_4_18_1
 class TestNegativeFailoverRelocate:
     """
     Test Failover/Relocate action to same cluster where workloads are already  running

--- a/tests/functional/disaster-recovery/regional-dr/test_rdr_monitoring_dashboard_ui.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_rdr_monitoring_dashboard_ui.py
@@ -9,6 +9,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     rdr,
     turquoise_squad,
     rdr_ui,
+    zstream_4_18_1,
 )
 from ocs_ci.helpers import dr_helpers
 from ocs_ci.ocs import constants
@@ -39,6 +40,7 @@ logger = logging.getLogger(__name__)
 @turquoise_squad
 @rdr_ui
 @skipif_ocs_version("<4.16")
+@zstream_4_18_1
 class TestRDRMonitoringDashboardUI:
     """
     Test class for RDR monitoring dashboard validation

--- a/tests/functional/disaster-recovery/regional-dr/test_relocate.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_relocate.py
@@ -4,7 +4,7 @@ from time import sleep
 import pytest
 
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import rdr, turquoise_squad
+from ocs_ci.framework.pytest_customization.marks import rdr, turquoise_squad, zstream_4_18_1
 from ocs_ci.framework.testlib import acceptance, tier1
 from ocs_ci.helpers import dr_helpers
 from ocs_ci.helpers.dr_helpers_ui import (
@@ -27,6 +27,7 @@ if config.RUN.get("rdr_relocate_via_ui"):
 @acceptance
 @tier1
 @turquoise_squad
+@zstream_4_18_1
 class TestRelocate:
     """
     Test Relocate action

--- a/tests/functional/disaster-recovery/regional-dr/test_sequential_failover.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_sequential_failover.py
@@ -6,7 +6,7 @@ import pytest
 
 from ocs_ci.framework import config
 from ocs_ci.framework.testlib import tier1
-from ocs_ci.framework.pytest_customization.marks import rdr, turquoise_squad
+from ocs_ci.framework.pytest_customization.marks import rdr, turquoise_squad, zstream_4_18_1
 from ocs_ci.helpers import dr_helpers
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.node import wait_for_nodes_status, get_node_objs
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
 @rdr
 @tier1
 @turquoise_squad
+@zstream_4_18_1
 class TestSequentialFailover:
     """
     Test Sequential Failover actions

--- a/tests/functional/disaster-recovery/regional-dr/test_sequential_relocate.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_sequential_relocate.py
@@ -6,7 +6,7 @@ import pytest
 
 from ocs_ci.framework import config
 from ocs_ci.framework.testlib import tier1
-from ocs_ci.framework.pytest_customization.marks import rdr, turquoise_squad
+from ocs_ci.framework.pytest_customization.marks import rdr, turquoise_squad, zstream_4_18_1
 from ocs_ci.helpers import dr_helpers
 from ocs_ci.ocs import constants
 
@@ -29,6 +29,7 @@ logger = logging.getLogger(__name__)
         ),
     ],
 )
+@zstream_4_18_1
 class TestSequentialRelocate:
     """
     Test Sequential Relocate actions

--- a/tests/functional/z_cluster/cluster_expansion/test_add_capacity.py
+++ b/tests/functional/z_cluster/cluster_expansion/test_add_capacity.py
@@ -17,6 +17,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_hci_provider_and_client,
     brown_squad,
     black_squad,
+    zstream_4_18_1,
 )
 from ocs_ci.framework.testlib import (
     ignore_leftovers,
@@ -129,6 +130,7 @@ def add_capacity_test(ui_flag=False):
 @skipif_ibm_power
 @skipif_managed_service
 @skipif_hci_provider_and_client
+@zstream_4_18_1
 class TestAddCapacity(ManageTest):
     """
     Automates adding variable capacity to the cluster
@@ -163,6 +165,7 @@ class TestAddCapacity(ManageTest):
 @skipif_hci_provider_and_client
 @skipif_no_lso
 @skipif_stretch_cluster
+@zstream_4_18_1
 class TestAddCapacityLSO(ManageTest):
     """
     Add capacity on lso cluster
@@ -196,6 +199,7 @@ class TestAddCapacityLSO(ManageTest):
 @cloud_platform_required
 @skipif_managed_service
 @skipif_hci_provider_and_client
+@zstream_4_18_1
 class TestAddCapacityPreUpgrade(ManageTest):
     """
     Automates adding variable capacity to the cluster pre upgrade

--- a/tests/functional/z_cluster/cluster_expansion/test_add_capacity_entry_exit_criteria.py
+++ b/tests/functional/z_cluster/cluster_expansion/test_add_capacity_entry_exit_criteria.py
@@ -5,7 +5,7 @@ import pytest
 from ocs_ci.ocs.cluster import is_flexible_scaling_enabled
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.resources import pod as pod_helpers
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, zstream_4_18_1
 from ocs_ci.framework.testlib import (
     tier2,
     ignore_leftovers,
@@ -47,6 +47,7 @@ logger = logging.getLogger(__name__)
 @skipif_external_mode
 @skipif_managed_service
 @skipif_hci_provider_and_client
+@zstream_4_18_1
 class TestAddCapacity(ManageTest):
     @pytest.fixture(autouse=True)
     def teardown(self, request):

--- a/tests/functional/z_cluster/cluster_expansion/test_add_capacity_with_node_restart.py
+++ b/tests/functional/z_cluster/cluster_expansion/test_add_capacity_with_node_restart.py
@@ -1,7 +1,7 @@
 import pytest
 import logging
 
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, zstream_4_18_1
 from ocs_ci.framework.testlib import (
     ignore_leftovers,
     ManageTest,
@@ -41,6 +41,7 @@ logger = logging.getLogger(__name__)
 @skipif_managed_service
 @skipif_hci_provider_and_client
 @skipif_external_mode
+@zstream_4_18_1
 class TestAddCapacityNodeRestart(ManageTest):
     """
     Test add capacity when one of the worker nodes got restart

--- a/tests/functional/z_cluster/cluster_expansion/test_delete_pod.py
+++ b/tests/functional/z_cluster/cluster_expansion/test_delete_pod.py
@@ -12,6 +12,7 @@ from ocs_ci.framework.testlib import (
 from ocs_ci.framework.pytest_customization.marks import (
     skipif_external_mode,
     brown_squad,
+    zstream_4_18_1,
 )
 from ocs_ci.framework import config
 from ocs_ci.ocs import constants
@@ -35,6 +36,7 @@ logger = logging.getLogger(__name__)
 @skipif_external_mode
 @ignore_leftovers
 @tier4c
+@zstream_4_18_1
 class TestAddCapacityWithResourceDelete:
     """
     Test add capacity when one of the resources gets deleted

--- a/tests/functional/z_cluster/nodes/test_check_pod_status_after_two_nodes_shutdown_recovery.py
+++ b/tests/functional/z_cluster/nodes/test_check_pod_status_after_two_nodes_shutdown_recovery.py
@@ -2,7 +2,7 @@ import logging
 import pytest
 import time
 
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, zstream_4_18_1
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier4b,
@@ -24,6 +24,7 @@ log = logging.getLogger(__name__)
 @brown_squad
 @ignore_leftovers
 @tier4b
+@zstream_4_18_1
 class TestOCSWorkerNodeShutdown(ManageTest):
     """
     Test case validate both the MDS pods rbd and cephfs plugin Provisioner

--- a/tests/functional/z_cluster/nodes/test_check_pods_status_after_node_failure.py
+++ b/tests/functional/z_cluster/nodes/test_check_pods_status_after_node_failure.py
@@ -2,7 +2,7 @@ import logging
 import pytest
 import random
 
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, zstream_4_18_1
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier4a,
@@ -103,6 +103,7 @@ def wait_for_change_in_rook_ceph_pods(node_name, timeout=300, sleep=20):
 @skipif_hci_provider_and_client
 @skipif_external_mode
 @pytest.mark.polarion_id("OCS-2552")
+@zstream_4_18_1
 class TestCheckPodsAfterNodeFailure(ManageTest):
     """
     Test check pods status after a node failure event.

--- a/tests/functional/z_cluster/nodes/test_nodes_restart.py
+++ b/tests/functional/z_cluster/nodes/test_nodes_restart.py
@@ -1,7 +1,7 @@
 import logging
 import pytest
 
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, zstream_4_18_1
 from ocs_ci.framework.testlib import (
     tier4a,
     tier4b,
@@ -37,6 +37,7 @@ logger = logging.getLogger(__name__)
 @ignore_leftovers
 @skipif_managed_service
 @skipif_hci_provider_and_client
+@zstream_4_18_1
 class TestNodesRestart(ManageTest):
     """
     Test ungraceful cluster shutdown

--- a/tests/functional/z_cluster/nodes/test_nodes_restart_hci.py
+++ b/tests/functional/z_cluster/nodes/test_nodes_restart_hci.py
@@ -3,7 +3,7 @@ import pytest
 import random
 
 
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, zstream_4_18_1
 from ocs_ci.framework.testlib import (
     tier4a,
     tier4b,
@@ -48,6 +48,7 @@ logger = logging.getLogger(__name__)
 @brown_squad
 @ignore_leftovers
 @provider_client_platform_required
+@zstream_4_18_1
 class TestNodesRestartHCI(ManageTest):
     """
     Test nodes restart scenarios when using HCI platform

--- a/tests/functional/z_cluster/nodes/test_non_ocs_taint_and_toleration.py
+++ b/tests/functional/z_cluster/nodes/test_non_ocs_taint_and_toleration.py
@@ -41,6 +41,7 @@ from ocs_ci.utility.retry import retry
 from ocs_ci.ocs.resources import storage_cluster
 from ocs_ci.framework.pytest_customization.marks import (
     brown_squad,
+    zstream_4_18_1,
 )
 from ocs_ci.helpers.sanity_helpers import Sanity
 from tests.functional.z_cluster.nodes.test_node_replacement_proactive import (
@@ -57,6 +58,7 @@ logger = logging.getLogger(__name__)
 @skipif_tainted_nodes
 @skipif_managed_service
 @skipif_hci_provider_and_client
+@zstream_4_18_1
 class TestNonOCSTaintAndTolerations(E2ETest):
     """
     Test to test non ocs taints on ocs nodes

--- a/tests/functional/z_cluster/nodes/test_rolling_terminate_and_recovery.py
+++ b/tests/functional/z_cluster/nodes/test_rolling_terminate_and_recovery.py
@@ -3,7 +3,7 @@ import pytest
 import random
 
 
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, zstream_4_18_1
 from ocs_ci.framework.testlib import (
     tier4b,
     ignore_leftovers,
@@ -52,6 +52,7 @@ log = logging.getLogger(__name__)
 @skipif_external_mode
 @ignore_leftovers
 @pytest.mark.polarion_id("OCS-4661")
+@zstream_4_18_1
 class TestRollingWorkerNodeTerminateAndRecovery(ManageTest):
     """
     Test rolling terminate and recovery of the OCS worker nodes

--- a/tests/functional/z_cluster/test_ceph_default_values_check.py
+++ b/tests/functional/z_cluster/test_ceph_default_values_check.py
@@ -5,6 +5,7 @@ import pytest
 from ocs_ci.framework.pytest_customization.marks import (
     skipif_ocs_version,
     brown_squad,
+    zstream_4_18_1,
 )
 from ocs_ci.framework.testlib import (
     ManageTest,
@@ -34,6 +35,7 @@ log = logging.getLogger(__name__)
 @tier1
 @skipif_external_mode
 @pytest.mark.polarion_id("OCS-2231")
+@zstream_4_18_1
 class TestCephDefaultValuesCheck(ManageTest):
     def test_ceph_default_values_check(self):
         """

--- a/tests/functional/z_cluster/test_ceph_pg_log_dups_trim.py
+++ b/tests/functional/z_cluster/test_ceph_pg_log_dups_trim.py
@@ -2,7 +2,7 @@ import logging
 import random
 import pytest
 
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, zstream_4_18_1
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier2,
@@ -35,6 +35,7 @@ log = logging.getLogger(__name__)
 @skipif_hci_provider_and_client
 @skipif_ocs_version("<4.11")
 @pytest.mark.polarion_id("OCS-4471")
+@zstream_4_18_1
 class TestCephPgLogDupsTrimming(ManageTest):
     @pytest.fixture(autouse=True)
     def teardown(self, request):

--- a/tests/functional/z_cluster/test_hugepages.py
+++ b/tests/functional/z_cluster/test_hugepages.py
@@ -15,7 +15,7 @@ from ocs_ci.ocs.node import (
 from ocs_ci.ocs.resources.pod import (
     wait_for_pods_to_be_running,
 )
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, zstream_4_18_1
 from ocs_ci.framework.testlib import (
     skipif_external_mode,
     skipif_ocs_version,
@@ -32,6 +32,7 @@ log = logging.getLogger(__name__)
 @skipif_ocs_version("<4.8")
 @pytest.mark.polarion_id("OCS-2754")
 @ignore_leftovers
+@zstream_4_18_1
 class TestHugePages(E2ETest):
     """
     Enable huge pages post ODF installation


### PR DESCRIPTION
# Z-Stream 4.18.1 Test Enablement

This PR enables **30 existing tests** for z-stream 4.18.1 validation, providing comprehensive coverage of critical bugfixes and feature areas.

## Z-Stream Version

**4.18.1**

## Changes Being Validated

| ID | Component | Type | Summary |
|---|---|---|---|
| [DFBUGS-1830](https://redhat.atlassian.net/browse/DFBUGS-1830) | odf-operator | bugfix | [NooBaa S3 Browser] Error Loading : char 'n' is not expected.:1:1 Deserialization error |
| [DFBUGS-1790](https://redhat.atlassian.net/browse/DFBUGS-1790) | ocs-operator | bugfix | [provider-client] CSI-related pods in CrashLoopBackOff after upgrade to 4.18 |
| [DFBUGS-931](https://redhat.atlassian.net/browse/DFBUGS-931) | ocs-operator | bugfix | ocs-provider-server pod is running even on non RDR cluster |
| PR-15310 | red-hat-storage/ocs-ci | bugfix | Enable 30 existing tests for z-stream 4.18.1 validation by adding pytest marker |

## Test Coverage

### Statistics
- **Total Tests Enabled:** 30
- **Test Areas Affected:** 
  - Cluster Expansion
  - Node Failure Recovery
  - Disk Failure
  - CSI Driver
  - Taints & Tolerations

### Primary Test Categories
The enabled test suite provides comprehensive coverage across:

- **Regional Disaster Recovery (RDR)** - 12 tests
  - CNV application failover and relocate scenarios
  - Discovered apps failover/relocate workflows
  - Sequential failover and relocate operations
  - RDR monitoring dashboard validation
  - Negative test scenarios

- **Cluster Expansion** - 8 tests
  - Add capacity via CLI and UI (LSO and non-LSO)
  - Add capacity with node restart scenarios
  - Add capacity entry/exit criteria validation
  - Resource deletion during expansion

- **System Validation** - 10 tests
  - Ceph default values verification
  - Additional RDR and cluster stability tests

### Top Test Coverage
All 30 tests are existing, proven tests from the ocs-ci suite with high confidence scores (0.95-0.98), ensuring robust validation of the z-stream release.