### PR TITLE
Add NooBaa health check to health_checker fixture

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -578,6 +578,7 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 334,
+        "line_number": 338,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -602,6 +603,7 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 382,
+        "line_number": 386,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -669,7 +671,7 @@
         "hashed_secret": "a12337323b638ab044b1166bff4b1a1f83162819",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 840,
+        "line_number": 848,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -677,7 +679,7 @@
         "hashed_secret": "fb947972c92f052c0a08866d182be0075a2b601b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 849,
+        "line_number": 857,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -686,6 +688,7 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 2023,
+        "line_number": 2060,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -694,6 +697,7 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 2130,
+        "line_number": 2167,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -702,6 +706,7 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 2131,
+        "line_number": 2168,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -710,6 +715,7 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 2132,
+        "line_number": 2169,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -718,6 +724,7 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 2133,
+        "line_number": 2170,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -726,6 +733,7 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 2138,
+        "line_number": 2182,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -734,6 +742,7 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 2153,
+        "line_number": 2197,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -742,6 +751,7 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 2154,
+        "line_number": 2198,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -750,6 +760,7 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 2162,
+        "line_number": 2206,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -758,6 +769,7 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 2163,
+        "line_number": 2207,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -766,6 +778,7 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 2164,
+        "line_number": 2208,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -774,6 +787,7 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 2165,
+        "line_number": 2209,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -782,6 +796,7 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 2166,
+        "line_number": 2210,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -790,6 +805,7 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 2757,
+        "line_number": 2807,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -798,6 +814,7 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 2914,
+        "line_number": 2972,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -806,6 +823,7 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 2915,
+        "line_number": 2973,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -814,6 +832,7 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 3636,
+        "line_number": 3694,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -822,6 +841,7 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 3637,
+        "line_number": 3695,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -39,9 +39,13 @@ RUN:
   load_status: None
   skip_reason_test_found: {}
   skipped_tests_ceph_health: 0
+  skipped_tests_noobaa_health: 0
   number_of_tests: None
   skipped_on_ceph_health_ratio: 0
   skipped_on_ceph_health_threshold: 0
+  noobaa_not_ready_at_setup: {}
+  noobaa_health_failure_source: {}
+  sc_ceph_health_mismatch: {}
 
 # In this section we are storing all deployment related configuration but not
 # the environment related data as those are defined in ENV_DATA section.

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -563,6 +563,14 @@ DEFAULT_MCG_BUCKET_NOTIFS_PVC = "noobaa-bucket-notifications-pvc"
 CUSTOM_MCG_LABEL = "custom=mcg-label"
 NOOBAA_RESOURCE_NAME = "noobaa"
 NOOBAA_DB_PVC_NAME = "noobaa-db-pg-cluster-1"
+NOOBAA_INITIALIZING_REASON = "NoobaaInitializing"
+NOOBAA_HEALTH_CHECK_DELAY = 30
+CEPH_CONDITION_REASONS = (
+    "CephClusterNotReady",
+    "CephClusterHealthNotOK",
+    "CephClusterCreating",
+    "CephClusterUpdating",
+)
 MIN_PV_BACKINGSTORE_SIZE_IN_GB = 17
 JENKINS_BUILD = "jax-rs-build"
 JENKINS_BUILD_COMPLETE = "Complete"

--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -9,6 +9,7 @@ import re
 import tempfile
 import json
 import time
+from typing import Optional
 
 from jsonschema import validate
 from jsonschema.exceptions import ValidationError
@@ -1303,6 +1304,55 @@ def verify_storage_system():
         )
 
 
+def get_noobaa_phase(namespace: str) -> Optional[str]:
+    """
+    Get the current phase of the NooBaa CR via a single lightweight API call.
+
+    Args:
+        namespace (str): Kubernetes namespace where NooBaa is deployed.
+
+    Returns:
+        Optional[str]: NooBaa phase string (e.g. "Ready", "Configuring"),
+            or None if the CR cannot be retrieved.
+
+    """
+    try:
+        noobaa = OCP(kind="noobaa", namespace=namespace).get(
+            resource_name=constants.NOOBAA_RESOURCE_NAME
+        )
+        return noobaa.get("status", {}).get("phase", "")
+    except CommandFailed as ex:
+        log.warning("Failed to get NooBaa CR (%s) — skipping NooBaa health check", ex)
+        return None
+
+
+def get_storage_cluster_phase(namespace: str) -> Optional[str]:
+    """
+    Get the current phase of the StorageCluster CR via a single lightweight
+    API call.
+
+    Args:
+        namespace (str): Kubernetes namespace where the StorageCluster is
+            deployed.
+
+    Returns:
+        Optional[str]: StorageCluster phase string (e.g. "Ready",
+            "Progressing"), or None if the CR cannot be retrieved.
+
+    """
+    try:
+        sc_name = config.ENV_DATA["storage_cluster_name"]
+        sc = OCP(kind=constants.STORAGECLUSTER, namespace=namespace).get(
+            resource_name=sc_name
+        )
+        return sc.get("status", {}).get("phase", "")
+    except CommandFailed as ex:
+        log.warning(
+            "Failed to get StorageCluster CR (%s) — skipping SC phase check", ex
+        )
+        return None
+
+
 def verify_storage_cluster():
     """
     Verify storage cluster status
@@ -1325,7 +1375,51 @@ def verify_storage_cluster():
             timeout = 1800
         else:
             timeout = 600
-        storage_cluster.wait_for_phase(phase="Ready", timeout=timeout)
+
+        try:
+            storage_cluster.wait_for_phase(phase="Ready", timeout=timeout)
+        except ResourceWrongStatusException:
+            noobaa_issue = config.RUN.get("noobaa_not_ready_at_setup")
+            if not noobaa_issue:
+                raise
+
+            fresh_sc = storage_cluster.get()
+            conditions = fresh_sc.get("status", {}).get("conditions", [])
+
+            noobaa_is_cause = any(
+                c.get("reason") == constants.NOOBAA_INITIALIZING_REASON
+                and c.get("type") == "Progressing"
+                for c in conditions
+            )
+            ceph_has_issues = any(
+                c.get("reason") in constants.CEPH_CONDITION_REASONS for c in conditions
+            )
+
+            if not noobaa_is_cause or ceph_has_issues:
+                raise
+
+            namespace = config.ENV_DATA["cluster_namespace"]
+            current_nb_phase = get_noobaa_phase(namespace)
+
+            if current_nb_phase == constants.STATUS_READY:
+                config.RUN.pop("noobaa_not_ready_at_setup", None)
+                raise
+
+            if current_nb_phase != noobaa_issue.get("phase"):
+                log.warning(
+                    "NooBaa phase changed from '%s' to '%s'"
+                    " — running full verification",
+                    noobaa_issue["phase"],
+                    current_nb_phase,
+                )
+                raise
+
+            log.warning(
+                "StorageCluster not Ready due to NooBaa (phase: %s),"
+                " which was already unhealthy at test setup."
+                " Waiving SC phase check — version check still runs.",
+                current_nb_phase,
+            )
 
     # verify storage cluster version
     if not config.ENV_DATA.get("disable_storage_cluster_version_check"):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2176,6 +2176,57 @@ def health_checker(request, tier_marks_name, upgrade_marks_name):
     if "FailurePropagator" in str(node.cls):
         return
 
+    from ocs_ci.ocs.resources.storage_cluster import (
+        get_noobaa_phase,
+        get_storage_cluster_phase,
+    )
+
+    def check_noobaa_health_at_setup():
+        """
+        Check NooBaa health after Ceph health passes. Skips NooBaa-dependent
+        tests if NooBaa is not Ready, lets other tests proceed with flag set.
+        """
+        if ocsci_config.DEPLOYMENT.get("external_mode") or ocsci_config.COMPONENTS.get(
+            "disable_noobaa"
+        ):
+            return
+
+        namespace = ocsci_config.ENV_DATA["cluster_namespace"]
+        noobaa_phase = get_noobaa_phase(namespace)
+
+        if noobaa_phase is None:
+            return
+
+        if noobaa_phase == constants.STATUS_READY:
+            ocsci_config.RUN.pop("noobaa_not_ready_at_setup", None)
+            return
+
+        already_detected = bool(ocsci_config.RUN.get("noobaa_not_ready_at_setup"))
+        if not already_detected:
+            log.warning(
+                "NooBaa is in phase '%s', waiting %ds for recovery...",
+                noobaa_phase or "(no phase set)",
+                constants.NOOBAA_HEALTH_CHECK_DELAY,
+            )
+            time.sleep(constants.NOOBAA_HEALTH_CHECK_DELAY)
+            noobaa_phase = get_noobaa_phase(namespace)
+            if noobaa_phase is None or noobaa_phase == constants.STATUS_READY:
+                ocsci_config.RUN.pop("noobaa_not_ready_at_setup", None)
+                return
+
+        log.warning(
+            "NooBaa is in phase '%s', not Ready",
+            noobaa_phase or "(no phase set)",
+        )
+        ocsci_config.RUN["noobaa_not_ready_at_setup"] = {
+            "phase": noobaa_phase,
+            "test_name": node.name,
+        }
+
+        if node.get_closest_marker("mcg"):
+            ocsci_config.RUN["skipped_tests_noobaa_health"] += 1
+            pytest.skip(f"NooBaa health check failed at setup (phase: {noobaa_phase})")
+
     def finalizer():
         if not skipped:
             multi_storagecluster_external_health_passed = False
@@ -2205,6 +2256,32 @@ def health_checker(request, tier_marks_name, upgrade_marks_name):
                             "Ceph health check for multi-storagecluster external cluster passed at teardown!"
                         )
                         multi_storagecluster_external_health_passed = True
+
+                    if not ocsci_config.DEPLOYMENT.get(
+                        "external_mode"
+                    ) and not ocsci_config.COMPONENTS.get("disable_noobaa"):
+                        namespace = ocsci_config.ENV_DATA["cluster_namespace"]
+                        nb_phase = get_noobaa_phase(namespace)
+                        nb_was_broken = bool(
+                            ocsci_config.RUN.get("noobaa_not_ready_at_setup")
+                        )
+                        nb_is_broken = (
+                            nb_phase is not None and nb_phase != constants.STATUS_READY
+                        )
+
+                        if not nb_was_broken and nb_is_broken:
+                            if not ocsci_config.RUN.get("noobaa_health_failure_source"):
+                                ocsci_config.RUN["noobaa_health_failure_source"] = {
+                                    "test_name": node.name,
+                                    "phase": nb_phase,
+                                }
+                        elif nb_was_broken and nb_is_broken:
+                            log.info(
+                                "NooBaa still not Ready at teardown (phase: %s)",
+                                nb_phase,
+                            )
+                        elif nb_was_broken and not nb_is_broken:
+                            log.info("NooBaa recovered to Ready during test execution")
 
             except CephHealthException:
                 if not ocsci_config.RUN["skip_reason_test_found"]:
@@ -2251,6 +2328,10 @@ def health_checker(request, tier_marks_name, upgrade_marks_name):
             "cephcluster"
         ):
             log.info("Checking for Ceph Health OK ")
+            namespace = ocsci_config.ENV_DATA["cluster_namespace"]
+            sc_phase = get_storage_cluster_phase(namespace)
+            if sc_phase is not None:
+                log.info("StorageCluster phase: %s", sc_phase)
             external_multi_storagecluster_status = False
             try:
                 status = ceph_health_check_with_toolbox_recovery(
@@ -2264,6 +2345,8 @@ def health_checker(request, tier_marks_name, upgrade_marks_name):
                 if not ocsci_config.DEPLOYMENT.get("multi_storagecluster"):
                     if status:
                         log.info("Ceph health check passed at setup")
+                        if sc_phase is None or sc_phase != constants.STATUS_READY:
+                            check_noobaa_health_at_setup()
                         return
                 else:
                     external_multi_storagecluster_status = (
@@ -2273,8 +2356,19 @@ def health_checker(request, tier_marks_name, upgrade_marks_name):
                         log.info(
                             "Ceph health check passed for internal and multi-storagecluster external at setup"
                         )
+                        if sc_phase is None or sc_phase != constants.STATUS_READY:
+                            check_noobaa_health_at_setup()
                         return
             except (CephHealthException, CephHealthNotRecoveredException):
+                if sc_phase == constants.STATUS_READY:
+                    log.error(
+                        "StorageCluster reports Ready but Ceph health check"
+                        " failed — SC phase and Ceph health are inconsistent"
+                    )
+                    if not ocsci_config.RUN.get("sc_ceph_health_mismatch"):
+                        ocsci_config.RUN["sc_ceph_health_mismatch"] = {
+                            "test_name": node.name,
+                        }
                 ocsci_config.RUN["skipped_tests_ceph_health"] += 1
                 skipped = True
                 # skip because ceph is not in good health

--- a/tests/test_failure_propagator.py
+++ b/tests/test_failure_propagator.py
@@ -74,6 +74,32 @@ class TestFailurePropagator:
             f"skipped_tests_ceph_health: {config.RUN.get('skipped_tests_ceph_health')}"
         )
 
+        noobaa_failure = config.RUN.get("noobaa_health_failure_source")
+        skipped_noobaa = config.RUN.get("skipped_tests_noobaa_health", 0)
+        noobaa_summary = ""
+        if noobaa_failure or skipped_noobaa:
+            parts = []
+            if skipped_noobaa:
+                parts.append(
+                    f"{skipped_noobaa} MCG tests skipped due to NooBaa not Ready"
+                )
+            if noobaa_failure:
+                parts.append(
+                    f"NooBaa became unhealthy (phase: {noobaa_failure['phase']})"
+                    f" first detected at test: {noobaa_failure['test_name']}"
+                )
+            noobaa_summary = ". ".join(parts) + "."
+            log.warning(noobaa_summary)
+
+        sc_mismatch = config.RUN.get("sc_ceph_health_mismatch")
+        sc_mismatch_summary = ""
+        if sc_mismatch:
+            sc_mismatch_summary = (
+                f"StorageCluster reported Ready but Ceph health failed"
+                f" (first detected at test: {sc_mismatch['test_name']})."
+            )
+            log.warning(sc_mismatch_summary)
+
         if number_of_eligible_tests > 0:
             config.RUN["skipped_on_ceph_health_ratio"] = round(
                 (
@@ -110,8 +136,18 @@ class TestFailurePropagator:
                     message = (
                         message + " Couldn't identify the test case that caused this"
                     )
+                if noobaa_summary:
+                    message = message + f". {noobaa_summary}"
+                if sc_mismatch_summary:
+                    message = message + f". {sc_mismatch_summary}"
                 config.RUN["display_skipped_msg_in_email"] = message
                 pytest.fail(message)
+
+        health_summary = " ".join(
+            part for part in (noobaa_summary, sc_mismatch_summary) if part
+        )
+        if health_summary and not config.RUN.get("display_skipped_msg_in_email"):
+            config.RUN["display_skipped_msg_in_email"] = health_summary
 
     @pytest.mark.order("last")
     def test_failure_propagator(self):


### PR DESCRIPTION
Fixes https://github.com/red-hat-storage/ocs-ci/issues/1962

## Summary

- Add NooBaa CR phase check to `health_checker` setup alongside the existing Ceph health check
- Skip NooBaa-dependent tests (`tests/functional/object/`) when NooBaa is not Ready; let Ceph tests proceed
- Modify `verify_storage_cluster()` to skip SC phase verification when NooBaa was already unhealthy at test setup, preventing misleading teardown failures
- Track NooBaa health state in `config.RUN` for `failure_propagator` reporting

The skip in `verify_storage_cluster()` is guarded by 4 safety conditions: the NooBaa flag must be set, `NoobaaInitializing` must be the Progressing reason, no CephCluster conditions present, and NooBaa phase must match what was recorded at setup.

## Test plan

- [x] Run tier1 on healthy cluster — verify no behavior change (+1 API call per test)
- [ ] Simulate NooBaa failure (scale down noobaa-core-0) — verify MCG tests skip, Ceph tests pass
- [ ] Verify flag clears when NooBaa recovers between tests
- [ ] Verify `verify_storage_cluster()` re-raises when Ceph has issues alongside NooBaa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Added NooBaa/Ceph health gating at test setup to detect NooBaa initialization delays and adjust which health checks run.
  * Introduced new runtime configuration flags to track NooBaa readiness, health-failure origin, and Ceph health mismatch context.
  * Enhanced failure reporting to append NooBaa and Ceph mismatch summaries to skip/failure messages and email-visible output.

* **Tests**
  * Updated health-check fixture logic to record NooBaa phase at setup, re-evaluate at teardown, and conditionally skip affected tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->