### PR TITLE
OCP 4-22-GA config

### DIFF
--- a/ocs_ci/framework/conf/ocp_version/ocp-4.22-ga-config.yaml
+++ b/ocs_ci/framework/conf/ocp_version/ocp-4.22-ga-config.yaml
@@ -1,0 +1,23 @@
+---
+# Config file for OCP GA 4.22 stable channel
+RUN:
+  client_version: '4.22-ga'
+DEPLOYMENT:
+  ocp_url_template: "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/{version}/{file_name}-{os_type}-{version}.tar.gz"
+  installer_version: "4.22-ga"
+  terraform_version: "1.0.11"
+  ignition_version: "3.2.0"
+ENV_DATA:
+  # https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.22/latest/
+  vm_template: "rhcos-4.22.0-x86_64-vmware.x86_64"
+  acm_hub_channel: "release-2.17"
+  # TODO: Versions bellow will be updated by RDR
+  acm_version: "2.17"
+  mce_version: "2.17"
+  submariner_version: "0.23.1"
+  submariner_image: "quay.io/redhat-user-workloads/submariner-tenant/submariner-fbc-4-21@sha256:1585a2a6c372f8a66b7644e742d95356b577072dfc83492c14759f6b2372b609"
+  # Below values needs to be changed when acm and submariner are GAed
+  submariner_source: "downstream"
+  submariner_release_type: "released"
+  acm_hub_unreleased: true
+  oadp_version: "1.6"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added OpenShift Container Platform 4.22 GA configuration including client and installer versions, infrastructure templates, and component versioning for ACM, MCE, Submariner, and OADP.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->