### PR TITLE
KMM deployment and image registry pvc

### DIFF
--- a/conf/ocsci/kmm_deployment/image_registry_pvc.yaml
+++ b/conf/ocsci/kmm_deployment/image_registry_pvc.yaml
@@ -1,0 +1,6 @@
+DEPLOYMENT:
+  image_registry_pvc_deployment: True
+  image_registry_pvc_size: "100Gi"
+  image_registry_pvc_storageclass: "thin-csi"
+
+# Made with Bob

--- a/conf/ocsci/kmm_deployment/kmm_deployment.yaml
+++ b/conf/ocsci/kmm_deployment/kmm_deployment.yaml
@@ -1,0 +1,4 @@
+DEPLOYMENT:
+  kmm_deployment: True
+
+# Made with Bob

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -208,6 +208,8 @@ from ocs_ci.helpers.helpers import (
 from ocs_ci.ocs.ui.helpers_ui import ui_deployment_conditions
 from ocs_ci.utility.ibmcloud import run_ibmcloud_cmd
 from ocs_ci.deployment.cnv import CNVInstaller
+from ocs_ci.deployment.kmm import deploy_kmm_operator
+from ocs_ci.deployment.image_registry import configure_image_registry_with_pvc
 
 logger = logging.getLogger(__name__)
 
@@ -1061,6 +1063,28 @@ class Deployment(object):
             except Exception as err:
                 logger.warning(
                     f"iSCSI setup failed: {err}. Continuing with deployment..."
+                )
+
+        # Deploy KMM operator if configured
+        if config.DEPLOYMENT.get("kmm_deployment"):
+            try:
+                logger.info("Deploying KMM operator after OCP deployment...")
+                deploy_kmm_operator()
+            except Exception as err:
+                logger.warning(
+                    f"KMM operator deployment failed: {err}. Continuing with deployment..."
+                )
+
+        # Configure image registry with PVC if configured
+        if config.DEPLOYMENT.get("image_registry_pvc_deployment"):
+            try:
+                logger.info(
+                    "Configuring image registry with PVC after OCP deployment..."
+                )
+                configure_image_registry_with_pvc()
+            except Exception as err:
+                logger.warning(
+                    f"Image registry PVC configuration failed: {err}. Continuing with deployment..."
                 )
 
     def label_and_taint_nodes(self):

--- a/ocs_ci/deployment/image_registry.py
+++ b/ocs_ci/deployment/image_registry.py
@@ -258,7 +258,7 @@ class ImageRegistryConfigurator(object):
         ocp = OCP(kind="pod", namespace=self.namespace)
 
         ocp.wait_for_resource(
-            condition="Ready",
+            condition="Running",
             selector=constants.OPENSHIFT_IMAGE_SELECTOR,
             timeout=timeout,
             sleep=15,

--- a/ocs_ci/deployment/image_registry.py
+++ b/ocs_ci/deployment/image_registry.py
@@ -1,0 +1,397 @@
+"""
+This module contains functionality required for configuring OpenShift internal image registry
+with PVC storage backend.
+"""
+
+import logging
+import tempfile
+import time
+
+from ocs_ci.framework import config
+from ocs_ci.ocs.exceptions import CommandFailed
+from ocs_ci.ocs.ocp import OCP
+from ocs_ci.ocs import constants
+from ocs_ci.utility import templating
+from ocs_ci.utility.utils import run_cmd, exec_cmd
+from ocs_ci.ocs import exceptions
+from ocs_ci.utility.utils import TimeoutSampler
+
+logger = logging.getLogger(__name__)
+
+
+class ImageRegistryConfigurator(object):
+    """
+    Image Registry Configurator class for configuring internal image registry with PVC
+    """
+
+    def __init__(self):
+        self.namespace = constants.OPENSHIFT_IMAGE_REGISTRY_NAMESPACE
+        self.registry_config_name = "cluster"
+        self.pvc_name = "image-registry-storage"
+
+    def check_registry_storage_type(self):
+        """
+        Check the current storage type of the image registry
+
+        Returns:
+            dict: Storage configuration of the image registry
+        """
+        logger.info("Checking current image registry storage configuration")
+        ocp = OCP(
+            kind="configs.imageregistry.operator.openshift.io",
+            resource_name=self.registry_config_name,
+        )
+        try:
+            storage_config = ocp.exec_oc_cmd(
+                f"get configs.imageregistry.operator.openshift.io {self.registry_config_name} "
+                "-o jsonpath='{.spec.storage}'"
+            )
+            logger.info(f"Current storage configuration: {storage_config}")
+            return storage_config
+        except CommandFailed as e:
+            logger.error(f"Failed to get image registry storage configuration: {e}")
+            raise
+
+    def is_registry_using_emptydir(self):
+        """
+        Check if the image registry is using emptyDir storage
+
+        Returns:
+            bool: True if using emptyDir, False otherwise
+        """
+        storage_config = self.check_registry_storage_type()
+        if "emptyDir" in str(storage_config):
+            logger.info("Image registry is currently using emptyDir storage")
+            return True
+        logger.info("Image registry is not using emptyDir storage")
+        return False
+
+    def is_registry_using_pvc(self):
+        """
+        Check if the image registry is already using PVC storage
+
+        Returns:
+            bool: True if using PVC, False otherwise
+        """
+        storage_config = self.check_registry_storage_type()
+        if "pvc" in str(storage_config).lower():
+            logger.info("Image registry is already using PVC storage")
+            return True
+        logger.info("Image registry is not using PVC storage")
+        return False
+
+    def check_pvc_exists(self):
+        """
+        Check if the image registry PVC already exists
+
+        Returns:
+            bool: True if PVC exists, False otherwise
+        """
+        logger.info(
+            f"Checking if PVC {self.pvc_name} exists in namespace {self.namespace}"
+        )
+        ocp = OCP(kind="pvc", namespace=self.namespace)
+        try:
+            pvc = ocp.get(resource_name=self.pvc_name)
+            if pvc:
+                logger.info(f"PVC {self.pvc_name} already exists")
+                return True
+        except (CommandFailed, exceptions.CommandFailed):
+            logger.info(f"PVC {self.pvc_name} does not exist")
+            return False
+
+    def create_image_registry_pvc(self, storage_class=None, size=None):
+        """
+        Create PVC for image registry storage
+
+        Args:
+            storage_class (str): Storage class name to use for PVC
+            size (str): Size of the PVC (e.g., "100Gi")
+
+        Raises:
+            CommandFailed: If PVC creation fails
+        """
+        if self.check_pvc_exists():
+            logger.info(f"PVC {self.pvc_name} already exists, skipping creation")
+            return
+
+        # Get storage class and size from config or use defaults
+        storage_class = storage_class or config.DEPLOYMENT.get(
+            "image_registry_pvc_storageclass", "thin-csi"
+        )
+        size = size or config.DEPLOYMENT.get("image_registry_pvc_size", "100Gi")
+
+        logger.info(
+            f"Creating PVC {self.pvc_name} with storage class {storage_class} and size {size}"
+        )
+
+        pvc_data = {
+            "apiVersion": "v1",
+            "kind": "PersistentVolumeClaim",
+            "metadata": {"name": self.pvc_name, "namespace": self.namespace},
+            "spec": {
+                "accessModes": ["ReadWriteOnce"],
+                "resources": {"requests": {"storage": size}},
+                "storageClassName": storage_class,
+            },
+        }
+
+        pvc_manifest = tempfile.NamedTemporaryFile(
+            mode="w+", prefix="image_registry_pvc", delete=False
+        )
+        templating.dump_data_to_temp_yaml(pvc_data, pvc_manifest.name)
+
+        try:
+            run_cmd(f"oc apply -f {pvc_manifest.name}")
+            logger.info(f"PVC {self.pvc_name} created successfully")
+        except CommandFailed as e:
+            logger.error(f"Failed to create PVC: {e}")
+            raise
+
+        # Wait for PVC to be bound
+        self.wait_for_pvc_bound()
+
+    def wait_for_pvc_bound(self, timeout=300):
+        """
+        Wait for the PVC to be in Bound state
+
+        Args:
+            timeout (int): Timeout in seconds
+
+        Raises:
+            TimeoutExpiredError: If PVC does not reach Bound state within timeout
+        """
+        logger.info(f"Waiting for PVC {self.pvc_name} to be Bound")
+        ocp = OCP(kind="pvc", namespace=self.namespace, resource_name=self.pvc_name)
+
+        try:
+            ocp.wait_for_resource(
+                condition="Bound",
+                resource_name=self.pvc_name,
+                timeout=timeout,
+                sleep=10,
+            )
+            logger.info(f"PVC {self.pvc_name} is now Bound")
+        except Exception:
+            # Alternative wait method using TimeoutSampler
+            for sample in TimeoutSampler(timeout, 10, ocp.get):
+                status = sample.get("status", {}).get("phase")
+                if status == "Bound":
+                    logger.info(f"PVC {self.pvc_name} is now Bound")
+                    return
+                logger.debug(f"PVC status: {status}, waiting for Bound state")
+            raise exceptions.TimeoutExpiredError(
+                f"PVC {self.pvc_name} did not reach Bound state within {timeout} seconds"
+            )
+
+    def patch_image_registry_to_use_pvc(self):
+        """
+        Patch the image registry configuration to use PVC storage
+
+        Raises:
+            CommandFailed: If patching fails
+        """
+        logger.info("Patching image registry configuration to use PVC storage")
+
+        patch_cmd = (
+            f"oc patch configs.imageregistry.operator.openshift.io {self.registry_config_name} "
+            "--type=merge "
+            '--patch=\'{"spec":{"managementState":"Managed","storage":{"emptyDir":null,'
+            f'"pvc":{{"claim":"{self.pvc_name}"}}}},"replicas":1,"rolloutStrategy":"Recreate"}}\''
+        )
+
+        try:
+            result = exec_cmd(patch_cmd, shell=True)
+            if result.returncode == 0:
+                logger.info("Image registry configuration patched successfully")
+                logger.info(result.stdout.decode("utf-8") if result.stdout else "")
+            else:
+                error_msg = (
+                    result.stderr.decode("utf-8") if result.stderr else "Unknown error"
+                )
+                raise CommandFailed(f"Failed to patch image registry: {error_msg}")
+        except Exception as e:
+            logger.error(f"Failed to patch image registry configuration: {e}")
+            raise
+
+    def verify_registry_using_pvc(self, timeout=300):
+        """
+        Verify that the image registry is using PVC storage
+
+        Args:
+            timeout (int): Timeout in seconds
+
+        Returns:
+            bool: True if registry is using PVC, False otherwise
+
+        Raises:
+            TimeoutExpiredError: If verification fails within timeout
+        """
+        logger.info("Verifying that image registry is using PVC storage")
+
+        for sample in TimeoutSampler(timeout, 10, self.check_registry_storage_type):
+            storage_config = sample
+            if "pvc" in str(storage_config).lower() and "emptyDir" not in str(
+                storage_config
+            ):
+                logger.info("Image registry is successfully using PVC storage")
+                return True
+            logger.debug(
+                f"Current storage config: {storage_config}, waiting for PVC configuration"
+            )
+
+        raise exceptions.TimeoutExpiredError(
+            f"Image registry did not switch to PVC storage within {timeout} seconds"
+        )
+
+    def wait_for_registry_pods_ready(self, timeout=600):
+        """
+        Wait for image registry pods to be ready after configuration change
+
+        Args:
+            timeout (int): Timeout in seconds
+
+        Raises:
+            TimeoutExpiredError: If pods are not ready within timeout
+        """
+        logger.info("Waiting for image registry pods to be ready")
+        ocp = OCP(kind="pod", namespace=self.namespace)
+
+        try:
+            ocp.wait_for_resource(
+                condition="Ready",
+                selector=constants.OPENSHIFT_IMAGE_SELECTOR,
+                timeout=timeout,
+                sleep=15,
+            )
+            logger.info("Image registry pods are ready")
+        except Exception as e:
+            logger.warning(f"Error waiting for registry pods: {e}")
+            # Give it some more time
+            time.sleep(30)
+
+    def configure_image_registry_with_pvc(
+        self, storage_class=None, size=None, force=False
+    ):
+        """
+        Configure the internal image registry to use PVC storage
+
+        Args:
+            storage_class (str): Storage class name to use for PVC
+            size (str): Size of the PVC (e.g., "100Gi")
+            force (bool): Force reconfiguration even if already using PVC
+
+        Returns:
+            bool: True if configuration was successful, False otherwise
+        """
+        logger.info("Starting image registry PVC configuration")
+
+        # Check if already using PVC
+        if self.is_registry_using_pvc() and not force:
+            logger.info(
+                "Image registry is already using PVC storage, skipping configuration"
+            )
+            return True
+
+        # Check if using emptyDir
+        if self.is_registry_using_emptydir():
+            logger.info("Image registry is using emptyDir, will configure PVC storage")
+        else:
+            logger.info("Image registry storage type is not emptyDir")
+
+        try:
+            # Step 1: Create PVC
+            self.create_image_registry_pvc(storage_class=storage_class, size=size)
+
+            # Step 2: Patch image registry configuration
+            self.patch_image_registry_to_use_pvc()
+
+            # Step 3: Verify configuration
+            self.verify_registry_using_pvc()
+
+            # Step 4: Wait for registry pods to be ready
+            self.wait_for_registry_pods_ready()
+
+            logger.info("Image registry PVC configuration completed successfully")
+            return True
+
+        except Exception as e:
+            logger.error(f"Failed to configure image registry with PVC: {e}")
+            raise
+
+    def post_configuration_verification(self):
+        """
+        Perform post-configuration verification
+
+        Returns:
+            bool: True if verification passes, False otherwise
+        """
+        logger.info("Performing post-configuration verification")
+
+        try:
+            # Verify PVC exists and is bound
+            if not self.check_pvc_exists():
+                logger.error("PVC does not exist")
+                return False
+
+            ocp_pvc = OCP(
+                kind="pvc", namespace=self.namespace, resource_name=self.pvc_name
+            )
+            pvc_data = ocp_pvc.get()
+            if pvc_data and isinstance(pvc_data, dict):
+                pvc_status = pvc_data.get("status", {}).get("phase")
+                if pvc_status != "Bound":
+                    logger.error(f"PVC is not Bound, current status: {pvc_status}")
+                    return False
+            else:
+                logger.error("Failed to get PVC data")
+                return False
+
+            # Verify registry is using PVC
+            if not self.is_registry_using_pvc():
+                logger.error("Image registry is not using PVC storage")
+                return False
+
+            # Verify registry is not using emptyDir
+            if self.is_registry_using_emptydir():
+                logger.error("Image registry is still using emptyDir storage")
+                return False
+
+            logger.info("Post-configuration verification passed")
+            return True
+
+        except Exception as e:
+            logger.error(f"Post-configuration verification failed: {e}")
+            return False
+
+
+def configure_image_registry_with_pvc():
+    """
+    Configure image registry with PVC based on configuration
+
+    """
+    if config.DEPLOYMENT.get("image_registry_pvc_deployment"):
+        logger.info("Image registry PVC deployment is enabled in configuration")
+        registry_configurator = ImageRegistryConfigurator()
+
+        storage_class = config.DEPLOYMENT.get("image_registry_pvc_storageclass")
+        size = config.DEPLOYMENT.get("image_registry_pvc_size")
+
+        registry_configurator.configure_image_registry_with_pvc(
+            storage_class=storage_class, size=size
+        )
+
+        # Perform post-configuration verification
+        if registry_configurator.post_configuration_verification():
+            logger.info(
+                "Image registry PVC configuration and verification completed successfully"
+            )
+        else:
+            logger.warning(
+                "Image registry PVC configuration completed but verification failed"
+            )
+    else:
+        logger.info("Image registry PVC deployment is not enabled in configuration")
+
+
+# Made with Bob

--- a/ocs_ci/deployment/image_registry.py
+++ b/ocs_ci/deployment/image_registry.py
@@ -148,8 +148,11 @@ class ImageRegistryConfigurator(object):
             logger.error(f"Failed to create PVC: {e}")
             raise
 
-        # Wait for PVC to be bound
-        self.wait_for_pvc_bound()
+        # Note: We don't wait for PVC to be bound here because storage class uses
+        # WaitForFirstConsumer binding mode. PVC will bind when registry pod tries to use it.
+        logger.info(
+            f"PVC {self.pvc_name} created. It will bind when the image registry pod consumes it."
+        )
 
     def wait_for_pvc_bound(self, timeout=300):
         """
@@ -300,17 +303,22 @@ class ImageRegistryConfigurator(object):
             logger.info("Image registry storage type is not emptyDir")
 
         try:
-            # Step 1: Create PVC
+            # Step 1: Create PVC (it will remain in Pending state with WaitForFirstConsumer)
             self.create_image_registry_pvc(storage_class=storage_class, size=size)
 
-            # Step 2: Patch image registry configuration
+            # Step 2: Patch image registry configuration to use PVC
+            # This will trigger the registry pod to consume the PVC, causing it to bind
             self.patch_image_registry_to_use_pvc()
 
-            # Step 3: Verify configuration
-            self.verify_registry_using_pvc()
-
-            # Step 4: Wait for registry pods to be ready
+            # Step 3: Wait for registry pods to be ready (this also allows PVC to bind)
             self.wait_for_registry_pods_ready()
+
+            # Step 4: Wait for PVC to be bound (should be quick now that pod is using it)
+            logger.info("Waiting for PVC to be bound after registry pod consumes it")
+            self.wait_for_pvc_bound(timeout=300)
+
+            # Step 5: Verify configuration
+            self.verify_registry_using_pvc()
 
             logger.info("Image registry PVC configuration completed successfully")
             return True

--- a/ocs_ci/deployment/image_registry.py
+++ b/ocs_ci/deployment/image_registry.py
@@ -5,7 +5,7 @@ with PVC storage backend.
 
 import logging
 import tempfile
-import time
+import json
 
 from ocs_ci.framework import config
 from ocs_ci.ocs.exceptions import CommandFailed
@@ -167,25 +167,13 @@ class ImageRegistryConfigurator(object):
         logger.info(f"Waiting for PVC {self.pvc_name} to be Bound")
         ocp = OCP(kind="pvc", namespace=self.namespace, resource_name=self.pvc_name)
 
-        try:
-            ocp.wait_for_resource(
-                condition="Bound",
-                resource_name=self.pvc_name,
-                timeout=timeout,
-                sleep=10,
-            )
-            logger.info(f"PVC {self.pvc_name} is now Bound")
-        except Exception:
-            # Alternative wait method using TimeoutSampler
-            for sample in TimeoutSampler(timeout, 10, ocp.get):
-                status = sample.get("status", {}).get("phase")
-                if status == "Bound":
-                    logger.info(f"PVC {self.pvc_name} is now Bound")
-                    return
-                logger.debug(f"PVC status: {status}, waiting for Bound state")
-            raise exceptions.TimeoutExpiredError(
-                f"PVC {self.pvc_name} did not reach Bound state within {timeout} seconds"
-            )
+        ocp.wait_for_resource(
+            condition="Bound",
+            resource_name=self.pvc_name,
+            timeout=timeout,
+            sleep=10,
+        )
+        logger.info(f"PVC {self.pvc_name} is now Bound")
 
     def patch_image_registry_to_use_pvc(self):
         """
@@ -196,11 +184,20 @@ class ImageRegistryConfigurator(object):
         """
         logger.info("Patching image registry configuration to use PVC storage")
 
+        patch = {
+            "spec": {
+                "managementState": "Managed",
+                "storage": {
+                    "emptyDir": None,
+                    "pvc": {"claim": self.pvc_name},
+                },
+                "replicas": 1,
+                "rolloutStrategy": "Recreate",
+            }
+        }
         patch_cmd = (
             f"oc patch configs.imageregistry.operator.openshift.io {self.registry_config_name} "
-            "--type=merge "
-            '--patch=\'{"spec":{"managementState":"Managed","storage":{"emptyDir":null,'
-            f'"pvc":{{"claim":"{self.pvc_name}"}}}}, "replicas":1,"rolloutStrategy":"Recreate"}}\''
+            f"--type=merge --patch='{json.dumps(patch)}'"
         )
 
         try:
@@ -260,18 +257,13 @@ class ImageRegistryConfigurator(object):
         logger.info("Waiting for image registry pods to be ready")
         ocp = OCP(kind="pod", namespace=self.namespace)
 
-        try:
-            ocp.wait_for_resource(
-                condition="Ready",
-                selector=constants.OPENSHIFT_IMAGE_SELECTOR,
-                timeout=timeout,
-                sleep=15,
-            )
-            logger.info("Image registry pods are ready")
-        except Exception as e:
-            logger.warning(f"Error waiting for registry pods: {e}")
-            # Give it some more time
-            time.sleep(30)
+        ocp.wait_for_resource(
+            condition="Ready",
+            selector=constants.OPENSHIFT_IMAGE_SELECTOR,
+            timeout=timeout,
+            sleep=15,
+        )
+        logger.info("Image registry pods are ready")
 
     def configure_image_registry_with_pvc(
         self, storage_class=None, size=None, force=False

--- a/ocs_ci/deployment/image_registry.py
+++ b/ocs_ci/deployment/image_registry.py
@@ -200,7 +200,7 @@ class ImageRegistryConfigurator(object):
             f"oc patch configs.imageregistry.operator.openshift.io {self.registry_config_name} "
             "--type=merge "
             '--patch=\'{"spec":{"managementState":"Managed","storage":{"emptyDir":null,'
-            f'"pvc":{{"claim":"{self.pvc_name}"}}}},"replicas":1,"rolloutStrategy":"Recreate"}}\''
+            f'"pvc":{{"claim":"{self.pvc_name}"}}}}, "replicas":1,"rolloutStrategy":"Recreate"}}\''
         )
 
         try:

--- a/ocs_ci/deployment/kmm.py
+++ b/ocs_ci/deployment/kmm.py
@@ -1,0 +1,336 @@
+"""
+This module contains functionality required for KMM (Kernel Module Management) operator installation.
+"""
+
+import logging
+import tempfile
+
+from ocs_ci.framework import config
+from ocs_ci.ocs.resources.ocs import OCS
+from ocs_ci.ocs.ocp import OCP
+from ocs_ci.ocs import constants
+from ocs_ci.utility import templating
+from ocs_ci.utility.utils import run_cmd
+from ocs_ci.ocs import exceptions
+from ocs_ci.ocs.resources.install_plan import wait_for_install_plan_and_approve
+from ocs_ci.ocs.resources.csv import CSV, get_csvs_start_with_prefix
+from ocs_ci.utility.retry import retry
+from ocs_ci.utility.utils import TimeoutSampler
+from ocs_ci.ocs.resources.pod import wait_for_pods_to_be_running
+
+logger = logging.getLogger(__name__)
+
+
+class KMMInstaller(object):
+    """
+    KMM Installer class for KMM operator deployment
+    """
+
+    def __init__(self):
+        self.namespace = "openshift-kmm"
+        self.operator_name = "kernel-module-management"
+        self.subscription_name = "kernel-module-management"
+
+    def create_kmm_namespace(self):
+        """
+        Creates the namespace for KMM operator resources
+
+        Raises:
+            CommandFailed: If the 'oc create' command fails.
+        """
+        try:
+            logger.info(f"Creating namespace {self.namespace} for KMM operator")
+            namespace_data = {
+                "apiVersion": "v1",
+                "kind": "Namespace",
+                "metadata": {
+                    "name": self.namespace,
+                    "labels": {"openshift.io/cluster-monitoring": "true"},
+                },
+            }
+            namespace_yaml = OCS(**namespace_data)
+            namespace_yaml.create()
+            logger.info(f"KMM namespace {self.namespace} was created successfully")
+        except exceptions.CommandFailed as ef:
+            if f'namespaces "{self.namespace}" already exists' in str(ef):
+                logger.info(f"Namespace {self.namespace} already present")
+            else:
+                raise ef
+
+    def create_kmm_operatorgroup(self):
+        """
+        Creates an OperatorGroup for KMM operator
+
+        """
+        logger.info("Creating OperatorGroup for KMM operator")
+        operatorgroup_data = {
+            "apiVersion": "operators.coreos.com/v1",
+            "kind": "OperatorGroup",
+            "metadata": {
+                "name": "kernel-module-management",
+                "namespace": self.namespace,
+            },
+            "spec": {"targetNamespaces": [self.namespace]},
+        }
+        operatorgroup_yaml = OCS(**operatorgroup_data)
+        try:
+            operatorgroup_yaml.create()
+            logger.info("KMM OperatorGroup created successfully")
+        except exceptions.CommandFailed as ef:
+            if "kernel-module-management already exists" in str(ef):
+                logger.info("kernel-module-management OperatorGroup already exists")
+            else:
+                raise ef
+
+    def create_kmm_subscription(self):
+        """
+        Creates subscription for KMM operator
+
+        """
+        # Create an operator group for KMM
+        logger.info("Creating OperatorGroup for KMM")
+        self.create_kmm_operatorgroup()
+
+        # Get the default channel for KMM operator
+        kmm_channel = config.DEPLOYMENT.get("kmm_channel", "stable")
+
+        subscription_data = {
+            "apiVersion": "operators.coreos.com/v1alpha1",
+            "kind": "Subscription",
+            "metadata": {"name": self.subscription_name, "namespace": self.namespace},
+            "spec": {
+                "channel": kmm_channel,
+                "installPlanApproval": "Automatic",
+                "name": self.operator_name,
+                "source": constants.OPERATOR_CATALOG_SOURCE_NAME,
+                "sourceNamespace": constants.MARKETPLACE_NAMESPACE,
+            },
+        }
+
+        subscription_manifest = tempfile.NamedTemporaryFile(
+            mode="w+", prefix="kmm_subscription_manifest", delete=False
+        )
+        templating.dump_data_to_temp_yaml(subscription_data, subscription_manifest.name)
+        logger.info("Creating subscription for KMM operator")
+        retry(exceptions.CommandFailed, tries=25, delay=60, backoff=1)(run_cmd)(
+            f"oc apply -f {subscription_manifest.name}"
+        )
+
+        # Wait for subscription to be created
+        self.wait_for_the_resource_to_discover(
+            kind=constants.SUBSCRIPTION_WITH_ACM,
+            namespace=self.namespace,
+            resource_name=self.subscription_name,
+        )
+
+        # Wait for install plan and approve if needed
+        wait_for_install_plan_and_approve(self.namespace, timeout=1500)
+
+        # Wait for CSV to be ready
+        csv = None
+        for csv in TimeoutSampler(
+            timeout=900,
+            sleep=15,
+            func=get_csvs_start_with_prefix,
+            csv_prefix=self.operator_name,
+            namespace=self.namespace,
+        ):
+            if csv:
+                break
+
+        if not csv:
+            raise exceptions.TimeoutExpiredError(
+                f"Timeout waiting for CSV with prefix {self.operator_name}"
+            )
+
+        csv_name = csv[0]["metadata"]["name"]
+        csv_obj = CSV(resource_name=csv_name, namespace=self.namespace)
+        csv_obj.wait_for_phase(phase="Succeeded", timeout=900)
+        logger.info(f"KMM operator CSV {csv_name} is in Succeeded phase")
+
+    def wait_for_the_resource_to_discover(self, kind, namespace, resource_name):
+        """
+        Waits for the specified resource to be discovered.
+
+        Args:
+            kind (str): The type of the resource to wait for.
+            namespace (str): The namespace in which to wait for the resource.
+            resource_name (str): The name of the resource to wait for.
+        """
+        logger.info(f"Waiting for resource {kind} to be discovered")
+        for sample in TimeoutSampler(300, 10, OCP, kind=kind, namespace=namespace):
+            resources = sample.get().get("items", [])
+            for resource in resources:
+                found_resource_name = resource.get("metadata", {}).get("name", "")
+                if resource_name in found_resource_name:
+                    logger.info(f"{kind} found: {found_resource_name}")
+                    return
+                logger.debug(f"Still waiting for the {kind}: {resource_name}")
+
+    def kmm_operator_installed(self):
+        """
+        Check if KMM operator is already installed.
+
+        Returns:
+             bool: True if KMM operator is installed, False otherwise
+        """
+        ocp = OCP(kind=constants.SUBSCRIPTION_WITH_ACM, namespace=self.namespace)
+        return ocp.check_resource_existence(
+            timeout=12, should_exist=True, resource_name=self.subscription_name
+        )
+
+    def post_install_verification(self, raise_exception=False):
+        """
+        Performs KMM operator post-installation verification.
+
+        Args:
+            raise_exception: If True, allow function to fail the job and raise an exception.
+                           If false, return False instead of raising an exception.
+
+        Returns:
+            bool: True if the verification conditions are met, False otherwise
+
+        Raises:
+            TimeoutExpiredError: If the verification conditions are not met within the timeout
+                               and raise_exception is True.
+            ResourceNotFoundError: If the namespace does not exist and raise_exception is True.
+            ResourceWrongStatusException: If pods are not running and raise_exception is True.
+        """
+        logger.info("Performing KMM operator post-installation verification")
+
+        try:
+            OCP(kind="namespace").get(self.namespace)
+        except exceptions.CommandFailed:
+            if raise_exception:
+                raise exceptions.ResourceNotFoundError(
+                    f"Namespace {self.namespace} does not exist"
+                )
+            else:
+                logger.warning(f"Namespace {self.namespace} does not exist")
+                return False
+
+        # Wait for KMM operator pods to be running
+        if wait_for_pods_to_be_running(namespace=self.namespace, timeout=600):
+            logger.info("All KMM operator pods are running")
+        else:
+            if raise_exception:
+                raise exceptions.ResourceWrongStatusException(
+                    "Not all KMM operator pods are running"
+                )
+            else:
+                logger.warning("Not all KMM operator pods are running")
+                return False
+
+        # Verify that all the deployments in the KMM namespace are in 'Available' condition
+        logger.info(f"Verify all the deployments status in {self.namespace}")
+        ocp = OCP(kind="deployments", namespace=self.namespace)
+
+        try:
+            ocp.wait(condition="Available", timeout=600)
+        except exceptions.TimeoutExpiredError:
+            if raise_exception:
+                raise exceptions.TimeoutExpiredError(
+                    "Timeout occurred, one or more deployments did not meet condition: Available"
+                )
+            else:
+                logger.warning(
+                    "Timeout occurred, or one or more deployments did not meet condition: Available"
+                )
+                return False
+
+        logger.info(
+            f"All the deployments in the {self.namespace} namespace met condition: Available"
+        )
+        return True
+
+    def deploy_kmm_operator(self, check_kmm_deployed=False, check_kmm_ready=False):
+        """
+        Installs KMM operator.
+
+        Args:
+            check_kmm_deployed (bool): If True, check if KMM is already deployed. If so, skip the deployment.
+            check_kmm_ready (bool): If True, check if KMM is ready. If so, skip the deployment.
+        """
+        if check_kmm_deployed:
+            if self.kmm_operator_installed():
+                logger.info("KMM operator is already deployed, skipping the deployment")
+                return
+
+        if check_kmm_ready:
+            if self.post_install_verification(raise_exception=False):
+                logger.info("KMM operator ready, skipping the deployment")
+                return
+
+        logger.info("Installing KMM operator")
+        # Create KMM namespace
+        self.create_kmm_namespace()
+        # Create KMM subscription
+        self.create_kmm_subscription()
+        # Post KMM installation checks
+        self.post_install_verification(raise_exception=True)
+        logger.info("KMM operator installation completed successfully")
+
+    def uninstall_kmm_operator(self, check_kmm_installed=True):
+        """
+        Uninstall KMM operator deployment
+
+        Args:
+            check_kmm_installed (bool): True if want to check if KMM installed
+        """
+        if check_kmm_installed:
+            if not self.kmm_operator_installed():
+                logger.info("KMM operator is not installed, skipping the cleanup...")
+                return
+
+        logger.info("Removing the KMM operator subscription")
+        try:
+            kmm_sub = OCP(
+                kind=constants.SUBSCRIPTION,
+                resource_name=self.subscription_name,
+                namespace=self.namespace,
+            )
+            kmm_sub.delete(resource_name=self.subscription_name)
+            logger.info(f"Deleted subscription {self.subscription_name}")
+        except exceptions.CommandFailed as e:
+            logger.warning(f"Failed to delete subscription: {e}")
+
+        logger.info("Removing the KMM operator CSV")
+        try:
+            kmm_csv = OCP(
+                kind=constants.CLUSTER_SERVICE_VERSION,
+                namespace=self.namespace,
+            )
+            csv_data = kmm_csv.get()
+            if csv_data and isinstance(csv_data, dict):
+                csvs = csv_data.get("items", [])
+                for csv in csvs:
+                    csv_name = csv.get("metadata", {}).get("name", "")
+                    if self.operator_name in csv_name:
+                        kmm_csv.delete(resource_name=csv_name)
+                        logger.info(f"Deleted ClusterServiceVersion {csv_name}")
+        except exceptions.CommandFailed as e:
+            logger.warning(f"Failed to delete CSV: {e}")
+
+        logger.info("Removing the namespace")
+        try:
+            kmm_namespace = OCP()
+            kmm_namespace.delete_project(self.namespace)
+            logger.info(f"Deleted the namespace {self.namespace}")
+        except exceptions.CommandFailed as e:
+            logger.warning(f"Failed to delete namespace: {e}")
+
+
+def deploy_kmm_operator():
+    """
+    Deploy KMM operator based on configuration
+
+    """
+    if config.DEPLOYMENT.get("kmm_deployment"):
+        logger.info("KMM deployment is enabled in configuration")
+        kmm_installer = KMMInstaller()
+        kmm_installer.deploy_kmm_operator(check_kmm_deployed=True, check_kmm_ready=True)
+    else:
+        logger.info("KMM deployment is not enabled in configuration")
+
+
+# Made with Bob

--- a/ocs_ci/deployment/kmm.py
+++ b/ocs_ci/deployment/kmm.py
@@ -59,6 +59,7 @@ class KMMInstaller(object):
     def create_kmm_operatorgroup(self):
         """
         Creates an OperatorGroup for KMM operator
+        KMM operator requires AllNamespaces install mode, so we don't specify targetNamespaces
 
         """
         logger.info("Creating OperatorGroup for KMM operator")
@@ -69,12 +70,12 @@ class KMMInstaller(object):
                 "name": "kernel-module-management",
                 "namespace": self.namespace,
             },
-            "spec": {"targetNamespaces": [self.namespace]},
+            "spec": {},
         }
         operatorgroup_yaml = OCS(**operatorgroup_data)
         try:
             operatorgroup_yaml.create()
-            logger.info("KMM OperatorGroup created successfully")
+            logger.info("KMM OperatorGroup created successfully (AllNamespaces mode)")
         except exceptions.CommandFailed as ef:
             if "kernel-module-management already exists" in str(ef):
                 logger.info("kernel-module-management OperatorGroup already exists")

--- a/ocs_ci/deployment/kmm.py
+++ b/ocs_ci/deployment/kmm.py
@@ -12,7 +12,6 @@ from ocs_ci.ocs import constants
 from ocs_ci.utility import templating
 from ocs_ci.utility.utils import run_cmd
 from ocs_ci.ocs import exceptions
-from ocs_ci.ocs.resources.install_plan import wait_for_install_plan_and_approve
 from ocs_ci.ocs.resources.csv import CSV, get_csvs_start_with_prefix
 from ocs_ci.utility.retry import retry
 from ocs_ci.utility.utils import TimeoutSampler
@@ -123,13 +122,14 @@ class KMMInstaller(object):
             resource_name=self.subscription_name,
         )
 
-        # Wait for install plan and approve if needed
-        wait_for_install_plan_and_approve(self.namespace, timeout=1500)
-
-        # Wait for CSV to be ready
+        # Since installPlanApproval is set to Automatic, we don't need to wait for manual approval
+        # Just wait for CSV to be ready
+        logger.info(
+            "Waiting for KMM operator CSV to be created and reach Succeeded phase"
+        )
         csv = None
         for csv in TimeoutSampler(
-            timeout=900,
+            timeout=1200,
             sleep=15,
             func=get_csvs_start_with_prefix,
             csv_prefix=self.operator_name,
@@ -144,6 +144,7 @@ class KMMInstaller(object):
             )
 
         csv_name = csv[0]["metadata"]["name"]
+        logger.info(f"Found KMM operator CSV: {csv_name}")
         csv_obj = CSV(resource_name=csv_name, namespace=self.namespace)
         csv_obj.wait_for_phase(phase="Succeeded", timeout=900)
         logger.info(f"KMM operator CSV {csv_name} is in Succeeded phase")

--- a/ocs_ci/deployment/kmm.py
+++ b/ocs_ci/deployment/kmm.py
@@ -16,6 +16,7 @@ from ocs_ci.ocs.resources.csv import CSV, get_csvs_start_with_prefix
 from ocs_ci.utility.retry import retry
 from ocs_ci.utility.utils import TimeoutSampler
 from ocs_ci.ocs.resources.pod import wait_for_pods_to_be_running
+from ocs_ci.ocs.resources.packagemanifest import PackageManifest
 
 logger = logging.getLogger(__name__)
 
@@ -94,6 +95,14 @@ class KMMInstaller(object):
         # Get the default channel for KMM operator
         kmm_channel = config.DEPLOYMENT.get("kmm_channel", "stable")
 
+        catalog_source = constants.OPERATOR_CATALOG_SOURCE_NAME
+        if config.DEPLOYMENT.get("disconnected"):
+            catalog_source = PackageManifest(
+                resource_name=self.operator_name,
+            ).get()[
+                "metadata"
+            ]["labels"]["catalog"]
+
         subscription_data = {
             "apiVersion": "operators.coreos.com/v1alpha1",
             "kind": "Subscription",
@@ -102,7 +111,7 @@ class KMMInstaller(object):
                 "channel": kmm_channel,
                 "installPlanApproval": "Automatic",
                 "name": self.operator_name,
-                "source": constants.OPERATOR_CATALOG_SOURCE_NAME,
+                "source": catalog_source,
                 "sourceNamespace": constants.MARKETPLACE_NAMESPACE,
             },
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional deployment support for KMM and an internal image registry backed by a persistent volume.
  * Introduced new deployment configuration to enable these features and customize image registry PVC size and storage class.

* **Bug Fixes**
  * Deployment now continues even if KMM and image registry post-deployment steps fail (warnings are logged).
  * Added stronger verification to ensure the image registry transitions from ephemeral storage to PVC and reaches readiness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->