### PR TITLE
[z-stream 4.18.1] Enable 56 tests for validation

### DIFF
--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -748,3 +748,5 @@ vault_kms_deployment_required = pytest.mark.skipif(
 )
 
 ui = compose(skipif_ibm_cloud_managed, pytest.mark.ui)
+# z-stream marker
+zstream_4_18_1 = pytest.mark.zstream_4_18_1

--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -750,3 +750,5 @@ vault_kms_deployment_required = pytest.mark.skipif(
 ui = compose(skipif_ibm_cloud_managed, pytest.mark.ui)
 # z-stream marker
 zstream_4_18_1 = pytest.mark.zstream_4_18_1
+# z-stream marker
+zstream_4_18_1_ocs_operator = pytest.mark.zstream_4_18_1_ocs_operator

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 markers =
+    zstream_4_18_1_ocs_operator: z-stream 4.18.1 ocs-operator component tests
     zstream_4_18_1: z-stream 4.18.1 test enablement
     run_this: testing marker for run this test, useful for development
     acceptance: marker for acceptance tests

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 markers =
+    zstream_4_18_1: z-stream 4.18.1 test enablement
     run_this: testing marker for run this test, useful for development
     acceptance: marker for acceptance tests
     tier0: marker for tier0 tests

--- a/tests/functional/deployment/test_acm.py
+++ b/tests/functional/deployment/test_acm.py
@@ -1,5 +1,5 @@
 from ocs_ci.ocs.acm.acm import import_clusters_with_acm
-from ocs_ci.framework.pytest_customization.marks import purple_squad
+from ocs_ci.framework.pytest_customization.marks import purple_squad, zstream_4_18_1, zstream_4_18_1_ocs_operator
 from ocs_ci.framework.testlib import acm_import
 
 ####################################################################################################
@@ -9,5 +9,7 @@ from ocs_ci.framework.testlib import acm_import
 
 @purple_squad
 @acm_import
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 def test_acm_import():
     import_clusters_with_acm()

--- a/tests/functional/deployment/test_deployment.py
+++ b/tests/functional/deployment/test_deployment.py
@@ -1,7 +1,7 @@
 import logging
 
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import purple_squad
+from ocs_ci.framework.pytest_customization.marks import purple_squad, zstream_4_18_1, zstream_4_18_1_ocs_operator
 from ocs_ci.framework.testlib import deployment, polarion_id
 from ocs_ci.ocs.resources.storage_cluster import (
     ocs_install_verification,
@@ -25,6 +25,8 @@ log = logging.getLogger(__name__)
 @purple_squad
 @deployment
 @polarion_id(get_polarion_id())
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 def test_deployment(pvc_factory, pod_factory):
     deploy = config.RUN["cli_params"].get("deploy")
     teardown = config.RUN["cli_params"].get("teardown")

--- a/tests/functional/z_cluster/cluster_expansion/test_add_capacity.py
+++ b/tests/functional/z_cluster/cluster_expansion/test_add_capacity.py
@@ -17,6 +17,8 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_hci_provider_and_client,
     brown_squad,
     black_squad,
+    zstream_4_18_1,
+    zstream_4_18_1_ocs_operator,
 )
 from ocs_ci.framework.testlib import (
     ignore_leftovers,
@@ -129,6 +131,8 @@ def add_capacity_test(ui_flag=False):
 @skipif_ibm_power
 @skipif_managed_service
 @skipif_hci_provider_and_client
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 class TestAddCapacity(ManageTest):
     """
     Automates adding variable capacity to the cluster
@@ -163,6 +167,8 @@ class TestAddCapacity(ManageTest):
 @skipif_hci_provider_and_client
 @skipif_no_lso
 @skipif_stretch_cluster
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 class TestAddCapacityLSO(ManageTest):
     """
     Add capacity on lso cluster
@@ -196,6 +202,8 @@ class TestAddCapacityLSO(ManageTest):
 @cloud_platform_required
 @skipif_managed_service
 @skipif_hci_provider_and_client
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 class TestAddCapacityPreUpgrade(ManageTest):
     """
     Automates adding variable capacity to the cluster pre upgrade

--- a/tests/functional/z_cluster/cluster_expansion/test_add_capacity_entry_exit_criteria.py
+++ b/tests/functional/z_cluster/cluster_expansion/test_add_capacity_entry_exit_criteria.py
@@ -5,7 +5,7 @@ import pytest
 from ocs_ci.ocs.cluster import is_flexible_scaling_enabled
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.resources import pod as pod_helpers
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, zstream_4_18_1, zstream_4_18_1_ocs_operator
 from ocs_ci.framework.testlib import (
     tier2,
     ignore_leftovers,
@@ -47,6 +47,8 @@ logger = logging.getLogger(__name__)
 @skipif_external_mode
 @skipif_managed_service
 @skipif_hci_provider_and_client
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 class TestAddCapacity(ManageTest):
     @pytest.fixture(autouse=True)
     def teardown(self, request):

--- a/tests/functional/z_cluster/cluster_expansion/test_add_capacity_with_node_restart.py
+++ b/tests/functional/z_cluster/cluster_expansion/test_add_capacity_with_node_restart.py
@@ -1,7 +1,7 @@
 import pytest
 import logging
 
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, zstream_4_18_1, zstream_4_18_1_ocs_operator
 from ocs_ci.framework.testlib import (
     ignore_leftovers,
     ManageTest,
@@ -41,6 +41,8 @@ logger = logging.getLogger(__name__)
 @skipif_managed_service
 @skipif_hci_provider_and_client
 @skipif_external_mode
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 class TestAddCapacityNodeRestart(ManageTest):
     """
     Test add capacity when one of the worker nodes got restart

--- a/tests/functional/z_cluster/cluster_expansion/test_crashcollector_pod_existence_on_ceph_pods_running_nodes.py
+++ b/tests/functional/z_cluster/cluster_expansion/test_crashcollector_pod_existence_on_ceph_pods_running_nodes.py
@@ -7,6 +7,8 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_bm,
     brown_squad,
     skipif_compact_mode,
+    zstream_4_18_1,
+    zstream_4_18_1_ocs_operator,
 )
 from ocs_ci.ocs.node import drain_nodes, schedule_nodes, is_node_rack_or_zone_exist
 from ocs_ci.helpers.helpers import get_failure_domin
@@ -42,6 +44,8 @@ logger = logging.getLogger(__name__)
 @skipif_hci_provider_and_client
 @skipif_compact_mode
 @pytest.mark.polarion_id("OCS-2594")
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 class TestAddNodeCrashCollector(ManageTest):
     """
     Add node with OCS label and verify crashcollector created on new node

--- a/tests/functional/z_cluster/cluster_expansion/test_create_multiple_device_classes.py
+++ b/tests/functional/z_cluster/cluster_expansion/test_create_multiple_device_classes.py
@@ -27,6 +27,7 @@ from ocs_ci.helpers.helpers import (
     create_rbd_deviceclass_storageclass,
 )
 from ocs_ci.utility.utils import ceph_health_check
+from ocs_ci.framework.pytest_customization.marks import zstream_4_18_1, zstream_4_18_1_ocs_operator
 
 
 log = logging.getLogger(__name__)
@@ -37,6 +38,8 @@ log = logging.getLogger(__name__)
 @skipif_no_lso
 @skipif_bm
 @skipif_hci_provider_or_client
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 class TestMultipleDeviceClasses(ManageTest):
     """
     Automate the multiple device classes tests

--- a/tests/functional/z_cluster/cluster_expansion/test_delete_pod.py
+++ b/tests/functional/z_cluster/cluster_expansion/test_delete_pod.py
@@ -12,6 +12,8 @@ from ocs_ci.framework.testlib import (
 from ocs_ci.framework.pytest_customization.marks import (
     skipif_external_mode,
     brown_squad,
+    zstream_4_18_1,
+    zstream_4_18_1_ocs_operator,
 )
 from ocs_ci.framework import config
 from ocs_ci.ocs import constants
@@ -35,6 +37,8 @@ logger = logging.getLogger(__name__)
 @skipif_external_mode
 @ignore_leftovers
 @tier4c
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 class TestAddCapacityWithResourceDelete:
     """
     Test add capacity when one of the resources gets deleted

--- a/tests/functional/z_cluster/cluster_expansion/test_node_expansion.py
+++ b/tests/functional/z_cluster/cluster_expansion/test_node_expansion.py
@@ -9,6 +9,8 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_managed_service,
     skipif_hci_provider_and_client,
     brown_squad,
+    zstream_4_18_1,
+    zstream_4_18_1_ocs_operator,
 )
 from ocs_ci.ocs.resources.storage_cluster import (
     in_transit_encryption_verification,
@@ -28,6 +30,8 @@ logger = logging.getLogger(__name__)
 @skipif_ibm_flash
 @ignore_leftovers
 @tier1
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 class TestAddNode(ManageTest):
     """
     Automates adding worker nodes to the cluster while IOs

--- a/tests/functional/z_cluster/cluster_expansion/test_nodes_rosa_hcp.py
+++ b/tests/functional/z_cluster/cluster_expansion/test_nodes_rosa_hcp.py
@@ -8,6 +8,8 @@ from ocs_ci.framework.pytest_customization.marks import (
     tier4a,
     polarion_id,
     brown_squad,
+    zstream_4_18_1,
+    zstream_4_18_1_ocs_operator,
 )
 from ocs_ci.framework.testlib import ManageTest
 from ocs_ci.ocs.cluster import CephCluster
@@ -51,6 +53,8 @@ def get_osd_pod_name(osd_node_name):
     return osd_pod_name
 
 
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 class TestAddDifferentInstanceTypeNode(ManageTest):
     @pytest.fixture
     def setup(self, request):

--- a/tests/functional/z_cluster/cluster_expansion/test_resize_osd.py
+++ b/tests/functional/z_cluster/cluster_expansion/test_resize_osd.py
@@ -16,6 +16,8 @@ from ocs_ci.framework.pytest_customization.marks import (
     black_squad,
     ibmcloud_platform_required,
     ui,
+    zstream_4_18_1,
+    zstream_4_18_1_ocs_operator,
 )
 from ocs_ci.framework.testlib import (
     ignore_leftovers,
@@ -72,6 +74,8 @@ logger = logging.getLogger(__name__)
 @skipif_ibm_power
 @skipif_managed_service
 @skipif_hci_provider_and_client
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 class TestResizeOSD(ManageTest):
     """
     Automates the resize OSD test procedure

--- a/tests/functional/z_cluster/cluster_expansion/test_verify_ceph_csidriver_runs_on_non_ocs_nodes.py
+++ b/tests/functional/z_cluster/cluster_expansion/test_verify_ceph_csidriver_runs_on_non_ocs_nodes.py
@@ -8,6 +8,8 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_hci_provider_and_client,
     skipif_multus_enabled,
     brown_squad,
+    zstream_4_18_1,
+    zstream_4_18_1_ocs_operator,
 )
 from ocs_ci.framework.testlib import tier2, ManageTest, ignore_leftovers
 from ocs_ci.ocs.node import get_worker_nodes_not_in_ocs
@@ -25,6 +27,8 @@ logger = logging.getLogger(__name__)
 @tier2
 @pytest.mark.polarion_id("OCS-2490")
 @ignore_leftovers
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 class TestCheckTolerationForCephCsiDriverDs(ManageTest):
     """
     Check toleration for Ceph CSI driver DS on non ocs node

--- a/tests/functional/z_cluster/nodes/test_automated_recovery_from_failed_nodes_proactive_IPI.py
+++ b/tests/functional/z_cluster/nodes/test_automated_recovery_from_failed_nodes_proactive_IPI.py
@@ -1,7 +1,7 @@
 import logging
 import pytest
 
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, zstream_4_18_1, zstream_4_18_1_ocs_operator
 from ocs_ci.framework.testlib import (
     tier4,
     tier4b,
@@ -32,6 +32,8 @@ log = logging.getLogger(__name__)
 @ignore_leftovers
 @aws_based_platform_required
 @ipi_deployment_required
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 class TestAutomatedRecoveryFromFailedNodes(ManageTest):
     """
     Knip-678 Automated recovery from failed nodes

--- a/tests/functional/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive_IPI.py
+++ b/tests/functional/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive_IPI.py
@@ -1,6 +1,6 @@
 import logging
 import pytest
-from ocs_ci.framework.pytest_customization.marks import brown_squad, skipif_compact_mode
+from ocs_ci.framework.pytest_customization.marks import brown_squad, skipif_compact_mode, zstream_4_18_1, zstream_4_18_1_ocs_operator
 from ocs_ci.framework.testlib import (
     tier4a,
     tier4b,
@@ -46,6 +46,8 @@ log = logging.getLogger(__name__)
 @ignore_leftovers
 @tier4b
 @ipi_deployment_required
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 class TestAutomatedRecoveryFromFailedNodes(ManageTest):
     """
     Knip-678 Automated recovery from failed nodes - Reactive
@@ -222,6 +224,8 @@ class TestAutomatedRecoveryFromFailedNodes(ManageTest):
 @ipi_deployment_required
 @skipif_ibm_cloud
 @skipif_compact_mode
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 class TestAutomatedRecoveryFromStoppedNodes(ManageTest):
 
     osd_worker_node = None

--- a/tests/functional/z_cluster/nodes/test_az_failure.py
+++ b/tests/functional/z_cluster/nodes/test_az_failure.py
@@ -6,6 +6,8 @@ import pytest
 from ocs_ci.framework.pytest_customization.marks import (
     aws_platform_required,
     brown_squad,
+    zstream_4_18_1,
+    zstream_4_18_1_ocs_operator,
 )
 from ocs_ci.framework.testlib import ManageTest, tier4, tier4b
 from ocs_ci.ocs.exceptions import CommandFailed
@@ -20,6 +22,8 @@ logger = logging.getLogger(__name__)
 @pytest.mark.polarion_id("OCS-1287")
 @aws_platform_required
 @pytest.mark.skip(reason="az blocking method need to be fixed")
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 class TestAvailabilityZones(ManageTest):
     """
     test availability zone failure:

--- a/tests/functional/z_cluster/nodes/test_check_pod_status_after_two_nodes_shutdown_recovery.py
+++ b/tests/functional/z_cluster/nodes/test_check_pod_status_after_two_nodes_shutdown_recovery.py
@@ -2,7 +2,7 @@ import logging
 import pytest
 import time
 
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, zstream_4_18_1, zstream_4_18_1_ocs_operator
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier4b,
@@ -24,6 +24,8 @@ log = logging.getLogger(__name__)
 @brown_squad
 @ignore_leftovers
 @tier4b
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 class TestOCSWorkerNodeShutdown(ManageTest):
     """
     Test case validate both the MDS pods rbd and cephfs plugin Provisioner

--- a/tests/functional/z_cluster/nodes/test_check_pods_status_after_node_failure.py
+++ b/tests/functional/z_cluster/nodes/test_check_pods_status_after_node_failure.py
@@ -2,7 +2,7 @@ import logging
 import pytest
 import random
 
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, zstream_4_18_1, zstream_4_18_1_ocs_operator
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier4a,
@@ -103,6 +103,8 @@ def wait_for_change_in_rook_ceph_pods(node_name, timeout=300, sleep=20):
 @skipif_hci_provider_and_client
 @skipif_external_mode
 @pytest.mark.polarion_id("OCS-2552")
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 class TestCheckPodsAfterNodeFailure(ManageTest):
     """
     Test check pods status after a node failure event.

--- a/tests/functional/z_cluster/nodes/test_disk_failures.py
+++ b/tests/functional/z_cluster/nodes/test_disk_failures.py
@@ -4,7 +4,7 @@ import pytest
 
 from ocs_ci.ocs import node, constants
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, zstream_4_18_1, zstream_4_18_1_ocs_operator
 from ocs_ci.framework.testlib import (
     tier4a,
     ignore_leftovers,
@@ -42,6 +42,8 @@ logger = logging.getLogger(__name__)
 @brown_squad
 @tier4a
 @ignore_leftovers
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 class TestDiskFailures(ManageTest):
     """
     Test class for detach and attach worker volume

--- a/tests/functional/z_cluster/nodes/test_node_kernel_crash_ceph_fsync.py
+++ b/tests/functional/z_cluster/nodes/test_node_kernel_crash_ceph_fsync.py
@@ -4,7 +4,7 @@ import pytest
 
 from time import sleep
 from ocs_ci.ocs import constants, node
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, zstream_4_18_1, zstream_4_18_1_ocs_operator
 from ocs_ci.framework.testlib import E2ETest, tier4, tier4b
 from ocs_ci.ocs.exceptions import ResourceWrongStatusException
 from ocs_ci.ocs.node import get_worker_nodes
@@ -15,6 +15,8 @@ log = logging.getLogger(__name__)
 
 
 @brown_squad
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 class TestKernelCrash(E2ETest):
     """
     Tests to verify kernel crash

--- a/tests/functional/z_cluster/nodes/test_node_replacement_proactive.py
+++ b/tests/functional/z_cluster/nodes/test_node_replacement_proactive.py
@@ -23,6 +23,8 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_hci_client,
     brown_squad,
     skipif_ibm_cloud_managed,
+    zstream_4_18_1,
+    zstream_4_18_1_ocs_operator,
 )
 from ocs_ci.helpers.helpers import (
     verify_storagecluster_nodetopology,
@@ -196,6 +198,8 @@ def delete_and_create_osd_node(osd_node_name):
 @skipif_hci_provider_and_client
 @skipif_bmpsi
 @skipif_external_mode
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 class TestNodeReplacementWithIO(ManageTest):
     """
     Knip-894 Node replacement proactive with IO
@@ -280,6 +284,8 @@ class TestNodeReplacementWithIO(ManageTest):
 @skipif_external_mode
 @skipif_ms_consumer
 @skipif_hci_client
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 class TestNodeReplacement(ManageTest):
     """
     Knip-894 Node replacement proactive
@@ -336,6 +342,8 @@ class TestNodeReplacement(ManageTest):
 @skipif_external_mode
 @skipif_managed_service
 @skipif_hci_provider_and_client
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 class TestNodeReplacementTwice(ManageTest):
     """
     Node replacement twice:

--- a/tests/functional/z_cluster/nodes/test_node_replacement_reactive_aws_ipi.py
+++ b/tests/functional/z_cluster/nodes/test_node_replacement_reactive_aws_ipi.py
@@ -1,7 +1,7 @@
 import logging
 import pytest
 
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, zstream_4_18_1, zstream_4_18_1_ocs_operator
 from ocs_ci.framework.testlib import (
     tier4a,
     ManageTest,
@@ -34,6 +34,8 @@ log = logging.getLogger(__name__)
 @tier4a
 @aws_based_platform_required
 @ipi_deployment_required
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 class TestNodeReplacement(ManageTest):
     """
     Knip-894 Node replacement - AWS-IPI-Reactive

--- a/tests/functional/z_cluster/nodes/test_nodes_maintenance.py
+++ b/tests/functional/z_cluster/nodes/test_nodes_maintenance.py
@@ -32,6 +32,8 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_hci_provider,
     skipif_rosa_hcp,
     skipif_compact_mode,
+    zstream_4_18_1,
+    zstream_4_18_1_ocs_operator,
 )
 from ocs_ci.framework.testlib import (
     tier1,
@@ -93,6 +95,8 @@ def teardown(request):
 
 @brown_squad
 @ignore_leftovers
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 class TestNodesMaintenance(ManageTest):
     """
     Test basic flows of maintenance (unschedule and drain) and

--- a/tests/functional/z_cluster/nodes/test_nodes_maintenance_provider_mode.py
+++ b/tests/functional/z_cluster/nodes/test_nodes_maintenance_provider_mode.py
@@ -4,7 +4,7 @@ import random
 import time
 
 
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, zstream_4_18_1, zstream_4_18_1_ocs_operator
 from ocs_ci.framework.testlib import (
     tier4a,
     tier4b,
@@ -72,6 +72,8 @@ def check_drain_and_unschedule_node(ocp_node):
 @brown_squad
 @ignore_leftovers
 @provider_client_platform_required
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 class TestNodesMaintenanceProviderMode(ManageTest):
     """
     Test nodes maintenance scenarios when using a Provider mode

--- a/tests/functional/z_cluster/nodes/test_nodes_restart.py
+++ b/tests/functional/z_cluster/nodes/test_nodes_restart.py
@@ -1,7 +1,7 @@
 import logging
 import pytest
 
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, zstream_4_18_1, zstream_4_18_1_ocs_operator
 from ocs_ci.framework.testlib import (
     tier4a,
     tier4b,
@@ -37,6 +37,8 @@ logger = logging.getLogger(__name__)
 @ignore_leftovers
 @skipif_managed_service
 @skipif_hci_provider_and_client
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 class TestNodesRestart(ManageTest):
     """
     Test ungraceful cluster shutdown

--- a/tests/functional/z_cluster/nodes/test_nodes_restart_hci.py
+++ b/tests/functional/z_cluster/nodes/test_nodes_restart_hci.py
@@ -3,7 +3,7 @@ import pytest
 import random
 
 
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, zstream_4_18_1, zstream_4_18_1_ocs_operator
 from ocs_ci.framework.testlib import (
     tier4a,
     tier4b,
@@ -48,6 +48,8 @@ logger = logging.getLogger(__name__)
 @brown_squad
 @ignore_leftovers
 @provider_client_platform_required
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 class TestNodesRestartHCI(ManageTest):
     """
     Test nodes restart scenarios when using HCI platform

--- a/tests/functional/z_cluster/nodes/test_non_ocs_taint_and_toleration.py
+++ b/tests/functional/z_cluster/nodes/test_non_ocs_taint_and_toleration.py
@@ -41,6 +41,8 @@ from ocs_ci.utility.retry import retry
 from ocs_ci.ocs.resources import storage_cluster
 from ocs_ci.framework.pytest_customization.marks import (
     brown_squad,
+    zstream_4_18_1,
+    zstream_4_18_1_ocs_operator,
 )
 from ocs_ci.helpers.sanity_helpers import Sanity
 from tests.functional.z_cluster.nodes.test_node_replacement_proactive import (
@@ -57,6 +59,8 @@ logger = logging.getLogger(__name__)
 @skipif_tainted_nodes
 @skipif_managed_service
 @skipif_hci_provider_and_client
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 class TestNonOCSTaintAndTolerations(E2ETest):
     """
     Test to test non ocs taints on ocs nodes

--- a/tests/functional/z_cluster/nodes/test_rolling_shutdown_and_recovery.py
+++ b/tests/functional/z_cluster/nodes/test_rolling_shutdown_and_recovery.py
@@ -3,7 +3,7 @@ import time
 import pytest
 
 
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, zstream_4_18_1, zstream_4_18_1_ocs_operator
 from ocs_ci.framework.testlib import (
     tier4b,
     ignore_leftovers,
@@ -27,6 +27,8 @@ log = logging.getLogger(__name__)
 @skipif_external_mode
 @skipif_managed_service
 @ignore_leftovers
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 class TestRollingWorkerNodeShutdownAndRecovery(ManageTest):
     """
     Test rolling shutdown and recovery of OCS pods running worker nodes

--- a/tests/functional/z_cluster/nodes/test_rolling_terminate_and_recovery.py
+++ b/tests/functional/z_cluster/nodes/test_rolling_terminate_and_recovery.py
@@ -3,7 +3,7 @@ import pytest
 import random
 
 
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, zstream_4_18_1, zstream_4_18_1_ocs_operator
 from ocs_ci.framework.testlib import (
     tier4b,
     ignore_leftovers,
@@ -52,6 +52,8 @@ log = logging.getLogger(__name__)
 @skipif_external_mode
 @ignore_leftovers
 @pytest.mark.polarion_id("OCS-4661")
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 class TestRollingWorkerNodeTerminateAndRecovery(ManageTest):
     """
     Test rolling terminate and recovery of the OCS worker nodes

--- a/tests/functional/z_cluster/nodes/test_toleration.py
+++ b/tests/functional/z_cluster/nodes/test_toleration.py
@@ -1,7 +1,7 @@
 import logging
 import pytest
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, zstream_4_18_1, zstream_4_18_1_ocs_operator
 from ocs_ci.framework.testlib import (
     tier4c,
     E2ETest,
@@ -30,6 +30,8 @@ logger = logging.getLogger(__name__)
 @skipif_managed_service
 @skipif_hci_provider_and_client
 @pytest.mark.polarion_id("OCS-2450")
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 class TestTaintAndTolerations(E2ETest):
     """
     Test to test taints and toleration

--- a/tests/functional/z_cluster/nodes/test_worker_nodes_network_failures.py
+++ b/tests/functional/z_cluster/nodes/test_worker_nodes_network_failures.py
@@ -11,6 +11,8 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_hci_provider_and_client,
     skipif_gcp_platform,
     brown_squad,
+    zstream_4_18_1,
+    zstream_4_18_1_ocs_operator,
 )
 from ocs_ci.framework.testlib import ignore_leftovers, ManageTest, tier4b
 from ocs_ci.ocs import constants, node
@@ -31,6 +33,8 @@ logger = logging.getLogger(__name__)
 @skipif_managed_service
 @skipif_hci_provider_and_client
 @ignore_leftovers
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 class TestWorkerNodesFailure(ManageTest):
     """
     Test all worker nodes simultaneous abrupt network failure for ~300 seconds

--- a/tests/functional/z_cluster/test_add_mds_to_cluster.py
+++ b/tests/functional/z_cluster/test_add_mds_to_cluster.py
@@ -8,7 +8,7 @@ import pytest
 
 from ocs_ci.ocs import constants, defaults, ocp
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, zstream_4_18_1, zstream_4_18_1_ocs_operator
 from ocs_ci.framework.testlib import ManageTest
 from ocs_ci.ocs.resources.ocs import OCS
 from ocs_ci.utility.utils import TimeoutSampler
@@ -76,6 +76,8 @@ def get_mds_active_count():
 # @tier1
 # Test case is disabled, as per requirement not to support this scenario
 @brown_squad
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 class TestCephFilesystemCreation(ManageTest):
     """
     Testing creation of Ceph FileSystem

--- a/tests/functional/z_cluster/test_ceph_default_values_check.py
+++ b/tests/functional/z_cluster/test_ceph_default_values_check.py
@@ -5,6 +5,8 @@ import pytest
 from ocs_ci.framework.pytest_customization.marks import (
     skipif_ocs_version,
     brown_squad,
+    zstream_4_18_1,
+    zstream_4_18_1_ocs_operator,
 )
 from ocs_ci.framework.testlib import (
     ManageTest,
@@ -34,6 +36,8 @@ log = logging.getLogger(__name__)
 @tier1
 @skipif_external_mode
 @pytest.mark.polarion_id("OCS-2231")
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 class TestCephDefaultValuesCheck(ManageTest):
     def test_ceph_default_values_check(self):
         """

--- a/tests/functional/z_cluster/test_ceph_pg_log_dups_trim.py
+++ b/tests/functional/z_cluster/test_ceph_pg_log_dups_trim.py
@@ -2,7 +2,7 @@ import logging
 import random
 import pytest
 
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, zstream_4_18_1, zstream_4_18_1_ocs_operator
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier2,
@@ -35,6 +35,8 @@ log = logging.getLogger(__name__)
 @skipif_hci_provider_and_client
 @skipif_ocs_version("<4.11")
 @pytest.mark.polarion_id("OCS-4471")
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 class TestCephPgLogDupsTrimming(ManageTest):
     @pytest.fixture(autouse=True)
     def teardown(self, request):

--- a/tests/functional/z_cluster/test_coredump_check_for_ceph_daemon_crash.py
+++ b/tests/functional/z_cluster/test_coredump_check_for_ceph_daemon_crash.py
@@ -7,7 +7,7 @@ from ocs_ci.utility.utils import TimeoutSampler
 from ocs_ci.helpers.disruption_helpers import Disruptions
 from ocs_ci.helpers.helpers import run_cmd_verify_cli_output
 from ocs_ci.utility.utils import ceph_health_check
-from ocs_ci.framework.pytest_customization.marks import skipif_rhel_os, brown_squad
+from ocs_ci.framework.pytest_customization.marks import skipif_rhel_os, brown_squad, zstream_4_18_1, zstream_4_18_1_ocs_operator
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier2,
@@ -35,6 +35,8 @@ log = logging.getLogger(__name__)
 @pytest.mark.polarion_id("OCS-2492")
 @pytest.mark.polarion_id("OCS-2493")
 @skipif_rhel_os
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 class TestKillCephDaemon(ManageTest):
     """
     Verify coredump getting generated for ceph daemon crash

--- a/tests/functional/z_cluster/test_delete_local_volume_sym_link.py
+++ b/tests/functional/z_cluster/test_delete_local_volume_sym_link.py
@@ -4,7 +4,7 @@ import pytest
 from ocs_ci.ocs.utils import get_pod_name_by_pattern
 from ocs_ci.framework.testlib import E2ETest, tier4b
 from ocs_ci.ocs import ocp, constants
-from ocs_ci.framework.pytest_customization.marks import skipif_no_lso, brown_squad
+from ocs_ci.framework.pytest_customization.marks import skipif_no_lso, brown_squad, zstream_4_18_1, zstream_4_18_1_ocs_operator
 from ocs_ci.helpers.helpers import wait_for_resource_state
 from ocs_ci.ocs.resources.pvc import get_deviceset_pvcs
 from ocs_ci.ocs.resources.pod import wait_for_storage_pods, get_pod_obj, get_pod_node
@@ -18,6 +18,8 @@ log = logging.getLogger(__name__)
 @tier4b
 @skipif_no_lso
 @pytest.mark.polarion_id("OCS-2316")
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 class TestDeleteLocalVolumeSymLink(E2ETest):
     """
     A test case to validate rook-ceph-crashcollector pods

--- a/tests/functional/z_cluster/test_delete_osd_deployment.py
+++ b/tests/functional/z_cluster/test_delete_osd_deployment.py
@@ -1,6 +1,6 @@
 import logging
 import pytest
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, zstream_4_18_1, zstream_4_18_1_ocs_operator
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier4c,
@@ -24,6 +24,8 @@ logger = logging.getLogger(__name__)
 @skipif_ocs_version("<4.10")
 @ignore_leftover_label(constants.OSD_APP_LABEL)
 @pytest.mark.polarion_id("OCS-3731")
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 class TestDeleteOSDDeployment(ManageTest):
     """
     This test case deletes all the OSD deployments one after the other.

--- a/tests/functional/z_cluster/test_delete_rook_ceph_mon_pod.py
+++ b/tests/functional/z_cluster/test_delete_rook_ceph_mon_pod.py
@@ -6,6 +6,8 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_external_mode,
     brown_squad,
     runs_on_provider,
+    zstream_4_18_1,
+    zstream_4_18_1_ocs_operator,
 )
 from ocs_ci.ocs.resources import pod
 from ocs_ci.ocs import constants
@@ -21,6 +23,8 @@ log = logging.getLogger(__name__)
 @tier2
 @skipif_external_mode
 @pytest.mark.polarion_id("OCS-2481")
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 class TestDeleteRookCephMonPod(ManageTest):
     """
     Tries to delete rook-ceph-operator pod.

--- a/tests/functional/z_cluster/test_hugepages.py
+++ b/tests/functional/z_cluster/test_hugepages.py
@@ -15,7 +15,7 @@ from ocs_ci.ocs.node import (
 from ocs_ci.ocs.resources.pod import (
     wait_for_pods_to_be_running,
 )
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, zstream_4_18_1, zstream_4_18_1_ocs_operator
 from ocs_ci.framework.testlib import (
     skipif_external_mode,
     skipif_ocs_version,
@@ -32,6 +32,8 @@ log = logging.getLogger(__name__)
 @skipif_ocs_version("<4.8")
 @pytest.mark.polarion_id("OCS-2754")
 @ignore_leftovers
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 class TestHugePages(E2ETest):
     """
     Enable huge pages post ODF installation

--- a/tests/functional/z_cluster/test_mon_data_avail_warn.py
+++ b/tests/functional/z_cluster/test_mon_data_avail_warn.py
@@ -9,7 +9,7 @@ import random
 import pytest
 
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, zstream_4_18_1, zstream_4_18_1_ocs_operator
 from ocs_ci.framework.testlib import (
     E2ETest,
     tier2,
@@ -35,6 +35,8 @@ DD_COUNT = 64
 @tier2
 @pytest.mark.polarion_id("OCS-2733")
 @skipif_ocs_version("<4.9")
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 class TestMonDataAvailWarn(E2ETest):
     """
     Testing MON disk low threshold.

--- a/tests/functional/z_cluster/test_mon_log_trimming.py
+++ b/tests/functional/z_cluster/test_mon_log_trimming.py
@@ -3,7 +3,7 @@ import random
 import threading
 import pytest
 from ocs_ci.ocs import constants
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, zstream_4_18_1, zstream_4_18_1_ocs_operator
 from ocs_ci.framework.testlib import E2ETest, tier2, skipif_external_mode
 from ocs_ci.ocs.resources import pod
 from ocs_ci.ocs.resources.pod import get_mon_pods
@@ -17,6 +17,8 @@ log = logging.getLogger(__name__)
 @tier2
 @skipif_external_mode
 @pytest.mark.polarion_id("OCS-2526")
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 class TestMonLogTrimming(E2ETest):
     """
     Test cases to validate mon store trimming

--- a/tests/functional/z_cluster/test_ms_pod_disruptions.py
+++ b/tests/functional/z_cluster/test_ms_pod_disruptions.py
@@ -4,7 +4,7 @@ from itertools import cycle
 import pytest
 
 from ocs_ci.ocs import constants
-from ocs_ci.framework.pytest_customization.marks import yellow_squad
+from ocs_ci.framework.pytest_customization.marks import yellow_squad, zstream_4_18_1, zstream_4_18_1_ocs_operator
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier4c,
@@ -26,6 +26,8 @@ log = logging.getLogger(__name__)
 @provider_client_ms_platform_required
 @ignore_leftover_label(constants.TOOL_APP_LABEL)
 @pytest.mark.polarion_id("OCS-3924")
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 class TestPodDisruptions(ManageTest):
     """
     Tests to verify pod disruption

--- a/tests/functional/z_cluster/test_multiple_mds.py
+++ b/tests/functional/z_cluster/test_multiple_mds.py
@@ -12,6 +12,8 @@ from ocs_ci.framework.pytest_customization.marks import (
     tier4c,
     skipif_external_mode,
     skipif_ibm_cloud_managed,
+    zstream_4_18_1,
+    zstream_4_18_1_ocs_operator,
 )
 from ocs_ci.framework import config
 from ocs_ci.helpers import helpers
@@ -51,6 +53,8 @@ def verify_active_and_standby_mds_count(target_count):
 @brown_squad
 @tier4c
 @skipif_external_mode
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 class TestMultipleMds:
     """
     Tests for support multiple mds

--- a/tests/functional/z_cluster/test_must_gather.py
+++ b/tests/functional/z_cluster/test_must_gather.py
@@ -2,7 +2,7 @@ import logging
 import pytest
 
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, zstream_4_18_1, zstream_4_18_1_ocs_operator
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier1,
@@ -31,6 +31,8 @@ def mustgather(request):
 
 
 @brown_squad
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 class TestMustGather(ManageTest):
     @tier1
     @pytest.mark.parametrize(

--- a/tests/functional/z_cluster/test_must_gather_minimal_crds.py
+++ b/tests/functional/z_cluster/test_must_gather_minimal_crds.py
@@ -10,6 +10,8 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_ms_consumer,
     skipif_hci_client,
     stretchcluster_required_skipif,
+    zstream_4_18_1,
+    zstream_4_18_1_ocs_operator,
 )
 from ocs_ci.ocs.must_gather.must_gather import MustGather
 from ocs_ci.ocs.must_gather import const_must_gather
@@ -18,6 +20,8 @@ logger = logging.getLogger(__name__)
 
 
 @brown_squad
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 class TestMustGather(ManageTest):
     @pytest.mark.parametrize(
         argnames=[

--- a/tests/functional/z_cluster/test_must_gather_modular.py
+++ b/tests/functional/z_cluster/test_must_gather_modular.py
@@ -1,7 +1,7 @@
 import logging
 import pytest
 
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, zstream_4_18_1, zstream_4_18_1_ocs_operator
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier2,
@@ -16,6 +16,8 @@ logger = logging.getLogger(__name__)
 
 
 @brown_squad
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 class TestMustGather(ManageTest):
     @tier2
     @pytest.mark.parametrize(

--- a/tests/functional/z_cluster/test_no_liveness_probe.py
+++ b/tests/functional/z_cluster/test_no_liveness_probe.py
@@ -13,6 +13,8 @@ from ocs_ci.framework.pytest_customization.marks import (
     tier1,
     polarion_id,
     brown_squad,
+    zstream_4_18_1,
+    zstream_4_18_1_ocs_operator,
 )
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.resources.pod import get_containers_names_by_pod
@@ -25,6 +27,8 @@ LIVENESS_CONTAINER = "liveness-prometheus"
 @brown_squad
 @tier1
 @polarion_id("OCS-4847")
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 def test_no_liveness_container():
     """
     Automated test for BZ #2142901

--- a/tests/functional/z_cluster/test_noobaa_xss_vulnerability.py
+++ b/tests/functional/z_cluster/test_noobaa_xss_vulnerability.py
@@ -5,7 +5,7 @@ import urllib.request
 import pytest
 
 from ocs_ci.helpers.helpers import get_noobaa_url
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, zstream_4_18_1, zstream_4_18_1_ocs_operator
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier2,
@@ -23,6 +23,8 @@ log = logging.getLogger(__name__)
 @skipif_ocs_version("<4.8")
 @skipif_external_mode
 @pytest.mark.polarion_id("OCS-2591")
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 class TestNoobaaXssVulnerability(ManageTest):
     """
     Test Process:

--- a/tests/functional/z_cluster/test_osd_heap_profile.py
+++ b/tests/functional/z_cluster/test_osd_heap_profile.py
@@ -3,7 +3,7 @@ import pytest
 import time
 import random
 
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, zstream_4_18_1, zstream_4_18_1_ocs_operator
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier2,
@@ -24,6 +24,8 @@ log = logging.getLogger(__name__)
 @skipif_ocs_version("<4.6")
 @pytest.mark.polarion_id("OCS-2512")
 @skipif_external_mode
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 class TestOSDHeapProfile(ManageTest):
     """
     1.Start heap profiler for osd

--- a/tests/functional/z_cluster/test_performance_profile_validation.py
+++ b/tests/functional/z_cluster/test_performance_profile_validation.py
@@ -6,6 +6,8 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_ocs_version,
     ignore_leftovers,
     brown_squad,
+    zstream_4_18_1,
+    zstream_4_18_1_ocs_operator,
 )
 from ocs_ci.framework.testlib import (
     ManageTest,
@@ -37,6 +39,8 @@ log = logging.getLogger(__name__)
 @pytest.mark.polarion_id("OCS-5646")
 @pytest.mark.polarion_id("OCS-5656")
 @pytest.mark.polarion_id("OCS-5657")
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 class TestProfileDefaultValuesCheck(ManageTest):
     @pytest.mark.parametrize(
         argnames=["perf_profile"],

--- a/tests/functional/z_cluster/test_remove_mon_from_cluster.py
+++ b/tests/functional/z_cluster/test_remove_mon_from_cluster.py
@@ -9,7 +9,7 @@ Polarion-ID- OCS-355
 import logging
 import pytest
 from ocs_ci.ocs import ocp, constants
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, zstream_4_18_1, zstream_4_18_1_ocs_operator
 from ocs_ci.framework.testlib import ManageTest, ignore_leftovers
 from ocs_ci.framework import config
 from ocs_ci.ocs.resources import pod
@@ -64,6 +64,8 @@ def run_io_on_pool(pool_obj):
 @ignore_leftovers
 @brown_squad
 # @pytest.mark.polarion_id("OCS-355")
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 class TestRemoveMonFromCluster(ManageTest):
     pool_obj = ""
 

--- a/tests/functional/z_cluster/test_restart_mgr_while_two_mons_down.py
+++ b/tests/functional/z_cluster/test_restart_mgr_while_two_mons_down.py
@@ -13,6 +13,8 @@ from ocs_ci.ocs.resources.pod import get_deployments_having_label
 from ocs_ci.framework.pytest_customization.marks import (
     skipif_external_mode,
     brown_squad,
+    zstream_4_18_1,
+    zstream_4_18_1_ocs_operator,
 )
 from ocs_ci.framework.testlib import (
     ManageTest,
@@ -27,6 +29,8 @@ log = logging.getLogger(__name__)
 @tier2
 @polarion_id("OCS-2696")
 @skipif_external_mode
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 class TestRestartMgrWhileTwoMonsDown(ManageTest):
     """
     Restart mgr pod while two mon pods are down

--- a/tests/functional/z_cluster/test_rook_ceph_log_rotate.py
+++ b/tests/functional/z_cluster/test_rook_ceph_log_rotate.py
@@ -11,7 +11,7 @@ from ocs_ci.ocs.resources import pod
 from ocs_ci.ocs.exceptions import TimeoutExpiredError
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs import constants
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, zstream_4_18_1, zstream_4_18_1_ocs_operator
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier2,
@@ -32,6 +32,8 @@ log = logging.getLogger(__name__)
 @skipif_external_mode
 @skipif_ocs_version("<4.10")
 @pytest.mark.polarion_id("OCS-4684")
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 class TestRookCephLogRotate(ManageTest):
     """
     Test Rook Ceph Log Rotate

--- a/tests/functional/z_cluster/test_rook_ceph_operator_log_type.py
+++ b/tests/functional/z_cluster/test_rook_ceph_operator_log_type.py
@@ -11,7 +11,7 @@ from ocs_ci.helpers.helpers import (
     check_osd_log_exist_on_rook_ceph_operator_pod,
 )
 from ocs_ci.helpers.odf_cli import ODFCLIRetriever, ODFCliRunner
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, zstream_4_18_1, zstream_4_18_1_ocs_operator
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier2,
@@ -29,6 +29,8 @@ log = logging.getLogger(__name__)
 @skipif_ocs_version("<4.8")
 @skipif_external_mode
 @pytest.mark.polarion_id("OCS-2581")
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 class TestRookCephOperatorLogType(ManageTest):
     """
     Test Process:

--- a/tests/functional/z_cluster/test_rook_ceph_osd_flapping.py
+++ b/tests/functional/z_cluster/test_rook_ceph_osd_flapping.py
@@ -13,7 +13,7 @@ from ocs_ci.helpers.helpers import (
 )
 from ocs_ci.ocs.cluster import ceph_health_check
 from ocs_ci.ocs.resources import pod
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, zstream_4_18_1, zstream_4_18_1_ocs_operator
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier2,
@@ -31,6 +31,8 @@ log = logging.getLogger(__name__)
 @skipif_external_mode
 @skipif_ocs_version("<4.14")
 @pytest.mark.polarion_id("OCS-5404")
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 class TestRookCephOsdFlapping(ManageTest):
     """
     Test Rook Ceph OSD Flapping

--- a/tests/functional/z_cluster/test_rook_operator_restart_during_mon_failover.py
+++ b/tests/functional/z_cluster/test_rook_operator_restart_during_mon_failover.py
@@ -9,7 +9,7 @@ from ocs_ci.ocs.resources.pod import (
     get_operator_pods,
     wait_for_pods_to_be_running,
 )
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, zstream_4_18_1, zstream_4_18_1_ocs_operator
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier4b,
@@ -29,6 +29,8 @@ log = logging.getLogger(__name__)
 @ignore_leftovers
 @pytest.mark.polarion_id("OCS-2572")
 @runs_on_provider
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 class TestDrainNodeMon(ManageTest):
     """
     1.Get worker node name where monitoring pod run

--- a/tests/functional/z_cluster/test_storagecluster_ceph_full_thresholds_params.py
+++ b/tests/functional/z_cluster/test_storagecluster_ceph_full_thresholds_params.py
@@ -16,6 +16,7 @@ from ocs_ci.framework.testlib import (
     pre_upgrade,
     post_upgrade,
 )
+from ocs_ci.framework.pytest_customization.marks import zstream_4_18_1, zstream_4_18_1_ocs_operator
 
 logger = logging.getLogger(__name__)
 
@@ -59,6 +60,8 @@ def thresholds_teardown_fixture(request):
 @brown_squad
 @skipif_external_mode
 @pytest.mark.polarion_id("OCS-6224")
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 class TestStorageClusterCephFullThresholdsParams(ManageTest):
     """
     Verify the ceph full thresholds storagecluster parameters move to cephcluster


### PR DESCRIPTION
# Z-Stream 4.18.1 Test Enablement

## Summary

This PR enables automated test validation for z-stream release **4.18.1**. The selected tests provide comprehensive coverage of the bugfixes included in this release, focusing on NooBaa S3 browser functionality, CSI-related pod stability after upgrades, and provider-server pod behavior on non-RDR clusters.

## Z-Stream Version

**4.18.1**

## Changes Being Validated

| Bug ID | Component | Type | Summary |
|--------|-----------|------|---------|
| [DFBUGS-1830](https://redhat.atlassian.net/browse/DFBUGS-1830) | odf-operator | bugfix | [NooBaa S3 Browser] Error Loading : char 'n' is not expected.:1:1 Deserialization error |
| [DFBUGS-1790](https://redhat.atlassian.net/browse/DFBUGS-1790) | ocs-operator | bugfix | [provider-client] CSI-related pods in CrashLoopBackOff after upgrade to 4.18 |
| [DFBUGS-931](https://redhat.atlassian.net/browse/DFBUGS-931) | ocs-operator | bugfix | ocs-provider-server pod is running even on non RDR cluster |

## Test Coverage

**Total Tests Enabled:** 56

### Coverage Breakdown by Component

- **ocs-operator:** 55 tests
- **odf-operator:** 1 test

### High-Confidence Test Selection (Top 20)

The following tests scored highest (0.90-0.93) for relevance to the z-stream changes:

| Test | Score | Coverage Area |
|------|-------|---------------|
| `test_noobaa_postgres_cm_post_ocs_upgrade` | 0.93 | NooBaa postgres configmap validation post-upgrade |
| `test_add_capacity_cli` | 0.90 | Capacity expansion on non-LSO clusters (CLI) |
| `test_add_capacity_ui` | 0.90 | Capacity expansion on non-LSO clusters (UI) |
| `test_add_capacity_lso_cli` | 0.90 | Capacity expansion on LSO clusters (CLI) |
| `test_add_capacity_lso_ui` | 0.90 | Capacity expansion on LSO clusters (UI) |
| `test_ceph_csidriver_runs_on_non_ocs_nodes` | 0.90 | CSI driver node placement and tolerations |
| `test_check_pod_status_after_two_nodes_shutdown_recovery` | 0.90 | Pod recovery after node shutdown |
| `test_check_pods_status_after_node_failure` | 0.90 | Pod status validation after node failure |
| `test_detach_attach_worker_volume` | 0.90 | Worker volume detachment/attachment |
| `test_detach_attach_2_data_volumes` | 0.90 | Multi-node volume operations |
| `test_recovery_from_volume_deletion` | 0.90 | Cluster recovery from volume deletion |
| `test_recovery_from_volume_deletion_cli_tool` | 0.90 | CLI-based volume deletion recovery |
| `test_nodes_restart` | 0.90 | Node restart resilience |
| `test_rolling_nodes_restart` | 0.90 | Rolling restart operations |
| `test_pv_provisioning_under_degraded_state_stop_provisioner_pod_node` | 0.90 | PV provisioning during degraded state |
| `test_pv_provisioning_under_degraded_state_stop_rook_operator_pod_node` | 0.90 | PV provisioning with rook operator degradation |
| `test_pv_after_reboot_node` | 0.90 | PV behavior after node reboot |
| `test_rolling_terminate_and_recovery_in_controlled_fashion_ipi` | 0.90 | Rolling node termination and recovery |
| `test_hugepages_post_odf_deployment` | 0.90 | Hugepages configuration validation |

### Test Categories

- **Cluster Expansion:** 6 tests
- **Node Resilience:** 9 tests
- **Disk/Volume Operations:** 4 tests
- **Upgrade/Configuration Validation:** 1 test

## Validation Approach

These tests were selected using semantic matching against the z-stream bugfix descriptions, prioritizing:
- Direct component coverage (CSI, NooBaa, provider-server)
- Upgrade and post-upgrade scenarios
- Pod stability and recovery patterns
- Node and volume failure scenarios