### PR TITLE
Fix test_sts_assume_role bucket name collisions and STS retry

### DIFF
--- a/tests/functional/object/mcg/test_sts_client.py
+++ b/tests/functional/object/mcg/test_sts_client.py
@@ -91,14 +91,8 @@ class TestSTSClient:
         logger.info("Changed the sts token expiration time to 10 minutes")
 
         # create a bucket using noobaa admin creds
-        bucket_1 = "first-bucket"
-        try:
-            retry(ClientError, tries=5, delay=5)(new_bucket)(bucket_name=bucket_1)
-        except ClientError as e:
-            if "BucketAlreadyExists" in str(e):
-                logger.info(f"Bucket {bucket_1} already exists")
-            else:
-                raise
+        bucket_1 = f"first-bucket-{uuid4().hex[:8]}"
+        retry(ClientError, tries=5, delay=5)(new_bucket)(bucket_name=bucket_1)
         logger.info(f"Created bucket {bucket_1}")
 
         # create a noobaa account
@@ -129,7 +123,7 @@ class TestSTSClient:
         logger.info(f"Assigned the assume role policy to the user {user_2}")
 
         # noobaa admin assumes the above role
-        creds_generated = sts_assume_role(
+        creds_generated = retry(CommandFailed, tries=5, delay=30)(sts_assume_role)(
             awscli_pod_session,
             role_name,
             nb_user_access_key_id,
@@ -140,7 +134,7 @@ class TestSTSClient:
         )
 
         # perform io to validate the role assumption
-        bucket_2 = "second-bucket"
+        bucket_2 = f"second-bucket-{uuid4().hex[:8]}"
         try:
             new_bucket(bucket_2, assumed_user_s3client)
             assert (


### PR DESCRIPTION
Fixes https://github.com/red-hat-storage/ocs-ci/issues/12778

Problem: 

  `test_sts_assume_role` has been failing intermittently across multiple OCS versions (4.17, 4.18, 4.20) with two distinct failure modes:

  1. **AssumeRole "Unknown" error** — After patching env vars into
     noobaa-core and noobaa-endpoint (which restarts pods), the
     `sts_assume_role` call fails with `An error occurred (Unknown)
     when calling the AssumeRole operation`. The STS endpoint is not
     fully functional immediately after pod restarts, even though
     `wait_for_ready_status()` reports ready.

  2. **BucketAlreadyOwnedByYou** — The test uses hardcoded bucket
     names (`"first-bucket"`, `"second-bucket"`) which collide across
     test runs on the same cluster. An existing try/except attempted
     to handle this but checked for the wrong S3 error code
     (`"BucketAlreadyExists"` instead of `"BucketAlreadyOwnedByYou"`).

Fixes:

  - Use unique bucket names (`f"first-bucket-{uuid4().hex[:8]}"`) to prevent cross-run collisions, eliminating the root cause of
    the BucketAlreadyOwnedByYou error
  - Remove the broken try/except with the wrong exception string check (no longer needed with unique names)
  - Wrap the `sts_assume_role` call with `retry(CommandFailed, tries=5, delay=30)` to handle STS endpoint readiness after pod restarts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test resilience with retry logic for STS assume-role operations
  * Improved test isolation through dynamic bucket naming
  * Simplified bucket creation error handling logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->