### PR TITLE
manual backport on clusters ACM dropdown 421

### DIFF
--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -1193,7 +1193,8 @@ acm_configuration_4_12 = {
         "//h2[text()='local-cluster'] | "
         "//span[contains(@class, 'c-menu-toggle__text') "
         "and text()='local-cluster']/.. | "
-        "//h2[normalize-space()='Fleet Management']",
+        "//h2[normalize-space()='Fleet Management'] | "
+        "//h2[normalize-space()='Core platform']",
         By.XPATH,
     ),
     # works for OCP 4.12 to 4.20


### PR DESCRIPTION
FIX #15339

apply the PR https://github.com/red-hat-storage/ocs-ci/pull/15080 to 4.21 

<img width="768" height="499" alt="image" src="https://github.com/user-attachments/assets/47310eba-9259-4c64-8514-3d6c33a739cf" />

Based on DOM analysis this fix should be working

```
 The locator WILL work. Specifically, the 4th alternative in the XPath union will match:                                                                                                                 
   
  //h2[normalize-space()='Core platform']                                                                                                                                                                 
                  
  matches this element in the DOM:

  <h2 data-ouia-component-type="PF6/Title" ... class="pf-v6-c-title pf-m-md">
    <svg>...</svg> Core platform
  </h2>

  ```


- [x] run test_dashboard_validation_ui on 4.21