### PR TITLE
[z-stream 4.20.14] Enable 62 tests for validation

### DIFF
--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -864,3 +864,5 @@ skipif_lean_deployment = pytest.mark.skipif(
     or not check_cluster_resources_for_nfs(),
     reason="Test cannot run on lean profile or requires higher cluster resources (insufficient CPU/memory)",
 )
+# z-stream marker
+zstream_4_20_14 = pytest.mark.zstream_4_20_14

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 markers =
+    zstream_4_20_14: z-stream 4.20.14 test enablement
     run_this: testing marker for run this test, useful for development
     acceptance: marker for acceptance tests
     tier0: marker for tier0 tests

--- a/tests/functional/data_replication_separation/test_host_network.py
+++ b/tests/functional/data_replication_separation/test_host_network.py
@@ -4,6 +4,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     data_replication_separation_required,
     jira,
     yellow_squad,
+    zstream_4_20_14,
 )
 from ocs_ci.framework.testlib import tier1
 from ocs_ci.ocs import data_replication_separation
@@ -13,6 +14,7 @@ from ocs_ci.ocs import data_replication_separation
 @yellow_squad
 @data_replication_separation_required
 @pytest.mark.polarion_id("OCS-7308")
+@zstream_4_20_14
 def test_ceph_pods_have_host_network():
     """
     Test that running ceph pods have set host network.
@@ -39,6 +41,7 @@ def test_ceph_pods_have_host_network():
 @data_replication_separation_required
 @jira("DFBUGS-4306")
 @pytest.mark.polarion_id("OCS-7307")
+@zstream_4_20_14
 def test_operator_and_csi_pods_have_host_network():
     """
     Test that running operator and csi pods have set host network.

--- a/tests/functional/disaster-recovery/metro-dr/test_replace_cluster.py
+++ b/tests/functional/disaster-recovery/metro-dr/test_replace_cluster.py
@@ -4,7 +4,7 @@ import time
 
 from concurrent.futures import ThreadPoolExecutor
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import turquoise_squad, mdr, tier4a
+from ocs_ci.framework.pytest_customization.marks import turquoise_squad, mdr, tier4a, zstream_4_20_14
 from ocs_ci.helpers.dr_helpers import get_active_acm_index
 from ocs_ci.ocs.node import get_node_objs
 from ocs_ci.ocs.dr.dr_workload import validate_data_integrity
@@ -31,6 +31,7 @@ logger = logging.getLogger(__name__)
 @mdr
 @tier4a
 @turquoise_squad
+@zstream_4_20_14
 class TestReplaceCluster:
     """
     Test for Recovery of replacement cluster

--- a/tests/functional/disaster-recovery/sc_arbiter/test_device_replacement.py
+++ b/tests/functional/disaster-recovery/sc_arbiter/test_device_replacement.py
@@ -8,6 +8,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     tier4a,
     tier4,
     jira,
+    zstream_4_20_14,
 )
 from ocs_ci.helpers.cnv_helpers import cal_md5sum_vm
 from ocs_ci.helpers.stretchcluster_helper import (
@@ -27,6 +28,7 @@ logger = logging.getLogger(__name__)
 @stretchcluster_required
 @turquoise_squad
 @jira("DFBUGS-1273")
+@zstream_4_20_14
 class TestDeviceReplacementInStretchCluster:
 
     @polarion_id("OCS-5047")

--- a/tests/functional/monitoring/prometheus/alerts/test_capacity.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_capacity.py
@@ -8,6 +8,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_managed_service,
     runs_on_provider,
     blue_squad,
+    zstream_4_20_14,
 )
 from ocs_ci.ocs import constants
 from ocs_ci.utility import prometheus
@@ -24,6 +25,7 @@ log = logging.getLogger(__name__)
 )
 @skipif_managed_service
 @runs_on_provider
+@zstream_4_20_14
 def test_rbd_capacity_workload_alerts(
     workload_storageutilization_97p_rbd, threading_lock
 ):
@@ -91,6 +93,7 @@ def test_rbd_capacity_workload_alerts(
 )
 @skipif_managed_service
 @runs_on_provider
+@zstream_4_20_14
 def test_cephfs_capacity_workload_alerts(
     workload_storageutilization_97p_cephfs, threading_lock
 ):

--- a/tests/functional/monitoring/prometheus/alerts/test_ceph.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_ceph.py
@@ -23,6 +23,7 @@ from ocs_ci.ocs.fiojob import get_timeout
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.resources.pod import get_osd_pods
 from ocs_ci.utility import prometheus
+from ocs_ci.framework.pytest_customization.marks import zstream_4_20_14
 
 log = logging.getLogger(__name__)
 
@@ -33,6 +34,7 @@ log = logging.getLogger(__name__)
 @pytest.mark.polarion_id("OCS-903")
 @skipif_managed_service
 @runs_on_provider
+@zstream_4_20_14
 def test_corrupt_pg_alerts(measure_corrupt_pg, threading_lock):
     """
     Test that there are appropriate alerts when Placement group
@@ -134,6 +136,7 @@ def deprecated_test_ceph_health(
 
 
 @runs_on_provider
+@zstream_4_20_14
 class TestCephOSDSlowOps(object):
     @pytest.fixture(scope="function")
     def setup(self, request, pod_factory, multi_pvc_factory):

--- a/tests/functional/monitoring/prometheus/alerts/test_deployment_status.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_deployment_status.py
@@ -1,7 +1,7 @@
 import logging
 import pytest
 
-from ocs_ci.framework.pytest_customization.marks import blue_squad, provider_mode
+from ocs_ci.framework.pytest_customization.marks import blue_squad, provider_mode, zstream_4_20_14
 from ocs_ci.framework.testlib import (
     tier4c,
     skipif_managed_service,
@@ -22,6 +22,7 @@ log = logging.getLogger(__name__)
 @pytest.mark.polarion_id("OCS-1052")
 @skipif_managed_service
 @runs_on_provider
+@zstream_4_20_14
 def test_ceph_manager_stopped(measure_stop_ceph_mgr, threading_lock):
     """
     Test that there is appropriate alert when ceph manager
@@ -54,6 +55,7 @@ def test_ceph_manager_stopped(measure_stop_ceph_mgr, threading_lock):
 @pytest.mark.polarion_id("OCS-904")
 @skipif_managed_service
 @runs_on_provider
+@zstream_4_20_14
 def test_ceph_monitor_stopped(measure_stop_ceph_mon, threading_lock):
     """
     Test that there is appropriate alert related to ceph monitor quorum
@@ -98,6 +100,7 @@ def test_ceph_monitor_stopped(measure_stop_ceph_mon, threading_lock):
 @skipif_managed_service
 @runs_on_provider
 @skipif_ocs_version("<4.9")
+@zstream_4_20_14
 def test_ceph_mons_quorum_lost(measure_stop_ceph_mon, threading_lock):
     """
     Test to verify that CephMonQuorumLost alert is seen and
@@ -128,6 +131,7 @@ def test_ceph_mons_quorum_lost(measure_stop_ceph_mon, threading_lock):
 @pytest.mark.polarion_id("OCS-900")
 @skipif_managed_service
 @runs_on_provider
+@zstream_4_20_14
 def test_ceph_osd_stopped(measure_stop_ceph_osd, threading_lock):
     """
     Test that there is appropriate alert related to situation when ceph osd

--- a/tests/functional/monitoring/prometheus/alerts/test_rgw.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_rgw.py
@@ -4,7 +4,7 @@ import pytest
 from semantic_version import Version
 
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import blue_squad
+from ocs_ci.framework.pytest_customization.marks import blue_squad, zstream_4_20_14
 from ocs_ci.framework.testlib import tier4c, runs_on_provider, skipif_managed_service
 from ocs_ci.ocs import constants
 from ocs_ci.utility import prometheus
@@ -19,6 +19,7 @@ log = logging.getLogger(__name__)
 @pytest.mark.polarion_id("OCS-2323")
 @runs_on_provider
 @skipif_managed_service
+@zstream_4_20_14
 def test_rgw_unavailable(measure_stop_rgw, threading_lock):
     """
     Test that there is appropriate alert when RGW is unavailable and that

--- a/tests/functional/monitoring/prometheus/metrics/test_monitoring_defaults.py
+++ b/tests/functional/monitoring/prometheus/metrics/test_monitoring_defaults.py
@@ -18,6 +18,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     provider_client_platform_required,
     provider_mode,
     skipif_external_mode,
+    zstream_4_20_14,
 )
 from ocs_ci.framework.testlib import skipif_ocs_version, tier1
 from ocs_ci.ocs import constants, ocp, defaults
@@ -39,6 +40,7 @@ logger = logging.getLogger(__name__)
 @pytest.mark.polarion_id("OCS-1261")
 @skipif_managed_service
 @runs_on_provider
+@zstream_4_20_14
 def test_monitoring_enabled(threading_lock):
     """
     OCS Monitoring is enabled after OCS installation (which is why this test
@@ -90,6 +92,7 @@ def test_monitoring_enabled(threading_lock):
 @pytest.mark.polarion_id("OCS-1265")
 @skipif_managed_service
 @runs_on_provider
+@zstream_4_20_14
 def test_ceph_mgr_dashboard_not_deployed():
     """
     Check that `ceph mgr dashboard`_ is not deployed after installation of OCS
@@ -130,6 +133,7 @@ def test_ceph_mgr_dashboard_not_deployed():
 @pytest.mark.polarion_id("OCS-1267")
 @skipif_managed_service
 @runs_on_provider
+@zstream_4_20_14
 def test_ceph_rbd_metrics_available(threading_lock):
     """
     Ceph RBD metrics should be provided via OCP Prometheus as well.
@@ -155,6 +159,7 @@ def test_ceph_rbd_metrics_available(threading_lock):
 @pytest.mark.polarion_id("OCS-1268")
 @skipif_managed_service
 @runs_on_provider
+@zstream_4_20_14
 def test_ceph_metrics_available(threading_lock):
     """
     Ceph metrics as listed in KNIP-634 should be provided via OCP Prometheus.
@@ -189,6 +194,7 @@ def test_ceph_metrics_available(threading_lock):
 @pytest.mark.polarion_id("OCS-1302")
 @skipif_managed_service
 @runs_on_provider
+@zstream_4_20_14
 def test_monitoring_reporting_ok_when_idle(workload_idle, threading_lock):
     """
     When nothing is happening, OCP Prometheus reports OCS status as OK.
@@ -272,6 +278,7 @@ def test_monitoring_reporting_ok_when_idle(workload_idle, threading_lock):
 @runs_on_provider
 @provider_client_platform_required
 @pytest.mark.polarion_id("OCS-5204")
+@zstream_4_20_14
 def test_provider_metrics_available(threading_lock):
     """
     Metrics added in provider-client mode should be provided via OCP Prometheus on provider.
@@ -291,6 +298,7 @@ def test_provider_metrics_available(threading_lock):
 @tier1
 @skipif_external_mode
 @pytest.mark.polarion_id("OCS-6796")
+@zstream_4_20_14
 def test_monitoring_ip_connectivity(threading_lock):
     """
     Procedure:

--- a/tests/functional/monitoring/prometheus/metrics/test_monitoring_negative.py
+++ b/tests/functional/monitoring/prometheus/metrics/test_monitoring_negative.py
@@ -8,7 +8,7 @@ import logging
 import pytest
 
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import blue_squad, jira
+from ocs_ci.framework.pytest_customization.marks import blue_squad, jira, zstream_4_20_14
 from ocs_ci.framework.testlib import (
     tier3,
     skipif_managed_service,
@@ -27,6 +27,7 @@ logger = logging.getLogger(__name__)
 @pytest.mark.polarion_id("OCS-1306")
 @skipif_managed_service
 @skipif_external_mode
+@zstream_4_20_14
 def test_monitoring_shows_mon_down(measure_stop_ceph_mon, threading_lock):
     """
     Make sure simple problems with MON daemons are reported via OCP Prometheus.
@@ -100,6 +101,7 @@ def test_monitoring_shows_mon_down(measure_stop_ceph_mon, threading_lock):
 @pytest.mark.polarion_id("OCS-1307")
 @skipif_managed_service
 @skipif_external_mode
+@zstream_4_20_14
 def test_monitoring_shows_osd_down(measure_stop_ceph_osd, threading_lock):
     """
     Make sure simple problems with OSD daemons are reported via OCP Prometheus.
@@ -171,6 +173,7 @@ def test_monitoring_shows_osd_down(measure_stop_ceph_osd, threading_lock):
 @tier3
 @pytest.mark.polarion_id("OCS-2734")
 @skipif_managed_service
+@zstream_4_20_14
 def test_ceph_metrics_presence_when_osd_down(measure_stop_ceph_osd, threading_lock):
     """
     Since ODF 4.9 ceph metrics covering disruptions will be available only

--- a/tests/functional/monitoring/prometheus/metrics/test_rgw.py
+++ b/tests/functional/monitoring/prometheus/metrics/test_rgw.py
@@ -9,7 +9,7 @@ import logging
 import pytest
 
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import blue_squad
+from ocs_ci.framework.pytest_customization.marks import blue_squad, zstream_4_20_14
 from ocs_ci.framework.testlib import (
     skipif_managed_service,
     runs_on_provider,
@@ -31,6 +31,7 @@ logger = logging.getLogger(__name__)
 @pytest.mark.polarion_id("OCS-2385")
 @skipif_managed_service
 @runs_on_provider
+@zstream_4_20_14
 def test_ceph_rgw_metrics_after_metrics_exporter_respin(
     rgw_deployments, threading_lock
 ):

--- a/tests/functional/nfs_feature/test_nfs_feature_enable_for_ODF_clusters.py
+++ b/tests/functional/nfs_feature/test_nfs_feature_enable_for_ODF_clusters.py
@@ -17,6 +17,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     brown_squad,
     skipif_rosa_hcp,
     skipif_lean_deployment,
+    zstream_4_20_14,
 )
 from ocs_ci.framework.testlib import (
     skipif_ocs_version,
@@ -60,6 +61,7 @@ ERRMSG = "Error in command"
 @skip_for_provider_or_client_if_ocs_version("<4.19")
 @skipif_lean_deployment
 @polarion_id("OCS-4270")
+@zstream_4_20_14
 class TestDefaultNfsDisabled(ManageTest):
     """
     Test nfs feature enable for ODF 4.11

--- a/tests/functional/object/mcg/test_admission_control.py
+++ b/tests/functional/object/mcg/test_admission_control.py
@@ -6,7 +6,7 @@ from ocs_ci.ocs.ocp import OCP
 from ocs_ci.utility import templating
 
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import red_squad, mcg
+from ocs_ci.framework.pytest_customization.marks import red_squad, mcg, zstream_4_20_14
 from ocs_ci.framework.testlib import (
     MCGTest,
     skipif_ocs_version,
@@ -30,6 +30,7 @@ logger = logging.getLogger(__name__)
 # Thus, it falsely recognizes leftovers that are deleted in a later stage
 @ignore_leftovers
 @runs_on_provider
+@zstream_4_20_14
 class TestAdmissionWebhooks(MCGTest):
     @pytest.mark.parametrize(
         argnames="spec_dict,err_msg",

--- a/tests/functional/object/mcg/test_bucket_creation_deletion.py
+++ b/tests/functional/object/mcg/test_bucket_creation_deletion.py
@@ -15,6 +15,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     runs_on_provider,
     red_squad,
     mcg,
+    zstream_4_20_14,
 )
 from ocs_ci.ocs.bucket_utils import sync_object_directory
 from ocs_ci.ocs.constants import DEFAULT_STORAGECLASS_RBD, AWSCLI_TEST_OBJ_DIR
@@ -31,6 +32,7 @@ logger = logging.getLogger(__name__)
 @red_squad
 @runs_on_provider
 @skipif_managed_service
+@zstream_4_20_14
 class TestBucketCreationAndDeletion(MCGTest):
     """
     Test creation of a bucket

--- a/tests/functional/object/mcg/test_bucket_notifications.py
+++ b/tests/functional/object/mcg/test_bucket_notifications.py
@@ -33,6 +33,7 @@ from ocs_ci.ocs.exceptions import TimeoutExpiredError
 from ocs_ci.ocs.resources.bucket_notifications_manager import BucketNotificationsManager
 from ocs_ci.ocs.resources.mcg_lifecycle_policies import ExpirationRule, LifecyclePolicy
 from ocs_ci.utility.utils import TimeoutSampler
+from ocs_ci.framework.pytest_customization.marks import zstream_4_20_14
 
 logger = logging.getLogger(__name__)
 
@@ -44,6 +45,7 @@ logger = logging.getLogger(__name__)
 @skipif_external_mode
 @skipif_proxy_cluster
 @ignore_leftover_label(constants.CUSTOM_MCG_LABEL)
+@zstream_4_20_14
 class TestBucketNotifications(MCGTest):
     """
     Test the MCG bucket notifications feature

--- a/tests/functional/object/mcg/test_bucketclass.py
+++ b/tests/functional/object/mcg/test_bucketclass.py
@@ -6,6 +6,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     red_squad,
     polarion_id,
     tier2,
+    zstream_4_20_14,
 )
 from ocs_ci.framework import config
 from ocs_ci.ocs import constants
@@ -18,6 +19,7 @@ logger = logging.getLogger(__name__)
 
 @mcg
 @red_squad
+@zstream_4_20_14
 class TestBucketClass:
 
     @tier2

--- a/tests/functional/object/mcg/test_default_backingstore_override.py
+++ b/tests/functional/object/mcg/test_default_backingstore_override.py
@@ -17,6 +17,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_disconnected_cluster,
     skipif_proxy_cluster,
     skipif_external_mode,
+    zstream_4_20_14,
 )
 from ocs_ci.framework.testlib import MCGTest
 from ocs_ci.ocs import constants
@@ -37,6 +38,7 @@ logger = logging.getLogger(__name__)
 @skipif_disconnected_cluster
 @skipif_proxy_cluster
 @skipif_external_mode
+@zstream_4_20_14
 class TestDefaultBackingstoreOverride(MCGTest):
     """
     Test overriding the default noobaa backingstore

--- a/tests/functional/object/mcg/test_loadbalancer_subnet_config.py
+++ b/tests/functional/object/mcg/test_loadbalancer_subnet_config.py
@@ -12,6 +12,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     polarion_id,
     red_squad,
     tier2,
+    zstream_4_20_14,
 )
 from ocs_ci.framework.testlib import MCGTest
 from ocs_ci.ocs.exceptions import CommandFailed
@@ -24,6 +25,7 @@ logger = logging.getLogger(__name__)
 @mcg
 @red_squad
 @aws_platform_required
+@zstream_4_20_14
 class TestLBSubnetConfig(MCGTest):
 
     @tier2

--- a/tests/functional/object/mcg/test_multi_region.py
+++ b/tests/functional/object/mcg/test_multi_region.py
@@ -14,6 +14,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     runs_on_provider,
     mcg,
     tier2,
+    zstream_4_20_14,
 )
 from ocs_ci.framework.testlib import MCGTest
 from ocs_ci.ocs import ocp, constants
@@ -35,6 +36,7 @@ logger = logging.getLogger(__name__)
 @skipif_disconnected_cluster
 @skipif_aws_creds_are_missing
 @runs_on_provider
+@zstream_4_20_14
 class TestMultiRegion(MCGTest):
     """
     Test the multi region functionality

--- a/tests/functional/object/mcg/test_multipart_upload.py
+++ b/tests/functional/object/mcg/test_multipart_upload.py
@@ -21,6 +21,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     red_squad,
     runs_on_provider,
     mcg,
+    zstream_4_20_14,
 )
 
 logger = logging.getLogger(__name__)
@@ -59,6 +60,7 @@ def setup(pod_obj, bucket_factory, test_directory_setup):
 @red_squad
 @runs_on_provider
 @skipif_managed_service
+@zstream_4_20_14
 class TestS3MultipartUpload(MCGTest):
     """
     Test Multipart upload on Noobaa buckets

--- a/tests/functional/object/mcg/test_obc_quota_update_using_cli.py
+++ b/tests/functional/object/mcg/test_obc_quota_update_using_cli.py
@@ -8,6 +8,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     polarion_id,
     red_squad,
     mcg,
+    zstream_4_20_14,
 )
 
 logger = logging.getLogger(__name__)
@@ -18,6 +19,7 @@ logger = logging.getLogger(__name__)
 @red_squad
 @jira("DFBUGS-1173")
 @polarion_id("OCS-6340")
+@zstream_4_20_14
 def test_obc_quota_update_using_cli(mcg_obj):
     """
     Test OBC quota update using mcg cli

--- a/tests/functional/object/rgw/test_bucket_creation.py
+++ b/tests/functional/object/rgw/test_bucket_creation.py
@@ -10,6 +10,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     runs_on_provider,
     tier1,
     tier3,
+    zstream_4_20_14,
 )
 from ocs_ci.ocs.resources.objectbucket import BUCKET_MAP
 from ocs_ci.ocs.exceptions import CommandFailed
@@ -23,6 +24,7 @@ logger = logging.getLogger(__name__)
 @red_squad
 @runs_on_provider
 @skipif_mcg_only
+@zstream_4_20_14
 class TestRGWBucketCreation:
     """
     Test creation of a bucket

--- a/tests/functional/object/rgw/test_cephobjectstore_user.py
+++ b/tests/functional/object/rgw/test_cephobjectstore_user.py
@@ -12,6 +12,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     red_squad,
     rgw,
     tier3,
+    zstream_4_20_14,
 )
 
 logger = logging.getLogger(__name__)
@@ -19,6 +20,7 @@ logger = logging.getLogger(__name__)
 
 @red_squad
 @rgw
+@zstream_4_20_14
 class TestObjectStoreUserCaps:
     @pytest.fixture()
     def create_test_cosu(self, request):

--- a/tests/functional/object/rgw/test_host_node_failure.py
+++ b/tests/functional/object/rgw/test_host_node_failure.py
@@ -2,7 +2,7 @@ import logging
 import pytest
 
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import red_squad, rgw, runs_on_provider
+from ocs_ci.framework.pytest_customization.marks import red_squad, rgw, runs_on_provider, zstream_4_20_14
 from ocs_ci.framework.testlib import (
     ignore_leftovers,
     ManageTest,
@@ -42,6 +42,7 @@ log = logging.getLogger(__name__)
 @on_prem_platform_required
 @skipif_external_mode
 @skipif_vsphere_ipi
+@zstream_4_20_14
 class TestRGWAndNoobaaDBHostNodeFailure(ManageTest):
     """
     Test to verify fail node hosting

--- a/tests/functional/object/rgw/test_multipart_upload.py
+++ b/tests/functional/object/rgw/test_multipart_upload.py
@@ -9,6 +9,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_mcg_only,
     rgw,
     runs_on_provider,
+    zstream_4_20_14,
 )
 from ocs_ci.ocs.bucket_utils import (
     verify_s3_object_integrity,
@@ -58,6 +59,7 @@ def setup(pod_obj, rgw_bucket_factory, test_directory_setup):
 @red_squad
 @runs_on_provider
 @skipif_mcg_only
+@zstream_4_20_14
 class TestS3MultipartUpload(ManageTest):
     """
     Test Multipart upload on RGW buckets

--- a/tests/functional/object/rgw/test_obc_quota.py
+++ b/tests/functional/object/rgw/test_obc_quota.py
@@ -20,6 +20,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     rgw,
     runs_on_provider,
     polarion_id,
+    zstream_4_20_14,
 )
 
 logger = logging.getLogger(__name__)
@@ -30,6 +31,7 @@ logger = logging.getLogger(__name__)
 @runs_on_provider
 @skipif_ocs_version("<4.10")
 @skipif_mcg_only
+@zstream_4_20_14
 class TestOBCQuota:
     """
     Test OBC Quota feature

--- a/tests/functional/object/rgw/test_object_integrity.py
+++ b/tests/functional/object/rgw/test_object_integrity.py
@@ -13,6 +13,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_mcg_only,
     rgw,
     runs_on_provider,
+    zstream_4_20_14,
 )
 from ocs_ci.framework.testlib import ManageTest, tier1, tier2
 from ocs_ci.ocs.resources.objectbucket import OBC
@@ -25,6 +26,7 @@ logger = logging.getLogger(__name__)
 @red_squad
 @runs_on_provider
 @skipif_mcg_only
+@zstream_4_20_14
 class TestObjectIntegrity(ManageTest):
     """
     Test data integrity of RGW buckets

--- a/tests/functional/object/rgw/test_rgw_pod_existence.py
+++ b/tests/functional/object/rgw/test_rgw_pod_existence.py
@@ -6,6 +6,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     red_squad,
     rgw,
     runs_on_provider,
+    zstream_4_20_14,
 )
 from ocs_ci.helpers.helpers import storagecluster_independent_check
 from ocs_ci.ocs import constants
@@ -22,6 +23,7 @@ logger = logging.getLogger(__name__)
 @red_squad
 @runs_on_provider
 @acceptance
+@zstream_4_20_14
 class TestRGWPodExistence:
     """
     Test the existence of RGW pods based on platform

--- a/tests/functional/object/rgw/test_rgw_read_affinity.py
+++ b/tests/functional/object/rgw/test_rgw_read_affinity.py
@@ -8,6 +8,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     rgw,
     skipif_no_lso,
     post_upgrade,
+    zstream_4_20_14,
 )
 from ocs_ci.ocs.resources.pod import get_rgw_pods
 from ocs_ci.ocs.ocp import OCP
@@ -27,6 +28,7 @@ DEFAULT_READ_AFFINITY = "localize"
 @rgw
 @red_squad
 @skipif_no_lso
+@zstream_4_20_14
 class TestRGWReadAffinityMode:
     """
     Test the RGW Read Affinity value in an ODF cluster

--- a/tests/functional/object/rgw/test_rgw_routes.py
+++ b/tests/functional/object/rgw/test_rgw_routes.py
@@ -11,6 +11,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     tier1,
     rgw,
     runs_on_provider,
+    zstream_4_20_14,
 )
 from ocs_ci.ocs import constants, ocp
 from ocs_ci.ocs.bucket_utils import (
@@ -28,6 +29,7 @@ log = logging.getLogger(__name__)
 @red_squad
 @runs_on_provider
 @on_prem_platform_required
+@zstream_4_20_14
 class TestRGWRoutes:
     """
     Test the RGW routes in an ODF cluster

--- a/tests/functional/odf-cli/test_debug_verbocity_of_ceph_component.py
+++ b/tests/functional/odf-cli/test_debug_verbocity_of_ceph_component.py
@@ -2,7 +2,7 @@ import pytest
 import logging
 
 from ocs_ci.helpers.helpers import get_ceph_log_level
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, zstream_4_20_14
 from ocs_ci.ocs.exceptions import CommandFailed
 from ocs_ci.framework.testlib import tier2, skipif_kms_deployment, skipif_external_mode
 
@@ -13,6 +13,7 @@ log = logging.getLogger(__name__)
 @tier2
 @skipif_kms_deployment
 @skipif_external_mode
+@zstream_4_20_14
 class TestDebugVerbosityOfCephComponents:
     @pytest.fixture(autouse=True)
     def setup(self, odf_cli_setup):

--- a/tests/functional/pv/pv_services/test_cephfs_fsync_consistency.py
+++ b/tests/functional/pv/pv_services/test_cephfs_fsync_consistency.py
@@ -5,6 +5,7 @@ from ocs_ci.framework.testlib import ManageTest, tier1, green_squad, polarion_id
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.ocp import exec_cmd
 from ocs_ci.ocs.node import get_worker_nodes
+from ocs_ci.framework.pytest_customization.marks import zstream_4_20_14
 
 
 logger = logging.getLogger(__name__)
@@ -13,6 +14,7 @@ logger = logging.getLogger(__name__)
 @tier1
 @green_squad
 @polarion_id("OCS-6797")
+@zstream_4_20_14
 class TestCephfsFsyncConsistency(ManageTest):
     """
     Ensuring File Completeness Post-fsync with Shared CephFS Volume

--- a/tests/functional/ui/test_capacity_breakdown_ui.py
+++ b/tests/functional/ui/test_capacity_breakdown_ui.py
@@ -18,6 +18,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     black_squad,
     runs_on_provider,
     skipif_ibm_cloud_managed,
+    zstream_4_20_14,
 )
 from ocs_ci.helpers import helpers
 from ocs_ci.ocs import constants
@@ -37,6 +38,7 @@ from ocs_ci.utility.utils import TimeoutSampler
 logger = logging.getLogger(__name__)
 
 
+@zstream_4_20_14
 class TestCapacityBreakdownUI(ManageTest):
     """
     Test Capacity Breakdown UI

--- a/tests/functional/workloads/app/amq/test_rgw_kafka_notifications.py
+++ b/tests/functional/workloads/app/amq/test_rgw_kafka_notifications.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from semantic_version import Version
 
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import magenta_squad
+from ocs_ci.framework.pytest_customization.marks import magenta_squad, zstream_4_20_14
 from ocs_ci.framework.testlib import (
     E2ETest,
     tier1,
@@ -58,6 +58,7 @@ def check_kafka_messages(kafkadrop_host, kafka_topic_name):
 @skipif_external_mode
 @skipif_disconnected_cluster
 @pytest.mark.polarion_id("OCS-2514")
+@zstream_4_20_14
 class TestRGWAndKafkaNotifications(E2ETest):
     """
     Test to verify rgw kafka notifications

--- a/tests/functional/z_cluster/test_ceph_default_values_check.py
+++ b/tests/functional/z_cluster/test_ceph_default_values_check.py
@@ -5,6 +5,7 @@ import pytest
 from ocs_ci.framework.pytest_customization.marks import (
     skipif_ocs_version,
     brown_squad,
+    zstream_4_20_14,
 )
 from ocs_ci.framework.testlib import (
     ManageTest,
@@ -38,6 +39,7 @@ log = logging.getLogger(__name__)
 @tier1
 @skipif_external_mode
 @pytest.mark.polarion_id("OCS-2231")
+@zstream_4_20_14
 class TestCephDefaultValuesCheck(ManageTest):
     def test_ceph_default_values_check(self):
         """


### PR DESCRIPTION
# Z-Stream Test Enablement: ODF 4.20.14

This PR enables automated test coverage for the ODF 4.20.14 z-stream release validation. It adds pytest markers to 62 test cases that validate bug fixes, security patches, and component updates included in this release.

## Z-Stream Version

**ODF 4.20.14**

## Changes Being Validated

This z-stream release includes **37 bug fixes** and **4 upstream PR integrations** across multiple ODF components:

### By Component

| Component | Bug Fixes | Security Fixes | Total |
|-----------|-----------|----------------|-------|
| odf-console | 4 | 19 | 23 |
| mcg | 7 | 0 | 7 |
| ocs-operator | 4 | 0 | 4 |
| rook | 3 | 0 | 3 |
| odf-dr/multicluster-orchestrator | 1 | 0 | 1 |
| ceph-csi | 1 | 0 | 1 |
| monitoring | 1 | 0 | 1 |
| must-gather | 1 | 0 | 1 |
| odf-cli | 0 | 1 | 1 |

### Critical Changes

**NooBaa/MCG:**
- [DFBUGS-7079](https://redhat.atlassian.net/browse/DFBUGS-7079): NooBaa upgrade failure due to remove_mongo_pool.js error
- [DFBUGS-6846](https://redhat.atlassian.net/browse/DFBUGS-6846): Intermittent S3 upload failures (HTTP 500) via JFrog Artifactory
- [DFBUGS-6872](https://redhat.atlassian.net/browse/DFBUGS-6872): INVALID_SCHEMA_REPLY SERVER after upgrading to 4.21
- [DFBUGS-7045](https://redhat.atlassian.net/browse/DFBUGS-7045): Update nodejs from v22.11.0 to v24.13.0

**Rook/Ceph:**
- [DFBUGS-7066](https://redhat.atlassian.net/browse/DFBUGS-7066): RHODF 4.20.14 release tracking
- [DFBUGS-7016](https://redhat.atlassian.net/browse/DFBUGS-7016): Upgrade Ceph to RHCEPH-8.1z6
- [DFBUGS-6705](https://redhat.atlassian.net/browse/DFBUGS-6705): Unnecessary OSD redeployments on 4.19.z upgrade for encrypted OSDs

**Security (odf-console):**
- CVE-2025-69873, CVE-2025-68458, CVE-2025-68157: webpack and build-time vulnerabilities
- CVE-2026-27942, CVE-2026-26278, CVE-2026-25896, CVE-2026-25128: fast-xml-parser DoS and XSS issues
- CVE-2026-27904, CVE-2026-26996: minimatch DoS vulnerabilities
- CVE-2026-22029: React Router XSS via Open Redirects
- CVE-2025-66031, CVE-2025-12816: node-forge cryptographic issues
- CVE-2026-4800: lodash arbitrary code execution
- CVE-2025-13465: lodash prototype pollution

**Operators:**
- [DFBUGS-6533](https://redhat.atlassian.net/browse/DFBUGS-6533): Missing default tolerations
- [DFBUGS-6531](https://redhat.atlassian.net/browse/DFBUGS-6531): Missing toleration for rook-ceph-rbd-mirror pod
- [DFBUGS-6541](https://redhat.atlassian.net/browse/DFBUGS-6541): Provider Server sub-channel handling

**Disaster Recovery:**
- [DFBUGS-6460](https://redhat.atlassian.net/browse/DFBUGS-6460): Partial s3StoreProfile missing after hub upgrade from 4.17 to 4.18

## Test Coverage

**Tests Enabled:** 62

### Coverage by Test Area

The enabled tests cover the following functional areas:

- **Monitoring & Metrics:** Ceph metrics availability, dashboard deployment validation, IP connectivity checks
- **NFS Feature:** NFS enablement, in-cluster/out-cluster exports, multiple mounts, access modes, plugin/provisioner resiliency
- **Object Storage (MCG):** OBC quota updates via CLI, RGW Kafka notifications
- **Data Services:** CephFS fsync consistency, host network validation
- **Storage Classes:** RBD metrics and provisioning

### Sample High-Priority Tests

| Test | Coverage Area |
|------|---------------|
| `test_ceph_pods_have_host_network` | Network configuration validation |
| `test_ceph_mgr_dashboard_not_deployed` | Deployment topology verification |
| `test_ceph_metrics_available` | Prometheus integration ([KNIP-634](https://redhat.atlassian.net/browse/KNIP-634)) |
| `test_nfs_feature_enable` | NFS feature enablement post-deployment |
| `test_rgw_kafka_notifications` | RGW notification system |
| `test_cephfs_fsync_consistency` | CephFS data consistency |

## Validation Scope

This PR ensures that the 4.20.14 z-stream release is validated against:
- Component upgrades and version bumps
- Security vulnerability fixes (19 CVEs addressed)
- Bug fixes affecting production deployments
- Disaster recovery scenarios
- Multi-cluster operations

All 62 tests are marked for execution in the z-stream validation pipeline.