### PR TITLE
Fix MDR deployment: Get worker node IPs only for fencing configuration

### DIFF
--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -1783,68 +1783,10 @@ def get_all_drclusters():
     return drclusters
 
 
-def ordered_unique_cidrs(cidrs):
-    """
-    Preserve order while removing duplicates
-    """
-    seen = set()
-    ordered = []
-    for cidr in cidrs:
-        if not cidr or cidr in seen:
-            continue
-        seen.add(cidr)
-        ordered.append(cidr)
-    return ordered
-
-
-@retry(UnexpectedBehaviour, tries=25, delay=10, backoff=2)
-def get_fencing_cidrs_from_drclusterconfig(cluster_name):
-    """
-    Read fencing CIDRs from DRClusterConfig.status.storageAccessDetails on the
-    current (managed) cluster context (ODF 4.21+ / Ramen).
-
-    Prefers the DRClusterConfig named like the managed cluster, then RBD CSI
-    provisioner entries, with sensible fallbacks.
-
-    Args:
-        cluster_name (str): Managed cluster name (matches DRCluster / DRClusterConfig name on hub)
-
-    Returns:
-        list: CIDR strings for hub DRCluster.spec.cidrs
-
-    Raises:
-        UnexpectedBehaviour: If CIDRs are not yet published or cannot be determined
-    """
-    drc_ocp = ocp.OCP(kind=constants.DRCLUSTERCONFIG)
-    items = (drc_ocp.get(silent=True) or {}).get("items") or []
-    if not items:
-        raise UnexpectedBehaviour(
-            "No DRClusterConfig resources found on managed cluster"
-        )
-    configs = [i for i in items if i.get("metadata", {}).get("name") == cluster_name]
-
-    cidrs = []
-    for item in configs:
-        details = (item.get("status") or {}).get("storageAccessDetails") or []
-        for detail in details:
-            detail_cidrs = detail.get("cidrs") or []
-            cidrs.extend(detail_cidrs)
-
-    cidrs = ordered_unique_cidrs(cidrs)
-    if not cidrs:
-        raise UnexpectedBehaviour(
-            f"DRClusterConfig on cluster {cluster_name} has no status.storageAccessDetails.cidrs yet"
-        )
-    logger.info(
-        f"Collected {len(cidrs)} fencing CIDR(s) from DRClusterConfig for {cluster_name}"
-    )
-
-    return cidrs
-
 
 def get_managed_cluster_node_ips():
     """
-    Gets node ips of individual managed clusters for enabling fencing from each managed cluster's DRClusterConfig
+    Gets worker node IPs of individual managed clusters for enabling fencing on MDR DRCluster configuration
 
     Returns:
         list: [[managed_cluster_name, multicluster_index, [cidr, ...]], ...]
@@ -1864,10 +1806,19 @@ def get_managed_cluster_node_ips():
     ]
     for cluster in cluster_data:
         config.switch_ctx(cluster[1])
-        logger.info(
-            f"Reading fencing CIDRs from DRClusterConfig on managed cluster {cluster[0]}"
-        )
-        cluster.append(get_fencing_cidrs_from_drclusterconfig(cluster[0]))
+        logger.info(f"Getting worker node IPs on managed cluster: {cluster[0]}")
+        node_obj = ocp.OCP(kind=constants.NODE).get()
+        external_ips = []
+        for node in node_obj.get("items"):
+            # Check if node has worker role
+            labels = node.get("metadata", {}).get("labels", {})
+            if "node-role.kubernetes.io/worker" in labels:
+                addresses = node.get("status", {}).get("addresses", [])
+                for address in addresses:
+                    if address.get("type") == "ExternalIP":
+                        external_ips.append(address.get("address"))
+        external_ips_with_cidr = [f"{ip}/32" for ip in external_ips]
+        cluster.append(external_ips_with_cidr)
     return cluster_data
 
 
@@ -1942,7 +1893,7 @@ def configure_drcluster_for_fencing():
             f"oc patch drcluster {drcluster_name} --type merge -p '{fence_ip_data}'"
         )
         logger.info(
-            f"Patching hub DRCluster {drcluster_name} with CIDRs from managed-cluster DRClusterConfig"
+            f"Patching hub DRCluster {drcluster_name} with CIDRs from worker node IPs"
         )
         run_cmd(fence_ip_cmd)
 

--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -1783,7 +1783,6 @@ def get_all_drclusters():
     return drclusters
 
 
-
 def get_managed_cluster_node_ips():
     """
     Gets worker node IPs of individual managed clusters for enabling fencing on MDR DRCluster configuration
@@ -1792,6 +1791,7 @@ def get_managed_cluster_node_ips():
         list: [[managed_cluster_name, multicluster_index, [cidr, ...]], ...]
 
     """
+    restore_index = config.cur_index
     primary_index = get_primary_cluster_config().MULTICLUSTER["multicluster_index"]
     secondary_index = [
         s.MULTICLUSTER["multicluster_index"]
@@ -1804,21 +1804,30 @@ def get_managed_cluster_node_ips():
         [cluster_name_primary, primary_index],
         [cluster_name_secondary, secondary_index],
     ]
-    for cluster in cluster_data:
-        config.switch_ctx(cluster[1])
-        logger.info(f"Getting worker node IPs on managed cluster: {cluster[0]}")
-        node_obj = ocp.OCP(kind=constants.NODE).get()
-        external_ips = []
-        for node in node_obj.get("items"):
-            # Check if node has worker role
-            labels = node.get("metadata", {}).get("labels", {})
-            if "node-role.kubernetes.io/worker" in labels:
-                addresses = node.get("status", {}).get("addresses", [])
-                for address in addresses:
-                    if address.get("type") == "ExternalIP":
-                        external_ips.append(address.get("address"))
-        external_ips_with_cidr = [f"{ip}/32" for ip in external_ips]
-        cluster.append(external_ips_with_cidr)
+    try:
+        for cluster in cluster_data:
+            config.switch_ctx(cluster[1])
+            logger.info(f"Getting worker node IPs on managed cluster: {cluster[0]}")
+            node_obj = ocp.OCP(kind=constants.NODE).get()
+            external_ips = []
+            for node in node_obj.get("items", []):
+                # Check if node has worker role
+                labels = node.get("metadata", {}).get("labels", {})
+                if "node-role.kubernetes.io/worker" in labels:
+                    addresses = node.get("status", {}).get("addresses", [])
+                    for address in addresses:
+                        if address.get("type") == "ExternalIP" and address.get(
+                            "address"
+                        ):
+                            external_ips.append(address["address"])
+            external_ips_with_cidr = [f"{ip}/32" for ip in dict.fromkeys(external_ips)]
+            if not external_ips_with_cidr:
+                raise UnexpectedBehaviour(
+                    f"No worker ExternalIP addresses found on managed cluster {cluster[0]}"
+                )
+            cluster.append(external_ips_with_cidr)
+    finally:
+        config.switch_ctx(restore_index)
     return cluster_data
 
 


### PR DESCRIPTION
Fixes #15277

Changes:
- Modified get_managed_cluster_node_ips() to retrieve worker node IPs directly from cluster nodes
- Added filtering to get only nodes with 'node-role.kubernetes.io/worker' label
- Removed obsolete functions:
  - get_fencing_cidrs_from_drclusterconfig()
  - ordered_unique_cidrs()
- Updated log messages to reflect the new approach

The function now:
1. Switches to each managed cluster context
2. Gets all nodes and filters for worker nodes only
3. Extracts ExternalIP addresses from worker nodes
4. Converts IPs to CIDR format (IP/32)
5. Returns the list for DRCluster fencing configuration

This aligns with updated documentation that specifies using only worker node IPs (not master nodes) for MDR DRCluster configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved disaster recovery cluster fencing by sourcing network access configuration directly from managed cluster worker node external IP addresses instead of stored settings, ensuring accurate and reliable network connectivity for disaster recovery operations and enhanced system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->