### PR TITLE
Add invalid forceful deployment key test, wipe-devices helper, and no-wipe verification

### DIFF
--- a/conf/deployment/vsphere/upi_1az_rhcos_vsan_lso_vmdk_3m_3w_ui_invalid_forceful_key.yaml
+++ b/conf/deployment/vsphere/upi_1az_rhcos_vsan_lso_vmdk_3m_3w_ui_invalid_forceful_key.yaml
@@ -1,0 +1,29 @@
+---
+# Deploys an LSO-backed ODF cluster via the UI on vSphere UPI (VMDK, 3m/3w).
+# Simulates pre-existing unencrypted bluestore OSDs on the worker disks before
+# deployment (simulate_bluestore_label), skips disk cleanup so the simulation
+# data is preserved, then tests that typing an invalid (non-"CONFIRM") string
+# into the forceful deployment confirmation input disables the Next button.
+# The checkbox is unchecked after the negative test so deployment proceeds
+# normally without forceful deployment.
+DEPLOYMENT:
+  allow_lower_instance_requirements: false
+  local_storage: true
+  type: 'VMDK'
+  provision_type: 'thick'
+  ui_deployment: true
+  odf_forceful_deployment: false
+  test_forceful_deployment_invalid_key: true
+ENV_DATA:
+  platform: 'vsphere'
+  deployment_type: 'upi'
+  worker_replicas: 3
+  master_replicas: 3
+  worker_num_cpus: '16'
+  master_num_cpus: '4'
+  master_memory: '16384'
+  compute_memory: '65536'
+  fio_storageutilization_min_mbps: 10.0
+  skip_disks_cleanup: true
+  simulate_bluestore_label: true
+  encryption_at_rest: false

--- a/conf/deployment/vsphere/upi_1az_rhcos_vsan_lso_vmdk_3m_3w_ui_invalid_forceful_key.yaml
+++ b/conf/deployment/vsphere/upi_1az_rhcos_vsan_lso_vmdk_3m_3w_ui_invalid_forceful_key.yaml
@@ -1,9 +1,7 @@
 ---
 # Deploys an LSO-backed ODF cluster via the UI on vSphere UPI (VMDK, 3m/3w).
-# Simulates pre-existing unencrypted bluestore OSDs on the worker disks before
-# deployment (simulate_bluestore_label), skips disk cleanup so the simulation
-# data is preserved, then tests that typing an invalid (non-"CONFIRM") string
-# into the forceful deployment confirmation input disables the Next button.
+# Tests that typing an invalid (non-"CONFIRM") string into the forceful
+# deployment confirmation input disables the Next button.
 # The checkbox is unchecked after the negative test so deployment proceeds
 # normally without forceful deployment.
 DEPLOYMENT:
@@ -24,6 +22,4 @@ ENV_DATA:
   master_memory: '16384'
   compute_memory: '65536'
   fio_storageutilization_min_mbps: 10.0
-  skip_disks_cleanup: true
-  simulate_bluestore_label: true
   encryption_at_rest: false

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -2278,6 +2278,18 @@ class Deployment(object):
                 assert (
                     verify_wipe_devices_from_other_clusters()
                 ), "Wipe devices from other clusters verification failed"
+            else:
+                from ocs_ci.deployment.helpers.ceph_cluster import (
+                    verify_no_wipe_devices_from_other_clusters,
+                )
+
+                logger.info(
+                    "Verify no wipe of foreign bluestore data occurred "
+                    "(StorageCluster CR flag and OSD prepare logs)"
+                )
+                assert (
+                    verify_no_wipe_devices_from_other_clusters()
+                ), "No-wipe verification failed"
 
             if not config.COMPONENTS["disable_cephfs"]:
                 # Check for CephFilesystem creation in ocp

--- a/ocs_ci/deployment/helpers/ceph_cluster.py
+++ b/ocs_ci/deployment/helpers/ceph_cluster.py
@@ -485,6 +485,90 @@ def simulate_full_ceph_bluestore_process_on_wnodes(
     return True
 
 
+def get_wipe_devices_from_other_clusters_flag():
+    """
+    Read the ``wipeDevicesFromOtherClusters`` flag from the StorageCluster CR.
+
+    Returns:
+        object: The raw value of
+            ``spec.managedResources.cephCluster.cleanupPolicy
+            .wipeDevicesFromOtherClusters`` — ``True``, ``False``, or
+            ``None`` when the key is absent.
+
+    """
+    from ocs_ci.ocs.resources.storage_cluster import get_storage_cluster
+
+    sc_obj = get_storage_cluster()
+    sc_data = sc_obj.get(resource_name=constants.DEFAULT_STORAGE_CLUSTER)
+    return (
+        sc_data.get("spec", {})
+        .get("managedResources", {})
+        .get("cephCluster", {})
+        .get("cleanupPolicy", {})
+        .get("wipeDevicesFromOtherClusters")
+    )
+
+
+def verify_no_wipe_devices_from_other_clusters():
+    """
+    Verify that no bluestore wipe of foreign OSD data occurred when neither
+    ``wipe_devices_from_other_clusters`` nor ``odf_forceful_deployment`` was
+    requested.
+
+    Performs two checks:
+
+    1. **StorageCluster CR** — asserts that
+       ``spec.managedResources.cephCluster.cleanupPolicy.wipeDevicesFromOtherClusters``
+       is **not** ``true``.
+
+    2. **OSD prepare logs** — checks each ``rook-ceph-osd-prepare`` pod and
+       asserts that the following pattern is **absent**:
+
+       - ``completed wiping OSD <id> device "<dev>" belonging to a different
+         ceph cluster`` — would indicate an unexpected wipe occurred
+
+    Returns:
+        bool: True if both checks pass (no wipe found), False otherwise.
+
+    """
+    from ocs_ci.ocs.resources.pod import get_osd_prepare_pods, get_pod_logs
+
+    # Check 1: StorageCluster CR flag must not be True
+    flag = get_wipe_devices_from_other_clusters_flag()
+    if flag is True:
+        logger.error(
+            "StorageCluster wipeDevicesFromOtherClusters is True"
+            " but wipe was not requested"
+        )
+        return False
+    logger.info(
+        "StorageCluster wipeDevicesFromOtherClusters is %r — no wipe expected",
+        flag,
+    )
+
+    # Check 2: wipe pattern must be absent from OSD prepare pod logs
+    wipe_pattern = re.compile(
+        r'completed wiping OSD \d+ device ".+" belonging to a'
+        r" different ceph cluster"
+    )
+    osd_prepare_pods = get_osd_prepare_pods()
+    if not osd_prepare_pods:
+        logger.warning("No rook-ceph-osd-prepare pods found")
+        return True
+
+    for pod in osd_prepare_pods:
+        logs = get_pod_logs(pod.name)
+        if wipe_pattern.search(logs):
+            logger.error(
+                "Unexpected wipe of foreign bluestore data found in pod %r logs",
+                pod.name,
+            )
+            return False
+
+    logger.info("Confirmed: no bluestore wipe in OSD prepare logs")
+    return True
+
+
 def verify_wipe_devices_from_other_clusters():
     """
     Verify that the cluster correctly wiped pre-existing bluestore OSDs from
@@ -512,18 +596,9 @@ def verify_wipe_devices_from_other_clusters():
 
     """
     from ocs_ci.ocs.resources.pod import get_osd_prepare_pods, get_pod_logs
-    from ocs_ci.ocs.resources.storage_cluster import get_storage_cluster
 
     # Check 1: StorageCluster CR flag
-    sc_obj = get_storage_cluster()
-    sc_data = sc_obj.get(resource_name=constants.DEFAULT_STORAGE_CLUSTER)
-    flag = (
-        sc_data.get("spec", {})
-        .get("managedResources", {})
-        .get("cephCluster", {})
-        .get("cleanupPolicy", {})
-        .get("wipeDevicesFromOtherClusters")
-    )
+    flag = get_wipe_devices_from_other_clusters_flag()
     if flag is True:
         logger.info("StorageCluster has wipeDevicesFromOtherClusters set to true")
     else:

--- a/ocs_ci/ocs/resources/csv.py
+++ b/ocs_ci/ocs/resources/csv.py
@@ -46,6 +46,8 @@ def get_csvs_start_with_prefix(csv_prefix, namespace):
 
     """
 
+    if not OCP(kind=constants.NAMESPACE).is_exist(resource_name=namespace):
+        return []
     csvs = CSV(namespace=namespace)
     csv_list = csvs.get()["items"]
     return [csv for csv in csv_list if csv["metadata"]["name"].startswith(csv_prefix)]

--- a/ocs_ci/ocs/ui/deployment_ui.py
+++ b/ocs_ci/ocs/ui/deployment_ui.py
@@ -558,7 +558,7 @@ class DeploymentUI(PageNavigator):
         Verify that typing an invalid confirmation string blocks the Next
         button, then undo the checkbox.
 
-        Enables the forceful deployment checkbox, sends a random 4-7
+        Enables the forceful deployment checkbox, sends a random 5-8
         character string to the confirmation input (not ``"CONFIRM"``),
         asserts that the Next button is greyed out (the UI must reject
         the invalid key), and finally unchecks the checkbox so deployment
@@ -584,13 +584,7 @@ class DeploymentUI(PageNavigator):
             text=invalid_key,
         )
         self.take_screenshot("odf_forceful_deployment_invalid_key")
-        # The disabled attribute lives on the <button>, not the inner <span>
-        # matched by dep_loc["next"], so check the button element directly.
-        _next_btn = (
-            "button.pf-v6-c-button.pf-m-primary",
-            By.CSS_SELECTOR,
-        )
-        assert self.is_element_greyed_out(_next_btn), (
+        assert self.is_element_greyed_out(self.dep_loc["next_button_element"]), (
             "Next button should be disabled when an invalid confirmation"
             " key is typed for forceful deployment"
         )

--- a/ocs_ci/ocs/ui/deployment_ui.py
+++ b/ocs_ci/ocs/ui/deployment_ui.py
@@ -168,6 +168,12 @@ class DeploymentUI(PageNavigator):
 
         """
         if config.DEPLOYMENT.get("local_storage"):
+            if csv.get_csvs_start_with_prefix(
+                constants.LOCAL_STORAGE_OPERATOR_NAME,
+                constants.LOCAL_STORAGE_NAMESPACE,
+            ):
+                logger.info("Local Storage operator already installed, skipping")
+                return
             self.navigate_operatorhub_page()
             logger.info(f"Search {self.operator_name} Operator")
             self.do_send_keys(self.dep_loc["search_operators"], text="Local Storage")
@@ -395,6 +401,13 @@ class DeploymentUI(PageNavigator):
                 )
             self.enable_forceful_deployment()
 
+        if config.DEPLOYMENT.get("test_forceful_deployment_invalid_key"):
+            if "enable_forceful_deployment" not in self.dep_loc:
+                raise ConfigurationError(
+                    "Forceful deployment UI automation is supported only on ODF/OCP 4.22+."
+                )
+            self.enable_forceful_deployment_invalid_key()
+
         if config.DEPLOYMENT.get("ec_default_pools"):
             if "use_erasure_coding" not in self.dep_loc:
                 raise ConfigurationError(
@@ -540,17 +553,71 @@ class DeploymentUI(PageNavigator):
         )
         self.take_screenshot("odf_forceful_deployment_enabled")
 
+    def enable_forceful_deployment_invalid_key(self):
+        """
+        Verify that typing an invalid confirmation string blocks the Next
+        button, then undo the checkbox.
+
+        Enables the forceful deployment checkbox, sends a random 4-7
+        character string to the confirmation input (not ``"CONFIRM"``),
+        asserts that the Next button is greyed out (the UI must reject
+        the invalid key), and finally unchecks the checkbox so deployment
+        can proceed normally.
+        """
+        import random
+        import string
+
+        invalid_key = "".join(
+            random.choices(string.ascii_letters, k=random.randint(5, 8))
+        )
+        if invalid_key == "CONFIRM":
+            invalid_key = invalid_key[:-1] + "x"
+        logger.info(
+            "Testing forceful deployment with invalid confirmation key %r",
+            invalid_key,
+        )
+        self.select_checkbox_status(
+            status=True, locator=self.dep_loc["enable_forceful_deployment"]
+        )
+        self.do_send_keys(
+            locator=self.dep_loc["forceful_deployment_confirmation"],
+            text=invalid_key,
+        )
+        self.take_screenshot("odf_forceful_deployment_invalid_key")
+        # The disabled attribute lives on the <button>, not the inner <span>
+        # matched by dep_loc["next"], so check the button element directly.
+        _next_btn = (
+            "button.pf-v6-c-button.pf-m-primary",
+            By.CSS_SELECTOR,
+        )
+        assert self.is_element_greyed_out(_next_btn), (
+            "Next button should be disabled when an invalid confirmation"
+            " key is typed for forceful deployment"
+        )
+        logger.info("Confirmed: Next button is disabled with invalid confirmation key")
+        self.select_checkbox_status(
+            status=False, locator=self.dep_loc["enable_forceful_deployment"]
+        )
+        self.take_screenshot("odf_forceful_deployment_unchecked")
+
     def is_element_greyed_out(self, locator):
         """
         Check if a UI element is disabled (greyed out).
+
+        Checks both the HTML ``disabled`` attribute and the PatternFly
+        ``aria-disabled`` attribute, since PF buttons use the latter
+        without setting the native disabled property.
 
         Args:
             locator (tuple): (selector str, By type) of the element to check.
 
         Returns:
-            bool: True if the element has the disabled attribute, False otherwise.
+            bool: True if the element is disabled by either attribute.
         """
-        return self.get_element_attribute(locator, "disabled") is not None
+        return (
+            self.get_element_attribute(locator, "disabled") is not None
+            or self.get_element_attribute(locator, "aria-disabled") == "true"
+        )
 
     def check_erasure_coding(self):
         """

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -391,6 +391,10 @@ deployment_4_22 = {
         "input#forceful-deployment-confirmation",
         By.CSS_SELECTOR,
     ),
+    "next_button_element": (
+        "//button[normalize-space(.)='Next']",
+        By.XPATH,
+    ),
     "use_erasure_coding": ("input#use-erasure-coding", By.CSS_SELECTOR),
     # Perspective switcher for ACM hub cluster (PF v6)
     "perspective_switcher_toggle": (


### PR DESCRIPTION
See more details in the feature: https://redhat.atlassian.net/browse/RHSTOR-8102. 

## Summary

  - Extract `get_wipe_devices_from_other_clusters_flag()` from
    `verify_wipe_devices_from_other_clusters()` to avoid duplicated
    StorageCluster CR traversal logic.
  - Add `verify_no_wipe_devices_from_other_clusters()` — the negative
    counterpart that asserts the SC CR flag is not `True` and that no
    "completed wiping OSD … belonging to a different ceph cluster" line
    appears in any `rook-ceph-osd-prepare` pod log.
  - Call the new verifier in `deployment.py` when neither
    `wipe_devices_from_other_clusters` nor `odf_forceful_deployment` is
    set, so every non-wipe deployment path is now actively verified.
  - Add `enable_forceful_deployment_invalid_key()` in `deployment_ui.py`:
    enables the forceful-deployment checkbox, sends a random non-`CONFIRM`
    string, asserts the Next button is disabled, then unchecks the
    checkbox so deployment proceeds normally.
  - Fix `is_element_greyed_out()` to also check `aria-disabled="true"`;
    PatternFly 6 buttons set only this attribute, not the native
    `disabled` property.
  - Skip LSO operator install when it is already present (idempotency).
  - Add `conf/deployment/vsphere/upi_1az_rhcos_vsan_lso_vmdk_3m_3w_ui_invalid_forceful_key.yaml`
    — runs the invalid-key UI test on top of a pre-labelled
    (`simulate_bluestore_label`) disk set with `skip_disks_cleanup`.

  ## Test plan

  - [ ] Run `upi_1az_rhcos_vsan_lso_vmdk_3m_3w_ui_invalid_forceful_key.yaml`
    on a 3m/3w vSphere UPI cluster and confirm the invalid-key assertion
    passes and deployment completes successfully.
  - [ ] Verify in the odf post-deployment checks that the function `verify_no_wipe_devices_from_other_clusters()` reports no wipe.
