### PR TITLE
[z-stream 4.20.14] Enable 62 tests for validation

### DIFF
--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -864,3 +864,5 @@ skipif_lean_deployment = pytest.mark.skipif(
     or not check_cluster_resources_for_nfs(),
     reason="Test cannot run on lean profile or requires higher cluster resources (insufficient CPU/memory)",
 )
+# z-stream marker
+zstream_4_20_14 = pytest.mark.zstream_4_20_14

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 markers =
+    zstream_4_20_14: z-stream 4.20.14 test enablement
     run_this: testing marker for run this test, useful for development
     acceptance: marker for acceptance tests
     tier0: marker for tier0 tests

--- a/tests/cross_functional/ui/test_add_capacity_ui.py
+++ b/tests/cross_functional/ui/test_add_capacity_ui.py
@@ -19,12 +19,14 @@ from ocs_ci.framework.pytest_customization.marks import (
     brown_squad,
     skipif_hci_provider_or_client,
     skipif_lean_deployment,
+    zstream_4_20_14,
 )
 
 logger = logging.getLogger(__name__)
 
 
 @skipif_lean_deployment
+@zstream_4_20_14
 class TestAddCapacityUI(object):
     """
     Test Add Capacity on via UI

--- a/tests/functional/disaster-recovery/metro-dr/test_replace_cluster.py
+++ b/tests/functional/disaster-recovery/metro-dr/test_replace_cluster.py
@@ -4,7 +4,7 @@ import time
 
 from concurrent.futures import ThreadPoolExecutor
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import turquoise_squad, mdr, tier4a
+from ocs_ci.framework.pytest_customization.marks import turquoise_squad, mdr, tier4a, zstream_4_20_14
 from ocs_ci.helpers.dr_helpers import get_active_acm_index
 from ocs_ci.ocs.node import get_node_objs
 from ocs_ci.ocs.dr.dr_workload import validate_data_integrity
@@ -31,6 +31,7 @@ logger = logging.getLogger(__name__)
 @mdr
 @tier4a
 @turquoise_squad
+@zstream_4_20_14
 class TestReplaceCluster:
     """
     Test for Recovery of replacement cluster

--- a/tests/functional/disaster-recovery/sc_arbiter/test_device_replacement.py
+++ b/tests/functional/disaster-recovery/sc_arbiter/test_device_replacement.py
@@ -8,6 +8,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     tier4a,
     tier4,
     jira,
+    zstream_4_20_14,
 )
 from ocs_ci.helpers.cnv_helpers import cal_md5sum_vm
 from ocs_ci.helpers.stretchcluster_helper import (
@@ -27,6 +28,7 @@ logger = logging.getLogger(__name__)
 @stretchcluster_required
 @turquoise_squad
 @jira("DFBUGS-1273")
+@zstream_4_20_14
 class TestDeviceReplacementInStretchCluster:
 
     @polarion_id("OCS-5047")

--- a/tests/functional/monitoring/prometheus/alerts/test_ceph.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_ceph.py
@@ -23,6 +23,7 @@ from ocs_ci.ocs.fiojob import get_timeout
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.resources.pod import get_osd_pods
 from ocs_ci.utility import prometheus
+from ocs_ci.framework.pytest_customization.marks import zstream_4_20_14
 
 log = logging.getLogger(__name__)
 
@@ -33,6 +34,7 @@ log = logging.getLogger(__name__)
 @pytest.mark.polarion_id("OCS-903")
 @skipif_managed_service
 @runs_on_provider
+@zstream_4_20_14
 def test_corrupt_pg_alerts(measure_corrupt_pg, threading_lock):
     """
     Test that there are appropriate alerts when Placement group
@@ -134,6 +136,7 @@ def deprecated_test_ceph_health(
 
 
 @runs_on_provider
+@zstream_4_20_14
 class TestCephOSDSlowOps(object):
     @pytest.fixture(scope="function")
     def setup(self, request, pod_factory, multi_pvc_factory):

--- a/tests/functional/monitoring/prometheus/metrics/test_monitoring_defaults.py
+++ b/tests/functional/monitoring/prometheus/metrics/test_monitoring_defaults.py
@@ -18,6 +18,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     provider_client_platform_required,
     provider_mode,
     skipif_external_mode,
+    zstream_4_20_14,
 )
 from ocs_ci.framework.testlib import skipif_ocs_version, tier1
 from ocs_ci.ocs import constants, ocp, defaults
@@ -39,6 +40,7 @@ logger = logging.getLogger(__name__)
 @pytest.mark.polarion_id("OCS-1261")
 @skipif_managed_service
 @runs_on_provider
+@zstream_4_20_14
 def test_monitoring_enabled(threading_lock):
     """
     OCS Monitoring is enabled after OCS installation (which is why this test
@@ -90,6 +92,7 @@ def test_monitoring_enabled(threading_lock):
 @pytest.mark.polarion_id("OCS-1265")
 @skipif_managed_service
 @runs_on_provider
+@zstream_4_20_14
 def test_ceph_mgr_dashboard_not_deployed():
     """
     Check that `ceph mgr dashboard`_ is not deployed after installation of OCS
@@ -130,6 +133,7 @@ def test_ceph_mgr_dashboard_not_deployed():
 @pytest.mark.polarion_id("OCS-1267")
 @skipif_managed_service
 @runs_on_provider
+@zstream_4_20_14
 def test_ceph_rbd_metrics_available(threading_lock):
     """
     Ceph RBD metrics should be provided via OCP Prometheus as well.
@@ -155,6 +159,7 @@ def test_ceph_rbd_metrics_available(threading_lock):
 @pytest.mark.polarion_id("OCS-1268")
 @skipif_managed_service
 @runs_on_provider
+@zstream_4_20_14
 def test_ceph_metrics_available(threading_lock):
     """
     Ceph metrics as listed in KNIP-634 should be provided via OCP Prometheus.
@@ -189,6 +194,7 @@ def test_ceph_metrics_available(threading_lock):
 @pytest.mark.polarion_id("OCS-1302")
 @skipif_managed_service
 @runs_on_provider
+@zstream_4_20_14
 def test_monitoring_reporting_ok_when_idle(workload_idle, threading_lock):
     """
     When nothing is happening, OCP Prometheus reports OCS status as OK.
@@ -272,6 +278,7 @@ def test_monitoring_reporting_ok_when_idle(workload_idle, threading_lock):
 @runs_on_provider
 @provider_client_platform_required
 @pytest.mark.polarion_id("OCS-5204")
+@zstream_4_20_14
 def test_provider_metrics_available(threading_lock):
     """
     Metrics added in provider-client mode should be provided via OCP Prometheus on provider.
@@ -291,6 +298,7 @@ def test_provider_metrics_available(threading_lock):
 @tier1
 @skipif_external_mode
 @pytest.mark.polarion_id("OCS-6796")
+@zstream_4_20_14
 def test_monitoring_ip_connectivity(threading_lock):
     """
     Procedure:

--- a/tests/functional/monitoring/prometheus/metrics/test_rgw.py
+++ b/tests/functional/monitoring/prometheus/metrics/test_rgw.py
@@ -9,7 +9,7 @@ import logging
 import pytest
 
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import blue_squad
+from ocs_ci.framework.pytest_customization.marks import blue_squad, zstream_4_20_14
 from ocs_ci.framework.testlib import (
     skipif_managed_service,
     runs_on_provider,
@@ -31,6 +31,7 @@ logger = logging.getLogger(__name__)
 @pytest.mark.polarion_id("OCS-2385")
 @skipif_managed_service
 @runs_on_provider
+@zstream_4_20_14
 def test_ceph_rgw_metrics_after_metrics_exporter_respin(
     rgw_deployments, threading_lock
 ):

--- a/tests/functional/nfs_feature/test_nfs_feature_enable_for_ODF_clusters.py
+++ b/tests/functional/nfs_feature/test_nfs_feature_enable_for_ODF_clusters.py
@@ -17,6 +17,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     brown_squad,
     skipif_rosa_hcp,
     skipif_lean_deployment,
+    zstream_4_20_14,
 )
 from ocs_ci.framework.testlib import (
     skipif_ocs_version,
@@ -60,6 +61,7 @@ ERRMSG = "Error in command"
 @skip_for_provider_or_client_if_ocs_version("<4.19")
 @skipif_lean_deployment
 @polarion_id("OCS-4270")
+@zstream_4_20_14
 class TestDefaultNfsDisabled(ManageTest):
     """
     Test nfs feature enable for ODF 4.11

--- a/tests/functional/object/mcg/test_bucket_notifications.py
+++ b/tests/functional/object/mcg/test_bucket_notifications.py
@@ -33,6 +33,7 @@ from ocs_ci.ocs.exceptions import TimeoutExpiredError
 from ocs_ci.ocs.resources.bucket_notifications_manager import BucketNotificationsManager
 from ocs_ci.ocs.resources.mcg_lifecycle_policies import ExpirationRule, LifecyclePolicy
 from ocs_ci.utility.utils import TimeoutSampler
+from ocs_ci.framework.pytest_customization.marks import zstream_4_20_14
 
 logger = logging.getLogger(__name__)
 
@@ -44,6 +45,7 @@ logger = logging.getLogger(__name__)
 @skipif_external_mode
 @skipif_proxy_cluster
 @ignore_leftover_label(constants.CUSTOM_MCG_LABEL)
+@zstream_4_20_14
 class TestBucketNotifications(MCGTest):
     """
     Test the MCG bucket notifications feature

--- a/tests/functional/object/mcg/test_bucketclass.py
+++ b/tests/functional/object/mcg/test_bucketclass.py
@@ -6,6 +6,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     red_squad,
     polarion_id,
     tier2,
+    zstream_4_20_14,
 )
 from ocs_ci.framework import config
 from ocs_ci.ocs import constants
@@ -18,6 +19,7 @@ logger = logging.getLogger(__name__)
 
 @mcg
 @red_squad
+@zstream_4_20_14
 class TestBucketClass:
 
     @tier2

--- a/tests/functional/object/mcg/test_loadbalancer_subnet_config.py
+++ b/tests/functional/object/mcg/test_loadbalancer_subnet_config.py
@@ -12,6 +12,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     polarion_id,
     red_squad,
     tier2,
+    zstream_4_20_14,
 )
 from ocs_ci.framework.testlib import MCGTest
 from ocs_ci.ocs.exceptions import CommandFailed
@@ -24,6 +25,7 @@ logger = logging.getLogger(__name__)
 @mcg
 @red_squad
 @aws_platform_required
+@zstream_4_20_14
 class TestLBSubnetConfig(MCGTest):
 
     @tier2

--- a/tests/functional/object/mcg/test_multi_region.py
+++ b/tests/functional/object/mcg/test_multi_region.py
@@ -14,6 +14,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     runs_on_provider,
     mcg,
     tier2,
+    zstream_4_20_14,
 )
 from ocs_ci.framework.testlib import MCGTest
 from ocs_ci.ocs import ocp, constants
@@ -35,6 +36,7 @@ logger = logging.getLogger(__name__)
 @skipif_disconnected_cluster
 @skipif_aws_creds_are_missing
 @runs_on_provider
+@zstream_4_20_14
 class TestMultiRegion(MCGTest):
     """
     Test the multi region functionality

--- a/tests/functional/odf-cli/test_debug_verbocity_of_ceph_component.py
+++ b/tests/functional/odf-cli/test_debug_verbocity_of_ceph_component.py
@@ -2,7 +2,7 @@ import pytest
 import logging
 
 from ocs_ci.helpers.helpers import get_ceph_log_level
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, zstream_4_20_14
 from ocs_ci.ocs.exceptions import CommandFailed
 from ocs_ci.framework.testlib import tier2, skipif_kms_deployment, skipif_external_mode
 
@@ -13,6 +13,7 @@ log = logging.getLogger(__name__)
 @tier2
 @skipif_kms_deployment
 @skipif_external_mode
+@zstream_4_20_14
 class TestDebugVerbosityOfCephComponents:
     @pytest.fixture(autouse=True)
     def setup(self, odf_cli_setup):

--- a/tests/functional/pv/pv_services/test_cephfs_fsync_consistency.py
+++ b/tests/functional/pv/pv_services/test_cephfs_fsync_consistency.py
@@ -5,6 +5,7 @@ from ocs_ci.framework.testlib import ManageTest, tier1, green_squad, polarion_id
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.ocp import exec_cmd
 from ocs_ci.ocs.node import get_worker_nodes
+from ocs_ci.framework.pytest_customization.marks import zstream_4_20_14
 
 
 logger = logging.getLogger(__name__)
@@ -13,6 +14,7 @@ logger = logging.getLogger(__name__)
 @tier1
 @green_squad
 @polarion_id("OCS-6797")
+@zstream_4_20_14
 class TestCephfsFsyncConsistency(ManageTest):
     """
     Ensuring File Completeness Post-fsync with Shared CephFS Volume

--- a/tests/functional/pv/pvc_clone/test_pvc_to_pvc_clone.py
+++ b/tests/functional/pv/pvc_clone/test_pvc_to_pvc_clone.py
@@ -7,6 +7,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     jira,
     provider_mode,
     run_on_all_clients_push_missing_configs,
+    zstream_4_20_14,
 )
 from ocs_ci.framework.pytest_customization.marks import skipif_hci_provider_and_client
 from ocs_ci.framework.testlib import (
@@ -28,6 +29,7 @@ logger = logging.getLogger(__name__)
 @green_squad
 @skipif_ocs_version("<4.9")
 @skipif_ocp_version("<4.9")
+@zstream_4_20_14
 class TestClone(ManageTest):
     """
     Tests to verify PVC to PVC clone feature

--- a/tests/functional/storageclass/test_cephfilesystem_creation.py
+++ b/tests/functional/storageclass/test_cephfilesystem_creation.py
@@ -7,11 +7,12 @@ from ocs_ci.helpers.helpers import (
 from ocs_ci.ocs.exceptions import CommandFailed
 import ocs_ci.ocs.resources.pod as pod
 from ocs_ci.framework.testlib import ManageTest
-from ocs_ci.framework.pytest_customization.marks import green_squad
+from ocs_ci.framework.pytest_customization.marks import green_squad, zstream_4_20_14
 
 logger = logging.getLogger(__name__)
 
 
+@zstream_4_20_14
 class TestCephFileSystemCreation(ManageTest):
     """
     Testing Creation of a filesystem and checking its existence.

--- a/tests/functional/storageclass/test_csi_subvolume_group_property.py
+++ b/tests/functional/storageclass/test_csi_subvolume_group_property.py
@@ -2,7 +2,7 @@ import logging
 
 from ocs_ci.framework import config
 from ocs_ci.framework.testlib import ManageTest, tier2, skipif_external_mode
-from ocs_ci.framework.pytest_customization.marks import green_squad, jira, polarion_id
+from ocs_ci.framework.pytest_customization.marks import green_squad, jira, polarion_id, zstream_4_20_14
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.ocp import OCP
 
@@ -12,6 +12,7 @@ logger = logging.getLogger(__name__)
 @green_squad
 @skipif_external_mode
 @tier2
+@zstream_4_20_14
 class TestCSISubvolumeGroup(ManageTest):
     @jira("DFBUGS-2759")
     @polarion_id("OCS-5740")

--- a/tests/functional/upgrade/test_storagecluster_upgrade_params.py
+++ b/tests/functional/upgrade/test_storagecluster_upgrade_params.py
@@ -13,6 +13,7 @@ from ocs_ci.framework.testlib import (
     skipif_external_mode,
     brown_squad,
 )
+from ocs_ci.framework.pytest_customization.marks import zstream_4_20_14
 
 logger = logging.getLogger(__name__)
 
@@ -21,6 +22,7 @@ logger = logging.getLogger(__name__)
 @brown_squad
 @skipif_external_mode
 @pytest.mark.polarion_id("OCS-6225")
+@zstream_4_20_14
 class TestStorageclusterUpgradeParams(ManageTest):
     """
     Verify the upgrade storagecluster parameters move to cephcluster

--- a/tests/functional/workloads/cnv/test_cnv_device_replacement.py
+++ b/tests/functional/workloads/cnv/test_cnv_device_replacement.py
@@ -7,6 +7,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     workloads,
     magenta_squad,
     skipif_external_mode,
+    zstream_4_20_14,
 )
 from ocs_ci.helpers.cnv_helpers import cal_md5sum_vm, run_dd_io
 from ocs_ci.ocs import constants
@@ -23,6 +24,7 @@ logger = logging.getLogger(__name__)
 @workloads
 @skipif_external_mode
 @ignore_leftovers
+@zstream_4_20_14
 class TestCnvDeviceReplace(E2ETest):
     """
     Test case for Device replacement

--- a/tests/functional/workloads/cnv/test_cnv_node_replacement.py
+++ b/tests/functional/workloads/cnv/test_cnv_node_replacement.py
@@ -9,6 +9,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     ignore_leftovers,
     skipif_external_mode,
     skipif_bm,
+    zstream_4_20_14,
 )
 from ocs_ci.helpers.cnv_helpers import cal_md5sum_vm, run_dd_io
 from ocs_ci.ocs import constants
@@ -29,6 +30,7 @@ logger = logging.getLogger(__name__)
 @ignore_leftovers
 @skipif_bm
 @skipif_external_mode
+@zstream_4_20_14
 class TestCnvNodeReplace(E2ETest):
     """
     Node replacement proactive

--- a/tests/functional/z_cluster/nodes/test_node_replacement_proactive.py
+++ b/tests/functional/z_cluster/nodes/test_node_replacement_proactive.py
@@ -23,6 +23,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_hci_client,
     brown_squad,
     skipif_ibm_cloud_managed,
+    zstream_4_20_14,
 )
 from ocs_ci.helpers.helpers import (
     verify_storagecluster_nodetopology,
@@ -196,6 +197,7 @@ def delete_and_create_osd_node(osd_node_name):
 @skipif_hci_provider_and_client
 @skipif_bmpsi
 @skipif_external_mode
+@zstream_4_20_14
 class TestNodeReplacementWithIO(ManageTest):
     """
     Knip-894 Node replacement proactive with IO
@@ -280,6 +282,7 @@ class TestNodeReplacementWithIO(ManageTest):
 @skipif_external_mode
 @skipif_ms_consumer
 @skipif_hci_client
+@zstream_4_20_14
 class TestNodeReplacement(ManageTest):
     """
     Knip-894 Node replacement proactive
@@ -336,6 +339,7 @@ class TestNodeReplacement(ManageTest):
 @skipif_external_mode
 @skipif_managed_service
 @skipif_hci_provider_and_client
+@zstream_4_20_14
 class TestNodeReplacementTwice(ManageTest):
     """
     Node replacement twice:

--- a/tests/functional/z_cluster/nodes/test_node_replacement_reactive_aws_ipi.py
+++ b/tests/functional/z_cluster/nodes/test_node_replacement_reactive_aws_ipi.py
@@ -1,7 +1,7 @@
 import logging
 import pytest
 
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, zstream_4_20_14
 from ocs_ci.framework.testlib import (
     tier4a,
     ManageTest,
@@ -34,6 +34,7 @@ log = logging.getLogger(__name__)
 @tier4a
 @aws_based_platform_required
 @ipi_deployment_required
+@zstream_4_20_14
 class TestNodeReplacement(ManageTest):
     """
     Knip-894 Node replacement - AWS-IPI-Reactive

--- a/tests/functional/z_cluster/nodes/test_nodes_restart_hci.py
+++ b/tests/functional/z_cluster/nodes/test_nodes_restart_hci.py
@@ -3,7 +3,7 @@ import pytest
 import random
 
 
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, zstream_4_20_14
 from ocs_ci.framework.testlib import (
     tier4a,
     tier4b,
@@ -48,6 +48,7 @@ logger = logging.getLogger(__name__)
 @brown_squad
 @ignore_leftovers
 @provider_client_platform_required
+@zstream_4_20_14
 class TestNodesRestartHCI(ManageTest):
     """
     Test nodes restart scenarios when using HCI platform

--- a/tests/functional/z_cluster/nodes/test_non_ocs_taint_and_toleration.py
+++ b/tests/functional/z_cluster/nodes/test_non_ocs_taint_and_toleration.py
@@ -41,6 +41,7 @@ from ocs_ci.utility.retry import retry
 from ocs_ci.ocs.resources import storage_cluster
 from ocs_ci.framework.pytest_customization.marks import (
     brown_squad,
+    zstream_4_20_14,
 )
 from ocs_ci.helpers.sanity_helpers import Sanity
 from tests.functional.z_cluster.nodes.test_node_replacement_proactive import (
@@ -67,6 +68,7 @@ def verify_pod_count_unchanged(number_of_pods_before):
 @skipif_tainted_nodes
 @skipif_managed_service
 @skipif_hci_provider_and_client
+@zstream_4_20_14
 class TestNonOCSTaintAndTolerations(E2ETest):
     """
     Test to test non ocs taints on ocs nodes

--- a/tests/functional/z_cluster/test_add_mds_to_cluster.py
+++ b/tests/functional/z_cluster/test_add_mds_to_cluster.py
@@ -8,7 +8,7 @@ import pytest
 
 from ocs_ci.ocs import constants, defaults, ocp
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, zstream_4_20_14
 from ocs_ci.framework.testlib import ManageTest
 from ocs_ci.ocs.resources.ocs import OCS
 from ocs_ci.utility.utils import TimeoutSampler
@@ -76,6 +76,7 @@ def get_mds_active_count():
 # @tier1
 # Test case is disabled, as per requirement not to support this scenario
 @brown_squad
+@zstream_4_20_14
 class TestCephFilesystemCreation(ManageTest):
     """
     Testing creation of Ceph FileSystem

--- a/tests/functional/z_cluster/test_mon_healthcheck_passthrough.py
+++ b/tests/functional/z_cluster/test_mon_healthcheck_passthrough.py
@@ -11,6 +11,7 @@ from ocs_ci.framework.testlib import (
 )
 from ocs_ci.ocs import constants, ocp
 from ocs_ci.utility.utils import TimeoutSampler
+from ocs_ci.framework.pytest_customization.marks import zstream_4_20_14
 
 logger = logging.getLogger(__name__)
 
@@ -85,6 +86,7 @@ def _healthcheck_matches(actual, desired):
 @brown_squad
 @skipif_external_mode
 @pytest.mark.polarion_id("OCS-7403")
+@zstream_4_20_14
 class TestMonHealthcheckPassthrough(ManageTest):
     """
     Verify StorageCluster.spec.managedResources.cephCluster.healthCheck.daemonHealth.mon

--- a/tests/functional/z_cluster/test_multiple_mds.py
+++ b/tests/functional/z_cluster/test_multiple_mds.py
@@ -12,6 +12,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     tier4c,
     skipif_external_mode,
     skipif_hci_client,
+    zstream_4_20_14,
 )
 from ocs_ci.framework import config
 from ocs_ci.helpers import helpers
@@ -52,6 +53,7 @@ def verify_active_and_standby_mds_count(target_count):
 @tier4c
 @skipif_external_mode
 @skipif_hci_client
+@zstream_4_20_14
 class TestMultipleMds:
     """
     Tests for support multiple mds

--- a/tests/functional/z_cluster/test_storagecluster_ceph_full_thresholds_params.py
+++ b/tests/functional/z_cluster/test_storagecluster_ceph_full_thresholds_params.py
@@ -16,6 +16,7 @@ from ocs_ci.framework.testlib import (
     pre_upgrade,
     post_upgrade,
 )
+from ocs_ci.framework.pytest_customization.marks import zstream_4_20_14
 
 logger = logging.getLogger(__name__)
 
@@ -59,6 +60,7 @@ def thresholds_teardown_fixture(request):
 @brown_squad
 @skipif_external_mode
 @pytest.mark.polarion_id("OCS-6224")
+@zstream_4_20_14
 class TestStorageClusterCephFullThresholdsParams(ManageTest):
     """
     Verify the ceph full thresholds storagecluster parameters move to cephcluster


### PR DESCRIPTION
# Z-Stream Test Enablement for ODF 4.20.14

This PR enables automated testing for z-stream release 4.20.14, validating 39 backported fixes and updates across multiple ODF components.

## Z-Stream Version

**4.20.14**

## Changes Being Validated

This z-stream includes 39 changes across 9 components:

| ID | Component | Type | Summary |
|----|-----------|------|---------|
| [DFBUGS-7079](https://redhat.atlassian.net/browse/DFBUGS-7079) | mcg | bugfix | NooBaa upgrade failure due to remove_mongo_pool.js error |
| [DFBUGS-6846](https://redhat.atlassian.net/browse/DFBUGS-6846) | mcg | bugfix | Backport intermittent S3 upload failures (HTTP 500 / InternalError) via JFrog Artifactory |
| [DFBUGS-6487](https://redhat.atlassian.net/browse/DFBUGS-6487) | must-gather | bugfix | rook-ceph-exporter log causes huge ODF must-gather |
| [DFBUGS-6872](https://redhat.atlassian.net/browse/DFBUGS-6872) | mcg | bugfix | INVALID_SCHEMA_REPLY SERVER after upgrading ODF to 4.21 |
| [DFBUGS-6533](https://redhat.atlassian.net/browse/DFBUGS-6533) | ocs-operator | bugfix | Missing default tolerations |
| [DFBUGS-6673](https://redhat.atlassian.net/browse/DFBUGS-6673) | ceph-csi | bugfix | Random Pod delete makes container in rbd.csi.ceph.com-nodeplugin-csi-addons restart |
| [DFBUGS-6666](https://redhat.atlassian.net/browse/DFBUGS-6666) | monitoring | bugfix | Remove duplicate PersistentVolumeUsageCritical alerts |
| [DFBUGS-7104](https://redhat.atlassian.net/browse/DFBUGS-7104) | odf-console | bugfix | ODF Console is breaking |
| [DFBUGS-7066](https://redhat.atlassian.net/browse/DFBUGS-7066) | rook | bugfix | RHODF 4.20.14 release |
| [DFBUGS-7045](https://redhat.atlassian.net/browse/DFBUGS-7045) | mcg | bugfix | Update nodejs from v22.11.0 to v24.13.0 |
| [DFBUGS-7016](https://redhat.atlassian.net/browse/DFBUGS-7016) | rook | bugfix | Upgrade ceph version to RHCEPH-8.1z6 |
| [DFBUGS-6953](https://redhat.atlassian.net/browse/DFBUGS-6953) | odf-console | security | Upgrade on-headers and undici to fix CVE-2025-7339, CVE-2026-22036 |
| [DFBUGS-6740](https://redhat.atlassian.net/browse/DFBUGS-6740) | mcg | bugfix | noobaa-endpoint crashes with Exit Code 1 due to unhandled AbortError from @azure/storage-blob |
| [DFBUGS-6705](https://redhat.atlassian.net/browse/DFBUGS-6705) | rook | bugfix | Unnecessary OSD redeployments on 4.19.z upgrade for already-encrypted OSDs |
| [DFBUGS-6653](https://redhat.atlassian.net/browse/DFBUGS-6653) | odf-console | security | CVE-2026-27942: fast-xml-parser Stack overflow DoS |
| [DFBUGS-6652](https://redhat.atlassian.net/browse/DFBUGS-6652) | odf-console | security | CVE-2026-27904: Minimatch DoS via catastrophic backtracking |
| [DFBUGS-6648](https://redhat.atlassian.net/browse/DFBUGS-6648) | odf-console | security | CVE-2026-26996: minimatch DoS via crafted glob patterns |
| [DFBUGS-6644](https://redhat.atlassian.net/browse/DFBUGS-6644) | odf-console | security | CVE-2026-26278: fast-xml-parser DoS via unlimited XML entity expansion |
| [DFBUGS-6643](https://redhat.atlassian.net/browse/DFBUGS-6643) | odf-console | security | CVE-2026-25896: fast-xml-parser XSS due to improper DOCTYPE entity handling |
| [DFBUGS-6642](https://redhat.atlassian.net/browse/DFBUGS-6642) | odf-console | security | CVE-2026-25128: fast-xml-parser RangeError DoS Numeric Entities Bug |
| [DFBUGS-6641](https://redhat.atlassian.net/browse/DFBUGS-6641) | odf-console | security | CVE-2026-22029: React Router XSS via Open Redirects |
| [DFBUGS-6640](https://redhat.atlassian.net/browse/DFBUGS-6640) | odf-console | security | CVE-2025-69873: ReDoS via $data reference |
| [DFBUGS-6639](https://redhat.atlassian.net/browse/DFBUGS-6639) | odf-console | security | CVE-2025-68458: webpack buildHttp allowedUris bypass leading to SSRF |
| [DFBUGS-6635](https://redhat.atlassian.net/browse/DFBUGS-6635) | odf-console | security | CVE-2025-68157: webpack buildHttp HttpUriPlugin allowedUris bypass via HTTP redirects |
| [DFBUGS-6631](https://redhat.atlassian.net/browse/DFBUGS-6631) | odf-console | security | CVE-2025-66031: node-forge ASN.1 Unbounded Recursion |
| [DFBUGS-6630](https://redhat.atlassian.net/browse/DFBUGS-6630) | odf-console | security | CVE-2025-15284: qs DoS via improper input validation in array parsing |
| [DFBUGS-6629](https://redhat.atlassian.net/browse/DFBUGS-6629) | odf-console | security | CVE-2025-13465: prototype pollution in _.unset and _.omit functions |
| [DFBUGS-6628](https://redhat.atlassian.net/browse/DFBUGS-6628) | odf-console | security | CVE-2025-12816: node-forge Interpretation conflict bypassing cryptographic verifications |
| [DFBUGS-6541](https://redhat.atlassian.net/browse/DFBUGS-6541) | ocs-operator | bugfix | Provider Server sends sub channel to client only when provider side csv is at tip |
| [DFBUGS-6531](https://redhat.atlassian.net/browse/DFBUGS-6531) | ocs-operator | bugfix | Missing toleration for node.ocs.openshift.io/storage in rook-ceph-rbd-mirror pod |
| [DFBUGS-6460](https://redhat.atlassian.net/browse/DFBUGS-6460) | odf-dr/multicluster-orchestrator | bugfix | Partial s3StoreProfile missing in ramen-hub-operator-config after upgrade from 4.17 to 4.18 |
| [DFBUGS-6220](https://redhat.atlassian.net/browse/DFBUGS-6220) | odf-console | security | CVE-2026-4800: lodash Arbitrary code execution via untrusted input in template imports |
| [DFBUGS-6176](https://redhat.atlassian.net/browse/DFBUGS-6176) | mcg | bugfix | Noobaa POD keeps Failing when Clusterwide encryption is enabled with IBM KeyProtect on ROKS |
| [DFBUGS-6098](https://redhat.atlassian.net/browse/DFBUGS-6098) | odf-cli | security | CVE-2026-33186: gRPC-Go Authorization bypass due to improper HTTP/2 path validation |
| [DFBUGS-6037](https://redhat.atlassian.net/browse/DFBUGS-6037) | odf-console | security | CVE-2026-29063: Immutable.js Prototype Pollution |
| [DFBUGS-5989](https://redhat.atlassian.net/browse/DFBUGS-5989) | odf-console | security | CVE-2026-33036: fast-xml-parser DoS via XML entity expansion bypass |
| [DFBUGS-5746](https://redhat.atlassian.net/browse/DFBUGS-5746) | ocs-operator | bugfix | Ceph PVC's not provisioning or mounting after ODF v4.20 upgrade |
| PR-NaturalIntelligence/fast-xml-parser-791 | NaturalIntelligence/fast-xml-parser | bugfix | Fix stack overflow in XMLBuilder with non-array values in arrToStr |
| PR-red-hat-storage/odf-multicluster-orchestrator-401 | disaster-recovery | bugfix | Remove generation-changed predicate from S3 controller for all ObjectBucketClaim updates |
| PR-red-hat-storage/odf-cli-297 | red-hat-storage/odf-cli | bugfix | Update gRPC to v1.80.0 and related networking dependencies |

### Changes by Component

- **odf-console**: 18 changes (17 security CVE fixes, 1 bugfix)
- **mcg**: 6 changes (5 bugfixes, 1 Node.js update)
- **ocs-operator**: 4 bugfixes
- **rook**: 3 changes (2 bugfixes, 1 release coordination)
- **odf-dr/multicluster-orchestrator**: 2 bugfixes
- **odf-cli**: 2 changes (1 security, 1 dependency update)
- **ceph-csi**: 1 bugfix
- **monitoring**: 1 bugfix
- **must-gather**: 1 bugfix

### Changes by Type

- **Bugfixes**: 22
- **Security fixes**: 17 CVEs addressed

## Test Coverage

**62 tests enabled** for this z-stream validation, covering:

- **Disaster Recovery**: Multi-cluster orchestration, Metro-DR, stretch cluster scenarios
- **NFS Feature**: Export/import validation, access modes, pod respin scenarios
- **Monitoring**: Prometheus metrics, alerts (corrupt PG, slow OSD ops), RGW metrics
- **Storage Services**: CephFS fsync consistency, PVC/PV operations
- **MCG**: Bucket notifications
- **Component Health**: Ceph cluster health, CSI operations, operator functionality

### Top Coverage Areas

- Disaster recovery and multi-cluster operations (12 tests)
- NFS feature validation across multiple scenarios (13 tests)
- Monitoring and alerting infrastructure (5 tests)
- Storage backend consistency and reliability (4 tests)

All tests are scored based on relevance to the z-stream changes, with priority given to disaster-recovery and multi-cluster orchestrator tests due to the critical S3 controller fix (PR-401).