### PR TITLE
Fix test_db_nfs_mount: skip on missing NFS config and increase timeout

### DIFF
--- a/tests/functional/object/mcg/test_db_nfs_mount.py
+++ b/tests/functional/object/mcg/test_db_nfs_mount.py
@@ -28,13 +28,18 @@ logger = logging.getLogger(__name__)
 @skipif_lean_deployment
 class TestNoobaaDbNFSMount:
     @pytest.fixture()
-    def mount_ngix_pod(self, request):
+    def nfs_config(self):
         nfs_server = config.ENV_DATA.get("nb_nfs_server")
         nfs_mount = config.ENV_DATA.get("nb_nfs_mount")
         if not nfs_server or not nfs_mount:
             pytest.skip(
                 f"NFS config not set: nb_nfs_server={nfs_server}, nb_nfs_mount={nfs_mount}"
             )
+        return nfs_server, nfs_mount
+
+    @pytest.fixture()
+    def mount_ngix_pod(self, request, nfs_config):
+        nfs_server, nfs_mount = nfs_config
 
         # try to mount the reesi004 nfs mount to nginx pod
         nginx_pod_data = templating.load_yaml(constants.NGINX_POD_YAML)
@@ -64,13 +69,8 @@ class TestNoobaaDbNFSMount:
         request.addfinalizer(finalizer)
 
     @pytest.fixture()
-    def mount_noobaa_db_pod(self, request):
-        nfs_server = config.ENV_DATA.get("nb_nfs_server")
-        nfs_mount = config.ENV_DATA.get("nb_nfs_mount")
-        if not nfs_server or not nfs_mount:
-            pytest.skip(
-                f"NFS config not set: nb_nfs_server={nfs_server}, nb_nfs_mount={nfs_mount}"
-            )
+    def mount_noobaa_db_pod(self, request, nfs_config):
+        nfs_server, nfs_mount = nfs_config
 
         # scale down noobaa db stateful set
         helpers.modify_statefulset_replica_count(

--- a/tests/functional/object/mcg/test_db_nfs_mount.py
+++ b/tests/functional/object/mcg/test_db_nfs_mount.py
@@ -29,6 +29,13 @@ logger = logging.getLogger(__name__)
 class TestNoobaaDbNFSMount:
     @pytest.fixture()
     def mount_ngix_pod(self, request):
+        nfs_server = config.ENV_DATA.get("nb_nfs_server")
+        nfs_mount = config.ENV_DATA.get("nb_nfs_mount")
+        if not nfs_server or not nfs_mount:
+            pytest.skip(
+                f"NFS config not set: nb_nfs_server={nfs_server}, nb_nfs_mount={nfs_mount}"
+            )
+
         # try to mount the reesi004 nfs mount to nginx pod
         nginx_pod_data = templating.load_yaml(constants.NGINX_POD_YAML)
         nginx_pod_data["metadata"]["namespace"] = config.ENV_DATA["cluster_namespace"]
@@ -38,18 +45,15 @@ class TestNoobaaDbNFSMount:
         ] = "/var/nfs"
         nginx_pod_data["spec"]["volumes"][0]["name"] = "nfs-vol"
         nginx_pod_data["spec"]["volumes"][0]["nfs"] = dict()
-        nginx_pod_data["spec"]["volumes"][0]["nfs"]["server"] = config.ENV_DATA.get(
-            "nb_nfs_server"
-        )
-        nginx_pod_data["spec"]["volumes"][0]["nfs"]["path"] = config.ENV_DATA.get(
-            "nb_nfs_mount"
-        )
+        nginx_pod_data["spec"]["volumes"][0]["nfs"]["server"] = nfs_server
+        nginx_pod_data["spec"]["volumes"][0]["nfs"]["path"] = nfs_mount
         nginx_pod_data["spec"]["volumes"][0].pop("persistentVolumeClaim")
         nginx_pod = helpers.create_resource(**nginx_pod_data)
 
         helpers.wait_for_resource_state(
             nginx_pod,
             constants.STATUS_RUNNING,
+            timeout=300,
         )
         logger.info(f"Pod {nginx_pod.name} is created and running")
 
@@ -61,6 +65,13 @@ class TestNoobaaDbNFSMount:
 
     @pytest.fixture()
     def mount_noobaa_db_pod(self, request):
+        nfs_server = config.ENV_DATA.get("nb_nfs_server")
+        nfs_mount = config.ENV_DATA.get("nb_nfs_mount")
+        if not nfs_server or not nfs_mount:
+            pytest.skip(
+                f"NFS config not set: nb_nfs_server={nfs_server}, nb_nfs_mount={nfs_mount}"
+            )
+
         # scale down noobaa db stateful set
         helpers.modify_statefulset_replica_count(
             constants.NOOBAA_DB_STATEFULSET, replica_count=0
@@ -76,8 +87,8 @@ class TestNoobaaDbNFSMount:
         params = (
             '{"spec": {"template": {"spec": {"containers": [{"name": "db", "volumeMounts": '
             '[{"mountPath": "/var/nfs", "name": "nfs-vol"}]}], "volumes":[{"name": "nfs-vol", '
-            f'"nfs": {{"server": "{config.ENV_DATA.get("nb_nfs_server")}", '
-            f'"path": "{config.ENV_DATA.get("nb_nfs_mount")}"}}}}]}}}}}}}}'
+            f'"nfs": {{"server": "{nfs_server}", '
+            f'"path": "{nfs_mount}"}}}}]}}}}}}}}'
         )
         ocp_obj.patch(params=params, format_type="strategic")
         logger.info("Patched noobaa sts to mount nfs")


### PR DESCRIPTION
Fixes https://github.com/red-hat-storage/ocs-ci/issues/11408

  Problem:
  
    `test_db_nfs_mount` has been failing persistently across multiple OCS
    versions with two distinct failure modes:

    1. **Missing NFS config** — On clusters where `nb_nfs_server` and
       `nb_nfs_mount` are not set in ENV_DATA, `config.ENV_DATA.get()`
       returns `None`, causing the nginx pod to be created with empty
       NFS server/path. Kubernetes rejects the pod with validation errors
       (`spec.volumes[0].nfs.server: Required value`).
       
    2. **Timeout** — When NFS config is present, the nginx pod can get
       stuck in `ContainerCreating` while mounting the NFS volume. The
       default 60-second timeout in `wait_for_resource_state` is too
       short for NFS mount operations.

  Fixes:
  
    - Add `pytest.skip()` in both `mount_ngix_pod` and
      `mount_noobaa_db_pod` fixtures when `nb_nfs_server` or
      `nb_nfs_mount` are not configured, so the test skips gracefully
      instead of failing
    - Increase the nginx pod wait timeout from 60s to 300s to
      accommodate slow NFS mounts
    - Reuse validated NFS config variables instead of calling
      `config.ENV_DATA.get()` multiple times


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced NFS mount test fixtures to retrieve configuration values upfront and gracefully skip tests when required values are unavailable, improving test reliability and configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->