### PR TITLE
Add GCP Workload Identity Federation (STS) deployment support

### DIFF
--- a/conf/deployment/gcp/ipi_1az_rhcos_sts_3m_3w.yaml
+++ b/conf/deployment/gcp/ipi_1az_rhcos_sts_3m_3w.yaml
@@ -1,0 +1,18 @@
+---
+DEPLOYMENT:
+  allow_lower_instance_requirements: false
+  sts_enabled: true
+  subscription_plan_approval: "Manual"
+ENV_DATA:
+  platform: 'gcp'
+  deployment_type: 'ipi'
+  region: 'europe-west1'
+  base_domain: 'gcp.qe.rh-ocs.com'
+  gcp_project_id: 'odf-dev-test'
+  worker_replicas: 3
+  master_replicas: 3
+  master_instance_type: 'n2-standard-16'
+  worker_instance_type: 'n2-standard-16'
+REPORTING:
+  polarion:
+    deployment_id: 'OCS-2372'

--- a/ocs_ci/deployment/gcp.py
+++ b/ocs_ci/deployment/gcp.py
@@ -79,7 +79,11 @@ class GCPBase(CloudDeploymentBase):
 
 class GCPIPI(GCPBase):
     """
-    A class to handle GCP IPI specific deployment
+    A class to handle GCP IPI specific deployment.
+
+    Supports both standard and STS (Workload Identity Federation)
+    deployments. STS behavior is activated when
+    config.DEPLOYMENT["sts_enabled"] is True.
     """
 
     def __init__(self):
@@ -87,15 +91,32 @@ class GCPIPI(GCPBase):
         super(GCPIPI, self).__init__()
 
     class OCPDeployment(IPIOCPDeployment):
+        """
+        GCP-specific OCP deployment that adds Workload Identity
+        Federation (WIF) setup when STS mode is enabled.
+
+        For non-STS deployments, behaves identically to the
+        base IPIOCPDeployment.
+        """
+
         def deploy_prereq(self):
+            """Run base prerequisites, then WIF setup if STS is enabled."""
             super().deploy_prereq()
             if config.DEPLOYMENT.get("sts_enabled"):
                 self.sts_setup()
 
         def sts_setup(self):
             """
-            Perform setup procedure for STS Mode (Workload Identity
-            Federation) deployments on GCP.
+            Set up GCP Workload Identity Federation via ccoctl.
+
+            Steps:
+                1. Set GCP authentication for ccoctl
+                2. Extract ccoctl binary from the release image
+                3. Extract CredentialsRequest manifests
+                4. Configure manual credentials mode
+                5. Generate install manifests
+                6. Run ccoctl gcp create-all to create WIF resources
+                7. Copy generated manifests and TLS into the cluster dir
             """
             cluster_path = config.ENV_DATA["cluster_path"]
             output_dir = os.path.join(cluster_path, "output-dir")
@@ -103,10 +124,12 @@ class GCPIPI(GCPBase):
             credentials_requests_dir = os.path.join(cluster_path, "creds_reqs")
             install_config = os.path.join(cluster_path, "install-config.yaml")
 
+            # 1. Set GCP authentication
             os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = SERVICE_ACCOUNT_KEY_FILEPATH
             sa_dict = load_service_account_key_dict()
             gcp_project = config.ENV_DATA.get("gcp_project_id") or sa_dict["project_id"]
 
+            # 2-3. Extract ccoctl binary and CredentialsRequest manifests
             release_image = get_ocp_release_image_from_installer()
             cco_image = cco.get_cco_container_image(release_image, pull_secret_path)
             cco.extract_ccoctl_binary(cco_image, pull_secret_path)
@@ -116,8 +139,12 @@ class GCPIPI(GCPBase):
                 pull_secret_path,
                 credentials_requests_dir,
             )
+
+            # 4-5. Configure manual credentials mode and generate manifests
             cco.set_credentials_mode_manual(install_config)
             cco.create_manifests(self.installer, cluster_path)
+
+            # 6. Run ccoctl gcp create-all
             infra_id = get_infra_id_from_openshift_install_state(cluster_path)
             cco.process_credentials_requests_gcp(
                 infra_id,
@@ -126,6 +153,8 @@ class GCPIPI(GCPBase):
                 credentials_requests_dir,
                 output_dir,
             )
+
+            # 7. Copy generated manifests and TLS into the cluster dir
             manifests_source_dir = os.path.join(output_dir, "manifests")
             manifests_target_dir = os.path.join(cluster_path, "manifests")
             file_names = os.listdir(manifests_source_dir)
@@ -140,7 +169,10 @@ class GCPIPI(GCPBase):
 
     def destroy_cluster(self, log_level="DEBUG"):
         """
-        Destroy OCP cluster specific to GCP IPI.
+        Destroy OCP cluster on GCP.
+
+        For STS deployments, deletes the WIF resources created by
+        ccoctl before running the standard cluster destroy.
 
         Args:
             log_level (str): log level openshift-installer (default: DEBUG)

--- a/ocs_ci/deployment/gcp.py
+++ b/ocs_ci/deployment/gcp.py
@@ -5,11 +5,22 @@ on Google Cloud Platform (aka GCP).
 """
 
 import logging
+import os
+import shutil
 
 from libcloud.compute.types import NodeState
 
 from ocs_ci.deployment.cloud import CloudDeploymentBase, IPIOCPDeployment
-from ocs_ci.utility.gcp import GoogleCloudUtil
+from ocs_ci.framework import config
+from ocs_ci.ocs import constants
+from ocs_ci.utility import cco
+from ocs_ci.utility.deployment import get_ocp_release_image_from_installer
+from ocs_ci.utility.gcp import (
+    GoogleCloudUtil,
+    load_service_account_key_dict,
+    SERVICE_ACCOUNT_KEY_FILEPATH,
+)
+from ocs_ci.utility.utils import get_infra_id_from_openshift_install_state
 
 
 logger = logging.getLogger(__name__)
@@ -71,8 +82,92 @@ class GCPIPI(GCPBase):
     A class to handle GCP IPI specific deployment
     """
 
-    OCPDeployment = IPIOCPDeployment
-
     def __init__(self):
         self.name = self.__class__.__name__
         super(GCPIPI, self).__init__()
+
+    class OCPDeployment(IPIOCPDeployment):
+        def deploy_prereq(self):
+            super().deploy_prereq()
+            if config.DEPLOYMENT.get("sts_enabled"):
+                self.sts_setup()
+
+        def sts_setup(self):
+            """
+            Perform setup procedure for STS Mode (Workload Identity
+            Federation) deployments on GCP.
+            """
+            cluster_path = config.ENV_DATA["cluster_path"]
+            output_dir = os.path.join(cluster_path, "output-dir")
+            pull_secret_path = os.path.join(constants.DATA_DIR, "pull-secret")
+            credentials_requests_dir = os.path.join(cluster_path, "creds_reqs")
+            install_config = os.path.join(cluster_path, "install-config.yaml")
+
+            os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = SERVICE_ACCOUNT_KEY_FILEPATH
+            sa_dict = load_service_account_key_dict()
+            gcp_project = config.ENV_DATA.get("gcp_project_id") or sa_dict["project_id"]
+
+            release_image = get_ocp_release_image_from_installer()
+            cco_image = cco.get_cco_container_image(release_image, pull_secret_path)
+            cco.extract_ccoctl_binary(cco_image, pull_secret_path)
+            cco.extract_credentials_requests(
+                release_image,
+                install_config,
+                pull_secret_path,
+                credentials_requests_dir,
+            )
+            cco.set_credentials_mode_manual(install_config)
+            cco.create_manifests(self.installer, cluster_path)
+            infra_id = get_infra_id_from_openshift_install_state(cluster_path)
+            cco.process_credentials_requests_gcp(
+                infra_id,
+                config.ENV_DATA["region"],
+                gcp_project,
+                credentials_requests_dir,
+                output_dir,
+            )
+            manifests_source_dir = os.path.join(output_dir, "manifests")
+            manifests_target_dir = os.path.join(cluster_path, "manifests")
+            file_names = os.listdir(manifests_source_dir)
+            for file_name in file_names:
+                shutil.move(
+                    os.path.join(manifests_source_dir, file_name), manifests_target_dir
+                )
+
+            tls_source_dir = os.path.join(output_dir, "tls")
+            tls_target_dir = os.path.join(cluster_path, "tls")
+            shutil.move(tls_source_dir, tls_target_dir)
+
+    def destroy_cluster(self, log_level="DEBUG"):
+        """
+        Destroy OCP cluster specific to GCP IPI.
+
+        Args:
+            log_level (str): log level openshift-installer (default: DEBUG)
+
+        """
+        if config.DEPLOYMENT.get("sts_enabled"):
+            os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = SERVICE_ACCOUNT_KEY_FILEPATH
+            sa_dict = load_service_account_key_dict()
+            gcp_project = config.ENV_DATA.get("gcp_project_id") or sa_dict["project_id"]
+            cluster_path = config.ENV_DATA["cluster_path"]
+            credentials_requests_dir = os.path.join(cluster_path, "creds_reqs")
+            if not os.path.isdir(credentials_requests_dir):
+                logger.info("Credentials requests directory not found, re-extracting")
+                pull_secret_path = os.path.join(constants.DATA_DIR, "pull-secret")
+                install_config = os.path.join(cluster_path, "install-config.yaml")
+                release_image = get_ocp_release_image_from_installer()
+                cco_image = cco.get_cco_container_image(release_image, pull_secret_path)
+                cco.extract_ccoctl_binary(cco_image, pull_secret_path)
+                cco.extract_credentials_requests(
+                    release_image,
+                    install_config,
+                    pull_secret_path,
+                    credentials_requests_dir,
+                )
+            cco.delete_gcp_sts_resources(
+                self.cluster_name,
+                gcp_project,
+                credentials_requests_dir,
+            )
+        super(GCPIPI, self).destroy_cluster(log_level)

--- a/ocs_ci/deployment/gcp.py
+++ b/ocs_ci/deployment/gcp.py
@@ -197,8 +197,9 @@ class GCPIPI(GCPBase):
                     pull_secret_path,
                     credentials_requests_dir,
                 )
+            infra_id = get_infra_id_from_openshift_install_state(cluster_path)
             cco.delete_gcp_sts_resources(
-                self.cluster_name,
+                infra_id,
                 gcp_project,
                 credentials_requests_dir,
             )

--- a/ocs_ci/deployment/gcp.py
+++ b/ocs_ci/deployment/gcp.py
@@ -179,28 +179,49 @@ class GCPIPI(GCPBase):
 
         """
         if config.DEPLOYMENT.get("sts_enabled"):
-            os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = SERVICE_ACCOUNT_KEY_FILEPATH
-            sa_dict = load_service_account_key_dict()
-            gcp_project = config.ENV_DATA.get("gcp_project_id") or sa_dict["project_id"]
-            cluster_path = config.ENV_DATA["cluster_path"]
-            credentials_requests_dir = os.path.join(cluster_path, "creds_reqs")
-            if not os.path.isdir(credentials_requests_dir):
-                logger.info("Credentials requests directory not found, re-extracting")
+            try:
+                # 1. Set GCP authentication
+                os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = (
+                    SERVICE_ACCOUNT_KEY_FILEPATH
+                )
+                sa_dict = load_service_account_key_dict()
+                gcp_project = (
+                    config.ENV_DATA.get("gcp_project_id") or sa_dict["project_id"]
+                )
+
+                # 2. Ensure ccoctl binary is available (may be missing if
+                # teardown runs on a different agent than the one that deployed)
+                cluster_path = config.ENV_DATA["cluster_path"]
                 pull_secret_path = os.path.join(constants.DATA_DIR, "pull-secret")
-                install_config = os.path.join(cluster_path, "install-config.yaml")
                 release_image = get_ocp_release_image_from_installer()
                 cco_image = cco.get_cco_container_image(release_image, pull_secret_path)
                 cco.extract_ccoctl_binary(cco_image, pull_secret_path)
-                cco.extract_credentials_requests(
-                    release_image,
-                    install_config,
-                    pull_secret_path,
+
+                # 3. Re-extract CredentialsRequest manifests if missing
+                credentials_requests_dir = os.path.join(cluster_path, "creds_reqs")
+                if not os.path.isdir(credentials_requests_dir):
+                    logger.info(
+                        "Credentials requests directory not found, re-extracting"
+                    )
+                    install_config = os.path.join(cluster_path, "install-config.yaml")
+                    cco.extract_credentials_requests(
+                        release_image,
+                        install_config,
+                        pull_secret_path,
+                        credentials_requests_dir,
+                    )
+
+                # 4. Run ccoctl gcp delete to remove WIF resources
+                infra_id = get_infra_id_from_openshift_install_state(cluster_path)
+                cco.delete_gcp_sts_resources(
+                    infra_id,
+                    gcp_project,
                     credentials_requests_dir,
                 )
-            infra_id = get_infra_id_from_openshift_install_state(cluster_path)
-            cco.delete_gcp_sts_resources(
-                infra_id,
-                gcp_project,
-                credentials_requests_dir,
-            )
-        super(GCPIPI, self).destroy_cluster(log_level)
+            except Exception:
+                logger.warning(
+                    "Failed to delete GCP STS resources. "
+                    "Proceeding with cluster destroy.",
+                    exc_info=True,
+                )
+        super().destroy_cluster(log_level)

--- a/ocs_ci/deployment/gcp.py
+++ b/ocs_ci/deployment/gcp.py
@@ -90,6 +90,46 @@ class GCPIPI(GCPBase):
         self.name = self.__class__.__name__
         super(GCPIPI, self).__init__()
 
+    @staticmethod
+    def _get_gcp_project():
+        """
+        Set GCP authentication and return the project ID.
+
+        Returns:
+            str: GCP project ID
+
+        """
+        os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = SERVICE_ACCOUNT_KEY_FILEPATH
+        sa_dict = load_service_account_key_dict()
+        return config.ENV_DATA.get("gcp_project_id") or sa_dict["project_id"]
+
+    @staticmethod
+    def _ensure_ccoctl_and_credentials_requests(credentials_requests_dir):
+        """
+        Ensure the ccoctl binary and CredentialsRequest manifests are
+        available. Both are extracted from the OCP release image if missing.
+
+        Args:
+            credentials_requests_dir (str): Path to the CredentialsRequest
+                directory. If this directory does not exist, the manifests
+                are re-extracted.
+
+        """
+        cluster_path = config.ENV_DATA["cluster_path"]
+        pull_secret_path = os.path.join(constants.DATA_DIR, "pull-secret")
+        release_image = get_ocp_release_image_from_installer()
+        cco_image = cco.get_cco_container_image(release_image, pull_secret_path)
+        cco.extract_ccoctl_binary(cco_image, pull_secret_path)
+        if not os.path.isdir(credentials_requests_dir):
+            logger.info("Credentials requests directory not found, re-extracting")
+            install_config = os.path.join(cluster_path, "install-config.yaml")
+            cco.extract_credentials_requests(
+                release_image,
+                install_config,
+                pull_secret_path,
+                credentials_requests_dir,
+            )
+
     class OCPDeployment(IPIOCPDeployment):
         """
         GCP-specific OCP deployment that adds Workload Identity
@@ -111,40 +151,28 @@ class GCPIPI(GCPBase):
 
             Steps:
                 1. Set GCP authentication for ccoctl
-                2. Extract ccoctl binary from the release image
-                3. Extract CredentialsRequest manifests
-                4. Configure manual credentials mode
-                5. Generate install manifests
-                6. Run ccoctl gcp create-all to create WIF resources
-                7. Copy generated manifests and TLS into the cluster dir
+                2. Extract ccoctl binary and CredentialsRequest manifests
+                3. Configure manual credentials mode
+                4. Generate install manifests
+                5. Run ccoctl gcp create-all to create WIF resources
+                6. Copy generated manifests and TLS into the cluster dir
             """
             cluster_path = config.ENV_DATA["cluster_path"]
             output_dir = os.path.join(cluster_path, "output-dir")
-            pull_secret_path = os.path.join(constants.DATA_DIR, "pull-secret")
             credentials_requests_dir = os.path.join(cluster_path, "creds_reqs")
             install_config = os.path.join(cluster_path, "install-config.yaml")
 
             # 1. Set GCP authentication
-            os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = SERVICE_ACCOUNT_KEY_FILEPATH
-            sa_dict = load_service_account_key_dict()
-            gcp_project = config.ENV_DATA.get("gcp_project_id") or sa_dict["project_id"]
+            gcp_project = GCPIPI._get_gcp_project()
 
-            # 2-3. Extract ccoctl binary and CredentialsRequest manifests
-            release_image = get_ocp_release_image_from_installer()
-            cco_image = cco.get_cco_container_image(release_image, pull_secret_path)
-            cco.extract_ccoctl_binary(cco_image, pull_secret_path)
-            cco.extract_credentials_requests(
-                release_image,
-                install_config,
-                pull_secret_path,
-                credentials_requests_dir,
-            )
+            # 2. Extract ccoctl binary and CredentialsRequest manifests
+            GCPIPI._ensure_ccoctl_and_credentials_requests(credentials_requests_dir)
 
-            # 4-5. Configure manual credentials mode and generate manifests
+            # 3-4. Configure manual credentials mode and generate manifests
             cco.set_credentials_mode_manual(install_config)
             cco.create_manifests(self.installer, cluster_path)
 
-            # 6. Run ccoctl gcp create-all
+            # 5. Run ccoctl gcp create-all
             infra_id = get_infra_id_from_openshift_install_state(cluster_path)
             cco.process_credentials_requests_gcp(
                 infra_id,
@@ -154,7 +182,7 @@ class GCPIPI(GCPBase):
                 output_dir,
             )
 
-            # 7. Copy generated manifests and TLS into the cluster dir
+            # 6. Copy generated manifests and TLS into the cluster dir
             manifests_source_dir = os.path.join(output_dir, "manifests")
             manifests_target_dir = os.path.join(cluster_path, "manifests")
             file_names = os.listdir(manifests_source_dir)
@@ -181,37 +209,16 @@ class GCPIPI(GCPBase):
         if config.DEPLOYMENT.get("sts_enabled"):
             try:
                 # 1. Set GCP authentication
-                os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = (
-                    SERVICE_ACCOUNT_KEY_FILEPATH
-                )
-                sa_dict = load_service_account_key_dict()
-                gcp_project = (
-                    config.ENV_DATA.get("gcp_project_id") or sa_dict["project_id"]
-                )
+                gcp_project = self._get_gcp_project()
 
-                # 2. Ensure ccoctl binary is available (may be missing if
-                # teardown runs on a different agent than the one that deployed)
+                # 2. Ensure ccoctl binary and CredentialsRequest manifests
+                # are available (may be missing if teardown runs on a
+                # different agent than the one that deployed)
                 cluster_path = config.ENV_DATA["cluster_path"]
-                pull_secret_path = os.path.join(constants.DATA_DIR, "pull-secret")
-                release_image = get_ocp_release_image_from_installer()
-                cco_image = cco.get_cco_container_image(release_image, pull_secret_path)
-                cco.extract_ccoctl_binary(cco_image, pull_secret_path)
-
-                # 3. Re-extract CredentialsRequest manifests if missing
                 credentials_requests_dir = os.path.join(cluster_path, "creds_reqs")
-                if not os.path.isdir(credentials_requests_dir):
-                    logger.info(
-                        "Credentials requests directory not found, re-extracting"
-                    )
-                    install_config = os.path.join(cluster_path, "install-config.yaml")
-                    cco.extract_credentials_requests(
-                        release_image,
-                        install_config,
-                        pull_secret_path,
-                        credentials_requests_dir,
-                    )
+                self._ensure_ccoctl_and_credentials_requests(credentials_requests_dir)
 
-                # 4. Run ccoctl gcp delete to remove WIF resources
+                # 3. Run ccoctl gcp delete to remove WIF resources
                 infra_id = get_infra_id_from_openshift_install_state(cluster_path)
                 cco.delete_gcp_sts_resources(
                     infra_id,

--- a/ocs_ci/utility/cco.py
+++ b/ocs_ci/utility/cco.py
@@ -75,7 +75,7 @@ def extract_credentials_requests(
     release_image, install_config, pull_secret, credentials_requests_dir
 ):
     """
-    Extract the CredentialsRequests (AWS and Azure STS variant).
+    Extract the CredentialsRequests (AWS, Azure, and GCP STS variant).
 
     Args:
         release_image (str): Release image from the openshift installer
@@ -235,6 +235,49 @@ def process_credentials_requests_azure(
         f"--credentials-requests-dir={credentials_requests_dir} "
         f"--dnszone-resource-group-name={dns_zone_group_name} --tenant-id={tenant_id} "
         f"--storage-account-name={storage_account_name}"
+    )
+    exec_cmd(cmd)
+
+
+def process_credentials_requests_gcp(
+    name, gcp_region, gcp_project, credentials_requests_dir, output_dir
+):
+    """
+    Process all CredentialsRequest objects for GCP.
+
+    Args:
+        name (str): Name used to tag any created cloud resources
+        gcp_region (str): GCP region to create cloud resources
+        gcp_project (str): GCP project ID
+        credentials_requests_dir (str): Path to the CredentialsRequest directory
+        output_dir (str): Path to the output directory
+
+    """
+    logger.info("Processing all CredentialsRequest objects for GCP")
+    cmd = (
+        f"ccoctl gcp create-all --name={name} --region={gcp_region} "
+        f"--project={gcp_project} "
+        f"--credentials-requests-dir={credentials_requests_dir} "
+        f"--output-dir={output_dir}"
+    )
+    exec_cmd(cmd)
+
+
+def delete_gcp_sts_resources(name, gcp_project, credentials_requests_dir):
+    """
+    Delete the GCP resources that ccoctl created.
+
+    Args:
+        name (str): Name used to tag any created cloud resources
+        gcp_project (str): GCP project ID
+        credentials_requests_dir (str): Path to the credentials requests directory
+
+    """
+    logger.info("Deleting GCP STS resources")
+    cmd = (
+        f"ccoctl gcp delete --name={name} --project={gcp_project} "
+        f"--credentials-requests-dir={credentials_requests_dir} "
+        f"--force-delete-custom-roles"
     )
     exec_cmd(cmd)
 

--- a/ocs_ci/utility/cco.py
+++ b/ocs_ci/utility/cco.py
@@ -276,8 +276,7 @@ def delete_gcp_sts_resources(name, gcp_project, credentials_requests_dir):
     logger.info("Deleting GCP STS resources")
     cmd = (
         f"ccoctl gcp delete --name={name} --project={gcp_project} "
-        f"--credentials-requests-dir={credentials_requests_dir} "
-        f"--force-delete-custom-roles"
+        f"--credentials-requests-dir={credentials_requests_dir}"
     )
     exec_cmd(cmd)
 


### PR DESCRIPTION
## Summary

- Add `ccoctl gcp create-all` / `delete` automation for GCP short-term credentials (Workload Identity Federation), following the existing AWS and Azure STS patterns
- Extend `GCPIPI` with an inner `OCPDeployment` class that runs WIF setup when `sts_enabled` is configured, and a `destroy_cluster` override that cleans up ccoctl-created GCP resources
- Add GCP STS deployment config (`ipi_1az_rhcos_sts_3m_3w.yaml`)

## Changes

- `ocs_ci/utility/cco.py` - add `process_credentials_requests_gcp()` and `delete_gcp_sts_resources()` functions
- `ocs_ci/deployment/gcp.py` - add STS-aware `OCPDeployment` subclass with `sts_setup()`, and `destroy_cluster()` with WIF resource cleanup
- `conf/deployment/gcp/ipi_1az_rhcos_sts_3m_3w.yaml` - new deployment config with `sts_enabled: true`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional STS/Workload Identity Federation support for GCP IPI deployments
  * Introduced a new GCP IPI deployment configuration enabling STS and manual subscription-plan approval

* **Improvements**
  * Updated STS-enabled deployment setup to generate and apply GCP STS/WIF credentials resources
  * Updated STS-enabled teardown to delete the created STS/WIF resources
  * Added GCP tooling support for creating and deleting STS CredentialsRequest resources
<!-- end of auto-generated comment: release notes by coderabbit.ai -->