### PR TITLE
use stable tag for ODF 4.23

### DIFF
--- a/ocs_ci/framework/conf/ocs_version/ocs-4.23.yaml
+++ b/ocs_ci/framework/conf/ocs_version/ocs-4.23.yaml
@@ -1,8 +1,7 @@
 ---
 DEPLOYMENT:
-  # TODO: Change to latest-stable-4.23 once we have stable build
-  default_ocs_registry_image: "quay.io/rhceph-dev/ocs-registry:latest-4.23"
-  default_latest_tag: 'latest-4.23'
+  default_ocs_registry_image: "quay.io/rhceph-dev/ocs-registry:latest-stable-4.23"
+  default_latest_tag: 'latest-stable-4.23'
   ocs_csv_channel: "stable-4.23"
   default_ocp_version: '4.22'
   konflux_build: true


### PR DESCRIPTION
Signed-off-by: vavuthu [vavuthu@redhat.com](mailto:vavuthu@redhat.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OCS version configuration to use stable registry image defaults, ensuring more reliable and consistent deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->