### PR TITLE
Add pre-commit and CI check to block new usage of deprecated functions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,6 +33,12 @@ repos:
         language: system
         types: [python]
         files: \.py$
+      - id: validate-deprecated-usage
+        name: Validate No New Deprecated Usage
+        entry: bash scripts/python/checks/validate_deprecated_usage.sh precommit
+        language: system
+        pass_filenames: false
+        types: [python]
   - repo: https://github.com/ibm/detect-secrets
     rev: 0.13.1+ibm.64.dss
     hooks:

--- a/scripts/python/checks/validate_deprecated_usage.sh
+++ b/scripts/python/checks/validate_deprecated_usage.sh
@@ -60,16 +60,14 @@ VIOLATIONS=$(echo "$DIFF_OUTPUT" | awk '
         sub("^b/", "", file)
     }
     /^@@ / {
-        # Parse the +line from hunk header (e.g., @@ -10,3 +20,5 @@)
-        # Match " +NNN" (space before +) to avoid greedy match on + in function context
         s = $0
-        sub(/.* \+/, "", s)
+        sub(/^@@ -[0-9,]+ \+/, "", s)
         sub(/[,@ ].*/, "", s)
         line = s + 0
         next
     }
-    /^\+[^+]/ {
-        # Added line (skip the +++ header)
+    /^\+\+\+ / { next }
+    /^\+/ {
         code = substr($0, 2)
         printf "%s:%d: %s\n", file, line, code
         line++

--- a/scripts/python/checks/validate_deprecated_usage.sh
+++ b/scripts/python/checks/validate_deprecated_usage.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+#
+# Detect new usage of deprecated functions in added lines.
+#
+# Modes:
+#   precommit  – check staged changes (git diff --cached)
+#   ci         – check branch changes vs origin/master
+#
+# Exit 0 if clean, 1 if violations found.
+
+set -euo pipefail
+
+MODE="${1:-precommit}"
+
+case "$MODE" in
+    precommit)
+        DIFF_CMD="git diff --cached --diff-filter=ACM --unified=0"
+        ;;
+    ci)
+        BASE="${2:-origin/master}"
+        DIFF_CMD="git diff ${BASE}...HEAD --diff-filter=ACM --unified=0"
+        ;;
+    *)
+        echo "Usage: $0 {precommit|ci [base_ref]}" >&2
+        exit 2
+        ;;
+esac
+
+# Deprecated patterns: "import <name>" or "<name>(" in added lines.
+# Each entry: grep_pattern|human_readable_name|replacement
+DEPRECATED_FUNCTIONS=(
+    "run_cmd|run_cmd|exec_cmd"
+    "download_file|download_file|download_with_retries"
+    "log_step|log_step|logger.test_step()"
+    "system_test|system_test mark|system mark"
+)
+
+# Build a single grep pattern for all deprecated names
+NAMES=()
+for entry in "${DEPRECATED_FUNCTIONS[@]}"; do
+    IFS='|' read -r pattern _ _ <<< "$entry"
+    NAMES+=("$pattern")
+done
+COMBINED=$(IFS='|'; echo "${NAMES[*]}")
+
+# Run diff command separately so failures aren't masked by || true
+DIFF_OUTPUT=$($DIFF_CMD -- '*.py') || {
+    echo "ERROR: diff command failed: $DIFF_CMD" >&2
+    exit 2
+}
+
+# Extract added Python lines from the diff
+VIOLATIONS=$(echo "$DIFF_OUTPUT" | awk '
+    /^diff --git/ {
+        file = $NF
+        sub("^b/", "", file)
+    }
+    /^@@ / {
+        # Parse the +line from hunk header (e.g., @@ -10,3 +20,5 @@)
+        # Match " +NNN" (space before +) to avoid greedy match on + in function context
+        s = $0
+        sub(/.* \+/, "", s)
+        sub(/[,@ ].*/, "", s)
+        line = s + 0
+        next
+    }
+    /^\+[^+]/ {
+        # Added line (skip the +++ header)
+        code = substr($0, 2)
+        printf "%s:%d: %s\n", file, line, code
+        line++
+    }
+    /^ / { line++ }
+' | grep -E "(from\s+\S+\s+import\s+.*\b(${COMBINED})\b|\b(${COMBINED})\s*\()" | \
+    grep -vE "def (${COMBINED})\s*\(" || true)
+
+if [ -z "$VIOLATIONS" ]; then
+    exit 0
+fi
+
+echo ""
+echo "========================================================"
+echo " DEPRECATED FUNCTION USAGE DETECTED IN NEW CODE"
+echo "========================================================"
+echo ""
+echo "The following added lines use deprecated functions."
+echo "Please use the recommended replacements:"
+echo ""
+
+for entry in "${DEPRECATED_FUNCTIONS[@]}"; do
+    IFS='|' read -r pattern name replacement <<< "$entry"
+    echo "  - ${name}  →  ${replacement}"
+done
+
+echo ""
+echo "Violations:"
+echo "--------------------------------------------------------"
+echo "$VIOLATIONS"
+echo "--------------------------------------------------------"
+echo ""
+exit 1

--- a/scripts/python/checks/validate_deprecated_usage.sh
+++ b/scripts/python/checks/validate_deprecated_usage.sh
@@ -6,7 +6,7 @@
 #   precommit  – check staged changes (git diff --cached)
 #   ci         – check branch changes vs origin/master
 #
-# Exit 0 if clean, 1 if violations found.
+# Exit 0 if clean. precommit exits 1 on violations; ci exits 0 with warnings.
 
 set -euo pipefail
 
@@ -75,10 +75,28 @@ VIOLATIONS=$(echo "$DIFF_OUTPUT" | awk '
         line++
     }
     /^ / { line++ }
-' | grep -E "(from\s+\S+\s+import\s+.*\b(${COMBINED})\b|\b(${COMBINED})\s*\()" | \
-    grep -vE "def (${COMBINED})\s*\(" || true)
+' | grep -E "(from\s+\S+\s+import\s+.*\b(${COMBINED})\b|\b(${COMBINED})\s*\(|@\s*(${COMBINED})\b)" | \
+    grep -vE "def (${COMBINED})\s*\(" | \
+    grep -vE "\.\s*(${COMBINED})\s*\(" | \
+    grep -vE "#\s*IgnoreDeprecation" || true)
 
 if [ -z "$VIOLATIONS" ]; then
+    exit 0
+fi
+
+REPLACEMENT_HELP=""
+for entry in "${DEPRECATED_FUNCTIONS[@]}"; do
+    IFS='|' read -r pattern name replacement <<< "$entry"
+    REPLACEMENT_HELP+="  - ${name}  →  ${replacement}\n"
+done
+
+if [ "$MODE" = "ci" ]; then
+    while IFS=: read -r file line_num code; do
+        echo "::warning file=${file},line=${line_num}::Deprecated usage:${code## }"
+    done <<< "$VIOLATIONS"
+    echo ""
+    echo "⚠ Deprecated function usage detected (warning only in CI)."
+    echo -e "Replacements:\n${REPLACEMENT_HELP}"
     exit 0
 fi
 
@@ -90,16 +108,13 @@ echo ""
 echo "The following added lines use deprecated functions."
 echo "Please use the recommended replacements:"
 echo ""
-
-for entry in "${DEPRECATED_FUNCTIONS[@]}"; do
-    IFS='|' read -r pattern name replacement <<< "$entry"
-    echo "  - ${name}  →  ${replacement}"
-done
-
+echo -e "$REPLACEMENT_HELP"
 echo ""
 echo "Violations:"
 echo "--------------------------------------------------------"
 echo "$VIOLATIONS"
 echo "--------------------------------------------------------"
+echo ""
+echo "Hint: add '# IgnoreDeprecation' to suppress false positives."
 echo ""
 exit 1

--- a/scripts/python/checks/validate_deprecated_usage.sh
+++ b/scripts/python/checks/validate_deprecated_usage.sh
@@ -17,8 +17,12 @@ case "$MODE" in
         DIFF_CMD="git diff --cached --diff-filter=ACM --unified=0"
         ;;
     ci)
-        BASE="${2:-origin/master}"
-        DIFF_CMD="git diff ${BASE}...HEAD --diff-filter=ACM --unified=0"
+        BASE="${2:-${GITHUB_BASE_REF:-master}}"
+        # In GitHub Actions (shallow clone), fetch the base branch if missing
+        if [ -n "${GITHUB_BASE_REF:-}" ] && ! git rev-parse --verify "origin/${BASE}" >/dev/null 2>&1; then
+            git fetch --depth=1 origin "${BASE}"
+        fi
+        DIFF_CMD="git diff origin/${BASE}...HEAD --diff-filter=ACM --unified=0"
         ;;
     *)
         echo "Usage: $0 {precommit|ci [base_ref]}" >&2

--- a/scripts/python/checks/validate_deprecated_usage.sh
+++ b/scripts/python/checks/validate_deprecated_usage.sh
@@ -18,11 +18,11 @@ case "$MODE" in
         ;;
     ci)
         BASE="${2:-${GITHUB_BASE_REF:-master}}"
-        # In GitHub Actions (shallow clone), fetch the base branch if missing
-        if [ -n "${GITHUB_BASE_REF:-}" ] && ! git rev-parse --verify "origin/${BASE}" >/dev/null 2>&1; then
-            git fetch --depth=1 origin "${BASE}"
+        # In GitHub Actions (shallow clone), fetch the base branch and create the tracking ref
+        if ! git rev-parse --verify "origin/${BASE}" >/dev/null 2>&1; then
+            git fetch --depth=1 origin "+refs/heads/${BASE}:refs/remotes/origin/${BASE}"
         fi
-        DIFF_CMD="git diff origin/${BASE}...HEAD --diff-filter=ACM --unified=0"
+        DIFF_CMD="git diff origin/${BASE} HEAD --diff-filter=ACM --unified=0"
         ;;
     *)
         echo "Usage: $0 {precommit|ci [base_ref]}" >&2

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
-envlist = black,py310,py311,flake8,docs,collectonly,logging,retry-check,detect-secrets
+envlist = black,py310,py311,flake8,docs,collectonly,logging,retry-check,deprecated-check,detect-secrets
 isolated_build = true
 
 [gh-actions]
 python =
     3.10: py310, flake8, collectonly
-    3.11: py311, black, docs, flake8, collectonly, logging, retry-check
+    3.11: py311, black, docs, flake8, collectonly, logging, retry-check, deprecated-check
 
 [testenv]
 deps =
@@ -75,6 +75,14 @@ skip_install = true
 skipsdist = true
 commands =
     bash -c 'git grep --name-only retry | grep -E "\.py$" | xargs -I {:} python scripts/python/checks/validate_retry_usage.py {:}'
+
+[testenv:deprecated-check]
+allowlist_externals = *
+deps =
+skip_install = true
+skipsdist = true
+commands =
+    bash scripts/python/checks/validate_deprecated_usage.sh ci
 
 [testenv:detect-secrets]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -78,6 +78,7 @@ commands =
 
 [testenv:deprecated-check]
 allowlist_externals = *
+passenv = GITHUB_BASE_REF
 deps =
 skip_install = true
 skipsdist = true


### PR DESCRIPTION
Adds a diff-based check (validate_deprecated_usage.sh) that detects new imports or calls to deprecated functions (run_cmd, download_file, log_step, system_test) in added lines only — existing usage is unaffected.