### PR TITLE
Wait for CephFS nodeplugin pods before configuring image registry

### DIFF
--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -123,6 +123,7 @@ from ocs_ci.ocs.resources.pod import (
     wait_for_ceph_cmd_execute_successfully,
     get_operator_pods,
     delete_pods,
+    get_cephfs_nodeplugin_pods,
     wait_for_pods_by_label_count,
     wait_for_pods_to_be_running,
     wait_for_pods_to_be_in_statuses,
@@ -2321,6 +2322,26 @@ class Deployment(object):
             )
 
         if not config.COMPONENTS["disable_cephfs"]:
+            worker_count = len(get_worker_nodes())
+            logger.info(
+                "Restarting CephFS CSI node plugin pods to clear any "
+                "transient ContainerCreating state before configuring "
+                "image registry"
+            )
+            nodeplugin_pods = get_cephfs_nodeplugin_pods(namespace=self.namespace)
+            if nodeplugin_pods:
+                delete_pods(nodeplugin_pods, wait=True)
+            logger.info(
+                "Waiting for CephFS CSI node plugin to be Running on all "
+                "%d worker nodes before configuring image registry",
+                worker_count,
+            )
+            assert pod.wait_for_resource(
+                condition=constants.STATUS_RUNNING,
+                selector=constants.CEPHFS_NODEPLUGIN_LABEL,
+                resource_count=worker_count,
+                timeout=600,
+            ), "CephFS CSI node plugin pods did not reach Running state"
             # Change registry backend to OCS CEPHFS RWX PVC
             registry.change_registry_backend_to_ocs()
 

--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -4408,6 +4408,23 @@ def get_ceph_csi_ctrl_pods(namespace=None):
     return ceph_csi_ctrl_pods
 
 
+def get_cephfs_nodeplugin_pods(namespace=None):
+    """
+    Fetch the CephFS CSI node plugin pod objects.
+
+    Args:
+        namespace (str): Namespace in which ceph cluster lives
+            (default: config.ENV_DATA["cluster_namespace"])
+
+    Returns:
+        list: List of Pod objects for the CephFS node plugin DaemonSet.
+
+    """
+    namespace = namespace or config.ENV_DATA["cluster_namespace"]
+    pods_data = get_pods_having_label(constants.CEPHFS_NODEPLUGIN_LABEL, namespace)
+    return [Pod(**pod_data) for pod_data in pods_data]
+
+
 def get_container_images(pod_obj):
     """
     Get all container images (both containers and initContainers) from the pod object


### PR DESCRIPTION
After ODF deployment, `change_registry_backend_to_ocs()` was called immediately without verifying that the CephFS CSI node plugin DaemonSet was fully running on all worker nodes. If a node rebooted during deployment (or image pulls were slow), the nodeplugin pods could be stuck in ContainerCreating, leaving the CephFS driver unregistered on those nodes. Any attempt to attach a CephFS PVC to such a node then fails with:

 

>  CSINode <node> does not contain driver
>   openshift-storage.cephfs.csi.ceph.com

Add `get_cephfs_nodeplugin_pods()` helper in `pod.py`. Use it in `deployment.py` to restart the nodeplugin pods before the wait to clear any transient ContainerCreating state caused by kubelet cache sync issues at reboot time, then block until all `worker_count` pods are Running (up to 600s) before reconfiguring the image registry backend.

See more details in the job: https://jenkins-csb-odf-qe-ocs4.dno.corp.redhat.com/job/qe-deploy-ocs-cluster/69130/console

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved CephFS CSI node plugin pod initialization during OCS deployment to prevent transient container state issues before registry backend configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->