### PR TITLE
[release-4.17] Fix test_sts_assume_role bucket name collisions and STS retry

### DIFF
--- a/tests/functional/object/mcg/test_sts_client.py
+++ b/tests/functional/object/mcg/test_sts_client.py
@@ -91,7 +91,7 @@ class TestSTSClient:
         logger.info("Changed the sts token expiration time to 10 minutes")
 
         # create a bucket using noobaa admin creds
-        bucket_1 = "first-bucket"
+        bucket_1 = f"first-bucket-{uuid4().hex[:8]}"
         retry(ClientError, tries=5, delay=5)(new_bucket)(bucket_name=bucket_1)
         logger.info(f"Created bucket {bucket_1}")
 
@@ -123,7 +123,7 @@ class TestSTSClient:
         logger.info(f"Assigned the assume role policy to the user {user_2}")
 
         # noobaa admin assumes the above role
-        creds_generated = sts_assume_role(
+        creds_generated = retry(CommandFailed, tries=5, delay=30)(sts_assume_role)(
             awscli_pod_session,
             role_name,
             nb_user_access_key_id,
@@ -134,7 +134,7 @@ class TestSTSClient:
         )
 
         # perform io to validate the role assumption
-        bucket_2 = "second-bucket"
+        bucket_2 = f"second-bucket-{uuid4().hex[:8]}"
         try:
             new_bucket(bucket_2, assumed_user_s3client)
             assert (


### PR DESCRIPTION
Cherry-pick of [https://github.com/https://github.com/https://github.com/red-hat-storage/ocs-ci/pull/15332] to release-4.17 (manual — automated cherry-pick failed due to merge conflict).

Use unique bucket names (first-bucket-{uuid}, second-bucket-{uuid}) to prevent cross-run collisions
Wrap sts_assume_role with retry(CommandFailed, tries=5, delay=30) to handle STS endpoint readiness after pod restarts.