### PR TITLE
Test fixes for system tests with bugs

### DIFF
--- a/tests/cross_functional/system_test/test_cluster_wide_key_rotation_systemtest.py
+++ b/tests/cross_functional/system_test/test_cluster_wide_key_rotation_systemtest.py
@@ -6,6 +6,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     magenta_squad,
     ignore_leftovers,
     encryption_at_rest_required,
+    jira,
 )
 from ocs_ci.framework.testlib import E2ETest
 from ocs_ci.helpers.keyrotation_helper import (
@@ -25,6 +26,7 @@ log = logging.getLogger(__name__)
 @system_test
 @ignore_leftovers
 @encryption_at_rest_required
+@jira("DFBUGS-5769")
 class TestKeyRotationWithClusterFull(E2ETest):
     @pytest.fixture(autouse=True)
     def init_sanity(self):

--- a/tests/cross_functional/system_test/test_mcg_replication_with_disruptions.py
+++ b/tests/cross_functional/system_test/test_mcg_replication_with_disruptions.py
@@ -270,7 +270,6 @@ class TestMCGReplicationWithDisruptions(E2ETest):
 
 @system_test
 @magenta_squad
-@skipif_vsphere_ipi
 class TestLogBasedReplicationWithDisruptions:
     @retry(Exception, tries=10, delay=5)
     def delete_objs_in_batch(self, objs_to_delete, mockup_logger, source_bucket):


### PR DESCRIPTION
Remove skip IPI sphere label from test case to let test execute on the sphere IPI configuration.
Add skip to cluster wid key rotation test case

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test metadata and configuration for internal test management and execution scope refinement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->