### PR TITLE
FDF Upgrade Integration

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -505,7 +505,7 @@
         "hashed_secret": "89a519cc7786f3290ad671412d92f325f9ef2a57",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 98,
+        "line_number": 100,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -513,7 +513,7 @@
         "hashed_secret": "cfcafdd35cb253bd1a95060758e671abe510920a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 347,
+        "line_number": 349,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -569,7 +569,7 @@
         "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 338,
+        "line_number": 340,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -577,7 +577,7 @@
         "hashed_secret": "de19c40310ad831a71524cd279e6f5f0577fb09a",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 386,
+        "line_number": 388,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -637,7 +637,7 @@
         "hashed_secret": "b7e9a6e2e04ed3edbf8b4e21def4beccbb6eb6b1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 233,
+        "line_number": 234,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -645,7 +645,7 @@
         "hashed_secret": "a12337323b638ab044b1166bff4b1a1f83162819",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 857,
+        "line_number": 858,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -653,7 +653,7 @@
         "hashed_secret": "fb947972c92f052c0a08866d182be0075a2b601b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 866,
+        "line_number": 867,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -661,7 +661,7 @@
         "hashed_secret": "03e227627ab8681281fdb8aa3d799b03f782d672",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2083,
+        "line_number": 2087,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -669,7 +669,7 @@
         "hashed_secret": "ef5f3d909f23bd0aa02b4253f98350384f709c86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2190,
+        "line_number": 2194,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -677,7 +677,7 @@
         "hashed_secret": "cb1ae2b504c4615841d8144267a131231d2bd677",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2191,
+        "line_number": 2195,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -685,7 +685,7 @@
         "hashed_secret": "1a1e70e87dd0452c42f33ce9bf74aa28134dba6b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2192,
+        "line_number": 2196,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -693,7 +693,7 @@
         "hashed_secret": "7b1ba2f04f2f1604dc4e3caffcadf9fcbce7df5b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2193,
+        "line_number": 2197,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -701,7 +701,7 @@
         "hashed_secret": "0fa3b21ced80146d752888f2b60ec80e0d4b8925",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2205,
+        "line_number": 2209,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -709,7 +709,7 @@
         "hashed_secret": "f084f2068494b8d1cd06811dd97d02c3d85f40ee",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2220,
+        "line_number": 2224,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -717,7 +717,7 @@
         "hashed_secret": "adfa401a3b0a733d8f00519ac8c6b3893a2e7e8e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2221,
+        "line_number": 2225,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -725,7 +725,7 @@
         "hashed_secret": "898e46bbadc12f87120548bd445eb4210c8407c8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2229,
+        "line_number": 2233,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -733,7 +733,7 @@
         "hashed_secret": "f57ccec6b8f7b12b635ab53d26c3bf7300247341",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2230,
+        "line_number": 2234,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -741,7 +741,7 @@
         "hashed_secret": "77b044ea736f8cbe568d1954424186d901f89db9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2231,
+        "line_number": 2235,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -749,7 +749,7 @@
         "hashed_secret": "d64368f12ca17c69568c6a132f17d44d56e60660",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2232,
+        "line_number": 2236,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -757,7 +757,7 @@
         "hashed_secret": "8f9ca35156c02cb6ba58c5b51230b9bedc38de4f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2233,
+        "line_number": 2237,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -765,7 +765,7 @@
         "hashed_secret": "9ec53cfd9929c70c3f87c210b6a7b77fb6d79d43",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2830,
+        "line_number": 2834,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -773,7 +773,7 @@
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2996,
+        "line_number": 3000,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -781,7 +781,7 @@
         "hashed_secret": "adc1f5c8707f7d7aba3aabe13c15e5ef1151872e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2997,
+        "line_number": 3001,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -789,7 +789,7 @@
         "hashed_secret": "ee46262b2df945e46ea310b925ad087465dbd3f2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3746,
+        "line_number": 3750,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -797,7 +797,7 @@
         "hashed_secret": "f678cad4ab874d71b559a069d5e34a95fe38a480",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3747,
+        "line_number": 3751,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/conf/README.md
+++ b/conf/README.md
@@ -179,6 +179,9 @@ version.
 * `fdf_image_tag`: FDF image tag, used to retrieve fdf_pre_release_image_digest.
 * `fdf_pre_release_registry`: Registry where the pre-release image of FDF is hosted.
 * `fdf_pre_release_image_digest`: sha256 of the pre-release image of FDF to deploy.
+* `fdf_upgrade_registry`: Registry URL for the FDF upgrade catalog image (Default: cp.stg.icr.io/cp/df). If not specified during upgrade, falls back to fdf_pre_release_registry.
+* `fdf_upgrade_image_tag`: Image tag for the FDF upgrade catalog (e.g., v4.22). If not specified during upgrade, falls back to fdf_image_tag.
+* `fdf_upgrade_image_digest`: sha256 of the pre-release image for FDF upgrade. If not provided, automatically retrieved using skopeo.
 * `storage_cluster_override` - Dictionary with data which will allow you to dynamically override data in storageCluster CR.
 * `konflux_build` - Set to True if build is made by Konflux build system.
 * `enable_data_replication_separation` - Set to True to label worker nodes with `network.rook.io/mon-ip: <IPAddress>` and enable data replication separation.

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -121,3 +121,28 @@ keep in stage content.
 > Or manually passing: `conf/ocsci/manual_subscription_plan_approval.yaml`
 > The cluster needs to be installed before push to the stage.
 > There is no way to install previous Z-stream version once content is pushed to the stage!
+
+## FDF (Fusion Data Foundation) upgrade
+
+For upgrading IBM Fusion Data Foundation (FDF) pre-release builds, you can specify
+the upgrade registry and image tag using CLI parameters:
+
+```bash
+run-ci tests/
+    --cluster-name kerberos_ID-fdf-deployment \
+    --cluster-path /home/my_user/my-fdf-dir \
+    -m 'pre_upgrade or fdf_upgrade or post_upgrade' \
+    --fdf-upgrade-registry cp.stg.icr.io/cp/df \
+    --fdf-upgrade-image-tag v4.22
+```
+
+Alternatively, you can specify these values in a configuration file:
+
+```yaml
+DEPLOYMENT:
+  fdf_upgrade_registry: "cp.stg.icr.io/cp/df"
+  fdf_upgrade_image_tag: "v4.22"
+```
+
+These parameters configure the registry and image tag used for the FDF upgrade catalog,
+similar to how `--upgrade-ocs-registry-image` works for OCS/ODF upgrades.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -68,6 +68,8 @@ to the pytest.
     is passed, the version is parsed from the registry image name but only
     if no version is passed via --ocs-version parameter.
 * `--upgrade-ocs-registry-image` - ocs registry image to be used for upgrade (e.g quay.io/rhceph-dev/ocs-olm-operator:latest-4.3)
+* `--fdf-upgrade-registry` - FDF upgrade registry for pre-release catalog image (e.g. cp.stg.icr.io/cp/df)
+* `--fdf-upgrade-image-tag` - FDF upgrade image tag for pre-release catalog (e.g. v4.22)
 * `--ocsci-conf` - with this configuration parameter you can overwrite the
     default OCS-CI config parameters defined in
     [default config](https://github.com/red-hat-storage/ocs-ci/tree/master/ocs_ci/framework/conf/default_config.yaml).

--- a/ocs_ci/deployment/fusion_data_foundation.py
+++ b/ocs_ci/deployment/fusion_data_foundation.py
@@ -19,7 +19,10 @@ from ocs_ci.framework import config
 
 from ocs_ci.helpers.helpers import create_lvs_resource
 from ocs_ci.ocs import constants, defaults, node
-from ocs_ci.ocs.exceptions import CommandFailed, TimeoutExpiredError
+from ocs_ci.ocs.exceptions import (
+    CommandFailed,
+    TimeoutExpiredError,
+)
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.utility import templating, version
 from ocs_ci.utility.retry import retry
@@ -106,12 +109,17 @@ class FusionDataFoundationDeployment:
             f"oc --kubeconfig {self.kubeconfig} apply -f {imagetag_file}", silent=True
         )
 
-    def create_image_digest_mirror_set(self):
+    def create_image_digest_mirror_set(self, upgrade=False):
         """
-        Create or update ImageTagMirrorSet.
+        Create or update ImageDigestMirrorSet.
+
+        Args:
+            upgrade (bool): If True, use upgrade-specific config values for
+                registry and image tag. Default is False.
+
         """
         logger.info("Creating FDF ImageDigestMirrorSet")
-        image_digest_mirror_set = extract_image_digest_mirror_set()
+        image_digest_mirror_set = extract_image_digest_mirror_set(upgrade=upgrade)
 
         run_cmd(
             f"oc --kubeconfig {self.kubeconfig} apply -f {image_digest_mirror_set}",
@@ -159,11 +167,31 @@ class FusionDataFoundationDeployment:
         """
         time.sleep(60)
         wait_for_machineconfigpool_status(node_type="all")
+        self.patch_fusion_service_definition()
 
-        fdf_image_tag = config.DEPLOYMENT.get("fdf_image_tag")
+    def patch_fusion_service_definition(self, upgrade=False):
+        """
+        Patch the FusionServiceDefinition with the imageDigest and registryPath of the build.
+
+        Args:
+            upgrade (bool): If True, use upgrade-specific config values
+                (fdf_upgrade_registry and fdf_upgrade_image_tag). Default is False.
+
+        """
+        if upgrade:
+            fdf_registry = config.DEPLOYMENT.get(
+                "fdf_upgrade_registry"
+            ) or config.DEPLOYMENT.get("fdf_pre_release_registry")
+            fdf_image_tag = config.DEPLOYMENT.get(
+                "fdf_upgrade_image_tag"
+            ) or config.DEPLOYMENT.get("fdf_image_tag")
+            fdf_image_digest = config.DEPLOYMENT.get("fdf_upgrade_image_digest")
+        else:
+            fdf_registry = config.DEPLOYMENT.get("fdf_pre_release_registry")
+            fdf_image_tag = config.DEPLOYMENT.get("fdf_image_tag")
+            fdf_image_digest = config.DEPLOYMENT.get("fdf_pre_release_image_digest")
+
         fdf_catalog_name = defaults.FUSION_CATALOG_NAME
-        fdf_registry = config.DEPLOYMENT.get("fdf_pre_release_registry")
-        fdf_image_digest = config.DEPLOYMENT.get("fdf_pre_release_image_digest")
         pull_secret = os.path.join(constants.DATA_DIR, "pull-secret")
 
         if not fdf_image_digest:
@@ -172,7 +200,10 @@ class FusionDataFoundationDeployment:
             catalog_data = run_cmd(cmd)
             fdf_image_digest = json.loads(catalog_data).get("Digest")
             logger.info(f"Retrieved image digest: {fdf_image_digest}")
-            config.DEPLOYMENT["fdf_pre_release_image_digest"] = fdf_image_digest
+            if upgrade:
+                config.DEPLOYMENT["fdf_upgrade_image_digest"] = fdf_image_digest
+            else:
+                config.DEPLOYMENT["fdf_pre_release_image_digest"] = fdf_image_digest
 
         ocp_version = f"ocp{get_running_ocp_version().replace('.', '')}-t"
         logger.info(f"OCP version: {ocp_version}")
@@ -380,18 +411,32 @@ def odfcluster_status_check():
     logger.info("OdfCluster created successfully")
 
 
-def extract_image_digest_mirror_set():
+def extract_image_digest_mirror_set(upgrade=False):
     """
     Extract the ImageDigestMirrorSet from the FDF build.
+
+    Args:
+        upgrade (bool): If True, use upgrade-specific config values
+            (fdf_upgrade_registry and fdf_upgrade_image_tag). Default is False.
 
     Returns:
         str: Name of the extracted ImageDigestMirrorSet
 
     """
     pull_secret = os.path.join(constants.DATA_DIR, "pull-secret")
-    fdf_registry = config.DEPLOYMENT.get("fdf_pre_release_registry")
+
+    if upgrade:
+        fdf_registry = config.DEPLOYMENT.get(
+            "fdf_upgrade_registry"
+        ) or config.DEPLOYMENT.get("fdf_pre_release_registry")
+        fdf_image_tag = config.DEPLOYMENT.get(
+            "fdf_upgrade_image_tag"
+        ) or config.DEPLOYMENT.get("fdf_image_tag")
+    else:
+        fdf_registry = config.DEPLOYMENT.get("fdf_pre_release_registry")
+        fdf_image_tag = config.DEPLOYMENT.get("fdf_image_tag")
+
     fdf_catalog_name = defaults.FUSION_CATALOG_NAME
-    fdf_image_tag = config.DEPLOYMENT.get("fdf_image_tag")
 
     filename = constants.FDF_IMAGE_DIGEST_MIRROR_SET_FILENAME
     cmd = (
@@ -411,7 +456,7 @@ def is_not_arbiter_node(node_obj):
         node_obj (ocs_ci.ocs.ocp.OCP): OCP Node object
 
     Returns:
-        bool: True if node doesn't contain the labelj, False if it does
+        bool: True if node doesn't contain the label, False if it does
 
     """
     arbiter_zone = config.DEPLOYMENT.get(
@@ -457,6 +502,7 @@ def storagecluster_health_check():
         AssertionError: If the StorageCluster is not in a Ready state
                         or Ceph health is not HEALTH_OK.
         KeyError: If expected status keys are missing.
+
     """
     storagecluster = StorageCluster(
         resource_name="ocs-storagecluster",

--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -141,6 +141,8 @@ DEPLOYMENT:
   enable_data_replication_separation: False # separates client data path from data replication
   # Erasure Coding: deploy ODF with EC as default pool type instead of replication
   ec_default_pools: False
+  # FDF
+  fdf_upgrade_registry: "cp.stg.icr.io/cp/df"
 
 # Section for reporting configuration
 REPORTING:

--- a/ocs_ci/framework/conf/fdf_version/fdf-4.18.yaml
+++ b/ocs_ci/framework/conf/fdf_version/fdf-4.18.yaml
@@ -4,3 +4,6 @@ DEPLOYMENT:
   fdf_image_tag: v4.18
   fdf_pre_release_registry: cp.stg.icr.io/cp/df
   fdf_pre_release_image_digest: null
+REPORTING:
+  default_ocs_must_gather_latest_tag: 'latest-4.18'
+  default_ocs_must_gather_image: "quay.io/rhceph-dev/odf4-odf-must-gather-rhel9"

--- a/ocs_ci/framework/conf/fdf_version/fdf-4.19.yaml
+++ b/ocs_ci/framework/conf/fdf_version/fdf-4.19.yaml
@@ -4,3 +4,6 @@ DEPLOYMENT:
   fdf_image_tag: v4.19
   fdf_pre_release_registry: cp.stg.icr.io/cp/df
   fdf_pre_release_image_digest: null
+REPORTING:
+  default_ocs_must_gather_latest_tag: 'v4.19'
+  default_ocs_must_gather_image: "quay.io/rhceph-dev/odf4-odf-must-gather-rhel9"

--- a/ocs_ci/framework/conf/fdf_version/fdf-4.20.yaml
+++ b/ocs_ci/framework/conf/fdf_version/fdf-4.20.yaml
@@ -4,3 +4,6 @@ DEPLOYMENT:
   fdf_image_tag: v4.20
   fdf_pre_release_registry: cp.stg.icr.io/cp/df
   fdf_pre_release_image_digest: null
+REPORTING:
+  default_ocs_must_gather_latest_tag: 'v4.20'
+  default_ocs_must_gather_image: "quay.io/rhceph-dev/odf4-odf-must-gather-rhel9"

--- a/ocs_ci/framework/conf/fdf_version/fdf-4.21.yaml
+++ b/ocs_ci/framework/conf/fdf_version/fdf-4.21.yaml
@@ -4,3 +4,6 @@ DEPLOYMENT:
   fdf_image_tag: v4.21
   fdf_pre_release_registry: cp.stg.icr.io/cp/df
   fdf_pre_release_image_digest: null
+REPORTING:
+  default_ocs_must_gather_latest_tag: 'v4.21'
+  default_ocs_must_gather_image: "quay.io/rhceph-dev/odf4-odf-must-gather-rhel9"

--- a/ocs_ci/framework/conf/fdf_version/fdf-4.22.yaml
+++ b/ocs_ci/framework/conf/fdf_version/fdf-4.22.yaml
@@ -4,3 +4,6 @@ DEPLOYMENT:
   fdf_image_tag: v4.22
   fdf_pre_release_registry: cp.stg.icr.io/cp/df
   fdf_pre_release_image_digest: null
+REPORTING:
+  default_ocs_must_gather_latest_tag: 'v4.22'
+  default_ocs_must_gather_image: "quay.io/rhceph-dev/odf4-odf-must-gather-rhel9"

--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -22,6 +22,9 @@ from ocs_ci.ocs.constants import (
     ORDER_OCS_UPGRADE,
     ORDER_AFTER_OCP_UPGRADE,
     ORDER_AFTER_OCS_UPGRADE,
+    ORDER_BEFORE_FDF_UPGRADE,
+    ORDER_FDF_UPGRADE,
+    ORDER_AFTER_FDF_UPGRADE,
     ORDER_AFTER_UPGRADE,
     CLOUD_PLATFORMS,
     ON_PREM_PLATFORMS,
@@ -135,6 +138,7 @@ tier_marks = [
 order_pre_upgrade = pytest.mark.order(ORDER_BEFORE_UPGRADE)
 order_pre_ocp_upgrade = pytest.mark.order(ORDER_BEFORE_OCP_UPGRADE)
 order_pre_ocs_upgrade = pytest.mark.order(ORDER_BEFORE_OCS_UPGRADE)
+order_pre_fdf_upgrade = pytest.mark.order(ORDER_BEFORE_FDF_UPGRADE)
 order_ocp_upgrade = pytest.mark.order(ORDER_OCP_UPGRADE)
 order_mco_upgrade = pytest.mark.order(ORDER_MCO_UPGRADE)
 order_dr_hub_upgrade = pytest.mark.order(ORDER_DR_HUB_UPGRADE)
@@ -144,10 +148,12 @@ order_dr_cluster_operator_upgrade = pytest.mark.order(ORDER_DR_HUB_UPGRADE)
 order_acm_upgrade = pytest.mark.order(ORDER_ACM_UPGRADE)
 order_mce_upgrade = pytest.mark.order(ORDER_MCE_UPGRADE)
 order_ocs_upgrade = pytest.mark.order(ORDER_OCS_UPGRADE)
+order_fdf_upgrade = pytest.mark.order(ORDER_FDF_UPGRADE)
 order_ocp_on_kubevirt_upgrade = pytest.mark.order(ORDER_OCP_ON_KUBEVIRT_UPGRADE)
 order_post_upgrade = pytest.mark.order(ORDER_AFTER_UPGRADE)
 order_post_ocp_upgrade = pytest.mark.order(ORDER_AFTER_OCP_UPGRADE)
 order_post_ocs_upgrade = pytest.mark.order(ORDER_AFTER_OCS_UPGRADE)
+order_post_fdf_upgrade = pytest.mark.order(ORDER_AFTER_FDF_UPGRADE)
 ocp_upgrade = compose(order_ocp_upgrade, pytest.mark.ocp_upgrade)
 
 # multicluster orchestrator
@@ -162,6 +168,8 @@ acm_upgrade = compose(order_acm_upgrade, pytest.mark.acm_upgrade)
 mce_upgrade = compose(order_mce_upgrade, pytest.mark.mce_upgrade)
 
 ocs_upgrade = compose(order_ocs_upgrade, pytest.mark.ocs_upgrade)
+
+fdf_upgrade = compose(order_fdf_upgrade, pytest.mark.fdf_upgrade)
 
 # provider operator upgrade
 provider_operator_upgrade = compose(
@@ -181,10 +189,15 @@ pre_ocs_upgrade = compose(
     order_pre_ocs_upgrade,
     pytest.mark.pre_ocs_upgrade,
 )
+pre_fdf_upgrade = compose(
+    order_pre_fdf_upgrade,
+    pytest.mark.pre_fdf_upgrade,
+)
 # post_*_upgrade markers
 post_upgrade = compose(order_post_upgrade, pytest.mark.post_upgrade)
 post_ocp_upgrade = compose(order_post_ocp_upgrade, pytest.mark.post_ocp_upgrade)
 post_ocs_upgrade = compose(order_post_ocs_upgrade, pytest.mark.post_ocs_upgrade)
+post_fdf_upgrade = compose(order_post_fdf_upgrade, pytest.mark.post_fdf_upgrade)
 
 upgrade_marks = [
     ocp_upgrade,
@@ -192,12 +205,15 @@ upgrade_marks = [
     dr_hub_upgrade,
     acm_upgrade,
     ocs_upgrade,
+    fdf_upgrade,
     pre_upgrade,
     pre_ocp_upgrade,
     pre_ocs_upgrade,
+    pre_fdf_upgrade,
     post_upgrade,
     post_ocp_upgrade,
     post_ocs_upgrade,
+    post_fdf_upgrade,
 ]
 
 # mark the test class with marker below to ignore leftover check

--- a/ocs_ci/framework/pytest_customization/ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/ocscilib.py
@@ -273,6 +273,19 @@ def pytest_addoption(parser):
         ),
     )
     parser.addoption(
+        "--fdf-upgrade-registry",
+        dest="fdf_upgrade_registry",
+        help=(
+            "FDF upgrade registry for pre-release catalog image "
+            "(e.g. cp.stg.icr.io/cp/df)"
+        ),
+    )
+    parser.addoption(
+        "--fdf-upgrade-image-tag",
+        dest="fdf_upgrade_image_tag",
+        help=("FDF upgrade image tag for pre-release catalog (e.g. v4.22)"),
+    )
+    parser.addoption(
         "--acm-version",
         dest="acm_version",
         help="acm version(e.g. 2.8) to be used for the current run",
@@ -725,6 +738,12 @@ def process_cluster_cli_params(config):
     upgrade_ocs_registry_image = get_cli_param(config, "upgrade_ocs_registry_image")
     if upgrade_ocs_registry_image:
         ocsci_config.UPGRADE["upgrade_ocs_registry_image"] = upgrade_ocs_registry_image
+    fdf_upgrade_registry = get_cli_param(config, "fdf_upgrade_registry")
+    if fdf_upgrade_registry:
+        ocsci_config.DEPLOYMENT["fdf_upgrade_registry"] = fdf_upgrade_registry
+    fdf_upgrade_image_tag = get_cli_param(config, "fdf_upgrade_image_tag")
+    if fdf_upgrade_image_tag:
+        ocsci_config.DEPLOYMENT["fdf_upgrade_image_tag"] = fdf_upgrade_image_tag
     ocsci_config.ENV_DATA["cluster_name"] = cluster_name
     ocsci_config.ENV_DATA["cluster_path"] = cluster_path
     get_cli_param(config, "collect-logs")

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -22,6 +22,7 @@ FUSION_CONF_DIR = os.path.join(DEPLOYMENT_CONF_DIR, "fusion_hci_pc")
 FRAMEWORK_CONF_DIR = os.path.join(TOP_DIR, "ocs_ci", "framework", "conf")
 OCP_VERSION_CONF_DIR = os.path.join(FRAMEWORK_CONF_DIR, "ocp_version")
 OCS_VERSION_CONF_DIR = os.path.join(FRAMEWORK_CONF_DIR, "ocs_version")
+FDF_VERSION_CONF_DIR = os.path.join(FRAMEWORK_CONF_DIR, "fdf_version")
 TEMPLATE_DIR = os.path.join(TOP_DIR, "ocs_ci", "templates")
 TEMPLATE_CLEANUP_DIR = os.path.join(TEMPLATE_DIR, "cleanup")
 REPO_DIR = os.path.join(TOP_DIR, "ocs_ci", "repos")
@@ -2055,6 +2056,9 @@ ORDER_OCP_ON_KUBEVIRT_UPGRADE = 48
 ORDER_BEFORE_OCS_UPGRADE = 50
 ORDER_OCS_UPGRADE = 60
 ORDER_AFTER_OCS_UPGRADE = 70
+ORDER_BEFORE_FDF_UPGRADE = 50
+ORDER_FDF_UPGRADE = 60
+ORDER_AFTER_FDF_UPGRADE = 70
 ORDER_AFTER_UPGRADE = 80
 
 # Deployment constants

--- a/ocs_ci/ocs/fdf_upgrade.py
+++ b/ocs_ci/ocs/fdf_upgrade.py
@@ -1,0 +1,455 @@
+import json
+import logging
+import os
+import time
+
+import yaml
+
+from ocs_ci.deployment.fusion_data_foundation import (
+    FusionDataFoundationDeployment,
+    FusionServiceInstance,
+    run_patch_cmd,
+)
+from ocs_ci.framework import config
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.cluster import CephCluster, CephHealthMonitor
+from ocs_ci.ocs.exceptions import (
+    ChannelNotFound,
+    ConfigurationError,
+    TimeoutExpiredError,
+)
+from ocs_ci.ocs.upgrade import BaseUpgrade
+from ocs_ci.utility.retry import retry
+from ocs_ci.utility.utils import exec_cmd, load_config_file
+
+
+logger = logging.getLogger(__name__)
+
+
+class FDFUpgrade(BaseUpgrade):
+    """
+    FDF (Fusion Data Foundation) Upgrade helper class.
+
+    This class handles the upgrade process for IBM Fusion Data Foundation,
+    including pre-release catalog updates, subscription channel management,
+    and upgrade execution via the fusionserviceinstance.
+
+    """
+
+    def __init__(self, namespace, version_before_upgrade):
+        """
+        Initialize FDF upgrade parameters.
+
+        Args:
+            namespace (str): Namespace where FDF is deployed
+            version_before_upgrade (str): Current FDF version before upgrade
+
+        """
+        super().__init__(namespace, version_before_upgrade)
+        self.fdf_deployment = FusionDataFoundationDeployment()
+        self.kubeconfig = config.RUN.get("kubeconfig")
+        self._fdf_upgrade_version = None
+        self._channel = None
+
+    @property
+    def fdf_upgrade_version(self):
+        """
+        Get the FDF upgrade version.
+
+        Returns:
+            str: FDF upgrade version
+
+        """
+        if self._fdf_upgrade_version is None:
+            self._fdf_upgrade_version = self.get_upgrade_version()
+        return self._fdf_upgrade_version
+
+    @fdf_upgrade_version.setter
+    def fdf_upgrade_version(self, value):
+        """
+        Set the FDF upgrade version.
+
+        Args:
+            value (str): FDF upgrade version to set
+
+        """
+        self._fdf_upgrade_version = value
+
+    @property
+    def channel(self):
+        """
+        Get the FDF upgrade channel.
+
+        Returns:
+            str: FDF upgrade channel
+
+        """
+        if self._channel is None:
+            self._channel = config.DEPLOYMENT.get("ocs_csv_channel")
+        return self._channel
+
+    @channel.setter
+    def channel(self, value):
+        """
+        Set the FDF upgrade channel.
+
+        Args:
+            value (str): FDF upgrade channel to set
+
+        """
+        self._channel = value
+        config.DEPLOYMENT["ocs_csv_channel"] = value
+
+    def get_upgrade_version(self):
+        """
+        Get the target FDF upgrade version.
+
+        Returns:
+            str: Target FDF version for upgrade
+
+        """
+        upgrade_version = config.DEPLOYMENT.get("fdf_upgrade_image_tag")
+        if not upgrade_version:
+            upgrade_version = config.DEPLOYMENT.get("fdf_image_tag")
+        if upgrade_version and upgrade_version.startswith("v"):
+            upgrade_version = upgrade_version[1:]
+        return upgrade_version or self.version_before_upgrade
+
+    def load_version_config_file(self, upgrade_version):
+        """
+        Load FDF version-specific configuration file.
+
+        Args:
+            upgrade_version (str): FDF version to load config for
+
+        """
+        version_config_file = os.path.join(
+            constants.FDF_VERSION_CONF_DIR, f"fdf-{upgrade_version}.yaml"
+        )
+        if os.path.exists(version_config_file):
+            logger.info(f"Loading config file for FDF version: {upgrade_version}")
+            load_config_file(version_config_file)
+        else:
+            logger.info(
+                f"FDF version config file not found: {version_config_file}, "
+                "using current configuration"
+            )
+
+    def run_upgrade(self):
+        """
+        Execute the complete FDF upgrade workflow.
+
+        This method orchestrates the FDF upgrade process including:
+        1. Version validation - ensures target version is >= current version
+        2. Version-specific configuration loading
+        3. ITMS, IDMS, and FusionServiceDefinition creation / updates
+        4. Subscription channel updates
+        5. Upgrade triggering via FusionServiceInstance
+        6. Install plan approval and monitoring
+        7. Health monitoring during upgrade via CephHealthMonitor
+        8. Post-upgrade verification
+
+        The upgrade is performed while monitoring Ceph cluster health. If health
+        degrades during the upgrade, the CephHealthMonitor context manager will
+        raise an exception.
+
+        Raises:
+            AssertionError: If target version is lower than current version
+            ConfigurationError: If required configuration is missing or invalid
+            ChannelNotFound: If the upgrade subscription channel is not available
+            TimeoutExpiredError: If upgrade does not complete within timeout
+            CephHealthException: If Ceph health degrades during upgrade
+
+        """
+        logger.info("Starting FDF upgrade procedure")
+        self.start_time = time.time()
+        logger.info(
+            f"Upgrading FDF from {self.version_before_upgrade} to {self.fdf_upgrade_version}"
+        )
+
+        parsed_versions = self.get_parsed_versions()
+        assert parsed_versions[1] >= parsed_versions[0], (
+            f"Target upgrade version {self.fdf_upgrade_version} is not higher than or equal to "
+            f"current version {self.version_before_upgrade}"
+        )
+
+        self.load_version_config_file(self.fdf_upgrade_version)
+        if not self.upgrade_in_current_source:
+            self.fdf_deployment.create_image_tag_mirror_set()
+            self.fdf_deployment.create_image_digest_mirror_set(upgrade=True)
+            self.fdf_deployment.patch_fusion_service_definition(upgrade=True)
+        ceph_cluster = CephCluster()
+        self.pre_upgrade_csv_data = self.get_csv_name_pre_upgrade()
+        self.pre_upgrade_image_data = self.get_pre_upgrade_image(
+            self.pre_upgrade_csv_data
+        )
+        with CephHealthMonitor(ceph_cluster):
+            self.update_subscription_channel()
+            self.trigger_fdf_upgrade()
+            self.fdf_deployment.ensure_install_plan_approval()
+            self.monitor_fusion_service_instance()
+            self.end_time = time.time()
+            self.duration = self.end_time - self.start_time
+            old_images = self.get_images_post_upgrade(
+                self.channel, self.pre_upgrade_image_data, self.fdf_upgrade_version
+            )
+        self.verify_required_csvs()
+        self.verify_image_versions(old_images, parsed_versions[1], parsed_versions[0])
+
+        version = self.fdf_deployment.get_installed_version()
+        logger.info(f"FDF upgraded to version {version} successfully")
+
+    def update_subscription_channel(self):
+        """
+        Update the ODF operator subscription channel based on fdf_upgrade_image_tag.
+
+        This method derives the channel from fdf_upgrade_image_tag, waits for it to
+        become available, and updates the odf-operator subscription channel.
+
+        Raises:
+            ConfigurationError: If fdf_upgrade_image_tag is not configured or cannot be parsed
+            ChannelNotFound: If the upgrade channel does not become available within timeout
+
+        """
+        fdf_upgrade_image_tag = config.DEPLOYMENT.get("fdf_upgrade_image_tag")
+        if not fdf_upgrade_image_tag:
+            raise ConfigurationError(
+                "fdf_upgrade_image_tag is not configured. "
+                "Cannot determine upgrade subscription channel."
+            )
+
+        version_str = fdf_upgrade_image_tag.lstrip("v")
+        version_parts = version_str.split(".")
+        if len(version_parts) < 2:
+            raise ConfigurationError(
+                f"Could not parse version from fdf_upgrade_image_tag: {fdf_upgrade_image_tag}. "
+                f"Expected format with at least major.minor version (e.g., 'v4.21', '4.18.8-2')"
+            )
+
+        self.channel = f"stable-{version_parts[0]}.{version_parts[1]}"
+        logger.info(
+            f"Derived upgrade channel '{self.channel}' from "
+            f"fdf_upgrade_image_tag '{fdf_upgrade_image_tag}'"
+        )
+
+        logger.info(f"Waiting for upgrade channel '{self.channel}' to be available")
+        if not self.wait_for_subscription_channel(self.channel, timeout=300):
+            raise ChannelNotFound(
+                f"Channel '{self.channel}' did not become available within 300 seconds. "
+                f"Cannot proceed with subscription channel update."
+            )
+
+        logger.info(f"Updating odf-operator subscription channel to: {self.channel}")
+        params_dict = {"spec": {"channel": self.channel}}
+        params = json.dumps(params_dict)
+        cmd = (
+            f"oc --kubeconfig {self.kubeconfig} -n {constants.OPENSHIFT_STORAGE_NAMESPACE} patch Subscription "
+            f"odf-operator -p '{params}' --type merge"
+        )
+        run_patch_cmd(cmd)
+        logger.info("Subscription channel updated successfully")
+
+    def trigger_fdf_upgrade(self):
+        """
+        Trigger FDF upgrade by patching fusionserviceinstance triggerUpdate to true.
+
+        This initiates the FDF upgrade process by setting the triggerUpdate field
+        in the fusionserviceinstance spec to true.
+
+        """
+        logger.test_step("Triggering FDF upgrade")
+        params_dict = {"spec": {"triggerUpdate": True}}
+        params = json.dumps(params_dict)
+        cmd = (
+            f"oc --kubeconfig {self.kubeconfig} -n {constants.FDF_NAMESPACE} patch FusionServiceInstance "
+            f"{constants.FDF_SERVICE_NAME} -p '{params}' --type merge"
+        )
+        run_patch_cmd(cmd)
+        logger.info("FDF upgrade triggered successfully")
+
+    def monitor_fusion_service_instance(self, timeout=1800):
+        """
+        Monitor the FDF upgrade progress and verify completion.
+
+        This method monitors the fusionserviceinstance status and waits for the
+        upgrade to complete. It logs important information during the upgrade and
+        in the event of failure.
+
+        Args:
+            timeout (int): Maximum time to wait for upgrade completion in seconds.
+                Default is 1800 (30 minutes).
+
+        Raises:
+            TimeoutExpiredError: If upgrade does not complete within timeout
+            AssertionError: If upgrade fails or encounters unhealthy state
+
+        """
+        logger.test_step("Monitoring FDF upgrade progress")
+
+        expected_version = config.DEPLOYMENT.get("fdf_upgrade_image_tag")
+
+        if expected_version and expected_version.startswith("v"):
+            expected_version = expected_version[1:]
+
+        logger.info(f"Expected upgrade version: {expected_version}")
+
+        last_state = {}
+
+        try:
+
+            @retry(AssertionError, tries=timeout // 30, delay=30, backoff=1)
+            def _wait_for_upgrade_completion():
+                instance = FusionServiceInstance(
+                    resource_name=constants.FDF_SERVICE_NAME,
+                    namespace=constants.FDF_NAMESPACE,
+                )
+                instance_status = instance.data.get("status", {})
+                upgrade_in_progress = instance_status.get("upgradeInProgress", False)
+                health = instance_status.get("health", "Unknown")
+                current_version = instance_status.get("currentVersion", "Unknown")
+
+                current_state = {
+                    "upgrade_in_progress": upgrade_in_progress,
+                    "health": health,
+                    "version": current_version,
+                }
+
+                if current_state != last_state:
+                    logger.info(
+                        f"Upgrade status - In Progress: {upgrade_in_progress}, "
+                        f"Health: {health}, Version: {current_version}"
+                    )
+                    last_state.update(current_state)
+                else:
+                    logger.debug(
+                        f"Upgrade status - In Progress: {upgrade_in_progress}, "
+                        f"Health: {health}, Version: {current_version}"
+                    )
+
+                if health not in ["Healthy", "Unknown"]:
+                    logger.warning(f"FusionServiceInstance health status: {health}")
+                    logger.info("Status details:")
+                    logger.info(yaml.dump(instance_status, default_flow_style=False))
+
+                assert not upgrade_in_progress, "Upgrade still in progress"
+                assert (
+                    health == "Healthy"
+                ), f"Service health is {health}, expected Healthy"
+
+                if expected_version:
+                    version_to_check = current_version
+                    if version_to_check.startswith("v"):
+                        version_to_check = version_to_check[1:]
+                    assert version_to_check.startswith(
+                        expected_version
+                    ), f"Current version {current_version} does not match expected version {expected_version}"
+
+            _wait_for_upgrade_completion()
+            logger.info("FDF upgrade monitoring completed successfully")
+
+        except (TimeoutExpiredError, AssertionError) as e:
+            logger.error(f"FDF upgrade monitoring failed: {e}")
+            self._log_upgrade_failure_details()
+            raise
+
+    def _log_upgrade_failure_details(self):
+        """
+        Log detailed information about upgrade failure for debugging.
+
+        This method collects and logs relevant information when an upgrade fails,
+        including fusionserviceinstance status, operator CSVs, and install plans.
+
+        """
+        logger.error("Collecting upgrade failure details")
+
+        try:
+            logger.info("FusionServiceInstance status:")
+            instance = FusionServiceInstance(
+                resource_name=constants.FDF_SERVICE_NAME,
+                namespace=constants.FDF_NAMESPACE,
+            )
+            logger.info(
+                yaml.dump(instance.data.get("status", {}), default_flow_style=False)
+            )
+        except Exception as e:
+            logger.error(f"Failed to get FusionServiceInstance status: {e}")
+
+        try:
+            logger.info("Operator CSV status:")
+            csvs_cmd = f"oc --kubeconfig {self.kubeconfig} get csv -n {constants.OPENSHIFT_STORAGE_NAMESPACE} -o yaml"
+            csvs_output = exec_cmd(csvs_cmd)
+            csvs_data = yaml.safe_load(csvs_output)
+            for csv in csvs_data.get("items", []):
+                csv_name = csv["metadata"]["name"]
+                phase = csv.get("status", {}).get("phase", "Unknown")
+                logger.info(f"  {csv_name}: {phase}")
+        except Exception as e:
+            logger.error(f"Failed to get CSV status: {e}")
+
+        try:
+            logger.info("Pending install plans:")
+            ip_cmd = (
+                f"oc --kubeconfig {self.kubeconfig} "
+                "get installplan -n {constants.OPENSHIFT_STORAGE_NAMESPACE} "
+                "-o yaml"
+            )
+            ip_output = exec_cmd(ip_cmd)
+            ip_data = yaml.safe_load(ip_output)
+            for ip in ip_data.get("items", []):
+                ip_name = ip["metadata"]["name"]
+                approved = ip["spec"].get("approved", False)
+                phase = ip.get("status", {}).get("phase", "Unknown")
+                logger.info(f"  {ip_name}: approved={approved}, phase={phase}")
+        except Exception as e:
+            logger.error(f"Failed to get install plan status: {e}")
+
+    def wait_for_subscription_channel(self, channel_name, timeout=300):
+        """
+        Wait for a specific subscription channel to become available in the packagemanifest.
+
+        Args:
+            channel_name (str): The channel name to wait for (e.g., "stable-4.21")
+            timeout (int): Maximum time to wait in seconds. Default is 300 (5 minutes).
+
+        Returns:
+            bool: True if the channel becomes available, False if timeout is reached
+
+        """
+        logger.info(
+            f"Waiting up to {timeout}s for channel '{channel_name}' to appear "
+            "in odf-operator packagemanifest"
+        )
+
+        start_time = time.time()
+        last_channels = None
+
+        while time.time() - start_time < timeout:
+            try:
+                cmd = (
+                    f"oc --kubeconfig {self.kubeconfig} get packagemanifest odf-operator "
+                    f"-n {constants.MARKETPLACE_NAMESPACE} -o yaml"
+                )
+                package_manifest_output = exec_cmd(cmd)
+                package_manifest = yaml.safe_load(package_manifest_output)
+
+                channels = package_manifest.get("status", {}).get("channels", [])
+                channel_names = [ch["name"] for ch in channels]
+
+                if channel_names != last_channels:
+                    logger.info(f"Available channels: {channel_names}")
+                    last_channels = channel_names
+                else:
+                    logger.debug(f"Available channels: {channel_names}")
+
+                if channel_name in channel_names:
+                    logger.info(f"Channel '{channel_name}' is now available")
+                    return True
+
+            except Exception as e:
+                logger.debug(f"Error checking for channel: {e}")
+
+            time.sleep(10)
+
+        elapsed = time.time() - start_time
+        logger.warning(f"Channel '{channel_name}' did not appear after {elapsed:.0f}s")
+        return False

--- a/ocs_ci/ocs/fdf_upgrade.py
+++ b/ocs_ci/ocs/fdf_upgrade.py
@@ -11,13 +11,14 @@ from ocs_ci.deployment.fusion_data_foundation import (
     run_patch_cmd,
 )
 from ocs_ci.framework import config
-from ocs_ci.ocs import constants
+from ocs_ci.ocs import constants, defaults
 from ocs_ci.ocs.cluster import CephCluster, CephHealthMonitor
 from ocs_ci.ocs.exceptions import (
     ChannelNotFound,
     ConfigurationError,
     TimeoutExpiredError,
 )
+from ocs_ci.ocs.resources.packagemanifest import get_packagemanifest_by_catalog_source
 from ocs_ci.ocs.upgrade import BaseUpgrade
 from ocs_ci.utility.retry import retry
 from ocs_ci.utility.utils import exec_cmd, load_config_file
@@ -377,7 +378,12 @@ class FDFUpgrade(BaseUpgrade):
         try:
             logger.info("Operator CSV status:")
             csvs_cmd = f"oc --kubeconfig {self.kubeconfig} get csv -n {constants.OPENSHIFT_STORAGE_NAMESPACE} -o yaml"
-            csvs_output = exec_cmd(csvs_cmd)
+            result = exec_cmd(csvs_cmd)
+            csvs_output = (
+                result.stdout.decode("utf-8")
+                if isinstance(result.stdout, bytes)
+                else result.stdout
+            )
             csvs_data = yaml.safe_load(csvs_output)
             for csv in csvs_data.get("items", []):
                 csv_name = csv["metadata"]["name"]
@@ -393,7 +399,12 @@ class FDFUpgrade(BaseUpgrade):
                 "get installplan -n {constants.OPENSHIFT_STORAGE_NAMESPACE} "
                 "-o yaml"
             )
-            ip_output = exec_cmd(ip_cmd)
+            result = exec_cmd(ip_cmd)
+            ip_output = (
+                result.stdout.decode("utf-8")
+                if isinstance(result.stdout, bytes)
+                else result.stdout
+            )
             ip_data = yaml.safe_load(ip_output)
             for ip in ip_data.get("items", []):
                 ip_name = ip["metadata"]["name"]
@@ -407,6 +418,9 @@ class FDFUpgrade(BaseUpgrade):
         """
         Wait for a specific subscription channel to become available in the packagemanifest.
 
+        This method uses the FDF catalog source to ensure we're checking the correct
+        packagemanifest when multiple catalog sources are present.
+
         Args:
             channel_name (str): The channel name to wait for (e.g., "stable-4.21")
             timeout (int): Maximum time to wait in seconds. Default is 300 (5 minutes).
@@ -415,9 +429,11 @@ class FDFUpgrade(BaseUpgrade):
             bool: True if the channel becomes available, False if timeout is reached
 
         """
+        catalog_source = defaults.FUSION_CATALOG_NAME
+        package_name = defaults.ODF_OPERATOR_NAME
         logger.info(
             f"Waiting up to {timeout}s for channel '{channel_name}' to appear "
-            "in odf-operator packagemanifest"
+            f"in {package_name} packagemanifest from catalog source '{catalog_source}'"
         )
 
         start_time = time.time()
@@ -425,12 +441,9 @@ class FDFUpgrade(BaseUpgrade):
 
         while time.time() - start_time < timeout:
             try:
-                cmd = (
-                    f"oc --kubeconfig {self.kubeconfig} get packagemanifest odf-operator "
-                    f"-n {constants.MARKETPLACE_NAMESPACE} -o yaml"
+                package_manifest = get_packagemanifest_by_catalog_source(
+                    package_name=package_name, catalog_source=catalog_source
                 )
-                package_manifest_output = exec_cmd(cmd)
-                package_manifest = yaml.safe_load(package_manifest_output)
 
                 channels = package_manifest.get("status", {}).get("channels", [])
                 channel_names = [ch["name"] for ch in channels]

--- a/ocs_ci/ocs/fdf_upgrade.py
+++ b/ocs_ci/ocs/fdf_upgrade.py
@@ -4,6 +4,7 @@ import os
 import time
 
 import yaml
+from packaging.version import parse as parse_version
 
 from ocs_ci.deployment.fusion_data_foundation import (
     FusionDataFoundationDeployment,
@@ -120,6 +121,35 @@ class FDFUpgrade(BaseUpgrade):
             upgrade_version = upgrade_version[1:]
         return upgrade_version or self.version_before_upgrade
 
+    def validate_upgrade_versions(self):
+        """
+        Validate that the target upgrade version is valid.
+
+        Normalizes both current and target versions to X.Y format and compares them.
+        Logs whether this is a Z-stream or Y-stream upgrade.
+
+        Raises:
+            AssertionError: If target version is lower than current version
+
+        """
+        current_parts = self.version_before_upgrade.split(".")
+        current_xy = f"{current_parts[0]}.{current_parts[1]}"
+        target_parts = self.fdf_upgrade_version.split(".")
+        target_xy = f"{target_parts[0]}.{target_parts[1]}"
+
+        assert parse_version(target_xy) >= parse_version(current_xy), (
+            f"Target upgrade version {target_xy} is lower than "
+            f"current version {current_xy}"
+        )
+
+        if current_xy == target_xy:
+            logger.info(
+                f"Z-stream upgrade: upgrading within {target_xy} stream "
+                f"from {self.version_before_upgrade}"
+            )
+        else:
+            logger.info(f"Y-stream upgrade: upgrading from {current_xy} to {target_xy}")
+
     def load_version_config_file(self, upgrade_version):
         """
         Load FDF version-specific configuration file.
@@ -172,12 +202,7 @@ class FDFUpgrade(BaseUpgrade):
             f"Upgrading FDF from {self.version_before_upgrade} to {self.fdf_upgrade_version}"
         )
 
-        parsed_versions = self.get_parsed_versions()
-        assert parsed_versions[1] >= parsed_versions[0], (
-            f"Target upgrade version {self.fdf_upgrade_version} is not higher than or equal to "
-            f"current version {self.version_before_upgrade}"
-        )
-
+        self.validate_upgrade_versions()
         self.load_version_config_file(self.fdf_upgrade_version)
         if not self.upgrade_in_current_source:
             self.fdf_deployment.create_image_tag_mirror_set()
@@ -200,6 +225,7 @@ class FDFUpgrade(BaseUpgrade):
                 self.channel, self.pre_upgrade_image_data, self.fdf_upgrade_version
             )
         self.verify_required_csvs()
+        parsed_versions = self.get_parsed_versions()
         self.verify_image_versions(old_images, parsed_versions[1], parsed_versions[0])
 
         version = self.fdf_deployment.get_installed_version()

--- a/ocs_ci/ocs/fdf_upgrade.py
+++ b/ocs_ci/ocs/fdf_upgrade.py
@@ -300,11 +300,13 @@ class FDFUpgrade(BaseUpgrade):
         logger.info(f"Expected upgrade version: {expected_version}")
 
         last_state = {}
+        last_logged_status = None
 
         try:
 
-            @retry(AssertionError, tries=timeout // 30, delay=30, backoff=1)
+            @retry(AssertionError, tries=timeout // 60, delay=60, backoff=1)
             def _wait_for_upgrade_completion():
+                nonlocal last_logged_status
                 instance = FusionServiceInstance(
                     resource_name=constants.FDF_SERVICE_NAME,
                     namespace=constants.FDF_NAMESPACE,
@@ -332,10 +334,19 @@ class FDFUpgrade(BaseUpgrade):
                         f"Health: {health}, Version: {current_version}"
                     )
 
+                # Only log detailed status if health is not Healthy/Unknown AND it has changed
                 if health not in ["Healthy", "Unknown"]:
-                    logger.warning(f"FusionServiceInstance health status: {health}")
-                    logger.info("Status details:")
-                    logger.info(yaml.dump(instance_status, default_flow_style=False))
+                    # Convert status to string for comparison
+                    status_str = yaml.dump(instance_status, default_flow_style=False)
+                    if status_str != last_logged_status:
+                        logger.warning(f"FusionServiceInstance health status: {health}")
+                        logger.info("Status details:")
+                        logger.info(status_str)
+                        last_logged_status = status_str
+                    else:
+                        logger.debug(
+                            f"FusionServiceInstance health status unchanged: {health}"
+                        )
 
                 assert not upgrade_in_progress, "Upgrade still in progress"
                 assert (

--- a/ocs_ci/ocs/fdf_upgrade.py
+++ b/ocs_ci/ocs/fdf_upgrade.py
@@ -21,7 +21,11 @@ from ocs_ci.ocs.exceptions import (
 from ocs_ci.ocs.resources.packagemanifest import get_packagemanifest_by_catalog_source
 from ocs_ci.ocs.upgrade import BaseUpgrade
 from ocs_ci.utility.retry import retry
-from ocs_ci.utility.utils import exec_cmd, load_config_file
+from ocs_ci.utility.utils import (
+    exec_cmd,
+    load_config_file,
+    wait_for_machineconfigpool_status,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -178,6 +182,7 @@ class FDFUpgrade(BaseUpgrade):
         if not self.upgrade_in_current_source:
             self.fdf_deployment.create_image_tag_mirror_set()
             self.fdf_deployment.create_image_digest_mirror_set(upgrade=True)
+            wait_for_machineconfigpool_status(node_type="all")
             self.fdf_deployment.patch_fusion_service_definition(upgrade=True)
         ceph_cluster = CephCluster()
         self.pre_upgrade_csv_data = self.get_csv_name_pre_upgrade()

--- a/ocs_ci/ocs/fdf_upgrade.py
+++ b/ocs_ci/ocs/fdf_upgrade.py
@@ -55,7 +55,6 @@ class FDFUpgrade(BaseUpgrade):
         self.fdf_deployment = FusionDataFoundationDeployment()
         self.kubeconfig = config.RUN.get("kubeconfig")
         self._fdf_upgrade_version = None
-        self._channel = None
 
     @property
     def fdf_upgrade_version(self):
@@ -80,31 +79,6 @@ class FDFUpgrade(BaseUpgrade):
 
         """
         self._fdf_upgrade_version = value
-
-    @property
-    def channel(self):
-        """
-        Get the FDF upgrade channel.
-
-        Returns:
-            str: FDF upgrade channel
-
-        """
-        if self._channel is None:
-            self._channel = config.DEPLOYMENT.get("ocs_csv_channel")
-        return self._channel
-
-    @channel.setter
-    def channel(self, value):
-        """
-        Set the FDF upgrade channel.
-
-        Args:
-            value (str): FDF upgrade channel to set
-
-        """
-        self._channel = value
-        config.DEPLOYMENT["ocs_csv_channel"] = value
 
     def get_upgrade_version(self):
         """

--- a/ocs_ci/ocs/fdf_upgrade.py
+++ b/ocs_ci/ocs/fdf_upgrade.py
@@ -25,6 +25,7 @@ from ocs_ci.utility.retry import retry
 from ocs_ci.utility.utils import (
     exec_cmd,
     load_config_file,
+    TimeoutSampler,
     wait_for_machineconfigpool_status,
 )
 
@@ -245,9 +246,10 @@ class FDFUpgrade(BaseUpgrade):
         )
 
         logger.info(f"Waiting for upgrade channel '{self.channel}' to be available")
-        if not self.wait_for_subscription_channel(self.channel, timeout=300):
+        timeout = 300
+        if not self.wait_for_subscription_channel(self.channel, timeout=timeout):
             raise ChannelNotFound(
-                f"Channel '{self.channel}' did not become available within 300 seconds. "
+                f"Channel '{self.channel}' did not become available within {timeout} seconds. "
                 f"Cannot proceed with subscription channel update."
             )
 
@@ -458,16 +460,17 @@ class FDFUpgrade(BaseUpgrade):
             f"in {package_name} packagemanifest from catalog source '{catalog_source}'"
         )
 
-        start_time = time.time()
         last_channels = None
 
-        while time.time() - start_time < timeout:
-            try:
-                package_manifest = get_packagemanifest_by_catalog_source(
-                    package_name=package_name, catalog_source=catalog_source
-                )
-
-                channels = package_manifest.get("status", {}).get("channels", [])
+        try:
+            for sample in TimeoutSampler(
+                timeout=timeout,
+                sleep=10,
+                func=get_packagemanifest_by_catalog_source,
+                package_name=package_name,
+                catalog_source=catalog_source,
+            ):
+                channels = sample.get("status", {}).get("channels", [])
                 channel_names = [ch["name"] for ch in channels]
 
                 if channel_names != last_channels:
@@ -480,11 +483,11 @@ class FDFUpgrade(BaseUpgrade):
                     logger.info(f"Channel '{channel_name}' is now available")
                     return True
 
-            except Exception as e:
-                logger.debug(f"Error checking for channel: {e}")
-
-            time.sleep(10)
-
-        elapsed = time.time() - start_time
-        logger.warning(f"Channel '{channel_name}' did not appear after {elapsed:.0f}s")
-        return False
+        except TimeoutExpiredError:
+            logger.warning(
+                f"Channel '{channel_name}' did not appear within {timeout}s timeout"
+            )
+            return False
+        except Exception as e:
+            logger.warning(f"Error while waiting for channel '{channel_name}': {e}")
+            return False

--- a/ocs_ci/ocs/fdf_upgrade.py
+++ b/ocs_ci/ocs/fdf_upgrade.py
@@ -233,35 +233,27 @@ class FDFUpgrade(BaseUpgrade):
 
     def update_subscription_channel(self):
         """
-        Update the ODF operator subscription channel based on fdf_upgrade_image_tag.
+        Update the ODF operator subscription channel based on fdf_upgrade_version.
 
-        This method derives the channel from fdf_upgrade_image_tag, waits for it to
+        This method derives the channel from fdf_upgrade_version, waits for it to
         become available, and updates the odf-operator subscription channel.
 
         Raises:
-            ConfigurationError: If fdf_upgrade_image_tag is not configured or cannot be parsed
+            ConfigurationError: If fdf_upgrade_version cannot be parsed
             ChannelNotFound: If the upgrade channel does not become available within timeout
 
         """
-        fdf_upgrade_image_tag = config.DEPLOYMENT.get("fdf_upgrade_image_tag")
-        if not fdf_upgrade_image_tag:
-            raise ConfigurationError(
-                "fdf_upgrade_image_tag is not configured. "
-                "Cannot determine upgrade subscription channel."
-            )
-
-        version_str = fdf_upgrade_image_tag.lstrip("v")
-        version_parts = version_str.split(".")
+        version_parts = self.fdf_upgrade_version.split(".")
         if len(version_parts) < 2:
             raise ConfigurationError(
-                f"Could not parse version from fdf_upgrade_image_tag: {fdf_upgrade_image_tag}. "
-                f"Expected format with at least major.minor version (e.g., 'v4.21', '4.18.8-2')"
+                f"Could not parse version from fdf_upgrade_version: {self.fdf_upgrade_version}. "
+                f"Expected format with at least major.minor version (e.g., '4.21', '4.18.8-2')"
             )
 
         self.channel = f"stable-{version_parts[0]}.{version_parts[1]}"
         logger.info(
             f"Derived upgrade channel '{self.channel}' from "
-            f"fdf_upgrade_image_tag '{fdf_upgrade_image_tag}'"
+            f"fdf_upgrade_version '{self.fdf_upgrade_version}'"
         )
 
         logger.info(f"Waiting for upgrade channel '{self.channel}' to be available")

--- a/ocs_ci/ocs/fdf_upgrade.py
+++ b/ocs_ci/ocs/fdf_upgrade.py
@@ -155,14 +155,28 @@ class FDFUpgrade(BaseUpgrade):
         Load FDF version-specific configuration file.
 
         Args:
-            upgrade_version (str): FDF version to load config for
+            upgrade_version (str): FDF version to load config for (e.g., "4.18.8-2")
 
         """
+        # Extract major.minor version from upgrade_version for config file lookup
+        # e.g., "4.18.8-2" -> "4.18"
+        version_parts = upgrade_version.split(".")
+        if len(version_parts) < 2:
+            logger.warning(
+                f"Cannot parse major.minor from upgrade_version: {upgrade_version}, "
+                "skipping version config load"
+            )
+            return
+
+        major_minor = f"{version_parts[0]}.{version_parts[1]}"
         version_config_file = os.path.join(
-            constants.FDF_VERSION_CONF_DIR, f"fdf-{upgrade_version}.yaml"
+            constants.FDF_VERSION_CONF_DIR, f"fdf-{major_minor}.yaml"
         )
         if os.path.exists(version_config_file):
-            logger.info(f"Loading config file for FDF version: {upgrade_version}")
+            logger.info(
+                f"Loading config file for FDF version {major_minor} "
+                f"(from upgrade_version {upgrade_version})"
+            )
             load_config_file(version_config_file)
         else:
             logger.info(

--- a/ocs_ci/ocs/fdf_upgrade.py
+++ b/ocs_ci/ocs/fdf_upgrade.py
@@ -324,7 +324,7 @@ class FDFUpgrade(BaseUpgrade):
         """
         logger.test_step("Monitoring FDF upgrade progress")
 
-        expected_version = config.DEPLOYMENT.get("fdf_upgrade_image_tag")
+        expected_version = self.fdf_upgrade_version
 
         if expected_version and expected_version.startswith("v"):
             expected_version = expected_version[1:]

--- a/ocs_ci/ocs/fdf_upgrade.py
+++ b/ocs_ci/ocs/fdf_upgrade.py
@@ -444,7 +444,7 @@ class FDFUpgrade(BaseUpgrade):
             logger.info("Pending install plans:")
             ip_cmd = (
                 f"oc --kubeconfig {self.kubeconfig} "
-                "get installplan -n {constants.OPENSHIFT_STORAGE_NAMESPACE} "
+                f"get installplan -n {constants.OPENSHIFT_STORAGE_NAMESPACE} "
                 "-o yaml"
             )
             result = exec_cmd(ip_cmd)

--- a/ocs_ci/ocs/resources/packagemanifest.py
+++ b/ocs_ci/ocs/resources/packagemanifest.py
@@ -3,6 +3,7 @@ Package manifest related functionalities
 """
 
 import logging
+import yaml
 
 from ocs_ci.framework import config
 from ocs_ci.ocs import constants
@@ -17,7 +18,7 @@ from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.resources.catalog_source import CatalogSource
 from ocs_ci.ocs.resources.install_plan import InstallPlan
 from ocs_ci.utility.retry import retry
-from ocs_ci.utility.utils import TimeoutSampler
+from ocs_ci.utility.utils import exec_cmd, TimeoutSampler
 
 
 log = logging.getLogger(__name__)
@@ -307,3 +308,93 @@ def get_selector_for_ocs_operator():
         log.info("Internal catalog source not found!")
     # TODO: we might need to limit this to ODF only as FDF might come from different source
     return constants.REDHAT_OPERATOR_SELECTOR
+
+
+def get_packagemanifest_by_catalog_source(package_name, catalog_source):
+    """
+    Get a specific packagemanifest filtered by catalog source.
+
+    In environments with multiple catalog sources, there may be multiple
+    packagemanifests with the same name (e.g., odf-operator from both
+    redhat-operators and isf-data-foundation-catalog). This function retrieves
+    the correct packagemanifest by filtering on the catalogSource field.
+
+    Args:
+        package_name (str): Name of the package manifest to retrieve
+            (e.g., "odf-operator").
+        catalog_source (str): Name of the catalog source to filter by
+            (e.g., "isf-data-foundation-catalog", "redhat-operators").
+
+    Returns:
+        dict: The packagemanifest data as a dictionary.
+
+    Raises:
+        CommandFailed: If the oc command fails or yq filtering fails.
+        ValueError: If no packagemanifest is found matching the criteria.
+
+    Example:
+        >>> pm = get_packagemanifest_by_catalog_source(
+        ...     package_name="odf-operator",
+        ...     catalog_source="isf-data-foundation-catalog"
+        ... )
+        >>> channels = pm.get("status", {}).get("channels", [])
+
+    """
+    kubeconfig = config.RUN.get("kubeconfig")
+    kubeconfig_flag = f"--kubeconfig {kubeconfig} " if kubeconfig else ""
+
+    log.info(
+        f"Retrieving packagemanifest '{package_name}' "
+        f"with catalogSource '{catalog_source}'"
+    )
+
+    # Escape any quotes in the values to prevent command injection
+    safe_package_name = package_name.replace('"', '\\"')
+    safe_catalog_source = catalog_source.replace('"', '\\"')
+
+    # Build yq filter to select by package name and catalog source
+    yq_filter = (
+        f'.items[] | select(.metadata.name == "{safe_package_name}" and '
+        f'.status.catalogSource == "{safe_catalog_source}")'
+    )
+
+    # Pipe oc command directly to yq to reduce memory usage
+    cmd = (
+        f"oc {kubeconfig_flag}get packagemanifest "
+        f"-n {constants.MARKETPLACE_NAMESPACE} -o yaml | "
+        f"yq eval '{yq_filter}' -"
+    )
+
+    try:
+        result = exec_cmd(cmd, shell=True)
+        filtered_output = (
+            result.stdout.decode("utf-8")
+            if isinstance(result.stdout, bytes)
+            else result.stdout
+        )
+        log.debug(f"Filtered output: {filtered_output}")
+    except CommandFailed as e:
+        raise CommandFailed(f"Failed to retrieve and filter packagemanifest: {e}")
+
+    # Check for empty, null, or whitespace-only output
+    if (
+        not filtered_output
+        or not filtered_output.strip()
+        or filtered_output.strip() == "null"
+    ):
+        raise ValueError(
+            f"No packagemanifest found for '{package_name}' with "
+            f"catalogSource '{catalog_source}'"
+        )
+
+    packagemanifest_data = yaml.safe_load(filtered_output)
+
+    if not packagemanifest_data:
+        raise ValueError(f"Failed to parse packagemanifest data for '{package_name}'")
+
+    log.info(
+        f"Retrieved packagemanifest '{package_name}' from catalogSource "
+        f"'{packagemanifest_data.get('status', {}).get('catalogSource', 'unknown')}'"
+    )
+
+    return packagemanifest_data

--- a/ocs_ci/ocs/resources/packagemanifest.py
+++ b/ocs_ci/ocs/resources/packagemanifest.py
@@ -331,6 +331,7 @@ def get_packagemanifest_by_catalog_source(package_name, catalog_source):
     Raises:
         CommandFailed: If the oc command fails or yq filtering fails.
         ValueError: If no packagemanifest is found matching the criteria.
+        yaml.YAMLError: If the packagemanifest data cannot be parsed as YAML.
 
     Example:
         >>> pm = get_packagemanifest_by_catalog_source(

--- a/ocs_ci/ocs/upgrade.py
+++ b/ocs_ci/ocs/upgrade.py
@@ -1,0 +1,537 @@
+import logging
+import time
+
+from packaging.version import parse as parse_version
+
+from ocs_ci.deployment.helpers.odf_deployment_helpers import get_required_csvs
+from ocs_ci.framework import config
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.defaults import OCS_OPERATOR_NAME
+from ocs_ci.ocs.exceptions import CSVNotFound
+from ocs_ci.ocs.node import get_worker_nodes
+from ocs_ci.ocs.ocp import OCP, get_images
+from ocs_ci.ocs.resources.csv import CSV, get_csvs_start_with_prefix
+from ocs_ci.ocs.resources.packagemanifest import (
+    PackageManifest,
+    get_selector_for_ocs_operator,
+)
+from ocs_ci.ocs.resources.pod import get_noobaa_pods, verify_pods_upgraded
+from ocs_ci.ocs.resources.storage_cluster import get_osd_count
+from ocs_ci.ocs.utils import get_expected_nb_db_psql_version, setup_ceph_toolbox
+from ocs_ci.utility import version
+from ocs_ci.utility.retry import retry
+from ocs_ci.utility.rgwutils import get_rgw_count
+
+
+logger = logging.getLogger(__name__)
+
+
+class BaseUpgrade(object):
+    """
+    Base class for upgrade operations.
+
+    This class provides a common interface and shared functionality
+    for upgrade implementations (OCS/ODF and FDF).
+
+    """
+
+    def __init__(self, namespace, version_before_upgrade):
+        """
+        Initialize base upgrade parameters.
+
+        Args:
+            namespace (str): Namespace where the product is deployed
+            version_before_upgrade (str): Current version before upgrade
+
+        """
+        self.namespace = namespace
+        self._version_before_upgrade = version_before_upgrade
+        self.subscription_plan_approval = config.DEPLOYMENT.get(
+            "subscription_plan_approval"
+        )
+        self.upgrade_in_current_source = config.UPGRADE.get(
+            "upgrade_in_current_source", False
+        )
+        self.start_time = None
+        self.end_time = None
+        self.duration = None
+        self.pre_upgrade_csv_data = None
+        self.pre_upgrade_image_data = None
+        self.post_upgrade_csv_data = None
+        self.post_upgrade_image_data = None
+
+    @property
+    def version_before_upgrade(self):
+        """
+        Get the version before upgrade.
+
+        Returns:
+            str: Version before upgrade
+
+        """
+        return self._version_before_upgrade
+
+    def get_upgrade_version(self):
+        """
+        Get the target upgrade version.
+
+        This method should be implemented by subclasses to determine
+        the version to upgrade to based on their specific logic.
+
+        Returns:
+            str: Target version for upgrade
+
+        Raises:
+            NotImplementedError: Must be implemented by subclass
+
+        """
+        raise NotImplementedError("Subclasses must implement get_upgrade_version()")
+
+    def get_parsed_versions(self):
+        """
+        Get parsed version objects for current and upgrade versions.
+
+        Returns:
+            tuple: (parsed_current_version, parsed_upgrade_version)
+
+        """
+        parsed_version_before_upgrade = parse_version(self.version_before_upgrade)
+        parsed_upgrade_version = parse_version(self.get_upgrade_version())
+
+        return parsed_version_before_upgrade, parsed_upgrade_version
+
+    def get_csv_name_pre_upgrade(self, resource_name=OCS_OPERATOR_NAME):
+        """
+        Get pre-upgrade CSV name
+
+        Earlier we used to depend on packagemanifest to find the pre-upgrade
+        csv name. Due to issues in catalogsource where csv names were not shown properly once
+        catalogsource for upgrade version has been created, we are taking new approach of
+        finding csv name from csv list and also look for pre-upgrade ocs version for finding out
+        the actual csv
+
+        Args:
+            resource_name (str, optional): String the resource CSVs start with . Defaults to OCS_OPERATOR_NAME.
+
+        Raises:
+            CSVNotFound: If the CSV with the provided resource isn't found.
+
+        Returns:
+            str: Name of the resource CSV
+
+        """
+        csv_name = None
+        csv_list = get_csvs_start_with_prefix(resource_name, namespace=self.namespace)
+        for csv in csv_list:
+            if resource_name in csv.get("metadata").get("name"):
+                logger.info(
+                    "searching for pre-upgrade csv with version: "
+                    f"{config.PREUPGRADE_CONFIG.get('ENV_DATA').get('ocs_version')}"
+                )
+                if config.PREUPGRADE_CONFIG.get("ENV_DATA").get(
+                    "ocs_version"
+                ) in csv.get("metadata").get("name"):
+                    csv_name = csv.get("metadata").get("name")
+                    return csv_name
+        raise CSVNotFound(f"No preupgrade CSV found for {resource_name}")
+
+    def get_pre_upgrade_image(self, csv_name_pre_upgrade):
+        """
+        Getting all OCS cluster images, before upgrade
+
+        Args:
+            csv_name_pre_upgrade (str): CSV name for the pre-upgrade operator
+
+        Returns:
+            dict: Contains all OCS cluster images
+                dict keys: Image name
+                dict values: Image full path
+
+        """
+        logger.info(f"CSV name before upgrade is: {csv_name_pre_upgrade}")
+        csv_pre_upgrade = CSV(
+            resource_name=csv_name_pre_upgrade, namespace=self.namespace
+        )
+        return get_images(csv_pre_upgrade.get())
+
+    def load_version_config_file(self, upgrade_version):
+        """
+        Load version-specific configuration file.
+
+        This method should be implemented by subclasses to load
+        configuration files appropriate for their product.
+
+        Args:
+            upgrade_version (str): Version to load config for
+
+        Raises:
+            NotImplementedError: Must be implemented by subclass
+
+        """
+        raise NotImplementedError(
+            "Subclasses must implement load_version_config_file()"
+        )
+
+    def run_upgrade(self):
+        """
+        Execute the upgrade procedure.
+
+        This method should be implemented by subclasses to perform
+        the specific upgrade steps for their product.
+
+        Raises:
+            NotImplementedError: Must be implemented by subclass
+
+        """
+        raise NotImplementedError("Subclasses must implement run_upgrade()")
+
+    def verify_required_csvs(self):
+        """
+        Verify all required CSVs post upgrade
+        """
+        ocs_operator_names = get_required_csvs()
+        channel = config.DEPLOYMENT.get("ocs_csv_channel")
+        operator_selector = get_selector_for_ocs_operator()
+        subscription_plan_approval = config.DEPLOYMENT.get("subscription_plan_approval")
+
+        for ocs_operator_name in ocs_operator_names:
+            package_manifest = PackageManifest(
+                resource_name=ocs_operator_name,
+                selector=operator_selector,
+                subscription_plan_approval=subscription_plan_approval,
+            )
+            package_manifest.wait_for_resource(timeout=300)
+            csv_name = package_manifest.get_current_csv(channel=channel)
+            csv = CSV(resource_name=csv_name, namespace=self.namespace)
+            csv.wait_for_phase("Succeeded", timeout=720)
+
+    def verify_image_versions(
+        self, old_images, upgrade_version, version_before_upgrade
+    ):
+        """
+        Verify if all the images of OCS objects got upgraded
+
+        Args:
+            old_images (set): set with old images
+            upgrade_version (packaging.version.Version): version of OCS
+            version_before_upgrade (packaging.version.Version): version of OCS before upgrade
+
+        """
+        # Get all worker nodes for CSI nodeplugin count (they run on all workers, not just storage-labeled)
+        all_worker_nodes = get_worker_nodes(skip_master_nodes=False)
+        number_of_all_worker_nodes = len(all_worker_nodes)
+        verify_pods_upgraded(old_images, selector=constants.OCS_OPERATOR_LABEL)
+        if not (
+            config.ENV_DATA.get("mcg_only_deployment")
+            and (
+                upgrade_version >= parse_version("4.20")
+                or (
+                    version_before_upgrade == parse_version("4.19")
+                    and upgrade_version == parse_version("4.19")
+                )
+            )
+        ):
+            verify_pods_upgraded(old_images, selector=constants.OPERATOR_LABEL)
+        self.verify_noobaa_pods_upgraded(old_images, upgrade_version)
+        if not config.ENV_DATA.get("mcg_only_deployment"):
+            odf_running_version = version.get_ocs_version_from_csv(
+                only_major_minor=True
+            )
+            # cephfs and rbdplugin label and count
+            csi_cephfsplugin_label = constants.CSI_CEPHFSPLUGIN_LABEL
+            csi_rbdplugin_label = constants.CSI_RBDPLUGIN_LABEL
+            csi_cephfsplugin_provisioner_label = (
+                constants.CSI_CEPHFSPLUGIN_PROVISIONER_LABEL
+            )
+            csi_rbdplugin_provisioner_label = constants.CSI_RBDPLUGIN_PROVISIONER_LABEL
+            # CSI nodeplugin pods run on ALL worker nodes (including app nodes), not just storage-labeled nodes
+            count_csi_cephfsplugin_label = count_csi_rbdplugin_label = (
+                number_of_all_worker_nodes
+            )
+            if odf_running_version >= version.VERSION_4_19:
+                csi_cephfsplugin_label = constants.CSI_CEPHFSPLUGIN_LABEL_419
+                csi_rbdplugin_label = constants.CSI_RBDPLUGIN_LABEL_419
+                csi_cephfsplugin_provisioner_label = (
+                    constants.CSI_CEPHFSPLUGIN_PROVISIONER_LABEL_419
+                )
+                csi_rbdplugin_provisioner_label = (
+                    constants.CSI_RBDPLUGIN_PROVISIONER_LABEL_419
+                )
+                # CSI nodeplugin pods run on ALL worker nodes (including app nodes), not just storage-labeled nodes
+                count_csi_cephfsplugin_label = count_csi_rbdplugin_label = (
+                    number_of_all_worker_nodes
+                )
+            else:
+                logger.info(
+                    f"Label for cephfsplugin and rbdplugin are {csi_cephfsplugin_label} and {csi_rbdplugin_label}"
+                )
+            verify_pods_upgraded(
+                old_images,
+                selector=csi_cephfsplugin_label,
+                count=count_csi_cephfsplugin_label,
+            )
+            verify_pods_upgraded(
+                old_images, selector=csi_cephfsplugin_provisioner_label, count=2
+            )
+            verify_pods_upgraded(
+                old_images,
+                selector=csi_rbdplugin_label,
+                count=count_csi_rbdplugin_label,
+            )
+            verify_pods_upgraded(
+                old_images, selector=csi_rbdplugin_provisioner_label, count=2
+            )
+        if not (
+            config.DEPLOYMENT.get("external_mode")
+            or config.ENV_DATA.get("mcg_only_deployment")
+        ):
+            mon_count = 3
+            if config.DEPLOYMENT.get("arbiter_deployment"):
+                mon_count = 5
+            verify_pods_upgraded(
+                old_images,
+                selector=constants.MON_APP_LABEL,
+                count=mon_count,
+                timeout=820,
+            )
+            mgr_count = constants.MGR_COUNT_415
+            if upgrade_version < parse_version("4.15"):
+                mgr_count = constants.MGR_COUNT
+            verify_pods_upgraded(
+                old_images, selector=constants.MGR_APP_LABEL, count=mgr_count
+            )
+            osd_timeout = 600 if upgrade_version >= parse_version("4.5") else 750
+            osd_count = get_osd_count()
+            # In the debugging issue:
+            # https://github.com/red-hat-storage/ocs-ci/issues/5031
+            # Noticed that it's taking about 1 more minute from previous check till actual
+            # OSD pods getting restarted.
+            # Hence adding sleep here for 120 seconds to be sure, OSD pods upgrade started.
+            logger.info("Waiting for 2 minutes before start checking OSD pods")
+            time.sleep(120)
+            verify_pods_upgraded(
+                old_images,
+                selector=constants.OSD_APP_LABEL,
+                count=osd_count,
+                timeout=osd_timeout * osd_count,
+            )
+            verify_pods_upgraded(old_images, selector=constants.MDS_APP_LABEL, count=2)
+            if config.ENV_DATA.get("platform") in constants.ON_PREM_PLATFORMS:
+                rgw_count = get_rgw_count(
+                    upgrade_version.base_version, True, version_before_upgrade
+                )
+                verify_pods_upgraded(
+                    old_images,
+                    selector=constants.RGW_APP_LABEL,
+                    count=rgw_count,
+                )
+        if upgrade_version >= parse_version("4.6"):
+            skip_metrics_exporter = upgrade_version >= parse_version("4.21") and (
+                config.DEPLOYMENT.get("external_mode")
+                or config.ENV_DATA.get("mcg_only_deployment")
+            )
+            if not skip_metrics_exporter:
+                verify_pods_upgraded(
+                    old_images, selector=constants.OCS_METRICS_EXPORTER
+                )
+            else:
+                logger.info(
+                    "Skipping ocs-metrics-exporter upgrade verification for ODF 4.21 "
+                    "external mode deployment due to bug DFBUGS-5811"
+                )
+
+    @retry(Exception, tries=3, delay=60, backoff=1)
+    def verify_noobaa_pods_upgraded(self, old_images, upgrade_version):
+        """
+        Verify noobaa pods are upgraded
+
+        Args:
+            old_images (set): set with old images
+            upgrade_version (packaging.version.Version): version of OCS
+
+        """
+        noobaa_pods = self.get_expected_noobaa_pod_count(upgrade_version)
+        noobaa_db_psql_version = get_expected_nb_db_psql_version()
+        ignore_psql_12_verification = (
+            int(noobaa_db_psql_version) != constants.NOOBAA_POSTGRES_12_VERSION
+        )
+
+        num_nodes = (
+            config.ENV_DATA["worker_replicas"]
+            + config.ENV_DATA["master_replicas"]
+            + config.ENV_DATA.get("infra_replicas", 0)
+        )
+        timeout = 600 if num_nodes < 6 else 900
+
+        verify_pods_upgraded(
+            old_images,
+            selector=constants.NOOBAA_APP_LABEL,
+            count=noobaa_pods,
+            timeout=timeout,
+            ignore_psql_12_verification=ignore_psql_12_verification,
+        )
+
+    @retry(ValueError, tries=20, delay=30, backoff=1)
+    def get_expected_noobaa_pod_count(self, upgrade_version):
+        """
+        Get the expected count of NooBaa pods for upgrade verification.
+
+        This method validates that the current NooBaa pod count matches expectations
+        based on deployment configuration and upgrade version.
+
+        Args:
+            upgrade_version (packaging.version.Version): version of OCS
+
+        Returns:
+            int: number of expected noobaa pods
+
+        Raises:
+            ValueError: If endpoint pod count is outside allowed range or pod count mismatch
+
+        """
+        expected_noobaa_pods = [
+            "noobaa-core-0",
+            "noobaa-operator",
+            "noobaa-db-pg-cluster-1",
+            "noobaa-db-pg-cluster-2",
+        ]
+
+        endpoint_count = 0
+        noobaa_pod_obj = get_noobaa_pods()
+        noobaa_pod_names = [pod.name for pod in noobaa_pod_obj]
+        logger.info(f"Current noobaa pods under validation: {noobaa_pod_names}")
+        for pod in noobaa_pod_obj:
+            if "pv-backingstore" in pod.name:
+                expected_noobaa_pods.append(pod.name)
+            if upgrade_version >= parse_version("4.19"):
+                if "noobaa-default-backing-store" in pod.name:
+                    logger.info(
+                        "In some cases like MCG only or HCI we are counting noobaa-default-backing-store"
+                    )
+                    expected_noobaa_pods.append(pod.name)
+                if "cnpg-controller-manager" in pod.name:
+                    expected_noobaa_pods.append(pod.name)
+            if "noobaa-endpoint" in pod.name:
+                endpoint_count += 1
+                expected_noobaa_pods.append(pod.name)
+
+        noobaa = OCP(kind="noobaa", namespace=config.ENV_DATA["cluster_namespace"])
+        resource = noobaa.get()["items"][0]
+        endpoints = resource.get("spec", {}).get("endpoints", {})
+        max_endpoints = endpoints.get("maxCount", constants.MAX_NB_ENDPOINT_COUNT)
+        min_endpoints = endpoints.get(
+            "minCount", constants.MIN_NB_ENDPOINT_COUNT_POST_DEPLOYMENT
+        )
+
+        if not (min_endpoints <= endpoint_count <= max_endpoints):
+            raise ValueError(
+                f"Endpoint pod count {endpoint_count} not in allowed range [{min_endpoints}, {max_endpoints}]"
+            )
+
+        if len(noobaa_pod_obj) != len(expected_noobaa_pods):
+            raise ValueError(
+                f"Expected noobaa pods: {expected_noobaa_pods} do not match actual noobaa pods: {noobaa_pod_names}"
+            )
+        return len(noobaa_pod_obj)
+
+    def get_images_post_upgrade(
+        self,
+        channel,
+        pre_upgrade_images,
+        upgrade_version,
+        resource_name=OCS_OPERATOR_NAME,
+    ):
+        """
+        Checks if all images of OCS cluster upgraded,
+            and return list of all images if upgrade success
+
+        Args:
+            channel (str): OCS subscription channel
+            pre_upgrade_images (dict): Contains all OCS cluster images
+            upgrade_version (str): version to be upgraded
+            resource_name (str, optional): Operator resource name. Defaults to OCS_OPERATOR_NAME.
+
+        Returns:
+            set: Contains full path of OCS cluster old images
+
+        """
+        operator_selector = get_selector_for_ocs_operator()
+        package_manifest = PackageManifest(
+            resource_name=resource_name,
+            selector=operator_selector,
+            subscription_plan_approval=self.subscription_plan_approval,
+        )
+        csv_name_post_upgrade = package_manifest.get_current_csv(channel)
+        csv_post_upgrade = CSV(
+            resource_name=csv_name_post_upgrade, namespace=self.namespace
+        )
+        logger.info(f"Waiting for CSV {csv_name_post_upgrade} to be in succeeded state")
+
+        # Workaround for patching missing ceph-rook-tools pod after upgrade
+        if self.version_before_upgrade == "4.2" and upgrade_version == "4.3":
+            logger.info("Force creating Ceph toolbox after upgrade 4.2 -> 4.3")
+            setup_ceph_toolbox(force_setup=True)
+        # End of workaround
+
+        if config.DEPLOYMENT.get("external_mode") or config.ENV_DATA.get(
+            "mcg_only_deployment"
+        ):
+            timeout = 200
+        else:
+            timeout = 200 * get_osd_count()
+        csv_post_upgrade.wait_for_phase("Succeeded", timeout=timeout)
+
+        post_upgrade_images = get_images(csv_post_upgrade.get())
+        old_images, _, _ = self.get_upgrade_image_info(
+            pre_upgrade_images, post_upgrade_images
+        )
+
+        return old_images
+
+    @staticmethod
+    def get_upgrade_image_info(old_csv_images, new_csv_images):
+        """
+        Log the info about the images which are going to be upgraded.
+
+        Args:
+            old_csv_images (dict): dictionary with the old images from pre upgrade CSV
+            new_csv_images (dict): dictionary with the post upgrade images
+
+        Returns:
+            tuple: with three sets which contain those types of images
+                old_images_for_upgrade - images which should be upgraded
+                new_images_to_upgrade - new images to which upgrade
+                unchanged_images - unchanged images without upgrade
+
+        """
+        old_csv_images = set(old_csv_images.values())
+        new_csv_images = set(new_csv_images.values())
+        # Ignore the same SHA images for BZ:
+        # https://bugzilla.redhat.com/show_bug.cgi?id=1994007
+        for old_image in old_csv_images.copy():
+            old_image_sha = None
+            if constants.SHA_SEPARATOR in old_image:
+                _, old_image_sha = old_image.split(constants.SHA_SEPARATOR)
+            if old_image_sha:
+                for new_image in new_csv_images:
+                    if old_image_sha in new_image:
+                        logger.info(
+                            f"There is a new image: {new_image} with the same SHA "
+                            f"which is the same as the old image: {old_image}. "
+                            "This image will be ignored because of this BZ: 1994007"
+                        )
+                        old_csv_images.remove(old_image)
+        old_images_for_upgrade = old_csv_images - new_csv_images
+        logger.info(
+            f"Old images which are going to be upgraded: "
+            f"{sorted(old_images_for_upgrade)}"
+        )
+        new_images_to_upgrade = new_csv_images - old_csv_images
+        logger.info(f"New images for upgrade: " f"{sorted(new_images_to_upgrade)}")
+        unchanged_images = old_csv_images.intersection(new_csv_images)
+        logger.info(f"Unchanged images after upgrade: " f"{sorted(unchanged_images)}")
+        return (
+            old_images_for_upgrade,
+            new_images_to_upgrade,
+            unchanged_images,
+        )

--- a/ocs_ci/ocs/upgrade.py
+++ b/ocs_ci/ocs/upgrade.py
@@ -52,6 +52,7 @@ class BaseUpgrade(object):
         self.upgrade_in_current_source = config.UPGRADE.get(
             "upgrade_in_current_source", False
         )
+        self._channel = None
         self.start_time = None
         self.end_time = None
         self.duration = None
@@ -70,6 +71,31 @@ class BaseUpgrade(object):
 
         """
         return self._version_before_upgrade
+
+    @property
+    def channel(self):
+        """
+        Get the upgrade channel.
+
+        Returns:
+            str: Upgrade channel
+
+        """
+        if self._channel is None:
+            self._channel = config.DEPLOYMENT.get("ocs_csv_channel")
+        return self._channel
+
+    @channel.setter
+    def channel(self, value):
+        """
+        Set the upgrade channel.
+
+        Args:
+            value (str): Upgrade channel to set
+
+        """
+        self._channel = value
+        config.DEPLOYMENT["ocs_csv_channel"] = value
 
     def get_upgrade_version(self):
         """

--- a/ocs_ci/templates/fusion-data-foundation/image-tag-mirror-set.yaml
+++ b/ocs_ci/templates/fusion-data-foundation/image-tag-mirror-set.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   imageTagMirrors:
   - mirrors:
+    - preprod.icr.io/cp/df/isf-data-foundation-catalog
     - cp.stg.icr.io/cp/df/isf-data-foundation-catalog
     source: icr.io/cpopen/isf-data-foundation-catalog
   mirrorSourcePolicy:

--- a/pytest.ini
+++ b/pytest.ini
@@ -37,6 +37,9 @@ markers =
     ocs_upgrade: marker for OCS upgrade test
     pre_ocs_upgrade: marker for pre OCS upgrade tests
     post_ocs_upgrade: marker for post OCS upgrade tests
+    fdf_upgrade: marker for FDF upgrade test
+    pre_fdf_upgrade: marker for pre FDF upgrade tests
+    post_fdf_upgrade: marker for post FDF upgrade tests
     ocp_upgrade: marker for OCP upgrade test
     pre_ocp_upgrade: marker for pre OCP upgrade tests
     post_ocp_upgrade: marker for post OCP upgrade tests

--- a/tests/functional/upgrade/test_upgrade.py
+++ b/tests/functional/upgrade/test_upgrade.py
@@ -19,10 +19,12 @@ from ocs_ci.framework.testlib import (
     dr_cluster_operator_upgrade,
     acm_upgrade,
     provider_operator_upgrade,
+    fdf_upgrade,
 )
 from ocs_ci.framework import config
 from ocs_ci.ocs.acm_upgrade import ACMUpgrade
 from ocs_ci.ocs.disruptive_operations import worker_node_shutdown, osd_node_reboot
+from ocs_ci.ocs.fdf_upgrade import FDFUpgrade
 from ocs_ci.ocs.ocs_upgrade import run_ocs_upgrade
 from ocs_ci.ocs.dr_upgrade import (
     DRClusterOperatorUpgrade,
@@ -215,3 +217,29 @@ def test_upgrade_kubevirt_clusters(zone_rank, role_rank, config_index):
     """
     hosted_clients = KubevirtClusterUpgrade()
     hosted_clients.run_upgrade_ocp_on_kubevirt_clusters()
+
+
+@purple_squad
+@fdf_upgrade
+def test_fdf_upgrade():
+    """
+    Test upgrade procedure for IBM Fusion Data Foundation (FDF)
+
+    """
+    from ocs_ci.deployment.fusion_data_foundation import (
+        FusionDataFoundationDeployment,
+    )
+
+    log.test_step("Getting current FDF version from cluster")
+    namespace = config.ENV_DATA["cluster_namespace"]
+
+    # Get current FDF version from the cluster
+    fdf_deployment = FusionDataFoundationDeployment()
+    fdf_version = fdf_deployment.get_installed_version()
+
+    # Strip 'v' prefix if present
+    if fdf_version.startswith("v"):
+        fdf_version = fdf_version[1:]
+
+    fdf_upgrade = FDFUpgrade(namespace=namespace, version_before_upgrade=fdf_version)
+    fdf_upgrade.run_upgrade()

--- a/tests/functional/upgrade/test_upgrade.py
+++ b/tests/functional/upgrade/test_upgrade.py
@@ -241,5 +241,7 @@ def test_fdf_upgrade():
     if fdf_version.startswith("v"):
         fdf_version = fdf_version[1:]
 
-    fdf_upgrade = FDFUpgrade(namespace=namespace, version_before_upgrade=fdf_version)
-    fdf_upgrade.run_upgrade()
+    fdf_upgrade_obj = FDFUpgrade(
+        namespace=namespace, version_before_upgrade=fdf_version
+    )
+    fdf_upgrade_obj.run_upgrade()


### PR DESCRIPTION
Add support for IBM Fusion Data Foundation (FDF) upgrades including Y-stream and Z-stream upgrade capabilities.

  Key Changes

  Core Upgrade Infrastructure:
  - Add BaseUpgrade class to provide common upgrade functionality
  - Add FDFUpgrade class implementing FDF-specific upgrade orchestration
  - Add upgrade test case test_fdf_upgrade with @fdf_upgrade marker

  Deployment & Configuration:
  - Update FDF deployment methods to support upgrade scenarios
  - Update version-specific config files for FDF 4.18-4.22
  - Add FDF upgrade parameters to default config and CLI
  - Add mirror registry support (preprod.icr.io, cp.stg.icr.io)

  Monitoring & Reliability:
  - Monitor FusionServiceInstance upgrade progress with Ceph health checks
  - Add catalog source filtering for packagemanifest retrieval

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an end-to-end Fusion Data Foundation (FDF) upgrade workflow with dedicated upgrade mode.
  * Added FDF upgrade CLI options and FDF-specific test ordering/markers.
  * Added default must-gather reporting settings for FDF/OCS versions 4.18–4.22.
  * Added a functional test for FDF upgrades.
* **Bug Fixes**
  * Implemented upgrade image digest resolution and clear fallback behavior when upgrade registry/tag aren’t provided.
* **Documentation**
  * Updated FDF deployment docs with new upgrade catalog parameters and fallback rules.
* **Chores**
  * Added an additional image mirror entry to improve upgrade image availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->