### PR TITLE
Use 'oc wait' command to wait for multiclusterhub Running status

### DIFF
--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -1014,6 +1014,9 @@ class OCP(object):
                 constants.STATUS_ACTIVE,
                 constants.STATUS_TERMINATING,
             ],
+            constants.ACM_MULTICLUSTER_HUB.lower(): [
+                constants.STATUS_RUNNING,
+            ],
         }
 
         if (


### PR DESCRIPTION
Fixes #15094 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cluster resource status monitoring so the STATUS column correctly supports multi-cluster hub resources and recognizes “Running” as a valid condition when waiting for resource state. This provides more accurate and reliable visibility into resource readiness across multi-cluster deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->