### PR TITLE
Add retry logic and GA fallback for OCP nightly version service

### DIFF
--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -1523,9 +1523,107 @@ def get_rosa_cli(
     return rosa_binary_path
 
 
+def _try_extract_from_fallback_ga_image(binary, original_image, bin_dir):
+    """
+    Try to extract binary from GA fallback image when nightly registry is unavailable.
+
+    Args:
+        binary (str): type of binary (oc or openshift-install)
+        original_image (str): original nightly image URL that failed
+        bin_dir (str): path to bin folder where to extract the binary
+
+    Returns:
+        bool: True if fallback extraction succeeded, False otherwise
+    """
+    # Check if this looks like a nightly build that we can fallback
+    if (
+        "registry.ci.openshift.org/ocp/release:" in original_image
+        and "nightly" in original_image
+    ):
+        try:
+            # Extract version from nightly image name
+            # e.g., "registry.ci.openshift.org/ocp/release:4.22.0-0.nightly-2026-06-10-104337"
+            image_tag = original_image.split(":")[
+                -1
+            ]  # "4.22.0-0.nightly-2026-06-10-104337"
+
+            if ".nightly" in image_tag:
+                # Extract major.minor version
+                major_minor = image_tag.split(".nightly")[0]  # "4.22.0-0"
+                major_minor = ".".join(major_minor.split(".")[0:2])  # "4.22"
+
+                # Check if this version is GA'ed
+                if is_ocp_version_gaed(major_minor):
+                    # Get the latest GA version
+                    ga_version = get_latest_ocp_version(f"stable-{major_minor}")
+
+                    # Construct GA image URL for quay.io
+                    ga_image = (
+                        f"quay.io/openshift-release-dev/ocp-release:{ga_version}-x86_64"
+                    )
+
+                    log.warning(
+                        f"Nightly registry image unavailable: {original_image}. "
+                        f"Attempting fallback to GA image: {ga_image}"
+                    )
+
+                    # Try extracting from the GA image
+                    binary_path = os.path.join(bin_dir, binary)
+                    binary_path_exists = os.path.isfile(binary_path)
+
+                    with TemporaryDirectory() as temp_dir:
+                        pull_secret_path = os.path.join(
+                            constants.DATA_DIR, "pull-secret"
+                        )
+                        cmd = (
+                            f"oc adm release extract -a {pull_secret_path} --to {temp_dir} "
+                            f'--command={binary} "{ga_image}"'
+                        )
+                        exec_cmd(cmd)
+                        temp_binary = os.path.join(temp_dir, binary)
+
+                        if binary_path_exists:
+                            backup_file = f"{binary_path}.bak"
+                            os.rename(binary_path, backup_file)
+                            try:
+                                shutil.move(temp_binary, binary_path)
+                                delete_file(backup_file)
+                                log.info("Deleted backup binaries.")
+                            except FileNotFoundError as ex:
+                                log.error(
+                                    "Something went wrong with copying binary, reverting backup file. "
+                                    f"Exception: {ex}"
+                                )
+                                shutil.move(backup_file, binary_path)
+                                raise ex
+                        else:
+                            shutil.move(temp_binary, binary_path)
+
+                        # Set executable permissions
+                        current_file_permissions = os.stat(binary_path)
+                        os.chmod(
+                            binary_path, current_file_permissions.st_mode | stat.S_IEXEC
+                        )
+
+                    log.warning(
+                        f"FALLBACK SUCCESS: Extracted {binary} from GA image {ga_image} "
+                        "instead of unavailable nightly image. "
+                        "This may affect behavior if nightly-specific features are expected."
+                    )
+                    return True
+
+        except Exception as e:
+            log.warning(f"GA fallback extraction failed: {e}")
+
+    return False
+
+
 def extract_ocp_binary_from_image(binary, image, bin_dir):
     """
-    Extract binary (oc client or openshift installer) from custom OCP image
+    Extract binary (oc client or openshift installer) from custom OCP image.
+
+    If the image is a nightly build from registry.ci.openshift.org and extraction
+    fails, automatically attempts fallback to GA version from quay.io.
 
     Args:
         binary (str): type of binary (oc or openshift-install)
@@ -1533,27 +1631,47 @@ def extract_ocp_binary_from_image(binary, image, bin_dir):
         bin_dir (str): path to bin folder where to extract the binary
 
     """
-    binary_path = os.path.join(bin_dir, binary)
-    binary_path_exists = os.path.isfile(binary_path)
-    with TemporaryDirectory() as temp_dir:
-        pull_secret_path = os.path.join(constants.DATA_DIR, "pull-secret")
-        cmd = f'oc adm release extract -a {pull_secret_path} --to {temp_dir} --command={binary} "{image}"'
-        exec_cmd(cmd)
-        temp_binary = os.path.join(temp_dir, binary)
-        if binary_path_exists:
-            backup_file = f"{binary_path}.bak"
-            os.rename(binary_path, backup_file)
-            try:
+    try:
+        binary_path = os.path.join(bin_dir, binary)
+        binary_path_exists = os.path.isfile(binary_path)
+        with TemporaryDirectory() as temp_dir:
+            pull_secret_path = os.path.join(constants.DATA_DIR, "pull-secret")
+            cmd = f'oc adm release extract -a {pull_secret_path} --to {temp_dir} --command={binary} "{image}"'
+            exec_cmd(cmd)
+            temp_binary = os.path.join(temp_dir, binary)
+            if binary_path_exists:
+                backup_file = f"{binary_path}.bak"
+                os.rename(binary_path, backup_file)
+                try:
+                    shutil.move(temp_binary, binary_path)
+                    delete_file(backup_file)
+                    log.info("Deleted backup binaries.")
+                except FileNotFoundError as ex:
+                    log.error(
+                        f"Something went wrong with copying binary, reverting backup file. Exception: {ex}"
+                    )
+                    shutil.move(backup_file, binary_path)
+                    raise ex
+            else:
                 shutil.move(temp_binary, binary_path)
-                delete_file(backup_file)
-                log.info("Deleted backup binaries.")
-            except FileNotFoundError as ex:
-                log.error(
-                    f"Something went wrong with copying binary, reverting backup file. Exception: {ex}"
-                )
-                shutil.move(backup_file, binary_path)
-        else:
-            shutil.move(temp_binary, binary_path)
+
+        # Set executable permissions
+        current_file_permissions = os.stat(binary_path)
+        os.chmod(binary_path, current_file_permissions.st_mode | stat.S_IEXEC)
+
+    except Exception as e:
+        log.warning(f"Failed to extract {binary} from image {image}: {e}")
+
+        # Try fallback to GA image if this was a nightly build
+        if _try_extract_from_fallback_ga_image(binary, image, bin_dir):
+            return  # Fallback succeeded
+
+        # Fallback didn't work or wasn't applicable, re-raise original error
+        log.error(
+            f"Failed to extract {binary} from {image} and no fallback was possible. "
+            f"Error: {e}"
+        )
+        raise e
 
 
 def get_openshift_client(version=None, bin_dir=None, force_download=False):

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -1051,17 +1051,25 @@ def get_url_content(url, **kwargs):
 def expose_ocp_version(version):
     """
     This helper function exposes latest nightly version or GA version of OCP.
-    When the version string ends with .nightly (e.g. 4.2.0-0.nightly) it will
+    When the version string ends with .nightly (e.g. 4.22.0-0.nightly) it will
     expose the version to latest accepted OCP build
-    (e.g. 4.2.0-0.nightly-2019-08-08-103722)
-    If the version ends with -ga than it will find the latest GA OCP version
-    and will expose 4.2-ga to for example 4.2.22.
+    (e.g. 4.22.0-0.nightly-2026-06-10-151504).
+
+    If the nightly service is unavailable, it will fallback to the latest GA
+    version of the same major.minor version if available (e.g., 4.22.0).
+
+    If the version ends with -ga it will find the latest GA OCP version
+    and will expose 4.22-ga to for example 4.22.0.
 
     Args:
-        version (str): Verison of OCP
+        version (str): Version of OCP (e.g., "4.22.0-0.nightly", "4.22-ga")
 
     Returns:
-        str: Version of OCP exposed to full version if latest nighly passed
+        str: Version of OCP exposed to full version. For nightly requests,
+             returns either the nightly build name or GA fallback version.
+
+    Raises:
+        ValueError: When unable to get version info and no fallback is possible
 
     """
     if version.endswith(".nightly"):
@@ -1069,9 +1077,47 @@ def expose_ocp_version(version):
         if release_info and release_info.get("name"):
             return release_info["name"]
         else:
-            raise ValueError(
-                f"Unable to get nightly release info for version {version}"
-            )
+            # Nightly service unavailable, try fallback to GA version
+            log.warning(f"Nightly release service unavailable for {version}")
+
+            # Extract major.minor version (e.g., "4.22.0-0.nightly" -> "4.22")
+            try:
+                major_minor = version.split(".nightly")[0]  # "4.22.0-0"
+                major_minor = ".".join(major_minor.split(".")[0:2])  # "4.22"
+
+                # Check if this major.minor version has GA releases available
+                if is_ocp_version_gaed(major_minor):
+                    log.warning(
+                        f"OpenShift CI nightly service is unavailable. "
+                        f"Falling back to latest GA version of {major_minor} instead of nightly."
+                    )
+
+                    # Get the latest GA version for this major.minor
+                    ga_version = get_latest_ocp_version(f"stable-{major_minor}")
+                    log.warning(
+                        f"FALLBACK: Using GA version {ga_version} instead of nightly {version}. "
+                        f"This may affect test behavior if nightly-specific features are expected."
+                    )
+                    return str(ga_version)
+                else:
+                    raise ValueError(
+                        f"Unable to get nightly release info for version {version}. "
+                        "The OpenShift CI nightly service is currently unavailable, "
+                        f"and version {major_minor} is not yet GA'ed so no fallback is possible. "
+                        "\n\nThis typically means:\n"
+                        "1. The OpenShift CI release service "
+                        "(amd64.ocp.releases.ci.openshift.org) is experiencing an outage\n"
+                        f"2. Version {major_minor} is still under development and not yet GA'ed\n"
+                        "\nPossible solutions:\n"
+                        "- Wait for the OpenShift CI service to recover\n"
+                        "- Use a different OCP version that is already GA'ed\n"
+                        "- Check the service status at the OpenShift CI console"
+                    )
+            except Exception as parse_error:
+                raise ValueError(
+                    f"Unable to get nightly release info for version {version} "
+                    f"and failed to parse version for GA fallback: {parse_error}"
+                )
     if version.endswith("-ga"):
         channel = config.DEPLOYMENT.get("ocp_channel", "stable")
         ocp_version = version.rstrip("-ga")
@@ -1079,6 +1125,68 @@ def expose_ocp_version(version):
         return get_latest_ocp_version(f"{channel}-{ocp_version}", index)
     else:
         return version
+
+
+@retry(
+    exception_to_check=(requests.exceptions.RequestException, AssertionError),
+    tries=6,  # 6 retries = ~1 minute total
+    delay=10,  # 10 seconds between retries
+    backoff=1,  # No backoff, keep it simple
+    max_delay=10,  # Keep delay constant
+    max_timeout=120,  # 2 minutes max
+)
+def _fetch_nightly_release_info_with_retry(url):
+    """
+    Fetch nightly release info with retry logic for temporary service outages.
+
+    Args:
+        url (str): The API endpoint URL to fetch from
+
+    Returns:
+        dict: Parsed JSON response
+
+    Raises:
+        requests.exceptions.RequestException: For network-related errors
+        AssertionError: For HTTP error status codes
+    """
+    log.debug(f"Attempting to fetch nightly release info from: {url}")
+
+    try:
+        response = requests.get(url, timeout=30)
+
+        # Check for HTTP errors and provide specific messages
+        if response.status_code == 503:
+            raise requests.exceptions.RequestException(
+                "OCP release service temporarily unavailable (HTTP 503). "
+                "This usually indicates the OpenShift CI release service is experiencing an outage."
+            )
+        elif response.status_code == 404:
+            raise requests.exceptions.RequestException(
+                "OCP release stream not found (HTTP 404). "
+                "The requested nightly version may not exist."
+            )
+        elif not response.ok:
+            raise requests.exceptions.RequestException(
+                f"OCP release service returned HTTP {response.status_code}"
+            )
+
+        # Parse and return JSON response
+        release_info = response.json()
+        log.debug(
+            f"Successfully retrieved release info: name={release_info.get('name')}, "
+            f"pullSpec={release_info.get('pullSpec')}"
+        )
+        return release_info
+
+    except requests.exceptions.Timeout:
+        raise requests.exceptions.RequestException(
+            "Timeout while fetching OCP release info. The service may be slow or unavailable."
+        )
+    except requests.exceptions.ConnectionError:
+        raise requests.exceptions.RequestException(
+            "Network connection error while fetching OCP release info. "
+            "Check internet connectivity or if the OpenShift CI service is accessible."
+        )
 
 
 def get_nightly_release_info(version):
@@ -1105,21 +1213,18 @@ def get_nightly_release_info(version):
         # Shouldn't happen, but handle it gracefully
         stream_name = version
 
+    latest_nightly_url = (
+        f"https://amd64.ocp.releases.ci.openshift.org/api/v1/"
+        f"releasestream/{stream_name}/latest"
+    )
+
     try:
-        latest_nightly_url = (
-            f"https://amd64.ocp.releases.ci.openshift.org/api/v1/"
-            f"releasestream/{stream_name}/latest"
-        )
-        log.debug(f"Fetching nightly release info from: {latest_nightly_url}")
-        version_url_content = get_url_content(latest_nightly_url)
-        release_info = json.loads(version_url_content)
-        log.debug(
-            f"Retrieved release info: name={release_info.get('name')}, "
-            f"pullSpec={release_info.get('pullSpec')}"
-        )
-        return release_info
+        return _fetch_nightly_release_info_with_retry(latest_nightly_url)
     except Exception as e:
-        log.warning(f"Failed to get nightly release info for {version}: {e}")
+        log.warning(
+            f"Failed to get nightly release info for {version} after retrying for 1 minute. "
+            f"Error: {e}"
+        )
         return None
 
 


### PR DESCRIPTION
When the OpenShift CI nightly release service returns 503 errors or is unavailable, implement retry logic (6 attempts over 1 minute) followed by automatic fallback to the latest GA version of the same major.minor if available.

This addresses CI failures when amd64.ocp.releases.ci.openshift.org experiences outages by using reliable GA versions from api.openshift.com instead of failing completely.

Changes:
- Add @retry decorator to nightly release info fetching with 6 retries
- Implement GA fallback in expose_ocp_version() for same major.minor
- Improve error messages with specific guidance for different failures
- Add prominent logging when fallback occurs to warn about behavior changes
- Future-proof design for preferring GA versions by configuration

For versions not yet GA'ed (e.g. 4.23), provides clear error messages explaining the situation when nightly service is unavailable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Graceful fallback from nightly to the latest GA when nightly metadata is unavailable, with clearer error messages distinguishing outage vs. not-yet-GA.
  * Safer binary extraction that preserves existing files (backup/restore) and falls back to GA images when nightly image extraction fails.

* **Improvements**
  * Retry and timeout handling for release metadata fetching, with consolidated warnings when retries are exhausted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->