### PR TITLE
[4.17]Deprecate old noobaa db backup and recovery testcase with old procedure

### DIFF
--- a/tests/cross_functional/kcs/test_noobaa_db_backup_and_recovery.py
+++ b/tests/cross_functional/kcs/test_noobaa_db_backup_and_recovery.py
@@ -44,7 +44,7 @@ class TestNoobaaBackupAndRecovery(E2ETest):
     @pytest.mark.polarion_id("OCS-2605")
     @pytest.mark.bugzilla("1924047")
     @skipif_ocs_version("<4.6")
-    def test_noobaa_db_backup_and_recovery(
+    def deprecated_test_noobaa_db_backup_and_recovery(
         self,
         pvc_factory,
         pod_factory,


### PR DESCRIPTION
Backport PR in 4.17 for https://github.com/red-hat-storage/ocs-ci/pull/12382/changes