### PR TITLE
Add self-ref MCG as ULS platform and test replication alert on underlying bucket deletion

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,6 +1,6 @@
 {
   "exclude": {
-    "files": "^.secrets.baseline$",
+    "files": null,
     "lines": null
   },
   "plugins_used": [
@@ -79,1347 +79,1303 @@
     "conf/deployment/ibmcloud/ibm_cloud_managed_3az_0m_3w_vpc_cluster.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 25,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 23,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_hpcs_external.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 25,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_stage.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 22,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_without_cos.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 21,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_without_cos_stage.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 23,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_zone_eu_de_1.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 23,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_zone_eu_de_2.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 23,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_zone_eu_de_3.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 23,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_zone_jp_tok_1.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 23,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_zone_jp_tok_2.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 23,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_zone_jp_tok_3.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 23,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_zone_us_east_1.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 23,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_zone_us_east_2.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 23,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_zone_us_east_3.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 23,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "conf/deployment/ibmcloud/ipi_1az_us_east1_rhcos_3m_3w.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 24,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "conf/deployment/ibmcloud/ipi_1az_us_east1_rhcos_custom_vpc_3m_3w.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 27,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "conf/deployment/ibmcloud/ipi_1az_us_east2_rhcos_3m_3w.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 24,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "conf/deployment/ibmcloud/ipi_1az_us_east3_rhcos_3m_3w.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 24,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "conf/deployment/ibmcloud/ipi_1az_us_south1_rhcos_custom_vpc_3m_3w.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 27,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "conf/deployment/ibmcloud/ipi_3az_rhcos_3m_3w.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 28,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "conf/deployment/ibmcloud/ipi_3az_rhcos_3m_6w.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 29,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "conf/deployment/ibmcloud/ipi_3az_rhcos_compactmode_3m_0w.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 28,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "conf/deployment/ibmcloud/ipi_3az_rhcos_lowerreq_3m_3w.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 28,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "conf/deployment/rhv/ipi_1az_rhcos_3m_3w.yaml": [
       {
         "hashed_secret": "ff55435345834a3fe224936776c2aa15f6ed5358",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 21,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "conf/deployment/rhv/ipi_1az_rhcos_lso_3m_3w.yaml": [
       {
         "hashed_secret": "ff55435345834a3fe224936776c2aa15f6ed5358",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 30,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "conf/deployment/vsphere/upi_1az_rhcos_vsan_3m_3w_disconnected_flexy.yaml": [
       {
         "hashed_secret": "66a1db0d75c1b2302b441a31b75b4d5a9f291d22",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 21,
         "type": "Base64 High Entropy String",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "conf/deployment/vsphere/upi_1az_rhcos_vsan_lso_vmdk_3m_3w_disconnected_flexy.yaml": [
       {
         "hashed_secret": "66a1db0d75c1b2302b441a31b75b4d5a9f291d22",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 24,
         "type": "Base64 High Entropy String",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "conf/examples/hpcs_external_standalone_mode.yaml": [
       {
         "hashed_secret": "fc4a8593743fd8a94fce1b137d964432bb1a9e91",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 13,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "conf/ocsci/disconnected_cluster.yaml.example": [
       {
         "hashed_secret": "1dee91010328c9606757a6ddb538d608b6d89d1c",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 6,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 9,
         "type": "Basic Auth Credentials",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "conf/ocsci/dr_workload.yaml": [
       {
         "hashed_secret": "3bb712fd293d3816c7c111dffc96dffc5c873602",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 345,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "conf/ocsci/hpcs_external_standalone_mode.yaml": [
       {
         "hashed_secret": "fc4a8593743fd8a94fce1b137d964432bb1a9e91",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 12,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "conf/ocsci/mdr_workload.yaml": [
       {
         "hashed_secret": "3bb712fd293d3816c7c111dffc96dffc5c873602",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 119,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "conf/ocsci/noobaa_external_pgsql.yaml": [
       {
         "hashed_secret": "6cb6eb9fabad447f4ec9965879927661143bdfed",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 12,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "conf/ocsci/openshift_dedicated.yaml": [
       {
         "hashed_secret": "66b2fcbc520c25a8087712aa85e95516a2b6c79b",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 14,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "conf/ocsci/vsphere_upi_vars.yaml.example": [
       {
         "hashed_secret": "e894b36b7cdd92461cad391cf01f52c9e53c41ad",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 26,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "conf/ocsci/vsphere_upi_vars.yaml.skeleton": [
       {
         "hashed_secret": "d63f8d34ad75f338f5b42b331e2fd883576a29bd",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 10,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "e894b36b7cdd92461cad391cf01f52c9e53c41ad",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 27,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "docs/getting_started.md": [
       {
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 174,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "docs/logging_guide.md": [
       {
         "hashed_secret": "605cf0632d1f0b7aebb3c0cd5c51a92145bb28a6",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 1421,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "docs/supported_platforms.md": [
       {
         "hashed_secret": "6eae3a5b062c6d0d79f070c26e6d62486b40cb46",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 30,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 171,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "docs/usage.md": [
       {
         "hashed_secret": "89a519cc7786f3290ad671412d92f325f9ef2a57",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 98,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "cfcafdd35cb253bd1a95060758e671abe510920a",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 347,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "ocs_ci/deployment/aws.py": [
       {
         "hashed_secret": "134f379c01b1cf36e5ee172c37ffeca5c679a5ee",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 802,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "ocs_ci/deployment/flexy.py": [
       {
         "hashed_secret": "bea1af2a15561a266eda3472673d24cb4f2020d4",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 242,
+        "line_number": 241,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "ocs_ci/deployment/hub_spoke.py": [
       {
         "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 7165,
+        "line_number": 7164,
         "type": "Private Key",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "ocs_ci/framework/conf/default_config.yaml": [
       {
         "hashed_secret": "613fb9979a1ab677719426dd2e81a60fad637cf2",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 28,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "eea97d7f2f305e7afdc0b9bf64859b660cd09232",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 31,
         "type": "Hex High Entropy String",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 330,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 334,
-        "line_number": 338,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "de19c40310ad831a71524cd279e6f5f0577fb09a",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 376,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "de19c40310ad831a71524cd279e6f5f0577fb09a",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 378,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "de19c40310ad831a71524cd279e6f5f0577fb09a",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 382,
-        "line_number": 386,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "ocs_ci/helpers/cluster_exp_helpers.py": [
       {
         "hashed_secret": "fa3798e69b10954419dfdcf70da00dce77b1416e",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 57,
         "type": "Hex High Entropy String",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "ocs_ci/helpers/helpers.py": [
       {
         "hashed_secret": "66a36e77fd002579809717841f998f4d21cd5913",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 2897,
+        "line_number": 2925,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "ocs_ci/krkn_chaos/template/krkn_global_config.yaml.j2": [
       {
         "hashed_secret": "d2e2ab0f407e4ee3cf2ab87d61c31b25a74085e5",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 50,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "ocs_ci/krkn_chaos/template/scenarios/keknctl/plan.json.j2": [
       {
         "hashed_secret": "d2e2ab0f407e4ee3cf2ab87d61c31b25a74085e5",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 760,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "ocs_ci/ocs/clients.py": [
       {
         "hashed_secret": "a8c1dc105c415cc7ccb286ecdb1156ebd9f957fb",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 14,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "ocs_ci/ocs/constants.py": [
       {
         "hashed_secret": "b7e9a6e2e04ed3edbf8b4e21def4beccbb6eb6b1",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 233,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "a12337323b638ab044b1166bff4b1a1f83162819",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 848,
+        "line_number": 840,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "fb947972c92f052c0a08866d182be0075a2b601b",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 857,
+        "line_number": 849,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "03e227627ab8681281fdb8aa3d799b03f782d672",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 2023,
-        "line_number": 2060,
+        "line_number": 2053,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "ef5f3d909f23bd0aa02b4253f98350384f709c86",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 2130,
-        "line_number": 2167,
+        "line_number": 2160,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "cb1ae2b504c4615841d8144267a131231d2bd677",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 2131,
-        "line_number": 2168,
+        "line_number": 2161,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "1a1e70e87dd0452c42f33ce9bf74aa28134dba6b",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 2132,
-        "line_number": 2169,
+        "line_number": 2162,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "7b1ba2f04f2f1604dc4e3caffcadf9fcbce7df5b",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 2133,
-        "line_number": 2170,
+        "line_number": 2163,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "0fa3b21ced80146d752888f2b60ec80e0d4b8925",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 2138,
-        "line_number": 2182,
+        "line_number": 2175,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "f084f2068494b8d1cd06811dd97d02c3d85f40ee",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 2153,
-        "line_number": 2197,
+        "line_number": 2190,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "adfa401a3b0a733d8f00519ac8c6b3893a2e7e8e",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 2154,
-        "line_number": 2198,
+        "line_number": 2191,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "898e46bbadc12f87120548bd445eb4210c8407c8",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 2162,
-        "line_number": 2206,
+        "line_number": 2199,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "f57ccec6b8f7b12b635ab53d26c3bf7300247341",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 2163,
-        "line_number": 2207,
+        "line_number": 2200,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "77b044ea736f8cbe568d1954424186d901f89db9",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 2164,
-        "line_number": 2208,
+        "line_number": 2201,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "d64368f12ca17c69568c6a132f17d44d56e60660",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 2165,
-        "line_number": 2209,
+        "line_number": 2202,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "8f9ca35156c02cb6ba58c5b51230b9bedc38de4f",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 2166,
-        "line_number": 2210,
+        "line_number": 2203,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "9ec53cfd9929c70c3f87c210b6a7b77fb6d79d43",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 2757,
-        "line_number": 2807,
+        "line_number": 2800,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 2914,
-        "line_number": 2972,
+        "line_number": 2966,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "adc1f5c8707f7d7aba3aabe13c15e5ef1151872e",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 2915,
-        "line_number": 2973,
+        "line_number": 2967,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "ee46262b2df945e46ea310b925ad087465dbd3f2",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 3636,
-        "line_number": 3694,
+        "line_number": 3688,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "f678cad4ab874d71b559a069d5e34a95fe38a480",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 3637,
-        "line_number": 3695,
+        "line_number": 3689,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "ocs_ci/ocs/defaults.py": [
       {
         "hashed_secret": "ca4dbbee191f1e04318439e30e4e9f55134e4513",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 123,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "9125b9994805d74d9545e381b9d5a90e65e2d63e",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 124,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "637138e061a7c9dc22f301dfcf7a43b638a2e1d8",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 125,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "ocs_ci/ocs/external_ceph.py": [
       {
         "hashed_secret": "d2137e76c2c4f75fe37e8c0a03670d3715849389",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 473,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "30274c47903bd1bac7633bbf09743149ebab805f",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 474,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "ocs_ci/ocs/fusion.py": [
       {
         "hashed_secret": "6eae3a5b062c6d0d79f070c26e6d62486b40cb46",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 97,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "ocs_ci/ocs/platform_nodes.py": [
       {
         "hashed_secret": "134f379c01b1cf36e5ee172c37ffeca5c679a5ee",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 1273,
+        "line_number": 1269,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "ocs_ci/ocs/resources/ocsconfigmaps.py": [
       {
         "hashed_secret": "347cd9c53ff77d41a7b22aa56c7b4efaf54658e3",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 404,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "ocs_ci/ocs/utils.py": [
       {
         "hashed_secret": "f2dde9105675b76e1f542230a642933ccffd8a8e",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 331,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "8f57c0c672ec244816d827f57ea488c2d609efc9",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 643,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "30274c47903bd1bac7633bbf09743149ebab805f",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 644,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "ocs_ci/templates/CSI/rbd/csi-kms-connection-details.yaml": [
       {
         "hashed_secret": "214d02537c8b2382bd599e97b100b78d1f9614aa",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 4,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "ocs_ci/templates/ocs-deployment/external-pgsql-noobaa-secret.yaml": [
       {
         "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 9,
         "type": "Basic Auth Credentials",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "ocs_ci/templates/ocs-deployment/multicluster/odr_s3_secret.yaml": [
       {
         "hashed_secret": "d3045fb7f8faed786bb7694d7d4ca06e357eea24",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 5,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "ocs_ci/templates/openshift-infra/hpcs/ibm-kp-kms-secret.yaml": [
       {
         "hashed_secret": "021b53ce46b72837170446bee4e579c4801bc67a",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 8,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "ocs_ci/templates/workloads/couchbase/server/couchbase-worker-secret.yaml": [
       {
         "hashed_secret": "7cf7ed86e8f660ade5996a1072d74cd35def47af",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 9,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "ocs_ci/templates/workloads/couchbase/server/couchbase-worker.yaml": [
       {
         "hashed_secret": "8d6478f5d35b469b1568d41c393b3e08d30e7a2e",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 27,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "ocs_ci/templates/workloads/hsbench/hsbench_obj.yaml": [
       {
         "hashed_secret": "7a9a4af7de5c6536e46cbee0856f11b46cdde7c9",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 5,
         "type": "Base64 High Entropy String",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "ocs_ci/templates/workloads/quay/quay_registry.yaml": [
       {
         "hashed_secret": "83f7cd4240b0182d4e26f6f5aa845d3d29e4adfb",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 7,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "ocs_ci/utility/managedservice.py": [
       {
         "hashed_secret": "6eae3a5b062c6d0d79f070c26e6d62486b40cb46",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 95,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "be4fc4886bd949b369d5e092eb87494f12e57e5b",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 169,
         "type": "Private Key",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "ocs_ci/utility/rosa.py": [
       {
         "hashed_secret": "6eae3a5b062c6d0d79f070c26e6d62486b40cb46",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 687,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "ocs_ci/utility/storage_cluster_setup.py": [
       {
         "hashed_secret": "f0e2d8610edefa0c02b673dcac7964b02ce3e890",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 748,
         "type": "Basic Auth Credentials",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "terraform/ai/vsphere/terraform.tfvars.example": [
       {
         "hashed_secret": "42a818da3bb789755a56f06412ebba442bf41edf",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 12,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "tests/cross_functional/kcs/test_noobaadb_pw_reset.py": [
       {
         "hashed_secret": "95b0665e64fa24c375f1db3797739dc833a01be1",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 87,
         "type": "Secret Keyword",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ],
     "tests/functional/ui/test_alert_text.py": [
       {
         "hashed_secret": "deed437581abf6a8a8c3f908a00739ec66bd1907",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 26,
         "type": "Hex High Entropy String",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "d3c7cf8a52f042f5ad10e7e04c6efa9b3edfc091",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 27,
         "type": "Hex High Entropy String",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "0e47f8d47cf71626c411322d5cc46463bb9ee63a",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 28,
         "type": "Hex High Entropy String",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "def6a0eb64808cbdf3e3985b380d06019ccaf15c",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 29,
         "type": "Hex High Entropy String",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "1eb02d1de1c583c352016b765c4470f14688c27f",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 30,
         "type": "Hex High Entropy String",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "beb03c56370648a8018847b7eb6f0ff17e2ec17d",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 31,
         "type": "Hex High Entropy String",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "c8a3e4b73af4fc164a18209fa3248cace0376de6",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 32,
         "type": "Hex High Entropy String",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "3b793d3c8f6140791030db45900185a24bc0f8d6",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 33,
         "type": "Hex High Entropy String",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "5e10a523088617ee53c02a050ecb4f3c02ff36a6",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 34,
         "type": "Hex High Entropy String",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "67cec59154e2b4dbc161ab590ea9836833a03879",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 35,
         "type": "Hex High Entropy String",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "a7051bbf0cbb04fbd58fea9202861924cf476965",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 36,
         "type": "Hex High Entropy String",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "711167a9e39213a023177fb6f8726eed4ae87724",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 37,
         "type": "Hex High Entropy String",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "62f46554adcad52e1b59156746059e8fe2b68114",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 38,
         "type": "Hex High Entropy String",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "6b6660ec37abef577585e08fbadd66a1daa126ad",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 39,
         "type": "Hex High Entropy String",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "ba9fdcab8f3a1c05e545c90657adeeca92457819",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 40,
         "type": "Hex High Entropy String",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "d92508b7e8714361d780028189182ccc838905fd",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 41,
         "type": "Hex High Entropy String",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "5d831603558fae694509e52443867d9d0fe15dab",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 42,
         "type": "Hex High Entropy String",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "70444c50c0b30525a518f749e570c2b5ab2ea159",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 43,
         "type": "Hex High Entropy String",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "b3a6d9ed97f183a3ed70fe50f8f5a1ab84eccfb5",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 44,
         "type": "Hex High Entropy String",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "d94d7c9ec8c812df775f85cf53d44fe0dacb153c",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 45,
         "type": "Hex High Entropy String",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "7fbab5f66d94793e754adf5eec572dd69895add7",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 46,
         "type": "Hex High Entropy String",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "d5164d922808f83e1bb2fb7ef4ae43a8fdc2d63a",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 47,
         "type": "Hex High Entropy String",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "474e5f07c32a4837e6685a64fb86c3b80ed14ef5",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 48,
         "type": "Hex High Entropy String",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "aee98b1d4cdc9ea965426edfff3e89413d648f28",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 49,
         "type": "Hex High Entropy String",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "cb44fa15b838b5bd5bb7cf855c8b65b83575b049",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 50,
         "type": "Hex High Entropy String",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "bfcb7bd33a4d476579e23a6ab6bef8270fd359a6",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 51,
         "type": "Hex High Entropy String",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "9109e09e3881791c6e7245a3e4dc3e9dd23305ec",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 52,
         "type": "Hex High Entropy String",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "44ac318f0525c62193986773a822397d9cd65220",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 53,
         "type": "Hex High Entropy String",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "a34ddb5f6561f1c681ea9d6369f2bf5ea5435bbf",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 54,
         "type": "Hex High Entropy String",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "a0f8bc5793f4cc0b1173b8e65c824e80bba32ec3",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 55,
         "type": "Hex High Entropy String",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "11b02033ace8079c90a25fe5dfef319b19363e56",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 56,
         "type": "Hex High Entropy String",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "c3bce19887dde7c21edbcc997f70e2d9b67a7845",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 57,
         "type": "Hex High Entropy String",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "918b8462281c3884363c68bd466e90e34bcb7b4f",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 58,
         "type": "Hex High Entropy String",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "5d279aca1022ec52d2f595199e74490d75bf3940",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 59,
         "type": "Hex High Entropy String",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "a9c2f9fb9293eac7f7055dc5ad8510ed89446890",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 60,
         "type": "Hex High Entropy String",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "6828bcb400541dcb69f04098c046c36947a664be",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 61,
         "type": "Hex High Entropy String",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "a7f8c0d263a1263d2f858d388e0f6ed799c3ed85",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 62,
         "type": "Hex High Entropy String",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "e7aac35a54098dff672130afc60ba0395f339089",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 63,
         "type": "Hex High Entropy String",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "642e4f0372448c534f32262a96e7d9f2b27b47d2",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 64,
         "type": "Hex High Entropy String",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "3bdd128c4f1e6c4d3ade5eb86dcfecc387e13a38",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 65,
         "type": "Hex High Entropy String",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "8308b864c9c12f694be52639f16fc312929c268a",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 68,
         "type": "Hex High Entropy String",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       },
       {
         "hashed_secret": "64d5413c9629cf6c976224d145450a839f213b96",
-        "is_secret": false,
         "is_verified": false,
         "line_number": 69,
         "type": "Hex High Entropy String",
-        "verified_result": null
+        "verified_result": null,
+        "is_secret": false
       }
     ]
   },

--- a/ocs_ci/ocs/bucket_utils.py
+++ b/ocs_ci/ocs/bucket_utils.py
@@ -1052,6 +1052,63 @@ def cli_create_rgw_backingstore(mcg_obj, cld_mgr, backingstore_name, uls_name, r
     )
 
 
+def oc_create_self_ref_mcg_backingstore(cld_mgr, backingstore_name, uls_name, region):
+    """
+    Create a new self-ref MCG backingstore using oc create command.
+    Self-ref MCG is an S3-compatible store backed by an MCG's own
+    bucket on the same cluster.
+
+    Args:
+        cld_mgr (CloudManager): holds secret for backingstore creation
+        backingstore_name (str): backingstore name
+        uls_name (str): underlying storage name
+        region (str): unused, kept for interface compatibility
+
+    """
+    bs_data = templating.load_yaml(constants.MCG_BACKINGSTORE_YAML)
+    bs_data["metadata"]["name"] = backingstore_name
+    bs_data["metadata"]["namespace"] = config.ENV_DATA["cluster_namespace"]
+    bs_data["spec"] = {
+        "type": "s3-compatible",
+        "s3Compatible": {
+            "targetBucket": uls_name,
+            "endpoint": cld_mgr.self_ref_mcg_client.s3_internal_endpoint,
+            "signatureVersion": "v4",
+            "secret": {
+                "name": cld_mgr.self_ref_mcg_client.secret.name,
+                "namespace": bs_data["metadata"]["namespace"],
+            },
+        },
+    }
+    create_resource(**bs_data)
+
+
+def cli_create_self_ref_mcg_backingstore(
+    mcg_obj, cld_mgr, backingstore_name, uls_name, region
+):
+    """
+    Create a new self-ref MCG backingstore using the NooBaa CLI.
+    Self-ref MCG is an S3-compatible store backed by an MCG's own
+    bucket on the same cluster.
+
+    Args:
+        mcg_obj (MCG): MCG object for executing CLI commands
+        cld_mgr (CloudManager): holds self-ref MCG client credentials
+        backingstore_name (str): backingstore name
+        uls_name (str): underlying storage name
+        region (str): unused, kept for interface compatibility
+
+    """
+    mcg_obj.exec_mcg_cmd(
+        f"backingstore create s3-compatible {backingstore_name} "
+        f"--endpoint {cld_mgr.self_ref_mcg_client.s3_internal_endpoint} "
+        f"--access-key {cld_mgr.self_ref_mcg_client.access_key} "
+        f"--secret-key {cld_mgr.self_ref_mcg_client.secret_key} "
+        f"--target-bucket {uls_name}",
+        use_yes=True,
+    )
+
+
 def oc_create_pv_backingstore(backingstore_name, vol_num, size, storage_class):
     """
     Create a new backingstore with pv underlying storage using oc create command

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -1825,6 +1825,7 @@ IBM_POWER_PLATFORM = "powervs"
 IBM_CLOUD_BAREMETAL_PLATFORM = "ibm_cloud_baremetal"
 BAREMETALPSI_PLATFORM = "baremetalpsi"
 RGW_PLATFORM = "rgw"
+SELF_REF_MCG_PLATFORM = "self-ref-mcg"
 IBMCLOUD_PLATFORM = "ibm_cloud"
 IBM_COS_PLATFORM = "ibmcos"
 IBM_PLATFORM = "ibm"
@@ -2958,6 +2959,7 @@ CLOUD_MNGR_PLATFORMS = [
     "IBMCOS",
     "AWS_STS",
     "AZURE_STS",
+    "SELF_REF_MCG",
 ]
 
 # Vault related configurations

--- a/ocs_ci/ocs/resources/backingstore.py
+++ b/ocs_ci/ocs/resources/backingstore.py
@@ -18,6 +18,8 @@ from ocs_ci.ocs.bucket_utils import (
     cli_create_aws_sts_backingstore,
     cli_create_azure_sts_backingstore,
     oc_create_azure_sts_backingstore,
+    oc_create_self_ref_mcg_backingstore,
+    cli_create_self_ref_mcg_backingstore,
 )
 from ocs_ci.ocs.exceptions import (
     TimeoutExpiredError,
@@ -286,6 +288,7 @@ def backingstore_factory(
                 "azure": oc_create_azure_backingstore,
                 "ibmcos": oc_create_ibmcos_backingstore,
                 "rgw": oc_create_rgw_backingstore,
+                "self-ref-mcg": oc_create_self_ref_mcg_backingstore,
                 "pv": oc_create_pv_backingstore,
                 "azure-sts": oc_create_azure_sts_backingstore,
             },
@@ -295,6 +298,7 @@ def backingstore_factory(
                 "azure": cli_create_azure_backingstore,
                 "ibmcos": cli_create_ibmcos_backingstore,
                 "rgw": cli_create_rgw_backingstore,
+                "self-ref-mcg": cli_create_self_ref_mcg_backingstore,
                 "pv": cli_create_pv_backingstore,
                 "aws-sts": cli_create_aws_sts_backingstore,
                 "azure-sts": cli_create_azure_sts_backingstore,

--- a/ocs_ci/ocs/resources/cloud_manager.py
+++ b/ocs_ci/ocs/resources/cloud_manager.py
@@ -24,6 +24,7 @@ from ocs_ci.ocs.exceptions import (
     ResourceWrongStatusException,
     ClusterNotInSTSModeException,
 )
+from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.resources.rgw import RGW
 from ocs_ci.utility import templating
 from ocs_ci.utility.aws import update_config_from_s3
@@ -62,6 +63,7 @@ class CloudManager(ABC):
             "AZURE_STS": AzureSTSClient,
             "IBMCOS": IbmCosClient,
             "RGW": RgwClient,
+            "SELF_REF_MCG": SelfRefMcgClient,
         }
         try:
             logger.info(
@@ -130,6 +132,15 @@ class CloudManager(ABC):
             )
         except ClusterNotInSTSModeException:
             setattr(self, "azure_sts_client", None)
+
+        try:
+            setattr(
+                self,
+                "self_ref_mcg_client",
+                cloud_map["SELF_REF_MCG"](),
+            )
+        except Exception:
+            setattr(self, "self_ref_mcg_client", None)
 
 
 class CloudClient(ABC):
@@ -449,6 +460,52 @@ class RgwClient(S3Client):
             "RGW_SECRET_ACCESS_KEY": secret_key,
         }
         super().__init__(rgw_creds_dict, verify, endpoint, *args, **kwargs)
+
+
+class SelfRefMcgClient(S3Client):
+    """
+    S3 client for the self-ref MCG platform - an S3-compatible store
+    backed by an MCG's own bucket on the same cluster.
+    Fetches credentials directly from the NooBaa CR and admin secret.
+    """
+
+    @config.run_with_provider_context_if_available
+    def __init__(self, auth_dict=None, verify=True, *args, **kwargs):
+        namespace = config.ENV_DATA["cluster_namespace"]
+
+        # Endpoints from the NooBaa CR status
+        get_noobaa = OCP(kind="noobaa", namespace=namespace).get()
+        noobaa_s3 = get_noobaa["items"][0]["status"]["services"]["serviceS3"]
+        external_endpoint = noobaa_s3["externalDNS"][0]
+        # Internal endpoint is used in backingstore/namespacestore specs
+        internal_endpoint = noobaa_s3["internalDNS"][0]
+
+        # Admin credentials from the NooBaa admin secret
+        creds_secret_name = get_noobaa["items"][0]["status"]["accounts"]["admin"][
+            "secretRef"
+        ]["name"]
+        secret_data = OCP(kind="secret", namespace=namespace).get(creds_secret_name)[
+            "data"
+        ]
+        access_key_id = base64.b64decode(secret_data["AWS_ACCESS_KEY_ID"]).decode()
+        secret_access_key = base64.b64decode(
+            secret_data["AWS_SECRET_ACCESS_KEY"]
+        ).decode()
+
+        # HTTP on port 80 for the boto3 client (used by cloud_uls_factory)
+        http_endpoint = external_endpoint.replace("https://", "http://").replace(
+            ":443", ":80"
+        )
+
+        mcg_creds_dict = {
+            "SECRET_PREFIX": "MCG",
+            "DATA_PREFIX": "AWS",
+            "ENDPOINT": http_endpoint,
+            "S3_INTERNAL_ENDPOINT": internal_endpoint,
+            "MCG_ACCESS_KEY_ID": access_key_id,
+            "MCG_SECRET_ACCESS_KEY": secret_access_key,
+        }
+        super().__init__(mcg_creds_dict, verify, http_endpoint, *args, **kwargs)
 
 
 class IbmCosClient(S3Client):

--- a/ocs_ci/ocs/resources/cloud_uls.py
+++ b/ocs_ci/ocs/resources/cloud_uls.py
@@ -35,6 +35,7 @@ def cloud_uls_factory(
         "azure-sts": set(),
         "ibmcos": set(),
         "rgw": set(),
+        "self-ref-mcg": set(),
     }
     try:
         ulsMap = {
@@ -67,6 +68,11 @@ def cloud_uls_factory(
     except AttributeError:
         log.warning("Cluster is not deployed in Azure STS mode")
 
+    try:
+        ulsMap["self-ref-mcg"] = cld_mgr.self_ref_mcg_client
+    except AttributeError:
+        log.info("Self-ref MCG is not available on this cluster")
+
     def _create_uls(uls_dict):
         """
         Creates and deletes all underlying storage that were created as part of the test
@@ -92,6 +98,7 @@ def cloud_uls_factory(
             "azure-sts": set(),
             "ibmcos": set(),
             "rgw": set(),
+            "self-ref-mcg": set(),
         }
 
         with cluster_context():

--- a/ocs_ci/ocs/resources/namespacestore.py
+++ b/ocs_ci/ocs/resources/namespacestore.py
@@ -253,6 +253,13 @@ def cli_create_namespacestore(
             f"--secret-key {get_attr_chain(cld_mgr, 'rgw_client.secret_key')} "
             f"--target-bucket {uls_name}"
         ),
+        constants.SELF_REF_MCG_PLATFORM: lambda: (
+            f"s3-compatible {nss_name} "
+            f"--endpoint {get_attr_chain(cld_mgr, 'self_ref_mcg_client.s3_internal_endpoint')} "
+            f"--access-key {get_attr_chain(cld_mgr, 'self_ref_mcg_client.access_key')} "
+            f"--secret-key {get_attr_chain(cld_mgr, 'self_ref_mcg_client.secret_key')} "
+            f"--target-bucket {uls_name}"
+        ),
         constants.IBM_COS_PLATFORM: lambda: (
             f"s3-compatible {nss_name} "
             f"--endpoint {get_attr_chain(cld_mgr, 'ibmcos_client.endpoint')} "
@@ -353,6 +360,20 @@ def oc_create_namespacestore(
                 "signatureVersion": "v2",
                 "secret": {
                     "name": get_attr_chain(cld_mgr, "rgw_client.secret.name"),
+                    "namespace": nss_data["metadata"]["namespace"],
+                },
+            },
+        },
+        constants.SELF_REF_MCG_PLATFORM: lambda: {
+            "type": "s3-compatible",
+            "s3Compatible": {
+                "targetBucket": uls_name,
+                "endpoint": get_attr_chain(
+                    cld_mgr, "self_ref_mcg_client.s3_internal_endpoint"
+                ),
+                "signatureVersion": "v4",
+                "secret": {
+                    "name": get_attr_chain(cld_mgr, "self_ref_mcg_client.secret.name"),
                     "namespace": nss_data["metadata"]["namespace"],
                 },
             },

--- a/tests/functional/object/mcg/test_mcg_replication_target_unreachable.py
+++ b/tests/functional/object/mcg/test_mcg_replication_target_unreachable.py
@@ -264,3 +264,133 @@ class TestMCGReplicationTargetUnreachableAlert(MCGTest):
         _wait_for_replication_alert(
             threading_lock, source_bucket.name, timeout=600, sleep=10, cleared=True
         )
+
+    @tier2
+    @pytest.mark.parametrize(
+        "store_type",
+        [
+            pytest.param(
+                "namespacestore", id="namespacestore", marks=polarion_id("OCS-8000")
+            ),
+            pytest.param(
+                "backingstore", id="backingstore", marks=polarion_id("OCS-7999")
+            ),
+        ],
+    )
+    def test_noobaa_replication_target_unreachable_underlying_bucket_deleted(
+        self,
+        store_type,
+        bucket_factory,
+        mcg_obj,
+        awscli_pod_session,
+        test_directory_setup,
+        threading_lock,
+    ):
+        """
+        1. Create a target OBC backed by a self-ref MCG store (an
+           S3-compatible store backed by an MCG's own bucket on the
+           same cluster)
+        2. Create a source OBC with a replication policy targeting it
+        3. Write test objects and verify replication works
+        4. Delete the underlying MCG bucket of the target's store
+        5. Upload new objects to trigger failing replication
+        6. Wait for the NooBaaReplicationTargetUnreachable alert to fire
+        7. Recreate the underlying MCG bucket
+        8. Write test objects and verify replication works again
+        9. Wait for the alert to clear
+        """
+
+        # 1. Create a target OBC backed by a self-ref MCG store
+        if store_type == "namespacestore":
+            bucketclass_dict = {
+                "interface": "CLI",
+                "namespace_policy_dict": {
+                    "type": "Single",
+                    "namespacestore_dict": {"self-ref-mcg": [(1, None)]},
+                },
+            }
+        else:
+            bucketclass_dict = {
+                "interface": "CLI",
+                "backingstore_dict": {"self-ref-mcg": [(1, None)]},
+            }
+        target_bucket = bucket_factory(1, "OC", bucketclass=bucketclass_dict)[0]
+        bc_obj = target_bucket.bucketclass
+        if store_type == "namespacestore":
+            underlying_bucket_name = bc_obj.namespacestores[0].uls_name
+        else:
+            underlying_bucket_name = bc_obj.backingstores[0].uls_name
+        logger.info(
+            f"Target OBC created: {target_bucket.name}, "
+            f"underlying MCG bucket: {underlying_bucket_name}"
+        )
+
+        # 2. Create a source OBC with a replication policy
+        replication_policy = ("repl-alert-rule", target_bucket.name, None)
+        source_bucket = bucket_factory(1, "OC", replication_policy=replication_policy)[
+            0
+        ]
+        logger.info(
+            f"Replication configured: {source_bucket.name} -> {target_bucket.name}"
+        )
+
+        # 3. Write test objects and verify replication works
+        pre_disrupt_dir = f"{test_directory_setup.origin_dir}/pre"
+        write_random_test_objects_to_bucket(
+            awscli_pod_session,
+            source_bucket.name,
+            pre_disrupt_dir,
+            amount=3,
+            pattern="pre-disrupt-",
+            mcg_obj=mcg_obj,
+        )
+        assert compare_bucket_object_list(
+            mcg_obj, source_bucket.name, target_bucket.name, timeout=600
+        ), "Replication did not work before underlying bucket deletion"
+        logger.info("Initial replication verified successfully")
+
+        # 4. Delete the underlying MCG bucket of the target's store
+        mcg_obj.s3_resource.Bucket(underlying_bucket_name).objects.all().delete()
+        mcg_obj.s3_resource.Bucket(underlying_bucket_name).delete()
+        logger.info(f"Underlying MCG bucket deleted: {underlying_bucket_name}")
+
+        # 5. Upload new objects to trigger failing replication
+        post_disrupt_dir = f"{test_directory_setup.origin_dir}/post_disrupt"
+        write_random_test_objects_to_bucket(
+            awscli_pod_session,
+            source_bucket.name,
+            post_disrupt_dir,
+            amount=3,
+            pattern="post-disrupt-",
+            mcg_obj=mcg_obj,
+        )
+
+        # 6. Wait for the NooBaaReplicationTargetUnreachable alert to fire
+        _wait_for_replication_alert(
+            threading_lock, source_bucket.name, timeout=600, sleep=10
+        )
+
+        # 7. Recreate the underlying MCG bucket (reuses the same name
+        # that cloud_uls_factory tracks, so its finalizer handles cleanup)
+        mcg_obj.s3_resource.create_bucket(Bucket=underlying_bucket_name)
+        logger.info(f"Underlying MCG bucket recreated: {underlying_bucket_name}")
+
+        # 8. Write test objects and verify replication works again
+        post_recovery_dir = f"{test_directory_setup.origin_dir}/post_recovery"
+        write_random_test_objects_to_bucket(
+            awscli_pod_session,
+            source_bucket.name,
+            post_recovery_dir,
+            amount=3,
+            pattern="post-recovery-",
+            mcg_obj=mcg_obj,
+        )
+        assert compare_bucket_object_list(
+            mcg_obj, source_bucket.name, target_bucket.name, timeout=600
+        ), "Replication did not work after underlying bucket recreation"
+        logger.info("Post-recovery replication verified successfully")
+
+        # 9. Wait for the alert to clear
+        _wait_for_replication_alert(
+            threading_lock, source_bucket.name, timeout=600, sleep=10, cleared=True
+        )


### PR DESCRIPTION
 ## Summary
  - Introduce the "self-ref MCG" ULS platform - an S3-compatible store backed by an MCG's own bucket on the same
  cluster
  - Add `SelfRefMcgClient` that fetches MCG creds directly from the NooBaa CR and admin secret
  - Add a new parametrized test for `NooBaaReplicationTargetUnreachable` alert when the underlying MCG bucket is
  deleted and recreated

  ## Changes
  - `constants.py`: Add `SELF_REF_MCG_PLATFORM` constant and register in `CLOUD_MNGR_PLATFORMS`
  - `cloud_manager.py`: Add `SelfRefMcgClient(S3Client)` class and wire it into `CloudManager`
  - `bucket_utils.py`: Add `oc_create_self_ref_mcg_backingstore` and `cli_create_self_ref_mcg_backingstore`
  - `backingstore.py`, `namespacestore.py`, `cloud_uls.py`: Register the new platform in factory maps
  - `test_mcg_replication_target_unreachable.py`: Add
  `test_noobaa_replication_target_unreachable_underlying_bucket_deleted` parametrized for backingstore (OCS-7999)
  and namespacestore (OCS-8000)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for **self-ref MCG** storage configurations, enabling creation of **s3-compatible backingstores** and **namespace stores** using the self-ref MCG’s own endpoints and credentials (supported via both OC and CLI flows).
* **Bug Fixes**
  * Improved platform registration/handling so the **self-ref MCG** option is recognized consistently across provisioning workflows.
* **Tests**
  * Added functional coverage for the **NooBaaReplicationTargetUnreachable** alert, verifying replication recovers after the underlying MCG target bucket is deleted and recreated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->