### PR TITLE
Fix and refactor test_monitor_recovery.py to align with updated steps

### DIFF
--- a/ocs_ci/ocs/platform_nodes.py
+++ b/ocs_ci/ocs/platform_nodes.py
@@ -3538,8 +3538,10 @@ class IBMCloudIPI(object):
     def restart_nodes(self, nodes, wait=True):
         self.ibmcloud_ipi.restart_nodes(nodes=nodes, wait=wait)
 
-    def restart_nodes_by_stop_and_start(self, nodes, force=True):
-        self.ibmcloud_ipi.restart_nodes_by_stop_and_start(nodes=nodes, force=force)
+    def restart_nodes_by_stop_and_start(self, nodes, wait=True, force=True):
+        self.ibmcloud_ipi.restart_nodes_by_stop_and_start(
+            nodes=nodes, wait=wait, force=force
+        )
 
     def detach_volume(self, volume, node=None, delete_from_backend=True):
         self.ibmcloud_ipi.detach_volume(volume=volume, node=node)

--- a/tests/cross_functional/kcs/test_monitor_recovery.py
+++ b/tests/cross_functional/kcs/test_monitor_recovery.py
@@ -724,10 +724,15 @@ class MonitorRecovery(object):
                 logger.debug("Waiting 30s before checking OSD pods")
                 time.sleep(30)
                 osd_pods = get_osd_pods()
-                for osd in osd_pods:
-                    logger.debug(f"Waiting for OSD pod: {osd.name}")
-                    wait_for_resource_state(
-                        resource=osd, state=constants.STATUS_RUNNING, timeout=600
+                logger.info(
+                    f"Verifying {len(osd_pods)} OSD pods with sandbox error recovery"
+                )
+                failed_osd_pods = verify_pods_running(
+                    osd_pods, pod_type="OSD", timeout=600
+                )
+                if failed_osd_pods:
+                    raise AssertionError(
+                        f"OSD deployment {dep_name} recovery failed: {failed_osd_pods}"
                     )
                 logger.info(
                     f"OSD deployment {dep_name}: all {len(osd_pods)} pods are running"
@@ -736,10 +741,15 @@ class MonitorRecovery(object):
                 logger.debug("Waiting 30s before checking MGR pods")
                 time.sleep(30)
                 mgr_pods = get_mgr_pods(namespace=config.ENV_DATA["cluster_namespace"])
-                for mgr_pod in mgr_pods:
-                    logger.debug(f"Waiting for MGR pod: {mgr_pod.name}")
-                    wait_for_resource_state(
-                        resource=mgr_pod, state=constants.STATUS_RUNNING, timeout=600
+                logger.info(
+                    f"Verifying {len(mgr_pods)} MGR pods with sandbox error recovery"
+                )
+                failed_mgr_pods = verify_pods_running(
+                    mgr_pods, pod_type="MGR", timeout=600
+                )
+                if failed_mgr_pods:
+                    raise AssertionError(
+                        f"MGR deployment {dep_name} recovery failed: {failed_mgr_pods}"
                     )
                 logger.info(
                     f"MGR deployment {dep_name}: all {len(mgr_pods)} pods are running"
@@ -748,10 +758,15 @@ class MonitorRecovery(object):
                 logger.debug("Waiting 30s before checking MDS pods")
                 time.sleep(30)
                 mds_pods = get_mds_pods()
-                for mds_pod in mds_pods:
-                    logger.debug(f"Waiting for MDS pod: {mds_pod.name}")
-                    wait_for_resource_state(
-                        resource=mds_pod, state=constants.STATUS_RUNNING, timeout=600
+                logger.info(
+                    f"Verifying {len(mds_pods)} MDS pods with sandbox error recovery"
+                )
+                failed_mds_pods = verify_pods_running(
+                    mds_pods, pod_type="MDS", timeout=600
+                )
+                if failed_mds_pods:
+                    raise AssertionError(
+                        f"MDS deployment {dep_name} recovery failed: {failed_mds_pods}"
                     )
                 logger.info(
                     f"MDS deployment {dep_name}: all {len(mds_pods)} pods are running"

--- a/tests/cross_functional/kcs/test_monitor_recovery.py
+++ b/tests/cross_functional/kcs/test_monitor_recovery.py
@@ -1400,9 +1400,22 @@ def ceph_fs_recovery():
 
     replace_mds_deployments()
 
+    logger.info(
+        "Waiting 3 minutes for old MDS pods to terminate after deployment replacement"
+    )
+    time.sleep(180)
+
     logger.info("Verifying MDS pods reach running state after CephFS recovery")
-    mds_pods = get_mds_pods()
-    logger.info(f"Found {len(mds_pods)} MDS pods to verify")
+    all_mds_pods = get_mds_pods()
+    mds_pods = [
+        pod
+        for pod in all_mds_pods
+        if not pod.get().get("metadata", {}).get("deletionTimestamp")
+    ]
+    logger.info(
+        f"Found {len(mds_pods)} active MDS pods to verify "
+        f"(filtered out {len(all_mds_pods) - len(mds_pods)} terminating pods)"
+    )
     failed_mds_pods = []
     for mds_pod in mds_pods:
         logger.debug(f"Checking MDS pod: {mds_pod.name}")

--- a/tests/cross_functional/kcs/test_monitor_recovery.py
+++ b/tests/cross_functional/kcs/test_monitor_recovery.py
@@ -262,9 +262,9 @@ class TestMonitorRecovery(E2ETest):
         if collections.Counter(new_md5_sum) == collections.Counter(self.md5sum):
             logger.info(f"Data integrity verified: checksums match for {self.filename}")
         else:
-            assert (
-                False
-            ), f"Data corruption detected: before={self.md5sum}, after={new_md5_sum}"
+            pytest.fail(
+                f"Data corruption detected: before={self.md5sum}, after={new_md5_sum}"
+            )
 
         logger.test_step("Verify S3 object retrieval after recovery")
         logger.assertion(
@@ -1088,6 +1088,9 @@ def recover_mcg():
     Recovery procedure for noobaa by re-spinning the pods after mon recovery.
     Handles multi-attach errors by deleting stale VolumeAttachment resources.
 
+    Raises:
+        AssertionError: If any NooBaa or RGW pods fail to reach running state
+
     """
     logger.info("Starting MCG recovery by re-spinning noobaa pods")
     noobaa_pods = get_noobaa_pods()
@@ -1101,12 +1104,23 @@ def recover_mcg():
     time.sleep(120)
 
     logger.info("Verifying noobaa pods reached running state")
+    failed_noobaa_pods = []
     respawned_noobaa_pods = get_noobaa_pods()
     for noobaa_pod in respawned_noobaa_pods:
         logger.debug(f"Checking noobaa pod: {noobaa_pod.name}")
         if not handle_multi_attach_error(noobaa_pod, timeout=600):
-            logger.warning(f"Noobaa pod {noobaa_pod.name} did not reach running state")
-    logger.info("MCG noobaa pods recovery completed")
+            logger.error(f"Noobaa pod {noobaa_pod.name} failed to reach running state")
+            failed_noobaa_pods.append(noobaa_pod.name)
+
+    if failed_noobaa_pods:
+        logger.error(
+            f"MCG recovery failed: {len(failed_noobaa_pods)} noobaa pods not running: {failed_noobaa_pods}"
+        )
+        raise AssertionError(f"NooBaa pod recovery failed: {failed_noobaa_pods}")
+
+    logger.info(
+        f"MCG noobaa pods recovery completed: all {len(respawned_noobaa_pods)} pods running"
+    )
 
     if config.ENV_DATA["platform"].lower() in constants.ON_PREM_PLATFORMS:
         logger.info("On-prem platform detected: recovering RGW pods")
@@ -1121,12 +1135,23 @@ def recover_mcg():
         time.sleep(120)
 
         logger.info("Verifying RGW pods reached running state")
+        failed_rgw_pods = []
         respawned_rgw_pods = get_rgw_pods()
         for rgw_pod in respawned_rgw_pods:
             logger.debug(f"Checking RGW pod: {rgw_pod.name}")
             if not handle_multi_attach_error(rgw_pod, timeout=600):
-                logger.warning(f"RGW pod {rgw_pod.name} did not reach running state")
-        logger.info("RGW pods recovery completed")
+                logger.error(f"RGW pod {rgw_pod.name} failed to reach running state")
+                failed_rgw_pods.append(rgw_pod.name)
+
+        if failed_rgw_pods:
+            logger.error(
+                f"RGW recovery failed: {len(failed_rgw_pods)} RGW pods not running: {failed_rgw_pods}"
+            )
+            raise AssertionError(f"RGW pod recovery failed: {failed_rgw_pods}")
+
+        logger.info(
+            f"RGW pods recovery completed: all {len(respawned_rgw_pods)} pods running"
+        )
     else:
         logger.debug(
             f"Skipping RGW recovery on non-on-prem platform: {config.ENV_DATA['platform']}"

--- a/tests/cross_functional/kcs/test_monitor_recovery.py
+++ b/tests/cross_functional/kcs/test_monitor_recovery.py
@@ -32,6 +32,7 @@ from ocs_ci.ocs.resources.pod import (
     get_osd_pods,
     get_deployments_having_label,
     get_mds_pods,
+    get_mgr_pods,
     get_cephfsplugin_provisioner_pods,
     get_rbdfsplugin_provisioner_pods,
     get_rgw_pods,
@@ -111,9 +112,6 @@ class TestMonitorRecovery(E2ETest):
         ), "Failed: PutObject"
 
     @jira("DFBUGS-4322")
-    @pytest.mark.skip(
-        reason="Skip due to issue https://github.com/red-hat-storage/ocs-ci/issues/14384"
-    )
     def test_monitor_recovery(
         self,
         deployment_pod_factory,
@@ -164,12 +162,16 @@ class TestMonitorRecovery(E2ETest):
         mon_recovery.copy_tar_to_pods(pod_type="mon")
 
         logger.info("Copy the previously retrieved monstore to the mon-a pod")
-        mon_pods = get_mon_pods(namespace=config.ENV_DATA["cluster_namespace"])
-        mon_a = mon_pods[0]
+        mon_a = next(
+            mon
+            for mon in get_mon_pods(namespace=config.ENV_DATA["cluster_namespace"])
+            if mon.get().get("metadata", {}).get("labels", {}).get("ceph_daemon_id")
+            == "a"
+        )
         logger.info(f"Copying mon-store into monitor: {mon_a.name}")
         ocp_obj = MonitorRecovery()
         ocp_obj._exec_oc_cmd(
-            cmd=f"cp -n {constants.OPENSHIFT_STORAGE_NAMESPACE} /tmp/monstore {mon_a.name}:/tmp/"
+            cmd=f"cp /tmp/monstore {constants.OPENSHIFT_STORAGE_NAMESPACE}/{mon_a.name}:/tmp/"
         )
 
         logger.info(
@@ -193,7 +195,7 @@ class TestMonitorRecovery(E2ETest):
             f"Copying the mon keyring stored locally from {file_path} to monitor: {mon_a.name}"
         )
         ocp_obj._exec_oc_cmd(
-            cmd=f"cp -n {constants.OPENSHIFT_STORAGE_NAMESPACE} {file_path} {mon_a.name}:/tmp/keyring"
+            cmd=f"cp {file_path} {constants.OPENSHIFT_STORAGE_NAMESPACE}/{mon_a.name}:/tmp/keyring"
         )
 
         logger.info("Generating monitor map command using the IPs")
@@ -325,7 +327,7 @@ class MonitorRecovery(object):
         osd_deployments = [OCS(**osd) for osd in osd_dep]
         for osd in osd_deployments:
             logger.info(
-                f"Patching OSD: {osd.name} with livenessProbe and sleep infinity"
+                f"Patching OSD: {osd.name} to remove livenessProbe and set sleep infinity"
             )
             params = '[{"op":"remove", "path":"/spec/template/spec/containers/0/livenessProbe"}]'
             self.dep_ocp.patch(
@@ -342,12 +344,16 @@ class MonitorRecovery(object):
                 params=params,
             )
         logger.info(
-            "Sleeping for 15 seconds and waiting for OSDs to reach running state"
+            "Sleeping for 60 seconds to allow OSD pods to restart with new configuration"
         )
-        time.sleep(15)
+        time.sleep(60)
+        logger.info("Waiting for OSD pods to reach running state")
         for osd in get_osd_pods():
-            wait_for_resource_state(resource=osd, state=constants.STATUS_RUNNING)
+            wait_for_resource_state(
+                resource=osd, state=constants.STATUS_RUNNING, timeout=600
+            )
 
+    @retry(CommandFailed, tries=10, delay=5, backoff=1)
     def copy_tar_to_pods(self, pod_type="osd"):
         """
         Copies local tar binary to the specified type of pods (OSD or MON) pod
@@ -372,7 +378,7 @@ class MonitorRecovery(object):
                 f"cat /usr/bin/tar | oc exec -i -n {constants.OPENSHIFT_STORAGE_NAMESPACE} {pod_obj.name}  -- bash -c "
                 f"'cat > /usr/bin/tar'"
             )
-            run_cmd(cmd)
+            run_cmd(cmd, shell=True)
             logger.info(
                 f"Setting execute permissions on /usr/bin/tar in pod: {pod_obj.name}"
             )
@@ -384,7 +390,7 @@ class MonitorRecovery(object):
         Prepares the script to retrieve the `monstore` cluster map from OSDs
 
         """
-        recover_mon = """
+        recover_mon = f"""
         #!/bin/bash
         ms=/tmp/monstore
 
@@ -398,7 +404,7 @@ class MonitorRecovery(object):
             podname=$(echo $osd_pod|sed 's/pod\\///g')
             oc exec -n {constants.OPENSHIFT_STORAGE_NAMESPACE} $osd_pod -- rm -rf $ms
             oc exec -n {constants.OPENSHIFT_STORAGE_NAMESPACE} $osd_pod -- mkdir $ms
-            oc cp -n {constants.OPENSHIFT_STORAGE_NAMESPACE} $ms $podname:$ms
+            oc cp $ms {constants.OPENSHIFT_STORAGE_NAMESPACE}/$podname:$ms
 
             rm -rf $ms
             mkdir $ms
@@ -409,11 +415,11 @@ class MonitorRecovery(object):
             ceph-objectstore-tool --type bluestore --data-path \\
             /var/lib/ceph/osd/ceph-$(oc get -n \\
             {constants.OPENSHIFT_STORAGE_NAMESPACE} $osd_pod \\
-            -ojsonpath='{ .metadata.labels.ceph_daemon_id }') \\
+            -ojsonpath='{{ .metadata.labels.ceph_daemon_id }}') \\
             --op update-mon-db --no-mon-config --mon-store-path $ms
             echo "Done with COT on pod: $osd_pod"
 
-            oc cp -n {constants.OPENSHIFT_STORAGE_NAMESPACE} $podname:$ms $ms
+            oc cp {constants.OPENSHIFT_STORAGE_NAMESPACE}/$podname:$ms $ms
 
             echo "Finished pulling COT data from pod: $osd_pod"
         done
@@ -506,19 +512,19 @@ class MonitorRecovery(object):
         )
         self._exec_oc_cmd(
             cmd=(
-                f"cp -n {constants.OPENSHIFT_STORAGE_NAMESPACE} "
+                f"cp {constants.OPENSHIFT_STORAGE_NAMESPACE}/"
                 f"{mon_a.name}:/var/lib/ceph/mon/ceph-a/store.db "
-                f"{self.backup_dir}/"
+                f"{self.backup_dir}/store.db"
             )
         )
         logger.info("Copying store.db to rest of the monitors")
         for mon in get_mon_pods(namespace=config.ENV_DATA["cluster_namespace"]):
-            if not mon.get().get("metadata").get("labels").get("ceph_daemon_id") == "a":
+            if mon.get().get("metadata").get("labels").get("ceph_daemon_id") != "a":
                 cmd = (
-                    f"cp -n {constants.OPENSHIFT_STORAGE_NAMESPACE} "
-                    f"{self.backup_dir}/store.db "
+                    f"cp {self.backup_dir}/store.db "
+                    f"{constants.OPENSHIFT_STORAGE_NAMESPACE}/"
                     f"{mon.name}:/var/lib/ceph/mon/ceph-"
-                    f"{mon.get().get('metadata').get('labels').get('ceph_daemon_id')}/ "
+                    f"{mon.get().get('metadata').get('labels').get('ceph_daemon_id')}/"
                 )
                 logger.info(f"Copying store.db to monitor: {mon.name}")
                 self._exec_oc_cmd(cmd)
@@ -542,6 +548,33 @@ class MonitorRecovery(object):
             logger.info(f"Reverting {dep}")
             revert_patch = f"replace --force -f {dep}"
             self.ocp_obj.exec_oc_cmd(revert_patch)
+
+            # Determine the type of deployment and wait for corresponding pods
+            dep_name = dep.split("/")[-1].replace(".yaml", "")
+            logger.info(
+                f"Waiting for pods from deployment {dep_name} to reach running state"
+            )
+
+            if "rook-ceph-mon" in dep_name:
+                logger.info("Waiting for monitor pods to reach running state")
+                time.sleep(30)
+                validate_mon_pods()
+            elif "rook-ceph-osd" in dep_name:
+                logger.info("Waiting for OSD pods to reach running state")
+                time.sleep(30)
+                for osd in get_osd_pods():
+                    wait_for_resource_state(
+                        resource=osd, state=constants.STATUS_RUNNING, timeout=600
+                    )
+            elif "rook-ceph-mgr" in dep_name:
+                logger.info("Waiting for MGR pods to reach running state")
+                time.sleep(30)
+                for mgr_pod in get_mgr_pods(
+                    namespace=config.ENV_DATA["cluster_namespace"]
+                ):
+                    wait_for_resource_state(
+                        resource=mgr_pod, state=constants.STATUS_RUNNING, timeout=600
+                    )
 
     def backup_deployments(self):
         """

--- a/tests/cross_functional/kcs/test_monitor_recovery.py
+++ b/tests/cross_functional/kcs/test_monitor_recovery.py
@@ -859,26 +859,100 @@ def corrupt_ceph_monitors():
         wait_for_resource_state(resource=mon, state=constants.STATUS_CLBO)
 
 
+def handle_multi_attach_error(pod_obj, timeout=300):
+    """
+    Handle multi-attach volume errors by deleting stale VolumeAttachment resources.
+
+    Args:
+        pod_obj: Pod object that may have multi-attach error
+        timeout: Maximum time to wait for pod to become running (default: 300s)
+
+    Returns:
+        bool: True if pod is running, False otherwise
+
+    """
+    logger.info(f"Checking pod {pod_obj.name} for multi-attach errors")
+
+    try:
+        pod_describe = pod_obj.ocp.exec_oc_cmd(
+            f"describe pod {pod_obj.name}", out_yaml_format=False
+        )
+
+        if "Multi-Attach error" in pod_describe:
+            logger.warning(f"Multi-attach error detected for pod {pod_obj.name}")
+
+            pvc_match = re.search(
+                r'Multi-Attach error for volume "([^"]+)"', pod_describe
+            )
+            if pvc_match:
+                pvc_id = pvc_match.group(1)
+                logger.info(f"Found PVC ID with multi-attach error: {pvc_id}")
+
+                # Find and delete stale VolumeAttachment
+                va_ocp = OCP(kind="VolumeAttachment", namespace="")
+                try:
+                    attachments = va_ocp.get()
+                    if attachments and "items" in attachments:
+                        for attachment in attachments["items"]:
+                            if (
+                                attachment.get("spec", {})
+                                .get("source", {})
+                                .get("persistentVolumeName")
+                                == pvc_id
+                            ):
+                                va_name = attachment["metadata"]["name"]
+                                logger.info(
+                                    f"Deleting stale VolumeAttachment: {va_name}"
+                                )
+                                va_ocp.delete(resource_name=va_name)
+                                time.sleep(10)
+                                break
+                except Exception as e:
+                    logger.warning(f"Error handling VolumeAttachment: {e}")
+    except Exception as e:
+        logger.warning(f"Error checking for multi-attach: {e}")
+
+    try:
+        wait_for_resource_state(
+            resource=pod_obj, state=constants.STATUS_RUNNING, timeout=timeout
+        )
+        return True
+    except Exception as e:
+        logger.error(f"Pod {pod_obj.name} failed to reach running state: {e}")
+        return False
+
+
 def recover_mcg():
     """
-    Recovery procedure for noobaa by re-spinning the pods after mon recovery
+    Recovery procedure for noobaa by re-spinning the pods after mon recovery.
+    Handles multi-attach errors by deleting stale VolumeAttachment resources.
 
     """
     logger.info("Re-spinning noobaa pods")
     for noobaa_pod in get_noobaa_pods():
-        noobaa_pod.delete()
+        logger.info(f"Force deleting noobaa pod: {noobaa_pod.name}")
+        noobaa_pod.delete(force=True)
+
+    logger.info("Waiting for noobaa pods to reach running state")
+    time.sleep(120)
+
     for noobaa_pod in get_noobaa_pods():
-        wait_for_resource_state(
-            resource=noobaa_pod, state=constants.STATUS_RUNNING, timeout=600
-        )
+        logger.info(f"Checking noobaa pod: {noobaa_pod.name}")
+        if not handle_multi_attach_error(noobaa_pod, timeout=600):
+            logger.warning(f"Pod {noobaa_pod.name} did not reach running state")
     if config.ENV_DATA["platform"].lower() in constants.ON_PREM_PLATFORMS:
         logger.info("Re-spinning RGW pods")
         for rgw_pod in get_rgw_pods():
-            rgw_pod.delete()
+            logger.info(f"Force deleting RGW pod: {rgw_pod.name}")
+            rgw_pod.delete(force=True)
+
+        logger.info("Waiting for RGW pods to reach running state")
+        time.sleep(120)
+
         for rgw_pod in get_rgw_pods():
-            wait_for_resource_state(
-                resource=rgw_pod, state=constants.STATUS_RUNNING, timeout=600
-            )
+            logger.info(f"Checking RGW pod: {rgw_pod.name}")
+            if not handle_multi_attach_error(rgw_pod, timeout=600):
+                logger.warning(f"Pod {rgw_pod.name} did not reach running state")
 
 
 def remove_global_id_reclaim():

--- a/tests/cross_functional/kcs/test_monitor_recovery.py
+++ b/tests/cross_functional/kcs/test_monitor_recovery.py
@@ -39,7 +39,6 @@ from ocs_ci.ocs.resources.pod import (
     get_plugin_pods,
     get_ceph_tools_pod,
     wait_for_storage_pods,
-    wait_for_noobaa_pods_running,
 )
 from ocs_ci.ocs.resources import pod
 from ocs_ci.ocs import ocp, constants, defaults, bucket_utils
@@ -956,11 +955,17 @@ class MonitorRecovery(object):
             try:
                 wait_for_resource_state(resource=mds, state=constants.STATUS_RUNNING)
             except (CommandFailed, ResourceWrongStatusException):
+                # Pod may have been replaced (new name) during the deployment rollout.
+                # Confirm it is actually gone, then wait for the replacement to run.
                 if not _pod_exists(mds):
                     logger.info(
                         f"MDS pod {mds.name} no longer exists (replaced by deployment "
-                        "rollout) - skipping"
+                        "rollout) - waiting for replacement pod to reach Running state"
                     )
+                    if not _wait_for_replacement_pod(mds, 300, mds.namespace):
+                        raise AssertionError(
+                            f"Replacement for MDS pod {mds.name} did not reach Running state"
+                        )
                     continue
                 raise
         logger.info(f"All {len(mds_pods)} MDS pods are running")
@@ -1128,6 +1133,50 @@ def _pod_exists(pod_obj):
         raise
 
 
+def _wait_for_replacement_pod(pod_obj, timeout, namespace):
+    """
+    After an original pod has been replaced (new name, same app label), wait for
+    a fresh pod with the same 'app' label selector to reach Running state.
+
+    Args:
+        pod_obj: The original (now-deleted) pod object — its cached labels are read
+        timeout (int): Seconds to wait for the replacement pod
+        namespace (str): Namespace to search in
+
+    Returns:
+        bool: True if a replacement pod reaches Running, False otherwise
+    """
+    app_label = pod_obj.labels.get("app") if pod_obj.labels else None
+    if not app_label:
+        logger.warning(
+            f"Cannot determine app label for replaced pod {pod_obj.name} - "
+            "cannot verify replacement pod"
+        )
+        return False
+
+    selector = f"app={app_label}"
+    logger.info(
+        f"Waiting up to {timeout}s for replacement pod "
+        f"with selector '{selector}' to reach Running state"
+    )
+    ocp_pod = OCP(kind=constants.POD, namespace=namespace)
+    try:
+        ocp_pod.wait_for_resource(
+            condition=constants.STATUS_RUNNING,
+            selector=selector,
+            timeout=timeout,
+            sleep=10,
+        )
+        logger.info(f"Replacement pod(s) with selector '{selector}' confirmed running")
+        return True
+    except Exception as e:
+        logger.error(
+            f"Replacement pod for '{app_label}' did not reach Running state "
+            f"within {timeout}s: {e}"
+        )
+        return False
+
+
 def perform_node_restart(node_name, nodes_platform, node_objs):
     """
     Perform node restart operation using platform's restart_nodes_by_stop_and_start
@@ -1199,10 +1248,10 @@ def check_and_recover_sandbox_errors(
         except CommandFailed as e:
             if "NotFound" in str(e):
                 logger.info(
-                    f"Pod {pod_name} no longer exists (replaced by a new pod after restart) - "
-                    "treating as success"
+                    f"Pod {pod_name} no longer exists (replaced by a new pod) - "
+                    "waiting for replacement pod to reach Running state"
                 )
-                return True
+                return _wait_for_replacement_pod(pod_obj, timeout, namespace)
             raise
 
         node_name = pod_data.get("spec", {}).get("nodeName")
@@ -1291,11 +1340,13 @@ def check_and_recover_sandbox_errors(
                 pod_obj.reload()
             except CommandFailed as e:
                 if "NotFound" in str(e):
+                    remaining = max(int(timeout - (time.time() - start_time)), 30)
                     logger.info(
                         f"Pod {pod_name} no longer exists during monitoring (replaced by a new "
-                        "pod after node restart) - treating as success"
+                        f"pod after node restart) - waiting for replacement pod "
+                        f"(remaining timeout: {remaining}s)"
                     )
-                    return True
+                    return _wait_for_replacement_pod(pod_obj, remaining, namespace)
                 raise
             phase = pod_obj.get().get("status", {}).get("phase")
 
@@ -1674,31 +1725,20 @@ def recover_mcg():
     else:
         logger.warning("noobaa-db-pg-cluster-1 pod not found")
 
-    try:
-        wait_for_noobaa_pods_running(timeout=600, sleep=10)
-        logger.info(
-            "All NooBaa pods verified running via wait_for_noobaa_pods_running()"
-        )
-    except Exception as e:
-        logger.warning(
-            f"wait_for_noobaa_pods_running() did not complete successfully: {e}. "
-            "Will attempt individual pod recovery."
-        )
+    current_noobaa_pods = get_noobaa_pods()
+    logger.info(f"Verifying {len(current_noobaa_pods)} NooBaa pods are running")
 
-        current_noobaa_pods = get_noobaa_pods()
-        logger.info(f"Verifying {len(current_noobaa_pods)} NooBaa pods individually")
+    failed_noobaa_pods = verify_pods_running(
+        current_noobaa_pods, pod_type="NooBaa", timeout=600, parallel=False
+    )
 
-        failed_noobaa_pods = verify_pods_running(
-            current_noobaa_pods, pod_type="NooBaa", timeout=600, parallel=False
+    if failed_noobaa_pods:
+        error_msg = (
+            f"NooBaa recovery failed: {len(failed_noobaa_pods)} pods did not reach "
+            f"running state: {failed_noobaa_pods}"
         )
-
-        if failed_noobaa_pods:
-            error_msg = (
-                f"NooBaa recovery failed: {len(failed_noobaa_pods)} pods did not reach "
-                f"running state after recovery attempts: {failed_noobaa_pods}"
-            )
-            logger.error(error_msg)
-            raise ResourceWrongStatusException(error_msg)
+        logger.error(error_msg)
+        raise ResourceWrongStatusException(error_msg)
 
     logger.info("NooBaa pods recovery completed successfully")
 
@@ -1776,14 +1816,14 @@ def remove_global_id_reclaim():
     logger.info(f"Deleting {len(csi_pods)} CSI pods")
     for csi_pod in csi_pods:
         logger.debug(f"Deleting CSI pod: {csi_pod.name}")
-        csi_pod.delete()
+        csi_pod.delete(force=True)
 
     logger.info("Deleting MDS pods")
     mds_pods = get_mds_pods()
     logger.info(f"Found {len(mds_pods)} MDS pods to delete")
     for mds_pod in mds_pods:
         logger.debug(f"Deleting MDS pod: {mds_pod.name}")
-        mds_pod.delete()
+        mds_pod.delete(force=True)
 
     logger.info("Waiting for MDS pods to respawn and reach running state")
     respawned_mds_pods = get_mds_pods()
@@ -1797,7 +1837,7 @@ def remove_global_id_reclaim():
     logger.info(f"Found {len(mon_pods)} monitor pods to delete")
     for mon in mon_pods:
         logger.debug(f"Deleting monitor pod: {mon.name}")
-        mon.delete()
+        mon.delete(force=True)
 
     logger.info("Waiting for monitor pods to respawn and reach running state")
     respawned_mon_pods = get_mon_pods(namespace=config.ENV_DATA["cluster_namespace"])

--- a/tests/cross_functional/kcs/test_monitor_recovery.py
+++ b/tests/cross_functional/kcs/test_monitor_recovery.py
@@ -543,7 +543,7 @@ class MonitorRecovery(object):
             deployment_paths (list): List of paths to deployment yamls
 
         """
-        logger.info("Reverting patches on monitors, mgr and osd")
+        logger.info("Reverting patches on monitors, osd and mgr")
         for dep in deployment_paths:
             logger.info(f"Reverting {dep}")
             revert_patch = f"replace --force -f {dep}"
@@ -595,7 +595,8 @@ class MonitorRecovery(object):
 
     def deployments_to_revert(self):
         """
-        Gets mon, osd and mgr deployments to revert
+        Gets mon, osd and mgr deployments to revert.
+        Returns deployments in order: MON -> OSD -> MGR for proper cluster recovery.
 
         Returns:
             tuple: deployment paths to be reverted
@@ -603,11 +604,11 @@ class MonitorRecovery(object):
         """
         to_revert_patches = (
             get_deployments_having_label(
-                label=constants.OSD_APP_LABEL,
+                label=constants.MON_APP_LABEL,
                 namespace=config.ENV_DATA["cluster_namespace"],
             )
             + get_deployments_having_label(
-                label=constants.MON_APP_LABEL,
+                label=constants.OSD_APP_LABEL,
                 namespace=config.ENV_DATA["cluster_namespace"],
             )
             + get_deployments_having_label(
@@ -666,7 +667,7 @@ class MonitorRecovery(object):
             tmp_lines = out_str.strip().splitlines()
             keyring_data = [line.replace("\t", "").strip() for line in tmp_lines]
             pod_name = keyring_data[0].strip()
-            formatted_data.append(f"{pod_name}:")
+            formatted_data.append(pod_name)
             for block in keyring_data:
                 if block == "[client.admin]" and "[mon.]" in keyring_data:
                     logger.info(
@@ -704,7 +705,7 @@ class MonitorRecovery(object):
             lines = out_osd_str.strip().splitlines()
             osd_keyring_data = [line.replace("\t", "").strip() for line in lines]
             pod_name = osd_keyring_data[0].strip()
-            formatted_data.append(f"{pod_name}:")
+            formatted_data.append(pod_name)
             key = None
             for block in osd_keyring_data:
                 if block.startswith("key ="):

--- a/tests/cross_functional/kcs/test_monitor_recovery.py
+++ b/tests/cross_functional/kcs/test_monitor_recovery.py
@@ -44,11 +44,29 @@ from ocs_ci.ocs.resources import pod
 from ocs_ci.ocs import ocp, constants, defaults, bucket_utils
 from ocs_ci.helpers.helpers import wait_for_resource_state, get_secret_names
 from ocs_ci.utility.retry import retry
-from ocs_ci.utility.utils import exec_cmd, run_cmd, TimeoutSampler
+from ocs_ci.utility.utils import exec_cmd, run_cmd
 from ocs_ci.ocs.platform_nodes import PlatformNodesFactory
 from ocs_ci.ocs.node import get_node_objs
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 logger = logging.getLogger(__name__)
+
+SANDBOX_ERROR_PATTERNS = [
+    "FailedCreatePodSandBox",
+    "DeadlineExceeded",
+    "stream terminated",
+    "context deadline exceeded",
+]
+
+RWOP_ERROR_PATTERNS = [
+    "ReadWriteOncePod access mode and is already in use",
+    "volume is already exclusively attached",
+]
+
+ALL_POD_ERROR_PATTERNS = SANDBOX_ERROR_PATTERNS + RWOP_ERROR_PATTERNS
+
+_node_restart_tracker = {}  # {node_name: timestamp}
+NODE_RESTART_COOLDOWN = 300
 
 
 @magenta_squad
@@ -1070,17 +1088,76 @@ def corrupt_ceph_monitors():
     )
 
 
-def check_and_recover_sandbox_errors(pod_obj, timeout=600):
+def is_pod_running(pod_obj):
+    """
+    Check if pod is in Running phase
+
+    Args:
+        pod_obj: Pod object to check
+
+    Returns:
+        bool: True if pod is running, False otherwise
+    """
+    try:
+        phase = pod_obj.get().get("status", {}).get("phase")
+        return phase == constants.STATUS_RUNNING
+    except Exception:
+        return False
+
+
+def perform_node_restart(node_name, nodes_platform, node_objs):
+    """
+    Perform node restart operation using platform's restart_nodes_by_stop_and_start
+
+    Args:
+        node_name: Name of the node to restart
+        nodes_platform: Platform-specific nodes object
+        node_objs: List of node objects
+
+    Returns:
+        bool: True if restart successful, False otherwise
+    """
+    target_node = None
+    for n in node_objs:
+        if n.name == node_name:
+            target_node = n
+            break
+
+    if not target_node:
+        logger.error(f"Could not find node object for {node_name}")
+        return False
+
+    logger.info(
+        f"Restarting node {node_name} using platform: {nodes_platform.__class__.__name__}"
+    )
+
+    try:
+        nodes_platform.restart_nodes_by_stop_and_start([target_node], wait=True)
+        logger.info(f"Node {node_name} restarted successfully")
+    except Exception as e:
+        logger.error(f"Failed to restart node {node_name}: {e}")
+        return False
+
+    logger.info("Waiting 60s for pods to stabilize after node restart...")
+    time.sleep(60)
+
+    return True
+
+
+def check_and_recover_sandbox_errors(
+    pod_obj, timeout=600, max_recovery_attempts=2, _attempt=0
+):
     """
     Check if a pod has sandbox errors and recover by power cycling its node.
-    After node recovery, delegates to handle_multi_attach_error for volume issues.
+    After node recovery, continues monitoring for pod readiness with periodic error checks.
 
-    This is a lightweight helper specifically for recover_mcg() and ceph_fs_recovery()
-    to handle FailedCreatePodSandBox errors during pod recovery.
+    This handles FailedCreatePodSandBox and ReadWriteOncePod errors during pod recovery.
 
     Args:
         pod_obj: Pod object to check
         timeout: Maximum time to wait for recovery (default: 600s)
+        max_recovery_attempts: Maximum number of recovery attempts (default: 2)
+        _attempt: Internal counter for recursion depth (do not set manually)
 
     Returns:
         bool: True if pod reaches running state, False otherwise
@@ -1090,10 +1167,7 @@ def check_and_recover_sandbox_errors(pod_obj, timeout=600):
         pod_name = pod_obj.name
         namespace = pod_obj.namespace
 
-        pod_status = pod_obj.get().get("status", {})
-        phase = pod_status.get("phase")
-
-        if phase == constants.STATUS_RUNNING:
+        if is_pod_running(pod_obj):
             logger.debug(f"Pod {pod_name} is already running, no recovery needed")
             return True
 
@@ -1103,6 +1177,7 @@ def check_and_recover_sandbox_errors(pod_obj, timeout=600):
             logger.debug(f"Pod {pod_name} not scheduled to a node yet")
             return handle_multi_attach_error(pod_obj, timeout)
 
+        phase = pod_obj.get().get("status", {}).get("phase")
         logger.info(f"Pod {pod_name} is in phase '{phase}', checking for errors...")
 
         ocp_pod = OCP(kind=constants.POD, namespace=namespace)
@@ -1119,104 +1194,122 @@ def check_and_recover_sandbox_errors(pod_obj, timeout=600):
             msg = event.get("message", "")
             reason = event.get("reason", "")
 
-            # Check for sandbox errors
-            if any(
-                err in msg
-                for err in [
-                    "FailedCreatePodSandBox",
-                    "DeadlineExceeded",
-                    "stream terminated",
-                    "context deadline exceeded",
-                ]
-            ):
+            if any(err in msg for err in SANDBOX_ERROR_PATTERNS):
                 has_sandbox_error = True
                 error_messages.append(f"{reason}: {msg[:150]}")
 
-            # Check for ReadWriteOncePod volume already in use error
-            if any(
-                err in msg
-                for err in [
-                    "ReadWriteOncePod access mode and is already in use",
-                    "volume is already exclusively attached",
-                ]
-            ):
+            if any(err in msg for err in RWOP_ERROR_PATTERNS):
                 has_rwop_error = True
                 error_messages.append(f"{reason}: {msg[:150]}")
 
-        if not has_sandbox_error and not has_rwop_error:
-            logger.debug(
-                f"Pod {pod_name} has no sandbox or RWOP errors, using standard recovery"
+        if has_sandbox_error or has_rwop_error:
+            error_type = (
+                "sandbox/RWOP"
+                if (has_sandbox_error and has_rwop_error)
+                else ("sandbox" if has_sandbox_error else "ReadWriteOncePod")
             )
-            return handle_multi_attach_error(pod_obj, timeout)
+            logger.warning(
+                f"Pod {pod_name} on node {node_name} has {error_type} errors:"
+            )
+            for msg in error_messages[:3]:
+                logger.warning(f"  - {msg}")
 
-        error_type = (
-            "sandbox/RWOP"
-            if (has_sandbox_error and has_rwop_error)
-            else ("sandbox" if has_sandbox_error else "ReadWriteOncePod")
-        )
-        logger.warning(f"Pod {pod_name} on node {node_name} has {error_type} errors:")
-        for msg in error_messages[:3]:
-            logger.warning(f"  - {msg}")
+            # Check if node was recently restarted to avoid redundant restarts
+            current_time = time.time()
+            should_restart_node = True
 
-        logger.info(f"Recovering pod {pod_name} by restarting node {node_name}")
+            if node_name in _node_restart_tracker:
+                last_restart_time = _node_restart_tracker[node_name]
+                time_since_restart = current_time - last_restart_time
 
-        # Get platform-specific nodes object
-        nodes_platform = PlatformNodesFactory().get_nodes_platform()
+                if time_since_restart < NODE_RESTART_COOLDOWN:
+                    logger.info(
+                        f"Node {node_name} was restarted {int(time_since_restart)}s ago, "
+                        f"skipping restart (cooldown: {NODE_RESTART_COOLDOWN}s)"
+                    )
+                    should_restart_node = False
+                else:
+                    logger.info(
+                        f"Node {node_name} restart cooldown expired ({int(time_since_restart)}s), "
+                        "proceeding with restart"
+                    )
 
-        # Get all node objects to find the target node
-        node_objs = get_node_objs()
-        target_node = None
-        for n in node_objs:
-            if n.name == node_name:
-                target_node = n
-                break
+            if should_restart_node:
+                logger.info(f"Recovering pod {pod_name} by restarting node {node_name}")
+                nodes_platform = PlatformNodesFactory().get_nodes_platform()
+                node_objs = get_node_objs()
 
-        if not target_node:
-            logger.error(f"Could not find node object for {node_name}")
-            return handle_multi_attach_error(pod_obj, timeout)
+                if perform_node_restart(node_name, nodes_platform, node_objs):
+                    _node_restart_tracker[node_name] = current_time
+                else:
+                    logger.error(f"Node restart failed for {node_name}")
+                    return handle_multi_attach_error(pod_obj, timeout)
+        else:
+            logger.debug(f"Pod {pod_name} has no sandbox/RWOP errors initially")
 
-        logger.info(
-            f"Stopping node {node_name} using platform: {nodes_platform.__class__.__name__}"
-        )
-        nodes_platform.stop_nodes([target_node])
+        logger.info(f"Monitoring pod {pod_name} for up to {timeout}s...")
+        start_time = time.time()
+        last_check = 0
+        check_interval = 120
 
-        logger.info("Waiting 30s for node to stop...")
-        time.sleep(30)
+        while time.time() - start_time < timeout:
+            pod_obj.reload()
+            phase = pod_obj.get().get("status", {}).get("phase")
 
-        logger.info(f"Starting node {node_name}...")
-        nodes_platform.start_nodes([target_node])
+            if phase == constants.STATUS_RUNNING:
+                logger.info(f"Pod {pod_name} is running")
+                return True
 
-        logger.info(f"Waiting for node {node_name} to become Ready...")
-        ocp_node = OCP(kind=constants.NODE)
-        for sample in TimeoutSampler(
-            timeout=300, sleep=10, func=ocp_node.get, resource_name=node_name
-        ):
-            node_status = sample
-            conditions = node_status.get("status", {}).get("conditions", [])
-            for condition in conditions:
-                if (
-                    condition.get("type") == "Ready"
-                    and condition.get("status") == "True"
-                ):
-                    logger.info(f"Node {node_name} is Ready")
-                    break
-            else:
-                continue
-            break
+            elapsed = time.time() - start_time
 
-        logger.info("Waiting 60s for pod to stabilize after node restart...")
-        time.sleep(60)
+            if elapsed - last_check >= check_interval:
+                logger.debug(f"Checking for errors after {int(elapsed)}s...")
+                try:
+                    events = ocp_pod.exec_oc_cmd(
+                        f"get events --field-selector involvedObject.name={pod_name} "
+                        f"-n {namespace} -o json"
+                    )
 
-        logger.info("Node restart complete, checking for volume attachment issues...")
+                    for event in events.get("items", []):
+                        msg = event.get("message", "")
+                        if any(err in msg for err in ALL_POD_ERROR_PATTERNS):
+                            logger.warning(f"New error detected: {msg[:150]}")
 
-        return handle_multi_attach_error(pod_obj, timeout)
+                            if _attempt >= max_recovery_attempts:
+                                logger.error(
+                                    f"Pod {pod_name} still has errors after {max_recovery_attempts} "
+                                    "recovery attempts, giving up on automatic recovery"
+                                )
+                                return False
+
+                            logger.info(
+                                f"Triggering recovery for newly detected error "
+                                f"(attempt {_attempt + 1}/{max_recovery_attempts})..."
+                            )
+                            return check_and_recover_sandbox_errors(
+                                pod_obj,
+                                int(timeout - elapsed),
+                                max_recovery_attempts,
+                                _attempt + 1,
+                            )
+                except Exception as e:
+                    logger.debug(f"Error checking events: {e}")
+
+                last_check = elapsed
+
+            time.sleep(10)
+
+        logger.error(f"Pod {pod_name} failed to reach running state after {timeout}s")
+        return False
 
     except Exception as e:
         logger.error(f"Error during sandbox error recovery for {pod_obj.name}: {e}")
         return handle_multi_attach_error(pod_obj, timeout)
 
 
-def verify_pods_running(pod_list, pod_type="pod", timeout=600):
+def verify_pods_running(
+    pod_list, pod_type="pod", timeout=600, parallel=True, max_workers=5
+):
     """
     Verify that a list of pods reach running state, with sandbox error recovery.
 
@@ -1224,18 +1317,47 @@ def verify_pods_running(pod_list, pod_type="pod", timeout=600):
         pod_list: List of pod objects to verify
         pod_type: Type of pods for logging (e.g., "noobaa", "RGW", "MDS")
         timeout: Maximum time to wait for each pod
+        parallel: If True, check pods in parallel (default: True)
+        max_workers: Maximum number of concurrent workers when parallel=True (default: 5)
 
     Returns:
         list: List of failed pod names (empty if all succeeded)
     """
-    logger.info(f"Verifying {len(pod_list)} {pod_type} pods reach running state")
+    logger.info(
+        f"Verifying {len(pod_list)} {pod_type} pods reach running state "
+        f"({'parallel' if parallel else 'sequential'})"
+    )
     failed_pods = []
 
-    for pod_obj in pod_list:
+    def check_single_pod(pod_obj):
+        """Check a single pod and return its name if it fails"""
         logger.debug(f"Checking {pod_type} pod: {pod_obj.name}")
         if not check_and_recover_sandbox_errors(pod_obj, timeout=timeout):
             logger.error(f"{pod_type} pod {pod_obj.name} failed to reach running state")
-            failed_pods.append(pod_obj.name)
+            return pod_obj.name
+        return None
+
+    if parallel and len(pod_list) > 1:
+        with ThreadPoolExecutor(
+            max_workers=min(max_workers, len(pod_list))
+        ) as executor:
+            futures = {executor.submit(check_single_pod, pod): pod for pod in pod_list}
+            for future in as_completed(futures):
+                try:
+                    result = future.result()
+                    if result:
+                        failed_pods.append(result)
+                except Exception as e:
+                    pod = futures[future]
+                    logger.error(
+                        f"Exception while checking {pod_type} pod {pod.name}: {e}"
+                    )
+                    failed_pods.append(pod.name)
+    else:
+        for pod_obj in pod_list:
+            result = check_single_pod(pod_obj)
+            if result:
+                failed_pods.append(result)
 
     if failed_pods:
         logger.error(

--- a/tests/cross_functional/kcs/test_monitor_recovery.py
+++ b/tests/cross_functional/kcs/test_monitor_recovery.py
@@ -66,7 +66,7 @@ RWOP_ERROR_PATTERNS = [
 
 ALL_POD_ERROR_PATTERNS = SANDBOX_ERROR_PATTERNS + RWOP_ERROR_PATTERNS
 
-_node_restart_tracker = {}  # {node_name: timestamp}
+_node_restart_tracker = {}
 NODE_RESTART_COOLDOWN = 300
 
 
@@ -301,13 +301,16 @@ class TestMonitorRecovery(E2ETest):
         logger.test_step("Remove global ID reclaim warnings")
         remove_global_id_reclaim()
         logger.test_step("Verify data integrity after recovery")
-        for pod_obj in self.dc_pods:
+
+        logger.info("Checking current state of application pods before verification")
+        current_dc_pods = get_spun_dc_pods(self.dc_pods)
+        for pod_obj in current_dc_pods:
             logger.debug(f"Force deleting pod: {pod_obj.name}")
             pod_obj.delete(force=True)
 
         new_md5_sum = []
         logger.info("Waiting for pods to respawn and calculating checksums")
-        for pod_obj in get_spun_dc_pods(self.dc_pods):
+        for pod_obj in get_spun_dc_pods(current_dc_pods):
             pod_obj.ocp.wait_for_resource(
                 condition=constants.STATUS_RUNNING,
                 resource_name=pod_obj.name,
@@ -1467,7 +1470,6 @@ def handle_multi_attach_error(pod_obj, timeout=300):
 def recover_mcg():
     """
     Recovery procedure for NooBaa by re-spinning the pods after mon recovery
-    Simplified to use existing ocs-ci functions with expected pod count verification
 
     Raises:
         ResourceWrongStatusException: If any NooBaa or RGW pods fail to reach running state
@@ -1476,9 +1478,32 @@ def recover_mcg():
 
     noobaa_pods_before = get_noobaa_pods()
     expected_pod_count = len(noobaa_pods_before)
-    expected_pod_names = {pod.name for pod in noobaa_pods_before}
+
+    NOOBAA_POD_PREFIXES = [
+        "noobaa-db-pg-cluster-1",
+        "noobaa-db-pg-cluster-2",
+        "cnpg-controller-manager",
+        "noobaa-core",
+        "noobaa-endpoint",
+        "noobaa-operator",
+    ]
+
+    def get_pod_type_prefix(pod_name):
+        """Extract pod type prefix from pod name using known prefixes"""
+        for prefix in NOOBAA_POD_PREFIXES:
+            if pod_name.startswith(prefix):
+                return prefix
+        logger.warning(f"Unknown NooBaa pod type: {pod_name}")
+        parts = pod_name.rsplit("-", 2)
+        return parts[0] if len(parts) > 1 else pod_name
+
+    expected_pod_types = {}
+    for pod_obj in noobaa_pods_before:
+        prefix = get_pod_type_prefix(pod_obj.name)
+        expected_pod_types[prefix] = expected_pod_types.get(prefix, 0) + 1
+
     logger.info(
-        f"Found {expected_pod_count} NooBaa pods to respawn: {sorted(expected_pod_names)}"
+        f"Found {expected_pod_count} NooBaa pods to respawn by type: {expected_pod_types}"
     )
 
     for idx, noobaa_pod in enumerate(noobaa_pods_before):
@@ -1501,24 +1526,39 @@ def recover_mcg():
     for retry_attempt in range(max_count_retries):
         current_noobaa_pods = get_noobaa_pods()
         current_pod_count = len(current_noobaa_pods)
-        current_pod_names = {pod.name for pod in current_noobaa_pods}
+
+        current_pod_types = {}
+        for pod_obj in current_noobaa_pods:
+            prefix = get_pod_type_prefix(pod_obj.name)
+            current_pod_types[prefix] = current_pod_types.get(prefix, 0) + 1
 
         logger.info(
             f"Pod count check attempt {retry_attempt + 1}/{max_count_retries}: "
-            f"Found {current_pod_count}/{expected_pod_count} NooBaa pods"
+            f"Found {current_pod_count}/{expected_pod_count} NooBaa pods by type: {current_pod_types}"
         )
 
-        if current_pod_count >= expected_pod_count:
+        missing_types = []
+        for pod_type, expected_count in expected_pod_types.items():
+            current_count = current_pod_types.get(pod_type, 0)
+            if current_count < expected_count:
+                missing_types.append(f"{pod_type} ({current_count}/{expected_count})")
+
+        if not missing_types and current_pod_count >= expected_pod_count:
             logger.info(
-                f"All {expected_pod_count} expected NooBaa pods found: {sorted(current_pod_names)}"
+                f"All {expected_pod_count} expected NooBaa pods found with correct types"
             )
             break
 
-        missing_pods = expected_pod_names - current_pod_names
-        logger.warning(
-            f"Missing {len(missing_pods)} NooBaa pods: {sorted(missing_pods)}. "
-            f"Waiting {retry_wait_time}s..."
-        )
+        if missing_types:
+            logger.warning(
+                f"Missing or incomplete pod types: {missing_types}. "
+                f"Waiting {retry_wait_time}s..."
+            )
+        else:
+            logger.warning(
+                f"Pod count mismatch: {current_pod_count}/{expected_pod_count}. "
+                f"Waiting {retry_wait_time}s..."
+            )
 
         if retry_attempt < max_count_retries - 1:
             time.sleep(retry_wait_time)
@@ -1526,7 +1566,7 @@ def recover_mcg():
             error_msg = (
                 f"NooBaa recovery failed: Expected {expected_pod_count} pods "
                 f"but only found {current_pod_count} after {max_count_retries} attempts. "
-                f"Missing pods: {sorted(missing_pods)}"
+                f"Expected types: {expected_pod_types}, Current types: {current_pod_types}"
             )
             logger.error(error_msg)
             raise ResourceWrongStatusException(error_msg)
@@ -1696,13 +1736,25 @@ def replace_mds_deployments():
 
         logger.info(f"Successfully backed up {len(mds_deployment_names)} deployments")
 
-        logger.info(f"Replacing {len(mds_deployment_names)} MDS deployments")
-        for deployment in mds_deployment_names:
+        logger.info(
+            f"Replacing {len(mds_deployment_names)} MDS deployments sequentially"
+        )
+        for idx, deployment in enumerate(mds_deployment_names):
             deployment_yaml = join(backup_dir, deployment + ".yaml")
-            logger.debug(f"Replacing deployment: {deployment}")
+            logger.info(
+                f"Replacing MDS deployment {idx + 1}/{len(mds_deployment_names)}: {deployment}"
+            )
             exec_cmd(
                 f"oc replace --force -f {deployment_yaml} -n {defaults.ROOK_CLUSTER_NAMESPACE}"
             )
+
+            if idx < len(mds_deployment_names) - 1:
+                wait_time = 120
+                logger.info(
+                    f"Waiting {wait_time}s for {deployment} to complete "
+                    f"before replacing next deployment"
+                )
+                time.sleep(wait_time)
 
         logger.info(
             f"Successfully replaced {len(mds_deployment_names)} MDS deployments"

--- a/tests/cross_functional/kcs/test_monitor_recovery.py
+++ b/tests/cross_functional/kcs/test_monitor_recovery.py
@@ -271,8 +271,6 @@ class TestMonitorRecovery(E2ETest):
         mon_recovery.patch_sleep_on_mds()
         logger.info("Resetting CephFS")
         ceph_fs_recovery()
-        logger.info("Reverting MDS deployments to original configuration")
-        mon_recovery.revert_patches(mds_revert)
         logger.info("Scaling back rook and ocs operators after CephFS recovery")
         mon_recovery.scale_rook_ocs_operators(replica=1)
 
@@ -499,6 +497,9 @@ class MonitorRecovery(object):
         Prepares the script to retrieve the `monstore` cluster map from OSDs
 
         """
+        logger.info(
+            f"Preparing mon-store recovery script: {self.backup_dir}/recover_mon.sh"
+        )
         recover_mon = f"""
         #!/bin/bash
         ms=/tmp/monstore
@@ -537,6 +538,7 @@ class MonitorRecovery(object):
         with open(f"{self.backup_dir}/recover_mon.sh", "w") as file:
             file.write(recover_mon)
         exec_cmd(cmd=f"chmod +x {self.backup_dir}/recover_mon.sh")
+        logger.info("Mon-store recovery script prepared successfully")
 
     @retry(CommandFailed, tries=15, delay=5, backoff=1)
     def run_mon_store(self):
@@ -768,6 +770,7 @@ class MonitorRecovery(object):
             tuple: deployment paths to be reverted
 
         """
+        logger.debug("Identifying deployments to revert")
         to_revert_patches = (
             get_deployments_having_label(
                 label=constants.MON_APP_LABEL,
@@ -786,6 +789,10 @@ class MonitorRecovery(object):
             label=constants.MDS_APP_LABEL,
             namespace=config.ENV_DATA["cluster_namespace"],
         )
+        logger.debug(
+            f"Found {len(to_revert_patches)} MON/OSD/MGR deployments and {len(to_revert_mds)} MDS deployments"
+        )
+
         to_revert_patches_path = []
         to_revert_mds_path = []
         for dep in to_revert_patches:
@@ -793,7 +800,6 @@ class MonitorRecovery(object):
                 join(self.backup_dir, dep["metadata"]["name"] + ".yaml")
             )
         for dep in to_revert_mds:
-            logger.info(dep)
             to_revert_mds_path.append(
                 join(self.backup_dir, dep["metadata"]["name"] + ".yaml")
             )
@@ -850,10 +856,10 @@ class MonitorRecovery(object):
                 elif "caps" in block:
                     caps.append(block.strip())
                 if key:
-                    logger.info("Found key entry in keyring data")
+                    logger.debug("Found key entry in keyring data")
                     formatted_data.append(f"    key = {key}")
                 for cap in caps:
-                    logger.info(f"Found cap :{cap}")
+                    logger.debug(f"Found cap: {cap}")
                     formatted_data.append(f"    {cap}")
         with open(f"{self.keyring_dir}/keyring-mon-a", "w") as f:
             f.write("\n".join(formatted_data))
@@ -1313,9 +1319,52 @@ def remove_global_id_reclaim():
     logger.info("Global ID reclaim warning removal completed")
 
 
+def replace_mds_deployments():
+    """
+    Backup and replace MDS deployments to recover from CephFS reset
+
+    This function backs up the MDS deployments and replaces them using oc replace --force
+
+    """
+    logger.info("Replacing MDS deployments to recover from CephFS reset")
+
+    mds_deployment_names = [
+        "rook-ceph-mds-ocs-storagecluster-cephfilesystem-a",
+        "rook-ceph-mds-ocs-storagecluster-cephfilesystem-b",
+    ]
+
+    dep_ocp = OCP(kind=constants.DEPLOYMENT, namespace=defaults.ROOK_CLUSTER_NAMESPACE)
+
+    with tempfile.TemporaryDirectory() as backup_dir:
+        logger.info(
+            f"Backing up {len(mds_deployment_names)} MDS deployments to temporary directory"
+        )
+        logger.debug(f"Backup directory: {backup_dir}")
+
+        for deployment in mds_deployment_names:
+            logger.debug(f"Backing up deployment: {deployment}")
+            deployment_get = dep_ocp.get(resource_name=deployment)
+            deployment_yaml = join(backup_dir, deployment + ".yaml")
+            templating.dump_data_to_temp_yaml(deployment_get, deployment_yaml)
+
+        logger.info(f"Successfully backed up {len(mds_deployment_names)} deployments")
+
+        logger.info(f"Replacing {len(mds_deployment_names)} MDS deployments")
+        for deployment in mds_deployment_names:
+            deployment_yaml = join(backup_dir, deployment + ".yaml")
+            logger.debug(f"Replacing deployment: {deployment}")
+            exec_cmd(
+                f"oc replace --force -f {deployment_yaml} -n {defaults.ROOK_CLUSTER_NAMESPACE}"
+            )
+
+        logger.info(
+            f"Successfully replaced {len(mds_deployment_names)} MDS deployments"
+        )
+
+
 def ceph_fs_recovery():
     """
-    Resets the CephFS
+    Resets the CephFS and replaces MDS deployments
 
     """
     logger.info(
@@ -1343,32 +1392,30 @@ def ceph_fs_recovery():
                 f"ceph fs reset {defaults.CEPHFILESYSTEM_NAME} --yes-i-really-mean-it"
             )
             logger.info("CephFS reset successful after recreation")
-
-            logger.info("Verifying MDS pods reach running state after CephFS creation")
-            mds_pods = get_mds_pods()
-            logger.info(f"Found {len(mds_pods)} MDS pods to verify")
-            failed_mds_pods = []
-            for mds_pod in mds_pods:
-                logger.debug(f"Checking MDS pod: {mds_pod.name}")
-                if not handle_multi_attach_error(mds_pod, timeout=600):
-                    logger.warning(
-                        f"MDS pod {mds_pod.name} did not reach running state"
-                    )
-                    failed_mds_pods.append(mds_pod.name)
-
-            if failed_mds_pods:
-                logger.warning(
-                    f"{len(failed_mds_pods)} MDS pods did not reach running state: {failed_mds_pods}"
-                )
-            else:
-                logger.info(
-                    f"All {len(mds_pods)} MDS pods are running after CephFS creation"
-                )
         except CommandFailed:
             logger.exception(
                 f"Failed to recover CephFS: {defaults.CEPHFILESYSTEM_NAME}"
             )
             raise
+
+    replace_mds_deployments()
+
+    logger.info("Verifying MDS pods reach running state after CephFS recovery")
+    mds_pods = get_mds_pods()
+    logger.info(f"Found {len(mds_pods)} MDS pods to verify")
+    failed_mds_pods = []
+    for mds_pod in mds_pods:
+        logger.debug(f"Checking MDS pod: {mds_pod.name}")
+        if not handle_multi_attach_error(mds_pod, timeout=600):
+            logger.warning(f"MDS pod {mds_pod.name} did not reach running state")
+            failed_mds_pods.append(mds_pod.name)
+
+    if failed_mds_pods:
+        logger.warning(
+            f"{len(failed_mds_pods)} MDS pods did not reach running state: {failed_mds_pods}"
+        )
+    else:
+        logger.info(f"All {len(mds_pods)} MDS pods are running after CephFS recovery")
 
 
 def get_spun_dc_pods(pod_list):

--- a/tests/cross_functional/kcs/test_monitor_recovery.py
+++ b/tests/cross_functional/kcs/test_monitor_recovery.py
@@ -953,7 +953,16 @@ class MonitorRecovery(object):
         mds_pods = get_mds_pods(namespace=config.ENV_DATA["cluster_namespace"])
         for mds in mds_pods:
             logger.debug(f"Waiting for MDS pod: {mds.name}")
-            wait_for_resource_state(resource=mds, state=constants.STATUS_RUNNING)
+            try:
+                wait_for_resource_state(resource=mds, state=constants.STATUS_RUNNING)
+            except (CommandFailed, ResourceWrongStatusException):
+                if not _pod_exists(mds):
+                    logger.info(
+                        f"MDS pod {mds.name} no longer exists (replaced by deployment "
+                        "rollout) - skipping"
+                    )
+                    continue
+                raise
         logger.info(f"All {len(mds_pods)} MDS pods are running")
 
     @retry(CommandFailed, tries=10, delay=10, backoff=1)
@@ -1100,6 +1109,25 @@ def is_pod_running(pod_obj):
         return False
 
 
+def _pod_exists(pod_obj):
+    """
+    Check whether a pod still exists on the cluster.
+
+    Args:
+        pod_obj: Pod object to check
+
+    Returns:
+        bool: True if the pod exists (regardless of phase), False if NotFound
+    """
+    try:
+        pod_obj.get()
+        return True
+    except CommandFailed as e:
+        if "NotFound" in str(e):
+            return False
+        raise
+
+
 def perform_node_restart(node_name, nodes_platform, node_objs):
     """
     Perform node restart operation using platform's restart_nodes_by_stop_and_start
@@ -1166,13 +1194,24 @@ def check_and_recover_sandbox_errors(
             logger.debug(f"Pod {pod_name} is already running, no recovery needed")
             return True
 
-        node_name = pod_obj.get().get("spec", {}).get("nodeName")
+        try:
+            pod_data = pod_obj.get()
+        except CommandFailed as e:
+            if "NotFound" in str(e):
+                logger.info(
+                    f"Pod {pod_name} no longer exists (replaced by a new pod after restart) - "
+                    "treating as success"
+                )
+                return True
+            raise
+
+        node_name = pod_data.get("spec", {}).get("nodeName")
 
         if not node_name:
             logger.debug(f"Pod {pod_name} not scheduled to a node yet")
             return handle_multi_attach_error(pod_obj, timeout)
 
-        phase = pod_obj.get().get("status", {}).get("phase")
+        phase = pod_data.get("status", {}).get("phase")
         logger.info(f"Pod {pod_name} is in phase '{phase}', checking for errors...")
 
         ocp_pod = OCP(kind=constants.POD, namespace=namespace)
@@ -1248,7 +1287,16 @@ def check_and_recover_sandbox_errors(
         check_interval = 120
 
         while time.time() - start_time < timeout:
-            pod_obj.reload()
+            try:
+                pod_obj.reload()
+            except CommandFailed as e:
+                if "NotFound" in str(e):
+                    logger.info(
+                        f"Pod {pod_name} no longer exists during monitoring (replaced by a new "
+                        "pod after node restart) - treating as success"
+                    )
+                    return True
+                raise
             phase = pod_obj.get().get("status", {}).get("phase")
 
             if phase == constants.STATUS_RUNNING:
@@ -1861,21 +1909,28 @@ def ceph_fs_recovery():
 
     logger.info("Verifying MDS pods reach running state after CephFS recovery")
     all_mds_pods = get_mds_pods()
-    mds_pods = [
-        pod
-        for pod in all_mds_pods
-        if not pod.get().get("metadata", {}).get("deletionTimestamp")
-    ]
+    mds_pods = []
+    for p in all_mds_pods:
+        try:
+            pod_data = p.get()
+        except CommandFailed as e:
+            if "NotFound" in str(e):
+                logger.debug(f"MDS pod {p.name} already gone, skipping filter check")
+                continue
+            raise
+        if not pod_data.get("metadata", {}).get("deletionTimestamp"):
+            mds_pods.append(p)
     logger.info(
         f"Found {len(mds_pods)} active MDS pods to verify "
-        f"(filtered out {len(all_mds_pods) - len(mds_pods)} terminating pods)"
+        f"(filtered out {len(all_mds_pods) - len(mds_pods)} terminating/gone pods)"
     )
 
     failed_mds_pods = verify_pods_running(mds_pods, pod_type="MDS", timeout=600)
 
     if failed_mds_pods:
-        logger.warning(
-            f"{len(failed_mds_pods)} MDS pods did not reach running state: {failed_mds_pods}"
+        raise AssertionError(
+            f"CephFS recovery failed: {len(failed_mds_pods)} MDS pods did not reach "
+            f"running state: {failed_mds_pods}"
         )
 
 

--- a/tests/cross_functional/kcs/test_monitor_recovery.py
+++ b/tests/cross_functional/kcs/test_monitor_recovery.py
@@ -38,13 +38,15 @@ from ocs_ci.ocs.resources.pod import (
     get_noobaa_pods,
     get_plugin_pods,
     get_ceph_tools_pod,
+    get_deployment_name,
     wait_for_storage_pods,
 )
 from ocs_ci.ocs.resources import pod
 from ocs_ci.ocs import ocp, constants, defaults, bucket_utils
 from ocs_ci.helpers.helpers import wait_for_resource_state, get_secret_names
 from ocs_ci.utility.retry import retry
-from ocs_ci.utility.utils import exec_cmd, run_cmd
+from ocs_ci.utility.utils import exec_cmd, run_cmd, TimeoutSampler
+from ocs_ci.utility.utils import TimeoutExpiredError
 from ocs_ci.ocs.platform_nodes import PlatformNodesFactory
 from ocs_ci.ocs.node import get_node_objs
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -1135,46 +1137,55 @@ def _pod_exists(pod_obj):
 
 def _wait_for_replacement_pod(pod_obj, timeout, namespace):
     """
-    After an original pod has been replaced (new name, same app label), wait for
-    a fresh pod with the same 'app' label selector to reach Running state.
+    Wait for the replacement of a deleted pod to reach Running state.
+
+    Derives the stable name prefix from the original pod's name and polls all
+    pods in the namespace until one with that prefix is Running.
 
     Args:
-        pod_obj: The original (now-deleted) pod object — its cached labels are read
+        pod_obj: The original (now-deleted) pod object — its name is read
         timeout (int): Seconds to wait for the replacement pod
         namespace (str): Namespace to search in
 
     Returns:
-        bool: True if a replacement pod reaches Running, False otherwise
+        bool: True if the replacement pod reaches Running, False otherwise
     """
-    app_label = pod_obj.labels.get("app") if pod_obj.labels else None
-    if not app_label:
-        logger.warning(
-            f"Cannot determine app label for replaced pod {pod_obj.name} - "
-            "cannot verify replacement pod"
-        )
+    pod_name = pod_obj.name
+    last_segment = pod_name.rsplit("-", 1)[-1]
+    if last_segment.isdigit():
+        prefix = pod_name
+    else:
+        prefix = get_deployment_name(pod_name)
+    logger.info(
+        f"Waiting up to {timeout}s for replacement of pod '{pod_obj.name}' "
+        f"(name prefix: '{prefix}') to reach Running state"
+    )
+
+    ocp_pod = OCP(kind=constants.POD, namespace=namespace)
+
+    def _replacement_is_running():
+        all_pods = ocp_pod.get().get("items", [])
+        for p in all_pods:
+            name = p.get("metadata", {}).get("name", "")
+            phase = p.get("status", {}).get("phase", "")
+            if name.startswith(prefix) and phase == constants.STATUS_RUNNING:
+                logger.info(f"Replacement pod '{name}' is Running")
+                return True
         return False
 
-    selector = f"app={app_label}"
-    logger.info(
-        f"Waiting up to {timeout}s for replacement pod "
-        f"with selector '{selector}' to reach Running state"
-    )
-    ocp_pod = OCP(kind=constants.POD, namespace=namespace)
     try:
-        ocp_pod.wait_for_resource(
-            condition=constants.STATUS_RUNNING,
-            selector=selector,
-            timeout=timeout,
-            sleep=10,
-        )
-        logger.info(f"Replacement pod(s) with selector '{selector}' confirmed running")
-        return True
-    except Exception as e:
+        for result in TimeoutSampler(
+            timeout=timeout, sleep=10, func=_replacement_is_running
+        ):
+            if result:
+                return True
+    except TimeoutExpiredError:
         logger.error(
-            f"Replacement pod for '{app_label}' did not reach Running state "
-            f"within {timeout}s: {e}"
+            f"Replacement pod for '{pod_obj.name}' (prefix='{prefix}') did not reach "
+            f"Running state within {timeout}s"
         )
         return False
+    return False
 
 
 def perform_node_restart(node_name, nodes_platform, node_objs):

--- a/tests/cross_functional/kcs/test_monitor_recovery.py
+++ b/tests/cross_functional/kcs/test_monitor_recovery.py
@@ -67,6 +67,7 @@ class TestMonitorRecovery(E2ETest):
     @pytest.fixture(autouse=True)
     def mon_recovery_setup(
         self,
+        request,
         deployment_pod_factory,
         mcg_obj,
         bucket_factory,
@@ -75,6 +76,51 @@ class TestMonitorRecovery(E2ETest):
         Creates project, pvcs, dc-pods and obcs
 
         """
+
+        def finalizer():
+            """
+            Teardown: Force delete pods and clean up volume attachments
+            """
+            logger.test_step("Teardown: Clean up test resources")
+            logger.info("Force deleting test pods to release PVCs")
+            for dc_pod in self.dc_pods:
+                try:
+                    logger.debug(f"Force deleting pod: {dc_pod.name}")
+                    dc_pod.delete(force=True, wait=False)
+                except Exception as e:
+                    logger.warning(f"Failed to delete pod {dc_pod.name}: {e}")
+
+            logger.info("Waiting 30s for pods to terminate")
+            time.sleep(30)
+
+            logger.info("Cleaning up stale volume attachments")
+            try:
+                va_ocp = OCP(kind="VolumeAttachment", namespace="")
+                attachments = va_ocp.get()
+                if attachments and "items" in attachments:
+                    deleted_count = 0
+                    for attachment in attachments["items"]:
+                        if not attachment.get("status", {}).get("attached", False):
+                            va_name = attachment["metadata"]["name"]
+                            logger.debug(
+                                f"Deleting unattached VolumeAttachment: {va_name}"
+                            )
+                            try:
+                                va_ocp.delete(resource_name=va_name)
+                                deleted_count += 1
+                            except Exception as e:
+                                logger.warning(
+                                    f"Failed to delete VolumeAttachment {va_name}: {e}"
+                                )
+                    if deleted_count > 0:
+                        logger.info(f"Deleted {deleted_count} stale volume attachments")
+                    else:
+                        logger.debug("No stale volume attachments found")
+            except Exception:
+                logger.exception("Error during volume attachment cleanup")
+
+        request.addfinalizer(finalizer)
+
         self.filename = "sample_file.txt"
         self.object_key = "obj-key"
         self.object_data = "string data"
@@ -1103,9 +1149,46 @@ def recover_mcg():
     logger.info("Waiting 120s for noobaa pods to respawn")
     time.sleep(120)
 
-    logger.info("Verifying noobaa pods reached running state")
-    failed_noobaa_pods = []
+    logger.info("Waiting for postgres cluster pods to spawn (timeout: 300s)")
+    max_wait_time = 300
+    start_time = time.time()
+    expected_pg_pods = 2
+    active_pg_pods = []
+
+    while time.time() - start_time < max_wait_time:
+        noobaa_db_pods = pod.get_pods_having_label(
+            constants.NOOBAA_DB_LABEL_419_AND_ABOVE,
+            config.ENV_DATA["cluster_namespace"],
+        )
+        active_pg_pods = [
+            p
+            for p in noobaa_db_pods
+            if p.get("metadata", {}).get("deletionTimestamp") is None
+        ]
+        if len(active_pg_pods) >= expected_pg_pods:
+            elapsed = int(time.time() - start_time)
+            logger.info(
+                f"All {len(active_pg_pods)} postgres cluster pods spawned after {elapsed}s"
+            )
+            break
+        logger.debug(
+            f"Postgres pods: active={len(active_pg_pods)}, total={len(noobaa_db_pods)}, "
+            f"expected={expected_pg_pods}, elapsed={int(time.time() - start_time)}s"
+        )
+        time.sleep(10)
+    else:
+        logger.warning(
+            f"Timeout waiting for postgres pods after {max_wait_time}s: "
+            f"found {len(active_pg_pods)}/{expected_pg_pods} expected"
+        )
+
+    logger.info("Verifying all noobaa pods reached running state")
     respawned_noobaa_pods = get_noobaa_pods()
+    logger.info(
+        f"Found {len(respawned_noobaa_pods)} noobaa pods to verify (includes postgres cluster)"
+    )
+    failed_noobaa_pods = []
+
     for noobaa_pod in respawned_noobaa_pods:
         logger.debug(f"Checking noobaa pod: {noobaa_pod.name}")
         if not handle_multi_attach_error(noobaa_pod, timeout=600):
@@ -1248,6 +1331,27 @@ def ceph_fs_recovery():
                 f"ceph fs reset {defaults.CEPHFILESYSTEM_NAME} --yes-i-really-mean-it"
             )
             logger.info("CephFS reset successful after recreation")
+
+            logger.info("Verifying MDS pods reach running state after CephFS creation")
+            mds_pods = get_mds_pods()
+            logger.info(f"Found {len(mds_pods)} MDS pods to verify")
+            failed_mds_pods = []
+            for mds_pod in mds_pods:
+                logger.debug(f"Checking MDS pod: {mds_pod.name}")
+                if not handle_multi_attach_error(mds_pod, timeout=600):
+                    logger.warning(
+                        f"MDS pod {mds_pod.name} did not reach running state"
+                    )
+                    failed_mds_pods.append(mds_pod.name)
+
+            if failed_mds_pods:
+                logger.warning(
+                    f"{len(failed_mds_pods)} MDS pods did not reach running state: {failed_mds_pods}"
+                )
+            else:
+                logger.info(
+                    f"All {len(mds_pods)} MDS pods are running after CephFS creation"
+                )
         except CommandFailed:
             logger.exception(
                 f"Failed to recover CephFS: {defaults.CEPHFILESYSTEM_NAME}"

--- a/tests/cross_functional/kcs/test_monitor_recovery.py
+++ b/tests/cross_functional/kcs/test_monitor_recovery.py
@@ -1,8 +1,6 @@
 import collections
 import logging
-import base64
 import time
-import os
 from os.path import join
 import tempfile
 import re
@@ -44,9 +42,9 @@ from ocs_ci.ocs.resources.pod import (
 )
 from ocs_ci.ocs.resources import pod
 from ocs_ci.ocs import ocp, constants, defaults, bucket_utils
-from ocs_ci.helpers.helpers import wait_for_resource_state
+from ocs_ci.helpers.helpers import wait_for_resource_state, get_secret_names
 from ocs_ci.utility.retry import retry
-from ocs_ci.utility.utils import exec_cmd
+from ocs_ci.utility.utils import exec_cmd, run_cmd
 
 logger = logging.getLogger(__name__)
 
@@ -133,22 +131,27 @@ class TestMonitorRecovery(E2ETest):
         logger.info("Corrupting ceph monitors by deleting store.db")
         corrupt_ceph_monitors()
 
-        logger.info("Backing up all the deployments")
+        logger.info("Starting the monitor recovery procedure")
+        logger.info("Scaling down rook-ceph-operator and ocs operator deployments")
+        mon_recovery.scale_rook_ocs_operators(replica=0)
+
+        logger.info("Backing up all the deployments in openshift-storage namespace")
         mon_recovery.backup_deployments()
         dep_revert, mds_revert = mon_recovery.deployments_to_revert()
 
-        logger.info("Starting the monitor recovery procedure")
-        logger.info("Scaling down rook and ocs operators")
-        mon_recovery.scale_rook_ocs_operators(replica=0)
-
         logger.info(
-            "Preparing script and patching OSDs to remove LivenessProbe and sleep to infinity"
+            "Patching OSD deployments to remove LivenessProbe and sleep to infinity"
         )
-        mon_recovery.prepare_monstore_script()
         mon_recovery.patch_sleep_on_osds()
-        switch_to_project(config.ENV_DATA["cluster_namespace"])
 
-        logger.info("Getting mon-store from OSDs")
+        switch_to_project(config.ENV_DATA["cluster_namespace"])
+        logger.info("Copy tar to the OSDs")
+        mon_recovery.copy_tar_to_pods(pod_type="osd")
+
+        logger.info("Preparing the recover_mon.sh script")
+        mon_recovery.prepare_monstore_script()
+
+        logger.info("Getting mon-store from OSDs by running recover_mon.sh script")
         mon_recovery.run_mon_store()
 
         logger.info("Patching MONs to sleep infinitely")
@@ -157,11 +160,44 @@ class TestMonitorRecovery(E2ETest):
         logger.info("Updating initial delay on all monitors")
         update_mon_initial_delay()
 
+        logger.info("Copy tar to the MONs")
+        mon_recovery.copy_tar_to_pods(pod_type="mon")
+
+        logger.info("Copy the previously retrieved monstore to the mon-a pod")
+        mon_pods = get_mon_pods(namespace=config.ENV_DATA["cluster_namespace"])
+        mon_a = mon_pods[0]
+        logger.info(f"Copying mon-store into monitor: {mon_a.name}")
+        ocp_obj = MonitorRecovery()
+        ocp_obj._exec_oc_cmd(
+            cmd=f"cp -n {constants.OPENSHIFT_STORAGE_NAMESPACE} /tmp/monstore {mon_a.name}:/tmp/"
+        )
+
+        logger.info(
+            "Getting into the mon-a pod and changing the ownership of the retrieved monstore"
+        )
+        _exec_cmd_on_pod(cmd="chown -R ceph:ceph /tmp/monstore", pod_obj=mon_a)
+
+        logger.info(
+            "Getting the keyrings of all the Ceph daemons (OSD, MGR, MDS and RGW) from their respective secrets"
+        )
+        file_path = mon_recovery.get_ceph_daemons_keyrings()
+
+        logger.info("Copy the ceph daemons key ring to mon-a")
+        mon_a = next(
+            mon
+            for mon in get_mon_pods(namespace=config.ENV_DATA["cluster_namespace"])
+            if mon.get().get("metadata", {}).get("labels", {}).get("ceph_daemon_id")
+            == "a"
+        )
+        logger.info(
+            f"Copying the mon keyring stored locally from {file_path} to monitor: {mon_a.name}"
+        )
+        ocp_obj._exec_oc_cmd(
+            cmd=f"cp -n {constants.OPENSHIFT_STORAGE_NAMESPACE} {file_path} {mon_a.name}:/tmp/keyring"
+        )
+
         logger.info("Generating monitor map command using the IPs")
         mon_map_cmd = generate_monmap_cmd()
-
-        logger.info("Getting ceph keyring from ocs secrets")
-        mon_recovery.get_ceph_keyrings()
 
         logger.info("Rebuilding Monitors to recover store db")
         mon_recovery.monitor_rebuild(mon_map_cmd)
@@ -251,8 +287,7 @@ class MonitorRecovery(object):
 
         """
         self.backup_dir = tempfile.mkdtemp(prefix="mon-backup-")
-        self.keyring_dir = tempfile.mkdtemp(dir=self.backup_dir, prefix="keyring-")
-        self.keyring_files = []
+        self.keyring_dir = tempfile.mkdtemp(dir=self.backup_dir, prefix="keyring")
         self.dep_ocp = OCP(
             kind=constants.DEPLOYMENT, namespace=config.ENV_DATA["cluster_namespace"]
         )
@@ -313,6 +348,37 @@ class MonitorRecovery(object):
         for osd in get_osd_pods():
             wait_for_resource_state(resource=osd, state=constants.STATUS_RUNNING)
 
+    def copy_tar_to_pods(self, pod_type="osd"):
+        """
+        Copies local tar binary to the specified type of pods (OSD or MON) pod
+        using cat
+
+        Args:
+            pod_type (str): Type of pod ("osd" or "mon"). Defaults to "osd".
+
+        Raises:
+            ValueError: If the pod_type is neither "osd" nor "mon".
+
+        """
+        if pod_type == "osd":
+            pod_objs = get_osd_pods()
+        elif pod_type == "mon":
+            pod_objs = get_mon_pods()
+        else:
+            raise ValueError(f"Invalid pod type: {pod_type}. Use 'osd' or 'mon' ")
+        for pod_obj in pod_objs:
+            logger.info(f"Copying tar binary to pod: {pod_obj.name}")
+            cmd = (
+                f"cat /usr/bin/tar | oc exec -i -n {constants.OPENSHIFT_STORAGE_NAMESPACE} {pod_obj.name}  -- bash -c "
+                f"'cat > /usr/bin/tar'"
+            )
+            run_cmd(cmd)
+            logger.info(
+                f"Setting execute permissions on /usr/bin/tar in pod: {pod_obj.name}"
+            )
+            cmd = "chmod +x /usr/bin/tar"
+            _exec_cmd_on_pod(cmd=cmd, pod_obj=pod_obj)
+
     def prepare_monstore_script(self):
         """
         Prepares the script to retrieve the `monstore` cluster map from OSDs
@@ -321,25 +387,38 @@ class MonitorRecovery(object):
         recover_mon = """
         #!/bin/bash
         ms=/tmp/monstore
+
         rm -rf $ms
         mkdir $ms
+
         for osd_pod in $(oc get po -l app=rook-ceph-osd -oname -n openshift-storage); do
+
             echo "Starting with pod: $osd_pod"
-            podname=$(echo $osd_pod| cut -c5-)
-            oc exec $osd_pod -- rm -rf $ms
-            oc cp $ms $podname:$ms
+
+            podname=$(echo $osd_pod|sed 's/pod\\///g')
+            oc exec -n {constants.OPENSHIFT_STORAGE_NAMESPACE} $osd_pod -- rm -rf $ms
+            oc exec -n {constants.OPENSHIFT_STORAGE_NAMESPACE} $osd_pod -- mkdir $ms
+            oc cp -n {constants.OPENSHIFT_STORAGE_NAMESPACE} $ms $podname:$ms
+
             rm -rf $ms
             mkdir $ms
-            dp=/var/lib/ceph/osd/ceph-$(oc get $osd_pod -ojsonpath='{ .metadata.labels.ceph_daemon_id }')
-            op=update-mon-db
-            ot=ceph-objectstore-tool
+
             echo "pod in loop: $osd_pod ; done deleting local dirs"
-            oc exec $osd_pod -- $ot --type bluestore --data-path $dp --op $op --no-mon-config --mon-store-path $ms
+
+            oc exec -n {constants.OPENSHIFT_STORAGE_NAMESPACE} $osd_pod -- \\
+            ceph-objectstore-tool --type bluestore --data-path \\
+            /var/lib/ceph/osd/ceph-$(oc get -n \\
+            {constants.OPENSHIFT_STORAGE_NAMESPACE} $osd_pod \\
+            -ojsonpath='{ .metadata.labels.ceph_daemon_id }') \\
+            --op update-mon-db --no-mon-config --mon-store-path $ms
             echo "Done with COT on pod: $osd_pod"
-            oc cp $podname:$ms $ms
+
+            oc cp -n {constants.OPENSHIFT_STORAGE_NAMESPACE} $podname:$ms $ms
+
             echo "Finished pulling COT data from pod: $osd_pod"
         done
-    """
+        """
+
         with open(f"{self.backup_dir}/recover_mon.sh", "w") as file:
             file.write(recover_mon)
         exec_cmd(cmd=f"chmod +x {self.backup_dir}/recover_mon.sh")
@@ -395,73 +474,60 @@ class MonitorRecovery(object):
             mon_map_cmd (str): mon-store tool command
 
         """
-        logger.info("Re-spinning the mon pods")
-        for mon in get_mon_pods(namespace=config.ENV_DATA["cluster_namespace"]):
-            mon.delete()
-        mon_pods = get_mon_pods(namespace=config.ENV_DATA["cluster_namespace"])
-        for mon in mon_pods:
-            wait_for_resource_state(resource=mon, state=constants.STATUS_RUNNING)
-        mon_a = mon_pods[0]
+        mon_a = next(
+            mon
+            for mon in get_mon_pods(namespace=config.ENV_DATA["cluster_namespace"])
+            if mon.get().get("metadata", {}).get("labels", {}).get("ceph_daemon_id")
+            == "a"
+        )
         logger.info(f"Working on monitor: {mon_a.name}")
 
-        logger.info(f"Copying mon-store into monitor: {mon_a.name}")
-        self._exec_oc_cmd(f"cp /tmp/monstore {mon_a.name}:/tmp/")
-
-        logger.info("Changing ownership of monstore to ceph")
-        _exec_cmd_on_pod(cmd="chown -R ceph:ceph /tmp/monstore", pod_obj=mon_a)
-        self.copy_and_import_keys(mon_obj=mon_a)
-        logger.info("Creating monitor map")
-        _exec_cmd_on_pod(cmd=mon_map_cmd, pod_obj=mon_a)
+        logger.info(f"Creating monmap with command: {mon_map_cmd}")
+        mon_a.exec_cmd_on_pod(command=mon_map_cmd, out_yaml_format=False)
 
         rebuild_mon_cmd = "ceph-monstore-tool /tmp/monstore rebuild -- --keyring /tmp/keyring --monmap /tmp/monmap"
         logger.info("Running command to rebuild monitor")
         mon_a.exec_cmd_on_pod(command=rebuild_mon_cmd, out_yaml_format=False)
 
-        logger.info(f"Copying store.db directory from monitor: {mon_a.name}")
-        self._exec_oc_cmd(
-            f"cp {mon_a.name}:/tmp/monstore/store.db {self.backup_dir}/store.db"
-        )
+        logger.info("Changing ownership of monstore to ceph")
+        _exec_cmd_on_pod(cmd="chown -R ceph:ceph /tmp/monstore", pod_obj=mon_a)
 
+        logger.info("Copy the rebuild store.db file to the monstore directory")
+        _exec_cmd_on_pod(
+            cmd="mv /tmp/monstore/store.db /var/lib/ceph/mon/ceph-a/store.db",
+            pod_obj=mon_a,
+        )
+        logger.info("Changing ownership of monstore to ceph")
+        _exec_cmd_on_pod(
+            cmd="chown -R ceph:ceph /var/lib/ceph/mon/ceph-a/store.db", pod_obj=mon_a
+        )
+        logger.info(
+            f"Copying store.db directory from monitor: {mon_a.name} to {self.backup_dir}"
+        )
+        self._exec_oc_cmd(
+            cmd=(
+                f"cp -n {constants.OPENSHIFT_STORAGE_NAMESPACE} "
+                f"{mon_a.name}:/var/lib/ceph/mon/ceph-a/store.db "
+                f"{self.backup_dir}/"
+            )
+        )
         logger.info("Copying store.db to rest of the monitors")
         for mon in get_mon_pods(namespace=config.ENV_DATA["cluster_namespace"]):
-            cmd = (
-                f"cp {self.backup_dir}/store.db {mon.name}:/var/lib/ceph/mon/ceph-"
-                f"{mon.get().get('metadata').get('labels').get('ceph_daemon_id')}/ "
-            )
-            logger.info(f"Copying store.db to monitor: {mon.name}")
-            self._exec_oc_cmd(cmd)
-            logger.info("Changing ownership of store.db to ceph:ceph")
-            _exec_cmd_on_pod(
-                cmd=f"chown -R ceph:ceph /var/lib/ceph/mon/ceph-"
-                f"{mon.get().get('metadata').get('labels').get('ceph_daemon_id')}/store.db",
-                pod_obj=mon,
-            )
-
-    def copy_and_import_keys(self, mon_obj):
-        """
-        Copies the keys and imports it using ceph-auth
-
-        Args:
-            mon_obj (obj): Monitor object
-
-        """
-        logger.info(f"Copying keyring files to monitor: {mon_obj.name}")
-        for k_file in self.keyring_files:
-            cmd = f"cp {k_file} {mon_obj.name}:/tmp/"
-            logger.info(f"Copying keyring: {k_file} into mon {mon_obj.name}")
-            self._exec_oc_cmd(cmd)
-
-        logger.info(f"Importing ceph keyrings to a temporary file on: {mon_obj.name}")
-        _exec_cmd_on_pod(
-            cmd="cp /etc/ceph/keyring-store/keyring /tmp/keyring", pod_obj=mon_obj
-        )
-        for k_file in self.keyring_files:
-            k_file = k_file.split("/")
-            logger.info(f"Importing keyring {k_file[-1]}")
-            _exec_cmd_on_pod(
-                cmd=f"ceph-authtool /tmp/keyring --import-keyring /tmp/{k_file[-1]}",
-                pod_obj=mon_obj,
-            )
+            if not mon.get().get("metadata").get("labels").get("ceph_daemon_id") == "a":
+                cmd = (
+                    f"cp -n {constants.OPENSHIFT_STORAGE_NAMESPACE} "
+                    f"{self.backup_dir}/store.db "
+                    f"{mon.name}:/var/lib/ceph/mon/ceph-"
+                    f"{mon.get().get('metadata').get('labels').get('ceph_daemon_id')}/ "
+                )
+                logger.info(f"Copying store.db to monitor: {mon.name}")
+                self._exec_oc_cmd(cmd)
+                logger.info("Changing ownership of store.db to ceph:ceph")
+                _exec_cmd_on_pod(
+                    cmd=f"chown -R ceph:ceph /var/lib/ceph/mon/ceph-"
+                    f"{mon.get().get('metadata').get('labels').get('ceph_daemon_id')}/store.db",
+                    pod_obj=mon,
+                )
 
     def revert_patches(self, deployment_paths):
         """
@@ -533,48 +599,94 @@ class MonitorRecovery(object):
             )
         return to_revert_patches_path, to_revert_mds_path
 
-    def get_ceph_keyrings(self):
+    def get_all_keyring_secrets(self):
+        """
+        Get all the keyring secrets
+
+        Returns:
+            list: A list of keyring secrets
+
+        """
+        all_secrets = get_secret_names()
+        keyring_secrets = [keyring for keyring in all_secrets if "keyring" in keyring]
+        return keyring_secrets
+
+    def get_ceph_daemons_keyrings(self):
         """
         Gets all ceph and csi related keyring from OCS secrets
 
+        Returns:
+            file: A formatted file with ceph daemons keyrings
+
         """
-        mon_k = get_ceph_caps(["rook-ceph-mons-keyring"])
-        if config.ENV_DATA["platform"].lower() in constants.ON_PREM_PLATFORMS:
-            rgw_k = get_ceph_caps(
-                ["rook-ceph-rgw-ocs-storagecluster-cephobjectstore-a-keyring"]
+        logger.info("Getting the daemons keyrings...")
+        all_keyring_secrets = self.get_all_keyring_secrets()
+        formatted_data = []
+        for keyring_secret in all_keyring_secrets:
+            cmd = (
+                f"oc get secret {keyring_secret} -n "
+                f"{constants.OPENSHIFT_STORAGE_NAMESPACE} -ojson | "
+                f"jq .data.keyring | xargs echo | base64 -d"
             )
-        else:
-            rgw_k = None
-        mgr_k = get_ceph_caps(["rook-ceph-mgr-a-keyring"])
-        mds_k = get_ceph_caps(
-            [
-                "rook-ceph-mds-ocs-storagecluster-cephfilesystem-a-keyring",
-                "rook-ceph-mds-ocs-storagecluster-cephfilesystem-b-keyring",
-            ]
-        )
-        crash_k = get_ceph_caps(["rook-ceph-crash-collector-keyring"])
-        fs_node_k = get_ceph_caps([constants.CEPHFS_NODE_SECRET])
-        rbd_node_k = get_ceph_caps([constants.RBD_NODE_SECRET])
-        fs_provisinor_k = get_ceph_caps([constants.CEPHFS_PROVISIONER_SECRET])
-        rbd_provisinor_k = get_ceph_caps([constants.RBD_PROVISIONER_SECRET])
+            out = exec_cmd(cmd=cmd, shell=True)
+            out_str = out.stdout.decode("utf-8")
+            tmp_lines = out_str.strip().splitlines()
+            keyring_data = [line.replace("\t", "").strip() for line in tmp_lines]
+            pod_name = keyring_data[0].strip()
+            formatted_data.append(f"{pod_name}:")
+            for block in keyring_data:
+                if block == "[client.admin]" and "[mon.]" in keyring_data:
+                    logger.info(
+                        "Skipping adding the [client.admin] details present in rook-ceph-mons-keyring"
+                        "as the secret details are already fecthed with rook-ceph-admin-keyring"
+                    )
+                    break
+                key = None
+                caps = []
+                if block.startswith("key ="):
+                    key = block.split(" = ")[1].strip()
+                elif "caps" in block:
+                    caps.append(block.strip())
+                if key:
+                    logger.info("Found key entry in keyring data")
+                    formatted_data.append(f"    key = {key}")
+                for cap in caps:
+                    logger.info(f"Found cap :{cap}")
+                    formatted_data.append(f"    {cap}")
+        with open(f"{self.keyring_dir}/keyring-mon-a", "w") as f:
+            f.write("\n".join(formatted_data))
+            logger.info(f"Output saved to {self.keyring_dir}/keyring-mon-a")
 
-        keyring_caps = {
-            "mons": mon_k,
-            "rgws": rgw_k,
-            "mgrs": mgr_k,
-            "mdss": mds_k,
-            "crash": crash_k,
-            "fs_node": fs_node_k,
-            "rbd_node": rbd_node_k,
-            "fs_provisinor": fs_provisinor_k,
-            "rbd_provisinor": rbd_provisinor_k,
-        }
+        logger.info("Getting the OSDs keys")
+        osd_pods = get_osd_pods()
+        for osd_pod in osd_pods:
+            osd_id = osd_pod.get().get("metadata").get("labels").get("ceph-osd-id")
+            cmd = (
+                f"oc exec -i -n {constants.OPENSHIFT_STORAGE_NAMESPACE} "
+                f"{osd_pod.name} -- bash -c "
+                f"'cat /var/lib/ceph/osd/ceph-{osd_id}/keyring' "
+            )
+            out = exec_cmd(cmd=cmd, shell=True)
+            out_osd_str = out.stdout.decode("utf-8")
+            lines = out_osd_str.strip().splitlines()
+            osd_keyring_data = [line.replace("\t", "").strip() for line in lines]
+            pod_name = osd_keyring_data[0].strip()
+            formatted_data.append(f"{pod_name}:")
+            key = None
+            for block in osd_keyring_data:
+                if block.startswith("key ="):
+                    key = block.split(" = ")[1].strip()
+                if key:
+                    formatted_data.append(f"    key = {key}")
+                    formatted_data.append('    caps mgr = "allow profile osd"')
+                    formatted_data.append('    caps mon = "allow profile osd"')
+                    formatted_data.append('    caps osd = "allow *"')
 
-        for secret, caps in keyring_caps.items():
-            if caps:
-                with open(f"{self.keyring_dir}/{secret}.keyring", "w") as fd:
-                    fd.write(caps)
-                    self.keyring_files.append(f"{self.keyring_dir}/{secret}.keyring")
+        with open(f"{self.keyring_dir}/keyring-mon-a", "w") as f:
+            f.write("\n".join(formatted_data) + "\n")
+        logger.info(f"Keyring data saved to {self.keyring_dir}/keyring-mon-a")
+
+        return f"{self.keyring_dir}/keyring-mon-a"
 
     def patch_sleep_on_mds(self):
         """
@@ -610,7 +722,7 @@ class MonitorRecovery(object):
             wait_for_resource_state(resource=mds, state=constants.STATUS_RUNNING)
 
     @retry(CommandFailed, tries=10, delay=10, backoff=1)
-    def _exec_oc_cmd(self, cmd):
+    def _exec_oc_cmd(self, cmd, out_yaml_format=True):
         """
         Exec oc cmd with retry
 
@@ -618,7 +730,7 @@ class MonitorRecovery(object):
             cmd (str): Command
 
         """
-        self.ocp_obj.exec_oc_cmd(cmd)
+        self.ocp_obj.exec_oc_cmd(cmd, out_yaml_format=out_yaml_format)
 
 
 @retry(CommandFailed, tries=10, delay=10, backoff=1)
@@ -644,12 +756,14 @@ def insert_delay(mon_dep):
     """
     logger.info(f"Updating initialDelaySeconds on deployment: {mon_dep}")
     kubeconfig = config.RUN.get("kubeconfig")
+    namespace = config.ENV_DATA["cluster_namespace"]
     cmd = (
-        f"oc get --kubeconfig {kubeconfig} deployment {mon_dep} -o yaml | "
-        f'sed "s/initialDelaySeconds: 10/initialDelaySeconds: 10000/g" | oc replace -f - '
+        f"oc --kubeconfig {kubeconfig} -n {namespace} get deployment {mon_dep} -o yaml | "
+        f'sed "s/initialDelaySeconds: 10/initialDelaySeconds: 10000/g" | '
+        f"oc --kubeconfig {kubeconfig} -n {namespace} replace -f - "
     )
     logger.info(f"Executing {cmd}")
-    os.system(cmd)
+    exec_cmd(cmd=cmd, shell=True)
 
 
 def update_mon_initial_delay():
@@ -810,110 +924,6 @@ def get_spun_dc_pods(pod_list):
     return new_pods
 
 
-def get_ceph_caps(secret_resource):
-    """
-    Gets ocs secrets and decodes it to get ceph keyring
-
-    Args:
-        secret_resource (any): secret resource name
-
-    Returns:
-        str: Auth keyring
-
-    """
-    keyring = ""
-
-    fs_node_caps = """
-        caps mds = "allow rw"
-        caps mgr = "allow rw"
-        caps mon = "allow r"
-        caps osd = "allow rw tag cephfs *=*"
-"""
-    rbd_node_caps = """
-        caps mgr = "allow rw"
-        caps mon = "profile rbd"
-        caps osd = "profile rbd"
-"""
-    fs_provisinor_caps = """
-        caps mgr = "allow rw"
-        caps mon = "allow r"
-        caps osd = "allow rw tag cephfs metadata=*"
-"""
-    rbd_provisinor_caps = """
-        caps mgr = "allow rw"
-        caps mon = "profile rbd"
-        caps osd = "profile rbd"
-"""
-
-    for resource in secret_resource:
-        resource_obj = ocp.OCP(
-            resource_name=resource,
-            kind=constants.SECRET,
-            namespace=config.ENV_DATA["cluster_namespace"],
-        )
-        if constants.CEPHFS_NODE_SECRET in resource:
-            keyring = (
-                keyring
-                + base64.b64decode(resource_obj.get().get("data").get("adminKey"))
-                .decode()
-                .rstrip("\n")
-                + "\n"
-            )
-            keyring = (
-                "[client.csi-cephfs-node]" + "\n" + "\t" + "key = "
-                f"{keyring}" + fs_node_caps
-            )
-
-        elif constants.RBD_NODE_SECRET in resource:
-            keyring = (
-                keyring
-                + base64.b64decode(resource_obj.get().get("data").get("userKey"))
-                .decode()
-                .rstrip("\n")
-                + "\n"
-            )
-            keyring = (
-                "[client.csi-rbd-node]" + "\n" + "\t" + "key = "
-                f"{keyring}" + rbd_node_caps
-            )
-
-        elif constants.CEPHFS_PROVISIONER_SECRET in resource:
-            keyring = (
-                keyring
-                + base64.b64decode(resource_obj.get().get("data").get("adminKey"))
-                .decode()
-                .rstrip("\n")
-                + "\n"
-            )
-            keyring = (
-                "[client.csi-cephfs-provisioner]" + "\n" + "\t" + "key = "
-                f"{keyring}" + fs_provisinor_caps
-            )
-
-        elif constants.RBD_PROVISIONER_SECRET in resource:
-            keyring = (
-                keyring
-                + base64.b64decode(resource_obj.get().get("data").get("userKey"))
-                .decode()
-                .rstrip("\n")
-                + "\n"
-            )
-            keyring = (
-                "[client.csi-rbd-provisioner]" + "\n" + "\t" + "key = "
-                f"{keyring}" + rbd_provisinor_caps
-            )
-
-        else:
-            keyring = (
-                keyring
-                + base64.b64decode(resource_obj.get().get("data").get("keyring"))
-                .decode()
-                .rstrip("\n")
-                + "\n"
-            )
-    return keyring
-
-
 def generate_monmap_cmd():
     """
     Generates monmap-tool command used to rebuild monitors
@@ -932,12 +942,14 @@ def generate_monmap_cmd():
         mon_ids.append(mon.get().get("metadata").get("labels").get("ceph_daemon_id"))
         logger.info(f"getting public ip of {mon.name}")
         logger.info(mon_ids)
-        mon_ips.append(
-            re.findall(
-                r"[0-9]+(?:\.[0-9]+){3}",
-                mon.get().get("spec").get("initContainers")[1].get("args")[-2],
-            )
+        ip_match = re.findall(
+            r"[0-9]+(?:\.[0-9]+){3}",
+            mon.get().get("spec").get("initContainers")[1].get("args")[-2],
         )
+        if ip_match:
+            mon_ips.append(ip_match[0])
+        else:
+            raise ValueError(f"Could not extract IP from monitor {mon.name}")
 
     mon_a = mon_pods[0]
     logger.info(f"Working on monitor: {mon_a.name} to get FSID")
@@ -950,7 +962,7 @@ def generate_monmap_cmd():
     )
 
     for ids, ip in zip(mon_ids, mon_ips):
-        mon_ips_dict.update({ids: f"{ip}"})
+        mon_ips_dict.update({ids: ip})
 
     mon_ip_ids = ""
     for key, val in mon_ips_dict.items():

--- a/tests/cross_functional/kcs/test_monitor_recovery.py
+++ b/tests/cross_functional/kcs/test_monitor_recovery.py
@@ -114,31 +114,7 @@ class TestMonitorRecovery(E2ETest):
             logger.info("Waiting 30s for pods to terminate")
             time.sleep(30)
 
-            logger.info("Cleaning up stale volume attachments")
-            try:
-                va_ocp = OCP(kind="VolumeAttachment", namespace="")
-                attachments = va_ocp.get()
-                if attachments and "items" in attachments:
-                    deleted_count = 0
-                    for attachment in attachments["items"]:
-                        if not attachment.get("status", {}).get("attached", False):
-                            va_name = attachment["metadata"]["name"]
-                            logger.debug(
-                                f"Deleting unattached VolumeAttachment: {va_name}"
-                            )
-                            try:
-                                va_ocp.delete(resource_name=va_name)
-                                deleted_count += 1
-                            except Exception as e:
-                                logger.warning(
-                                    f"Failed to delete VolumeAttachment {va_name}: {e}"
-                                )
-                    if deleted_count > 0:
-                        logger.info(f"Deleted {deleted_count} stale volume attachments")
-                    else:
-                        logger.debug("No stale volume attachments found")
-            except Exception:
-                logger.exception("Error during volume attachment cleanup")
+            cleanup_stale_volume_attachments()
 
         request.addfinalizer(finalizer)
 
@@ -1388,6 +1364,40 @@ def verify_pods_running(
     return failed_pods
 
 
+def cleanup_stale_volume_attachments():
+    """
+    Clean up all unattached VolumeAttachment resources.
+
+    Returns:
+        int: Number of VolumeAttachments deleted
+    """
+    logger.info("Cleaning up stale volume attachments")
+    deleted_count = 0
+    try:
+        va_ocp = OCP(kind="VolumeAttachment", namespace="")
+        attachments = va_ocp.get()
+        if attachments and "items" in attachments:
+            for attachment in attachments["items"]:
+                if not attachment.get("status", {}).get("attached", False):
+                    va_name = attachment["metadata"]["name"]
+                    logger.debug(f"Deleting unattached VolumeAttachment: {va_name}")
+                    try:
+                        va_ocp.delete(resource_name=va_name)
+                        deleted_count += 1
+                    except Exception as e:
+                        logger.warning(
+                            f"Failed to delete VolumeAttachment {va_name}: {e}"
+                        )
+            if deleted_count > 0:
+                logger.info(f"Deleted {deleted_count} stale volume attachments")
+            else:
+                logger.debug("No stale volume attachments found")
+    except Exception:
+        logger.exception("Failed to cleanup stale volume attachments")
+
+    return deleted_count
+
+
 def handle_multi_attach_error(pod_obj, timeout=300):
     """
     Handle multi-attach volume errors by deleting stale VolumeAttachment resources.
@@ -1417,31 +1427,10 @@ def handle_multi_attach_error(pod_obj, timeout=300):
                 pvc_id = pvc_match.group(1)
                 logger.info(f"Identified PVC with multi-attach error: {pvc_id}")
 
-                va_ocp = OCP(kind="VolumeAttachment", namespace="")
-                try:
-                    attachments = va_ocp.get()
-                    if attachments and "items" in attachments:
-                        for attachment in attachments["items"]:
-                            if (
-                                attachment.get("spec", {})
-                                .get("source", {})
-                                .get("persistentVolumeName")
-                                == pvc_id
-                            ):
-                                va_name = attachment["metadata"]["name"]
-                                logger.info(
-                                    f"Deleting stale VolumeAttachment: {va_name}"
-                                )
-                                va_ocp.delete(resource_name=va_name)
-                                logger.info(
-                                    "Waiting 10s for VolumeAttachment cleanup to propagate"
-                                )
-                                time.sleep(10)
-                                break
-                except Exception:
-                    logger.exception(
-                        f"Failed to handle VolumeAttachment for PVC {pvc_id}"
-                    )
+                deleted_count = cleanup_stale_volume_attachments()
+                if deleted_count > 0:
+                    logger.info("Waiting 10s for VolumeAttachment cleanup to propagate")
+                    time.sleep(10)
             else:
                 logger.warning(
                     "Multi-attach error detected but could not extract PVC ID from pod description"

--- a/tests/cross_functional/kcs/test_monitor_recovery.py
+++ b/tests/cross_functional/kcs/test_monitor_recovery.py
@@ -8,7 +8,6 @@ import re
 import pytest
 
 from ocs_ci.framework.pytest_customization.marks import (
-    jira,
     skipif_ocs_version,
     ignore_leftovers,
     skipif_openshift_dedicated,
@@ -111,7 +110,6 @@ class TestMonitorRecovery(E2ETest):
             data=self.object_data,
         ), "Failed: PutObject"
 
-    @jira("DFBUGS-4322")
     def test_monitor_recovery(
         self,
         deployment_pod_factory,

--- a/tests/cross_functional/kcs/test_monitor_recovery.py
+++ b/tests/cross_functional/kcs/test_monitor_recovery.py
@@ -1512,6 +1512,8 @@ def recover_mcg():
     max_count_retries = 5
     retry_wait_time = 30
 
+    # Check if we have at least 4 pods (excluding noobaa-db-pg-cluster-2)
+    # If noobaa-db-pg-cluster-1 is not running, noobaa-db-pg-cluster-2 won't be created
     for retry_attempt in range(max_count_retries):
         current_noobaa_pods = get_noobaa_pods()
         current_pod_count = len(current_noobaa_pods)
@@ -1526,15 +1528,21 @@ def recover_mcg():
             f"Found {current_pod_count}/{expected_pod_count} NooBaa pods by type: {current_pod_types}"
         )
 
+        # Check if we have the minimum required pods (excluding db-pg-cluster-2)
+        # Expected: noobaa-core, noobaa-endpoint, noobaa-operator, cnpg-controller-manager, noobaa-db-pg-cluster-1
+        minimum_required_types = {
+            k: v for k, v in expected_pod_types.items() if k != "noobaa-db-pg-cluster-2"
+        }
         missing_types = []
-        for pod_type, expected_count in expected_pod_types.items():
+        for pod_type, expected_count in minimum_required_types.items():
             current_count = current_pod_types.get(pod_type, 0)
             if current_count < expected_count:
                 missing_types.append(f"{pod_type} ({current_count}/{expected_count})")
 
-        if not missing_types and current_pod_count >= expected_pod_count:
+        # If we have all minimum required pods (4 pods), proceed even if db-pg-cluster-2 is missing
+        if not missing_types and current_pod_count >= len(minimum_required_types):
             logger.info(
-                f"All {expected_pod_count} expected NooBaa pods found with correct types"
+                f"Found {current_pod_count} NooBaa pods including all minimum required types: {current_pod_types}"
             )
             break
 
@@ -1545,7 +1553,7 @@ def recover_mcg():
             )
         else:
             logger.warning(
-                f"Pod count mismatch: {current_pod_count}/{expected_pod_count}. "
+                f"Pod count mismatch: {current_pod_count}/{len(minimum_required_types)} minimum required. "
                 f"Waiting {retry_wait_time}s..."
             )
 
@@ -1553,12 +1561,70 @@ def recover_mcg():
             time.sleep(retry_wait_time)
         else:
             error_msg = (
-                f"NooBaa recovery failed: Expected {expected_pod_count} pods "
+                f"NooBaa recovery failed: Expected minimum {len(minimum_required_types)} pods "
                 f"but only found {current_pod_count} after {max_count_retries} attempts. "
-                f"Expected types: {expected_pod_types}, Current types: {current_pod_types}"
+                f"Expected types: {minimum_required_types}, Current types: {current_pod_types}"
             )
             logger.error(error_msg)
             raise ResourceWrongStatusException(error_msg)
+
+    # Special handling for noobaa-db-pg-cluster-1 pod
+    # If it's not running, noobaa-db-pg-cluster-2 won't be created
+    logger.info("Checking if noobaa-db-pg-cluster-1 needs recovery")
+    db_pg_1_pods = [
+        p for p in get_noobaa_pods() if p.name.startswith("noobaa-db-pg-cluster-1")
+    ]
+
+    if db_pg_1_pods:
+        db_pg_1_pod = db_pg_1_pods[0]
+        logger.info(f"Found noobaa-db-pg-cluster-1 pod: {db_pg_1_pod.name}")
+
+        try:
+            if (
+                db_pg_1_pod.get().get("status", {}).get("phase")
+                != constants.STATUS_RUNNING
+            ):
+                logger.info(
+                    f"noobaa-db-pg-cluster-1 pod {db_pg_1_pod.name} is not running, attempting recovery"
+                )
+
+                failed_pods = verify_pods_running(
+                    [db_pg_1_pod], pod_type="NooBaa DB", timeout=600, parallel=False
+                )
+
+                if not failed_pods:
+                    logger.info("noobaa-db-pg-cluster-1 pod recovered successfully")
+
+                    logger.info("Waiting 180s for noobaa-db-pg-cluster-2 to be created")
+                    time.sleep(180)
+
+                    db_pods = [
+                        p
+                        for p in get_noobaa_pods()
+                        if p.name.startswith("noobaa-db-pg-cluster-")
+                    ]
+                    logger.info(f"Verifying {len(db_pods)} NooBaa DB pods are running")
+
+                    failed_db_pods = verify_pods_running(
+                        db_pods, pod_type="NooBaa DB", timeout=300, parallel=False
+                    )
+
+                    if failed_db_pods:
+                        logger.warning(
+                            f"Some NooBaa DB pods failed recovery: {failed_db_pods}"
+                        )
+                    else:
+                        logger.info("Both NooBaa DB pods are running successfully")
+                else:
+                    logger.warning(
+                        f"noobaa-db-pg-cluster-1 pod recovery failed: {failed_pods}"
+                    )
+            else:
+                logger.info("noobaa-db-pg-cluster-1 pod is already running")
+        except Exception as e:
+            logger.warning(f"Error during noobaa-db-pg-cluster-1 recovery check: {e}")
+    else:
+        logger.warning("noobaa-db-pg-cluster-1 pod not found")
 
     try:
         wait_for_noobaa_pods_running(timeout=600, sleep=10)

--- a/tests/cross_functional/kcs/test_monitor_recovery.py
+++ b/tests/cross_functional/kcs/test_monitor_recovery.py
@@ -81,7 +81,8 @@ class TestMonitorRecovery(E2ETest):
         self.dd_cmd = f"dd if=/dev/urandom of=/mnt/{self.filename} bs=5M count=1"
 
         self.sanity_helpers = Sanity()
-        # Create project, pvc, dc pods
+
+        logger.test_step("Create test deployment pods with PVCs")
         self.dc_pods = []
         self.dc_pods.append(
             deployment_pod_factory(
@@ -94,15 +95,23 @@ class TestMonitorRecovery(E2ETest):
                 access_mode=constants.ACCESS_MODE_RWX,
             )
         )
+        logger.info(f"Created {len(self.dc_pods)} deployment pods")
+
+        logger.test_step("Write test data and calculate checksums")
         self.md5sum = []
         for pod_obj in self.dc_pods:
             pod_obj.exec_cmd_on_pod(command=self.dd_cmd)
-            # Calculate md5sum
-            self.md5sum.append(pod.cal_md5sum(pod_obj, self.filename))
-        logger.info(f"Md5sum calculated before recovery: {self.md5sum}")
+            checksum = pod.cal_md5sum(pod_obj, self.filename)
+            self.md5sum.append(checksum)
+            logger.info(f"Pod {pod_obj.name}: checksum={checksum}")
+        logger.info(f"Checksums before recovery: {self.md5sum}")
 
+        logger.test_step("Create test bucket and upload object")
         self.bucket_name = bucket_factory(interface="OC")[0].name
-        logger.info(f"Putting object on: {self.bucket_name}")
+        logger.info(f"Created bucket: {self.bucket_name}")
+        logger.assertion(
+            f"S3 PutObject: bucket={self.bucket_name}, key={self.object_key}"
+        )
         assert bucket_utils.s3_put_object(
             s3_obj=mcg_obj,
             bucketname=self.bucket_name,
@@ -121,112 +130,118 @@ class TestMonitorRecovery(E2ETest):
         https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.8/html/troubleshooting_openshift_container_storage/restoring-the-monitor-pods-in-openshift-container-storage_rhocs
 
         """
-        # Initialize mon recovery class
         mon_recovery = MonitorRecovery()
+        logger.info(
+            f"Monitor recovery initialized with backup dir: {mon_recovery.backup_dir}"
+        )
 
-        logger.info("Corrupting ceph monitors by deleting store.db")
+        logger.test_step("Corrupt ceph monitors by deleting store.db")
         corrupt_ceph_monitors()
 
-        logger.info("Starting the monitor recovery procedure")
-        logger.info("Scaling down rook-ceph-operator and ocs operator deployments")
+        logger.test_step("Scale down rook-ceph-operator and ocs-operator")
         mon_recovery.scale_rook_ocs_operators(replica=0)
 
-        logger.info("Backing up all the deployments in openshift-storage namespace")
+        logger.test_step("Backup all deployments in openshift-storage namespace")
         mon_recovery.backup_deployments()
         dep_revert, mds_revert = mon_recovery.deployments_to_revert()
-
         logger.info(
-            "Patching OSD deployments to remove LivenessProbe and sleep to infinity"
+            f"Identified {len(dep_revert)} deployments and {len(mds_revert)} MDS deployments to revert"
+        )
+
+        logger.test_step(
+            "Patch OSD deployments to remove LivenessProbe and sleep to infinity"
         )
         mon_recovery.patch_sleep_on_osds()
 
         switch_to_project(config.ENV_DATA["cluster_namespace"])
-        logger.info("Copy tar to the OSDs")
+        logger.test_step("Copy tar binary to OSD pods")
         mon_recovery.copy_tar_to_pods(pod_type="osd")
 
-        logger.info("Preparing the recover_mon.sh script")
+        logger.test_step("Prepare the recover_mon.sh script")
         mon_recovery.prepare_monstore_script()
 
-        logger.info("Getting mon-store from OSDs by running recover_mon.sh script")
+        logger.test_step("Retrieve mon-store from OSDs using recover_mon.sh script")
         mon_recovery.run_mon_store()
 
-        logger.info("Patching MONs to sleep infinitely")
+        logger.test_step("Patch monitor deployments to sleep infinitely")
         mon_recovery.patch_sleep_on_mon()
 
-        logger.info("Updating initial delay on all monitors")
+        logger.test_step("Update initial delay on all monitors")
         update_mon_initial_delay()
 
-        logger.info("Copy tar to the MONs")
+        logger.test_step("Copy tar binary to monitor pods")
         mon_recovery.copy_tar_to_pods(pod_type="mon")
 
-        logger.info("Copy the previously retrieved monstore to the mon-a pod")
+        logger.test_step("Copy retrieved monstore to mon-a pod")
         mon_a = next(
             mon
             for mon in get_mon_pods(namespace=config.ENV_DATA["cluster_namespace"])
             if mon.get().get("metadata", {}).get("labels", {}).get("ceph_daemon_id")
             == "a"
         )
-        logger.info(f"Copying mon-store into monitor: {mon_a.name}")
+        logger.info(f"Copying mon-store to monitor: {mon_a.name}")
         ocp_obj = MonitorRecovery()
         ocp_obj._exec_oc_cmd(
             cmd=f"cp /tmp/monstore {constants.OPENSHIFT_STORAGE_NAMESPACE}/{mon_a.name}:/tmp/"
         )
 
-        logger.info(
-            "Getting into the mon-a pod and changing the ownership of the retrieved monstore"
-        )
+        logger.info("Changing ownership of retrieved monstore to ceph:ceph")
         _exec_cmd_on_pod(cmd="chown -R ceph:ceph /tmp/monstore", pod_obj=mon_a)
 
-        logger.info(
-            "Getting the keyrings of all the Ceph daemons (OSD, MGR, MDS and RGW) from their respective secrets"
-        )
+        logger.test_step("Extract keyrings from Ceph daemon secrets")
         file_path = mon_recovery.get_ceph_daemons_keyrings()
+        logger.info(f"Keyrings extracted to: {file_path}")
 
-        logger.info("Copy the ceph daemons key ring to mon-a")
+        logger.test_step("Copy ceph daemon keyrings to mon-a pod")
         mon_a = next(
             mon
             for mon in get_mon_pods(namespace=config.ENV_DATA["cluster_namespace"])
             if mon.get().get("metadata", {}).get("labels", {}).get("ceph_daemon_id")
             == "a"
         )
-        logger.info(
-            f"Copying the mon keyring stored locally from {file_path} to monitor: {mon_a.name}"
-        )
+        logger.info(f"Copying keyring from {file_path} to monitor: {mon_a.name}")
         ocp_obj._exec_oc_cmd(
             cmd=f"cp {file_path} {constants.OPENSHIFT_STORAGE_NAMESPACE}/{mon_a.name}:/tmp/keyring"
         )
 
-        logger.info("Generating monitor map command using the IPs")
+        logger.test_step("Generate monitor map command using monitor IPs")
         mon_map_cmd = generate_monmap_cmd()
+        logger.debug(f"Generated monmap command: {mon_map_cmd}")
 
-        logger.info("Rebuilding Monitors to recover store db")
+        logger.test_step("Rebuild monitors to recover store.db")
         mon_recovery.monitor_rebuild(mon_map_cmd)
 
-        logger.info("Reverting mon, osd and mgr deployments")
+        logger.test_step("Revert patches on mon, osd and mgr deployments")
         mon_recovery.revert_patches(dep_revert)
 
-        logger.info("Scaling back rook and ocs operators")
+        logger.test_step("Scale up rook-ceph-operator and ocs-operator")
         mon_recovery.scale_rook_ocs_operators(replica=1)
 
-        logger.info("Recovering CephFS")
+        logger.test_step("Recover CephFS filesystem")
         mon_recovery.scale_rook_ocs_operators(replica=0)
         logger.info(
-            "Patching MDSs to remove LivenessProbe and setting sleep to infinity"
+            "Patching MDS deployments to remove LivenessProbe and sleep to infinity"
         )
         mon_recovery.patch_sleep_on_mds()
-        logger.info("Resetting the fs")
+        logger.info("Resetting CephFS")
         ceph_fs_recovery()
-        logger.info("Reverting MDS deployments")
+        logger.info("Reverting MDS deployments to original configuration")
         mon_recovery.revert_patches(mds_revert)
-        logger.info("Scaling back rook and ocs operators")
+        logger.info("Scaling back rook and ocs operators after CephFS recovery")
         mon_recovery.scale_rook_ocs_operators(replica=1)
-        logger.info("Recovering mcg by re-spinning the pods")
+
+        logger.test_step("Recover MCG by re-spinning noobaa pods")
         recover_mcg()
+
+        logger.test_step("Remove global ID reclaim warnings")
         remove_global_id_reclaim()
+        logger.test_step("Verify data integrity after recovery")
         for pod_obj in self.dc_pods:
+            logger.debug(f"Force deleting pod: {pod_obj.name}")
             pod_obj.delete(force=True)
+
         new_md5_sum = []
-        logger.info("Verifying md5sum of files after recovery")
+        logger.info("Waiting for pods to respawn and calculating checksums")
         for pod_obj in get_spun_dc_pods(self.dc_pods):
             pod_obj.ocp.wait_for_resource(
                 condition=constants.STATUS_RUNNING,
@@ -234,22 +249,36 @@ class TestMonitorRecovery(E2ETest):
                 timeout=600,
                 sleep=10,
             )
-            new_md5_sum.append(pod.cal_md5sum(pod_obj, self.filename))
-        logger.info(f"Md5sum calculated after recovery: {new_md5_sum}")
+            checksum = pod.cal_md5sum(pod_obj, self.filename)
+            new_md5_sum.append(checksum)
+            logger.info(f"Pod {pod_obj.name}: checksum={checksum}")
+
+        logger.info(f"Checksums after recovery: {new_md5_sum}")
+        logger.assertion(
+            f"Data integrity check: original={self.md5sum}, "
+            f"after_recovery={new_md5_sum}, "
+            f"match={collections.Counter(new_md5_sum) == collections.Counter(self.md5sum)}"
+        )
         if collections.Counter(new_md5_sum) == collections.Counter(self.md5sum):
-            logger.info(
-                f"Verified: md5sum of {self.filename} on pods matches with the original md5sum"
-            )
+            logger.info(f"Data integrity verified: checksums match for {self.filename}")
         else:
-            assert False, f"Data corruption found {new_md5_sum} and {self.md5sum}"
-        logger.info("Getting object after recovery")
+            assert (
+                False
+            ), f"Data corruption detected: before={self.md5sum}, after={new_md5_sum}"
+
+        logger.test_step("Verify S3 object retrieval after recovery")
+        logger.assertion(
+            f"S3 GetObject: bucket={self.bucket_name}, key={self.object_key}"
+        )
         assert bucket_utils.s3_get_object(
             s3_obj=mcg_obj,
             bucketname=self.bucket_name,
             object_key=self.object_key,
         ), "Failed: GetObject"
+        logger.info("S3 object retrieved successfully after recovery")
 
-        # New pvc, dc pods, obcs
+        logger.test_step("Create new resources to verify cluster functionality")
+        logger.info("Creating new deployment pods with PVCs")
         new_dc_pods = [
             deployment_pod_factory(
                 interface=constants.CEPHBLOCKPOOL,
@@ -259,20 +288,38 @@ class TestMonitorRecovery(E2ETest):
             ),
         ]
         for pod_obj in new_dc_pods:
+            logger.debug(f"Writing test data to pod: {pod_obj.name}")
             pod_obj.exec_cmd_on_pod(command=self.dd_cmd)
-        logger.info("Creating new bucket and write object")
+        logger.info(
+            f"Successfully created and wrote data to {len(new_dc_pods)} new pods"
+        )
+
+        logger.info("Creating new bucket and uploading object")
         new_bucket = bucket_factory(interface="OC")[0].name
+        logger.assertion(
+            f"S3 PutObject to new bucket: bucket={new_bucket}, key={self.object_key}"
+        )
         assert bucket_utils.s3_put_object(
             s3_obj=mcg_obj,
             bucketname=new_bucket,
             object_key=self.object_key,
             data=self.object_data,
-        ), "Failed: PutObject"
+        ), "Failed: PutObject to new bucket"
+        logger.info(
+            f"Successfully created new bucket and uploaded object: {new_bucket}"
+        )
+
+        logger.test_step("Verify all storage pods are running")
         wait_for_storage_pods()
-        logger.info("Archiving the ceph crash warnings")
+
+        logger.test_step("Archive ceph crash warnings and run health check")
+        logger.info("Archiving ceph crash warnings")
         tool_pod = get_ceph_tools_pod()
         tool_pod.exec_ceph_cmd(ceph_cmd="ceph crash archive-all", format=None)
+
+        logger.info("Running cluster health check")
         self.sanity_helpers.health_check(tries=10)
+        logger.info("Cluster health check passed")
 
 
 class MonitorRecovery(object):
@@ -301,17 +348,22 @@ class MonitorRecovery(object):
             replica (int): replica count
 
         """
-        logger.info(f"Scaling rook-ceph operator to replica: {replica}")
+        logger.info(f"Scaling rook-ceph-operator to {replica} replica(s)")
         self.dep_ocp.exec_oc_cmd(
             f"scale deployment {constants.ROOK_CEPH_OPERATOR} --replicas={replica}"
         )
-        logger.info(f"Scaling ocs-operator to replica: {replica}")
+
+        logger.info(f"Scaling ocs-operator to {replica} replica(s)")
         self.dep_ocp.exec_oc_cmd(
             f"scale deployment {defaults.OCS_OPERATOR_NAME} --replicas={replica}"
         )
+
         if replica == 1:
-            logger.info("Sleeping for 150 secs for cluster to stabilize")
+            logger.info(
+                "Waiting 150s for operators to stabilize and cluster to reconcile"
+            )
             time.sleep(150)
+        logger.info(f"Operator scaling to {replica} replica(s) completed")
 
     def patch_sleep_on_osds(self):
         """
@@ -323,16 +375,19 @@ class MonitorRecovery(object):
             namespace=config.ENV_DATA["cluster_namespace"],
         )
         osd_deployments = [OCS(**osd) for osd in osd_dep]
+        logger.info(f"Found {len(osd_deployments)} OSD deployments to patch")
+
         for osd in osd_deployments:
-            logger.info(
-                f"Patching OSD: {osd.name} to remove livenessProbe and set sleep infinity"
-            )
+            logger.debug(f"Patching OSD deployment: {osd.name}")
+            logger.debug(f"Removing livenessProbe from {osd.name}")
             params = '[{"op":"remove", "path":"/spec/template/spec/containers/0/livenessProbe"}]'
             self.dep_ocp.patch(
                 resource_name=osd.name,
                 params=params,
                 format_type="json",
             )
+
+            logger.debug(f"Setting sleep infinity command on {osd.name}")
             params = (
                 '{"spec": {"template": {"spec": {"containers": [{"name": "osd", "command":'
                 ' ["sleep", "infinity"], "args": []}]}}}}'
@@ -341,15 +396,19 @@ class MonitorRecovery(object):
                 resource_name=osd.name,
                 params=params,
             )
-        logger.info(
-            "Sleeping for 60 seconds to allow OSD pods to restart with new configuration"
-        )
+        logger.info(f"Successfully patched {len(osd_deployments)} OSD deployments")
+
+        logger.info("Waiting 60s for OSD pods to restart with new configuration")
         time.sleep(60)
-        logger.info("Waiting for OSD pods to reach running state")
-        for osd in get_osd_pods():
+
+        logger.info("Verifying all OSD pods reached running state")
+        osd_pods = get_osd_pods()
+        for osd in osd_pods:
+            logger.debug(f"Waiting for OSD pod: {osd.name}")
             wait_for_resource_state(
                 resource=osd, state=constants.STATUS_RUNNING, timeout=600
             )
+        logger.info(f"All {len(osd_pods)} OSD pods are running")
 
     @retry(CommandFailed, tries=10, delay=5, backoff=1)
     def copy_tar_to_pods(self, pod_type="osd"):
@@ -370,18 +429,24 @@ class MonitorRecovery(object):
             pod_objs = get_mon_pods()
         else:
             raise ValueError(f"Invalid pod type: {pod_type}. Use 'osd' or 'mon' ")
+
+        logger.info(f"Copying tar binary to {len(pod_objs)} {pod_type.upper()} pods")
         for pod_obj in pod_objs:
-            logger.info(f"Copying tar binary to pod: {pod_obj.name}")
+            logger.debug(f"Copying tar binary to pod: {pod_obj.name}")
             cmd = (
                 f"cat /usr/bin/tar | oc exec -i -n {constants.OPENSHIFT_STORAGE_NAMESPACE} {pod_obj.name}  -- bash -c "
                 f"'cat > /usr/bin/tar'"
             )
             run_cmd(cmd, shell=True)
-            logger.info(
+
+            logger.debug(
                 f"Setting execute permissions on /usr/bin/tar in pod: {pod_obj.name}"
             )
             cmd = "chmod +x /usr/bin/tar"
             _exec_cmd_on_pod(cmd=cmd, pod_obj=pod_obj)
+        logger.info(
+            f"Successfully copied tar binary to all {len(pod_objs)} {pod_type.upper()} pods"
+        )
 
     def prepare_monstore_script(self):
         """
@@ -435,19 +500,27 @@ class MonitorRecovery(object):
         Raise:
             CommandFailed
         """
-        logger.info("Running mon-store script..")
+        logger.info(
+            f"Executing mon-store retrieval script: {self.backup_dir}/recover_mon.sh"
+        )
         result = exec_cmd(cmd=f"sh {self.backup_dir}/recover_mon.sh")
         result.stdout = result.stdout.decode()
-        logger.info(f"OSD mon store retrieval stdout {result.stdout}")
         result.stderr = result.stderr.decode()
-        logger.info(f"OSD mon store retrieval stderr {result.stderr}")
+
+        logger.debug(f"Mon store retrieval stdout: {result.stdout}")
+        if result.stderr:
+            logger.debug(f"Mon store retrieval stderr: {result.stderr}")
+
         search_pattern = re.search(
             pattern="error|unable to open mon store", string=result.stderr
         )
         if search_pattern:
-            logger.info(f"Error found: {search_pattern}")
-            raise CommandFailed
-        logger.info("Successfully collected mon store from OSDs")
+            logger.warning(
+                f"Error pattern detected in stderr: {search_pattern.group()}"
+            )
+            raise CommandFailed(f"Mon store retrieval failed: {search_pattern.group()}")
+
+        logger.info("Successfully collected mon store from all OSDs")
 
     def patch_sleep_on_mon(self):
         """
@@ -459,16 +532,19 @@ class MonitorRecovery(object):
             namespace=config.ENV_DATA["cluster_namespace"],
         )
         mon_deployments = [OCS(**mon) for mon in mon_dep]
+        logger.info(f"Found {len(mon_deployments)} monitor deployments to patch")
+
         for mon in mon_deployments:
+            logger.debug(f"Patching monitor deployment: {mon.name} to sleep infinitely")
             params = (
                 '{"spec": {"template": {"spec": {"containers":'
                 ' [{"name": "mon", "command": ["sleep", "infinity"], "args": []}]}}}}'
             )
-            logger.info(f"Patching monitor: {mon.name} to sleep infinitely")
             self.dep_ocp.patch(
                 resource_name=mon.name,
                 params=params,
             )
+        logger.info(f"Successfully patched {len(mon_deployments)} monitor deployments")
 
     def monitor_rebuild(self, mon_map_cmd):
         """
@@ -478,36 +554,41 @@ class MonitorRecovery(object):
             mon_map_cmd (str): mon-store tool command
 
         """
+        logger.info("Starting monitor rebuild process on mon-a")
         mon_a = next(
             mon
             for mon in get_mon_pods(namespace=config.ENV_DATA["cluster_namespace"])
             if mon.get().get("metadata", {}).get("labels", {}).get("ceph_daemon_id")
             == "a"
         )
-        logger.info(f"Working on monitor: {mon_a.name}")
+        logger.info(f"Selected monitor for rebuild: {mon_a.name}")
 
-        logger.info(f"Creating monmap with command: {mon_map_cmd}")
+        logger.info("Creating monmap using extracted monitor IPs")
+        logger.debug(f"Monmap command: {mon_map_cmd}")
         mon_a.exec_cmd_on_pod(command=mon_map_cmd, out_yaml_format=False)
+        logger.info("Monmap created successfully")
 
         rebuild_mon_cmd = "ceph-monstore-tool /tmp/monstore rebuild -- --keyring /tmp/keyring --monmap /tmp/monmap"
-        logger.info("Running command to rebuild monitor")
+        logger.info("Rebuilding monitor using ceph-monstore-tool")
+        logger.debug(f"Rebuild command: {rebuild_mon_cmd}")
         mon_a.exec_cmd_on_pod(command=rebuild_mon_cmd, out_yaml_format=False)
+        logger.info("Monitor rebuild completed successfully")
 
-        logger.info("Changing ownership of monstore to ceph")
+        logger.info("Updating ownership of rebuilt monstore")
         _exec_cmd_on_pod(cmd="chown -R ceph:ceph /tmp/monstore", pod_obj=mon_a)
 
-        logger.info("Copy the rebuild store.db file to the monstore directory")
+        logger.info("Moving rebuilt store.db to monitor data directory")
         _exec_cmd_on_pod(
             cmd="mv /tmp/monstore/store.db /var/lib/ceph/mon/ceph-a/store.db",
             pod_obj=mon_a,
         )
-        logger.info("Changing ownership of monstore to ceph")
+
+        logger.info("Setting ownership on store.db in monitor data directory")
         _exec_cmd_on_pod(
             cmd="chown -R ceph:ceph /var/lib/ceph/mon/ceph-a/store.db", pod_obj=mon_a
         )
-        logger.info(
-            f"Copying store.db directory from monitor: {mon_a.name} to {self.backup_dir}"
-        )
+
+        logger.info(f"Backing up store.db from {mon_a.name} to {self.backup_dir}")
         self._exec_oc_cmd(
             cmd=(
                 f"cp {constants.OPENSHIFT_STORAGE_NAMESPACE}/"
@@ -515,23 +596,34 @@ class MonitorRecovery(object):
                 f"{self.backup_dir}/store.db"
             )
         )
-        logger.info("Copying store.db to rest of the monitors")
-        for mon in get_mon_pods(namespace=config.ENV_DATA["cluster_namespace"]):
-            if mon.get().get("metadata").get("labels").get("ceph_daemon_id") != "a":
-                cmd = (
-                    f"cp {self.backup_dir}/store.db "
-                    f"{constants.OPENSHIFT_STORAGE_NAMESPACE}/"
-                    f"{mon.name}:/var/lib/ceph/mon/ceph-"
-                    f"{mon.get().get('metadata').get('labels').get('ceph_daemon_id')}/"
-                )
-                logger.info(f"Copying store.db to monitor: {mon.name}")
-                self._exec_oc_cmd(cmd)
-                logger.info("Changing ownership of store.db to ceph:ceph")
-                _exec_cmd_on_pod(
-                    cmd=f"chown -R ceph:ceph /var/lib/ceph/mon/ceph-"
-                    f"{mon.get().get('metadata').get('labels').get('ceph_daemon_id')}/store.db",
-                    pod_obj=mon,
-                )
+
+        logger.info("Distributing store.db to remaining monitor pods")
+        other_mons = [
+            mon
+            for mon in get_mon_pods(namespace=config.ENV_DATA["cluster_namespace"])
+            if mon.get().get("metadata").get("labels").get("ceph_daemon_id") != "a"
+        ]
+        logger.info(f"Found {len(other_mons)} other monitors to update")
+
+        for mon in other_mons:
+            mon_id = mon.get().get("metadata").get("labels").get("ceph_daemon_id")
+            logger.info(f"Copying store.db to monitor: {mon.name} (mon-{mon_id})")
+
+            cmd = (
+                f"cp {self.backup_dir}/store.db "
+                f"{constants.OPENSHIFT_STORAGE_NAMESPACE}/"
+                f"{mon.name}:/var/lib/ceph/mon/ceph-{mon_id}/"
+            )
+            self._exec_oc_cmd(cmd)
+
+            logger.debug(f"Setting ownership on store.db for monitor: {mon.name}")
+            _exec_cmd_on_pod(
+                cmd=f"chown -R ceph:ceph /var/lib/ceph/mon/ceph-{mon_id}/store.db",
+                pod_obj=mon,
+            )
+        logger.info(
+            f"Successfully distributed store.db to all {len(other_mons) + 1} monitors"
+        )
 
     def revert_patches(self, deployment_paths):
         """
@@ -541,44 +633,57 @@ class MonitorRecovery(object):
             deployment_paths (list): List of paths to deployment yamls
 
         """
-        logger.info("Reverting patches on monitors, osd and mgr")
+        logger.info(
+            f"Reverting {len(deployment_paths)} deployments to original configuration"
+        )
         for dep in deployment_paths:
-            logger.info(f"Reverting {dep}")
+            dep_name = dep.split("/")[-1].replace(".yaml", "")
+            logger.info(f"Reverting deployment: {dep_name}")
             revert_patch = f"replace --force -f {dep}"
             self.ocp_obj.exec_oc_cmd(revert_patch)
 
-            # Determine the type of deployment and wait for corresponding pods
-            dep_name = dep.split("/")[-1].replace(".yaml", "")
             logger.info(
                 f"Waiting for pods from deployment {dep_name} to reach running state"
             )
 
             if "rook-ceph-mon" in dep_name:
-                logger.info("Waiting for monitor pods to reach running state")
+                logger.debug("Waiting 30s before validating monitor pods")
                 time.sleep(30)
+                logger.debug("Validating monitor pods are running")
                 validate_mon_pods()
+                logger.info(f"Monitor deployment {dep_name} pods are running")
             elif "rook-ceph-osd" in dep_name:
-                logger.info("Waiting for OSD pods to reach running state")
+                logger.debug("Waiting 30s before checking OSD pods")
                 time.sleep(30)
-                for osd in get_osd_pods():
+                osd_pods = get_osd_pods()
+                for osd in osd_pods:
+                    logger.debug(f"Waiting for OSD pod: {osd.name}")
                     wait_for_resource_state(
                         resource=osd, state=constants.STATUS_RUNNING, timeout=600
                     )
+                logger.info(
+                    f"OSD deployment {dep_name}: all {len(osd_pods)} pods are running"
+                )
             elif "rook-ceph-mgr" in dep_name:
-                logger.info("Waiting for MGR pods to reach running state")
+                logger.debug("Waiting 30s before checking MGR pods")
                 time.sleep(30)
-                for mgr_pod in get_mgr_pods(
-                    namespace=config.ENV_DATA["cluster_namespace"]
-                ):
+                mgr_pods = get_mgr_pods(namespace=config.ENV_DATA["cluster_namespace"])
+                for mgr_pod in mgr_pods:
+                    logger.debug(f"Waiting for MGR pod: {mgr_pod.name}")
                     wait_for_resource_state(
                         resource=mgr_pod, state=constants.STATUS_RUNNING, timeout=600
                     )
+                logger.info(
+                    f"MGR deployment {dep_name}: all {len(mgr_pods)} pods are running"
+                )
+        logger.info("All deployments successfully reverted")
 
     def backup_deployments(self):
         """
         Creates a backup of all deployments in the `openshift-storage` namespace
 
         """
+        logger.info("Retrieving all deployments in openshift-storage namespace")
         deployment_names = []
         deployments = self.dep_ocp.get("-o name", out_yaml_format=False)
         deployments_full_name = str(deployments).split()
@@ -586,10 +691,15 @@ class MonitorRecovery(object):
         for name in deployments_full_name:
             deployment_names.append(name.lstrip("deployment.apps").lstrip("/"))
 
+        logger.info(
+            f"Backing up {len(deployment_names)} deployments to {self.backup_dir}"
+        )
         for deployment in deployment_names:
+            logger.debug(f"Backing up deployment: {deployment}")
             deployment_get = self.dep_ocp.get(resource_name=deployment)
             deployment_yaml = join(self.backup_dir, deployment + ".yaml")
             templating.dump_data_to_temp_yaml(deployment_get, deployment_yaml)
+        logger.info(f"Successfully backed up {len(deployment_names)} deployments")
 
     def deployments_to_revert(self):
         """
@@ -651,10 +761,12 @@ class MonitorRecovery(object):
             file: A formatted file with ceph daemons keyrings
 
         """
-        logger.info("Getting the daemons keyrings...")
+        logger.info("Extracting Ceph daemon keyrings from secrets")
         all_keyring_secrets = self.get_all_keyring_secrets()
+        logger.info(f"Found {len(all_keyring_secrets)} keyring secrets")
         formatted_data = []
         for keyring_secret in all_keyring_secrets:
+            logger.debug(f"Processing keyring secret: {keyring_secret}")
             cmd = (
                 f"oc get secret {keyring_secret} -n "
                 f"{constants.OPENSHIFT_STORAGE_NAMESPACE} -ojson | "
@@ -687,11 +799,13 @@ class MonitorRecovery(object):
                     formatted_data.append(f"    {cap}")
         with open(f"{self.keyring_dir}/keyring-mon-a", "w") as f:
             f.write("\n".join(formatted_data))
-            logger.info(f"Output saved to {self.keyring_dir}/keyring-mon-a")
+        logger.debug(f"Saved daemon keyrings to {self.keyring_dir}/keyring-mon-a")
 
-        logger.info("Getting the OSDs keys")
+        logger.info("Extracting OSD keys from OSD pods")
         osd_pods = get_osd_pods()
+        logger.info(f"Found {len(osd_pods)} OSD pods")
         for osd_pod in osd_pods:
+            logger.debug(f"Extracting keyring from OSD pod: {osd_pod.name}")
             osd_id = osd_pod.get().get("metadata").get("labels").get("ceph-osd-id")
             cmd = (
                 f"oc exec -i -n {constants.OPENSHIFT_STORAGE_NAMESPACE} "
@@ -722,7 +836,7 @@ class MonitorRecovery(object):
 
     def patch_sleep_on_mds(self):
         """
-        Patch the OSD deployments to sleep and remove the `livenessProbe` parameter,
+        Patch the MDS deployments to sleep and remove the `livenessProbe` parameter,
 
         """
         mds_dep = get_deployments_having_label(
@@ -730,16 +844,19 @@ class MonitorRecovery(object):
             namespace=config.ENV_DATA["cluster_namespace"],
         )
         mds_deployments = [OCS(**mds) for mds in mds_dep]
+        logger.info(f"Found {len(mds_deployments)} MDS deployments to patch")
+
         for mds in mds_deployments:
-            logger.info(
-                f"Patching MDS: {mds.name} to remove livenessProbe and setting sleep infinity"
-            )
+            logger.debug(f"Patching MDS deployment: {mds.name}")
+            logger.debug(f"Removing livenessProbe from {mds.name}")
             params = '[{"op":"remove", "path":"/spec/template/spec/containers/0/livenessProbe"}]'
             self.dep_ocp.patch(
                 resource_name=mds.name,
                 params=params,
                 format_type="json",
             )
+
+            logger.debug(f"Setting sleep infinity command on {mds.name}")
             params = (
                 '{"spec": {"template": {"spec": {"containers": '
                 '[{"name": "mds", "command": ["sleep", "infinity"], "args": []}]}}}}'
@@ -748,10 +865,17 @@ class MonitorRecovery(object):
                 resource_name=mds.name,
                 params=params,
             )
-        logger.info("Sleeping for 60s and waiting for MDS pods to reach running state")
+        logger.info(f"Successfully patched {len(mds_deployments)} MDS deployments")
+
+        logger.info("Waiting 60s for MDS pods to restart with new configuration")
         time.sleep(60)
-        for mds in get_mds_pods(namespace=config.ENV_DATA["cluster_namespace"]):
+
+        logger.info("Verifying all MDS pods reached running state")
+        mds_pods = get_mds_pods(namespace=config.ENV_DATA["cluster_namespace"])
+        for mds in mds_pods:
+            logger.debug(f"Waiting for MDS pod: {mds.name}")
             wait_for_resource_state(resource=mds, state=constants.STATUS_RUNNING)
+        logger.info(f"All {len(mds_pods)} MDS pods are running")
 
     @retry(CommandFailed, tries=10, delay=10, backoff=1)
     def _exec_oc_cmd(self, cmd, out_yaml_format=True):
@@ -786,7 +910,7 @@ def insert_delay(mon_dep):
         mon_dep (str): Name of a monitor deployment
 
     """
-    logger.info(f"Updating initialDelaySeconds on deployment: {mon_dep}")
+    logger.debug(f"Updating initialDelaySeconds on monitor deployment: {mon_dep}")
     kubeconfig = config.RUN.get("kubeconfig")
     namespace = config.ENV_DATA["cluster_namespace"]
     cmd = (
@@ -794,8 +918,9 @@ def insert_delay(mon_dep):
         f'sed "s/initialDelaySeconds: 10/initialDelaySeconds: 10000/g" | '
         f"oc --kubeconfig {kubeconfig} -n {namespace} replace -f - "
     )
-    logger.info(f"Executing {cmd}")
+    logger.debug(f"Executing command: {cmd}")
     exec_cmd(cmd=cmd, shell=True)
+    logger.debug(f"Successfully updated initialDelaySeconds for {mon_dep}")
 
 
 def update_mon_initial_delay():
@@ -803,19 +928,24 @@ def update_mon_initial_delay():
     Inserts delay on all monitors
 
     """
+    logger.info("Updating initialDelaySeconds on all monitor deployments")
     mon_dep = get_deployments_having_label(
         label=constants.MON_APP_LABEL,
         namespace=config.ENV_DATA["cluster_namespace"],
     )
     mon_deployments = [OCS(**mon) for mon in mon_dep]
+    logger.info(f"Found {len(mon_deployments)} monitor deployments to update")
+
     for mon in mon_deployments:
-        logger.info(f"Updating initialDelaySeconds on {mon.name} deployment")
+        logger.debug(f"Updating initialDelaySeconds on deployment: {mon.name}")
         insert_delay(mon_dep=mon.name)
 
-    logger.info("Sleeping for mons to get initialized")
+    logger.info("Waiting 90s for monitors to initialize with new delay settings")
     time.sleep(90)
-    logger.info("Validating whether all mons reached running state")
+
+    logger.info("Validating all monitor pods reached running state")
     validate_mon_pods()
+    logger.info("All monitor pods are running")
 
 
 @retry(
@@ -827,8 +957,11 @@ def validate_mon_pods():
 
     """
     mon_pods = get_mon_pods(namespace=config.ENV_DATA["cluster_namespace"])
+    logger.debug(f"Validating {len(mon_pods)} monitor pods are in running state")
     for mon in mon_pods:
+        logger.debug(f"Waiting for monitor pod: {mon.name}")
         wait_for_resource_state(resource=mon, state=constants.STATUS_RUNNING)
+    logger.debug(f"All {len(mon_pods)} monitor pods validated successfully")
 
 
 def corrupt_ceph_monitors():
@@ -837,26 +970,38 @@ def corrupt_ceph_monitors():
 
     """
     mon_pods = get_mon_pods(namespace=config.ENV_DATA["cluster_namespace"])
+    logger.info(f"Corrupting {len(mon_pods)} monitor pods by deleting store.db")
+
     for mon in mon_pods:
-        logger.info(f"Corrupting monitor: {mon.name}")
         mon_id = mon.get().get("metadata").get("labels").get("ceph_daemon_id")
+        logger.info(f"Corrupting monitor pod: {mon.name} (mon-{mon_id})")
         _exec_cmd_on_pod(
             cmd=f"rm -rf /var/lib/ceph/mon/ceph-{mon_id}/store.db", pod_obj=mon
         )
+        logger.debug(f"Deleted store.db from monitor: {mon.name}")
+
         try:
+            logger.debug(f"Waiting for {mon.name} to reach CrashLoopBackOff state")
             wait_for_resource_state(resource=mon, state=constants.STATUS_CLBO)
         except ResourceWrongStatusException:
-            if (
-                mon.ocp.get_resource(resource_name=mon.name, column="STATUS")
-                != constants.STATUS_CLBO
-            ):
-                logger.info(
-                    f"Re-spinning monitor: {mon.name} since it did not reach CLBO state"
+            current_status = mon.ocp.get_resource(
+                resource_name=mon.name, column="STATUS"
+            )
+            if current_status != constants.STATUS_CLBO:
+                logger.warning(
+                    f"Monitor {mon.name} did not reach CLBO state (current: {current_status}), "
+                    f"forcing pod deletion"
                 )
                 mon.delete()
-    logger.info("Validating all the monitors are in CLBO state")
-    for mon in get_mon_pods(namespace=config.ENV_DATA["cluster_namespace"]):
+
+    logger.info("Validating all monitors are in CrashLoopBackOff state")
+    corrupted_mons = get_mon_pods(namespace=config.ENV_DATA["cluster_namespace"])
+    for mon in corrupted_mons:
+        logger.debug(f"Verifying monitor {mon.name} is in CLBO state")
         wait_for_resource_state(resource=mon, state=constants.STATUS_CLBO)
+    logger.info(
+        f"All {len(corrupted_mons)} monitors successfully corrupted and in CLBO state"
+    )
 
 
 def handle_multi_attach_error(pod_obj, timeout=300):
@@ -871,7 +1016,7 @@ def handle_multi_attach_error(pod_obj, timeout=300):
         bool: True if pod is running, False otherwise
 
     """
-    logger.info(f"Checking pod {pod_obj.name} for multi-attach errors")
+    logger.debug(f"Checking pod {pod_obj.name} for multi-attach errors")
 
     try:
         pod_describe = pod_obj.ocp.exec_oc_cmd(
@@ -879,16 +1024,15 @@ def handle_multi_attach_error(pod_obj, timeout=300):
         )
 
         if "Multi-Attach error" in pod_describe:
-            logger.warning(f"Multi-attach error detected for pod {pod_obj.name}")
+            logger.warning(f"Multi-attach error detected for pod: {pod_obj.name}")
 
             pvc_match = re.search(
                 r'Multi-Attach error for volume "([^"]+)"', pod_describe
             )
             if pvc_match:
                 pvc_id = pvc_match.group(1)
-                logger.info(f"Found PVC ID with multi-attach error: {pvc_id}")
+                logger.info(f"Identified PVC with multi-attach error: {pvc_id}")
 
-                # Find and delete stale VolumeAttachment
                 va_ocp = OCP(kind="VolumeAttachment", namespace="")
                 try:
                     attachments = va_ocp.get()
@@ -905,20 +1049,37 @@ def handle_multi_attach_error(pod_obj, timeout=300):
                                     f"Deleting stale VolumeAttachment: {va_name}"
                                 )
                                 va_ocp.delete(resource_name=va_name)
+                                logger.info(
+                                    "Waiting 10s for VolumeAttachment cleanup to propagate"
+                                )
                                 time.sleep(10)
                                 break
-                except Exception as e:
-                    logger.warning(f"Error handling VolumeAttachment: {e}")
-    except Exception as e:
-        logger.warning(f"Error checking for multi-attach: {e}")
+                except Exception:
+                    logger.exception(
+                        f"Failed to handle VolumeAttachment for PVC {pvc_id}"
+                    )
+            else:
+                logger.warning(
+                    "Multi-attach error detected but could not extract PVC ID from pod description"
+                )
+    except Exception:
+        logger.exception(
+            f"Error while checking pod {pod_obj.name} for multi-attach errors"
+        )
 
+    logger.debug(
+        f"Waiting for pod {pod_obj.name} to reach running state (timeout: {timeout}s)"
+    )
     try:
         wait_for_resource_state(
             resource=pod_obj, state=constants.STATUS_RUNNING, timeout=timeout
         )
+        logger.info(f"Pod {pod_obj.name} is running")
         return True
     except Exception as e:
-        logger.error(f"Pod {pod_obj.name} failed to reach running state: {e}")
+        logger.error(
+            f"Pod {pod_obj.name} failed to reach running state after {timeout}s: {e}"
+        )
         return False
 
 
@@ -928,31 +1089,48 @@ def recover_mcg():
     Handles multi-attach errors by deleting stale VolumeAttachment resources.
 
     """
-    logger.info("Re-spinning noobaa pods")
-    for noobaa_pod in get_noobaa_pods():
+    logger.info("Starting MCG recovery by re-spinning noobaa pods")
+    noobaa_pods = get_noobaa_pods()
+    logger.info(f"Found {len(noobaa_pods)} noobaa pods to respawn")
+
+    for noobaa_pod in noobaa_pods:
         logger.info(f"Force deleting noobaa pod: {noobaa_pod.name}")
         noobaa_pod.delete(force=True)
 
-    logger.info("Waiting for noobaa pods to reach running state")
+    logger.info("Waiting 120s for noobaa pods to respawn")
     time.sleep(120)
 
-    for noobaa_pod in get_noobaa_pods():
-        logger.info(f"Checking noobaa pod: {noobaa_pod.name}")
+    logger.info("Verifying noobaa pods reached running state")
+    respawned_noobaa_pods = get_noobaa_pods()
+    for noobaa_pod in respawned_noobaa_pods:
+        logger.debug(f"Checking noobaa pod: {noobaa_pod.name}")
         if not handle_multi_attach_error(noobaa_pod, timeout=600):
-            logger.warning(f"Pod {noobaa_pod.name} did not reach running state")
+            logger.warning(f"Noobaa pod {noobaa_pod.name} did not reach running state")
+    logger.info("MCG noobaa pods recovery completed")
+
     if config.ENV_DATA["platform"].lower() in constants.ON_PREM_PLATFORMS:
-        logger.info("Re-spinning RGW pods")
-        for rgw_pod in get_rgw_pods():
+        logger.info("On-prem platform detected: recovering RGW pods")
+        rgw_pods = get_rgw_pods()
+        logger.info(f"Found {len(rgw_pods)} RGW pods to respawn")
+
+        for rgw_pod in rgw_pods:
             logger.info(f"Force deleting RGW pod: {rgw_pod.name}")
             rgw_pod.delete(force=True)
 
-        logger.info("Waiting for RGW pods to reach running state")
+        logger.info("Waiting 120s for RGW pods to respawn")
         time.sleep(120)
 
-        for rgw_pod in get_rgw_pods():
-            logger.info(f"Checking RGW pod: {rgw_pod.name}")
+        logger.info("Verifying RGW pods reached running state")
+        respawned_rgw_pods = get_rgw_pods()
+        for rgw_pod in respawned_rgw_pods:
+            logger.debug(f"Checking RGW pod: {rgw_pod.name}")
             if not handle_multi_attach_error(rgw_pod, timeout=600):
-                logger.warning(f"Pod {rgw_pod.name} did not reach running state")
+                logger.warning(f"RGW pod {rgw_pod.name} did not reach running state")
+        logger.info("RGW pods recovery completed")
+    else:
+        logger.debug(
+            f"Skipping RGW recovery on non-on-prem platform: {config.ENV_DATA['platform']}"
+        )
 
 
 def remove_global_id_reclaim():
@@ -960,28 +1138,59 @@ def remove_global_id_reclaim():
     Removes global id warning by re-spinning client and mon pods
 
     """
+    logger.info(
+        "Removing global ID reclaim warnings by re-spinning CSI, MDS, and monitor pods"
+    )
+
+    logger.info("Collecting CSI plugin and provisioner pods")
     csi_pods = []
     interfaces = [constants.CEPHBLOCKPOOL, constants.CEPHFILESYSTEM]
     for interface in interfaces:
         plugin_pods = get_plugin_pods(interface)
+        logger.debug(f"Found {len(plugin_pods)} plugin pods for interface: {interface}")
         csi_pods += plugin_pods
 
     cephfs_provisioner_pods = get_cephfsplugin_provisioner_pods()
     rbd_provisioner_pods = get_rbdfsplugin_provisioner_pods()
+    logger.debug(f"Found {len(cephfs_provisioner_pods)} CephFS provisioner pods")
+    logger.debug(f"Found {len(rbd_provisioner_pods)} RBD provisioner pods")
 
     csi_pods += cephfs_provisioner_pods
     csi_pods += rbd_provisioner_pods
+    logger.info(f"Deleting {len(csi_pods)} CSI pods")
     for csi_pod in csi_pods:
+        logger.debug(f"Deleting CSI pod: {csi_pod.name}")
         csi_pod.delete()
-    for mds_pod in get_mds_pods():
+
+    logger.info("Deleting MDS pods")
+    mds_pods = get_mds_pods()
+    logger.info(f"Found {len(mds_pods)} MDS pods to delete")
+    for mds_pod in mds_pods:
+        logger.debug(f"Deleting MDS pod: {mds_pod.name}")
         mds_pod.delete()
-    for mds_pod in get_mds_pods():
+
+    logger.info("Waiting for MDS pods to respawn and reach running state")
+    respawned_mds_pods = get_mds_pods()
+    for mds_pod in respawned_mds_pods:
+        logger.debug(f"Waiting for MDS pod: {mds_pod.name}")
         wait_for_resource_state(resource=mds_pod, state=constants.STATUS_RUNNING)
-    for mon in get_mon_pods(namespace=config.ENV_DATA["cluster_namespace"]):
-        mon.delete()
+    logger.info(f"All {len(respawned_mds_pods)} MDS pods are running")
+
+    logger.info("Deleting monitor pods")
     mon_pods = get_mon_pods(namespace=config.ENV_DATA["cluster_namespace"])
+    logger.info(f"Found {len(mon_pods)} monitor pods to delete")
     for mon in mon_pods:
+        logger.debug(f"Deleting monitor pod: {mon.name}")
+        mon.delete()
+
+    logger.info("Waiting for monitor pods to respawn and reach running state")
+    respawned_mon_pods = get_mon_pods(namespace=config.ENV_DATA["cluster_namespace"])
+    for mon in respawned_mon_pods:
+        logger.debug(f"Waiting for monitor pod: {mon.name}")
         wait_for_resource_state(resource=mon, state=constants.STATUS_RUNNING)
+    logger.info(f"All {len(respawned_mon_pods)} monitor pods are running")
+
+    logger.info("Global ID reclaim warning removal completed")
 
 
 def ceph_fs_recovery():
@@ -989,19 +1198,36 @@ def ceph_fs_recovery():
     Resets the CephFS
 
     """
+    logger.info(
+        f"Starting CephFS recovery for filesystem: {defaults.CEPHFILESYSTEM_NAME}"
+    )
     toolbox = pod.get_ceph_tools_pod()
+    logger.debug(f"Using ceph tools pod: {toolbox.name}")
+
     try:
+        logger.info(f"Attempting to reset CephFS: {defaults.CEPHFILESYSTEM_NAME}")
         toolbox.exec_cmd_on_pod(
             f"ceph fs reset {defaults.CEPHFILESYSTEM_NAME} --yes-i-really-mean-it"
         )
-    except CommandFailed:
-        toolbox.exec_cmd_on_pod(
-            f"ceph fs new {defaults.CEPHFILESYSTEM_NAME} ocs-storagecluster-cephfilesystem-metadata "
-            f"ocs-storagecluster-cephfilesystem-data0 --force"
-        )
-        toolbox.exec_cmd_on_pod(
-            f"ceph fs reset {defaults.CEPHFILESYSTEM_NAME}  --yes-i-really-mean-it"
-        )
+        logger.info("CephFS reset successful")
+    except CommandFailed as e:
+        logger.warning(f"CephFS reset failed, creating new filesystem: {e}")
+        try:
+            logger.info(f"Creating new CephFS: {defaults.CEPHFILESYSTEM_NAME}")
+            toolbox.exec_cmd_on_pod(
+                f"ceph fs new {defaults.CEPHFILESYSTEM_NAME} ocs-storagecluster-cephfilesystem-metadata "
+                f"ocs-storagecluster-cephfilesystem-data0 --force"
+            )
+            logger.info("New CephFS created, attempting reset again")
+            toolbox.exec_cmd_on_pod(
+                f"ceph fs reset {defaults.CEPHFILESYSTEM_NAME} --yes-i-really-mean-it"
+            )
+            logger.info("CephFS reset successful after recreation")
+        except CommandFailed:
+            logger.exception(
+                f"Failed to recover CephFS: {defaults.CEPHFILESYSTEM_NAME}"
+            )
+            raise
 
 
 def get_spun_dc_pods(pod_list):
@@ -1015,16 +1241,21 @@ def get_spun_dc_pods(pod_list):
         list : list of respun pod objects
 
     """
+    logger.debug(f"Looking for re-spun pods for {len(pod_list)} deployment configs")
     new_pods = []
+
     for pod_obj in pod_list:
         pod_label = pod_obj.labels.get("deploymentconfig")
         label_selector = f"deploymentconfig={pod_label}"
+        logger.debug(f"Searching for pods with label: {label_selector}")
 
         pods_data = pod.get_pods_having_label(label_selector, pod_obj.namespace)
         for pod_data in pods_data:
             pod_name = pod_data.get("metadata").get("name")
             if "-deploy" not in pod_name and pod_name not in pod_obj.name:
+                logger.debug(f"Found re-spun pod: {pod_name}")
                 new_pods.append(pod.get_pod_obj(pod_name, pod_obj.namespace))
+
     logger.info(f"Previous pods: {[pod_obj.name for pod_obj in pod_list]}")
     logger.info(f"Re-spun pods: {[pod_obj.name for pod_obj in new_pods]}")
     return new_pods
@@ -1042,23 +1273,30 @@ def generate_monmap_cmd():
     mon_ids = []
     mon_ips = []
 
-    logger.info("Getting monitor pods public IP")
+    logger.info("Extracting monitor IPs and IDs for monmap generation")
     mon_pods = get_mon_pods(namespace=config.ENV_DATA["cluster_namespace"])
+    logger.info(f"Found {len(mon_pods)} monitor pods")
+
     for mon in mon_pods:
-        mon_ids.append(mon.get().get("metadata").get("labels").get("ceph_daemon_id"))
-        logger.info(f"getting public ip of {mon.name}")
-        logger.info(mon_ids)
+        mon_id = mon.get().get("metadata").get("labels").get("ceph_daemon_id")
+        mon_ids.append(mon_id)
+
+        logger.debug(
+            f"Extracting public IP from monitor pod: {mon.name} (mon-{mon_id})"
+        )
         ip_match = re.findall(
             r"[0-9]+(?:\.[0-9]+){3}",
             mon.get().get("spec").get("initContainers")[1].get("args")[-2],
         )
         if ip_match:
             mon_ips.append(ip_match[0])
+            logger.debug(f"Monitor {mon.name}: ID={mon_id}, IP={ip_match[0]}")
         else:
+            logger.error(f"Could not extract IP from monitor {mon.name}")
             raise ValueError(f"Could not extract IP from monitor {mon.name}")
 
     mon_a = mon_pods[0]
-    logger.info(f"Working on monitor: {mon_a.name} to get FSID")
+    logger.debug(f"Extracting FSID from monitor: {mon_a.name}")
     fsid = (
         mon_a.get()
         .get("spec")
@@ -1066,14 +1304,18 @@ def generate_monmap_cmd():
         .get("args")[0]
         .replace("--fsid=", "")
     )
+    logger.info(f"Cluster FSID: {fsid}")
 
-    for ids, ip in zip(mon_ids, mon_ips):
-        mon_ips_dict.update({ids: ip})
+    for mon_id, ip in zip(mon_ids, mon_ips):
+        mon_ips_dict.update({mon_id: ip})
+
+    logger.debug(f"Monitor ID to IP mapping: {mon_ips_dict}")
 
     mon_ip_ids = ""
     for key, val in mon_ips_dict.items():
         mon_ip_ids = mon_ip_ids + f"--add {key} {val}" + " "
 
     mon_map_cmd = f"monmaptool --create {mon_ip_ids} --enable-all-features --clobber /tmp/monmap --fsid {fsid}"
-    logger.info(f"Generated monitor map creation command: {mon_map_cmd}")
+    logger.info(f"Generated monmap command with {len(mon_ips_dict)} monitors")
+    logger.debug(f"Monmap command: {mon_map_cmd}")
     return mon_map_cmd

--- a/tests/cross_functional/kcs/test_monitor_recovery.py
+++ b/tests/cross_functional/kcs/test_monitor_recovery.py
@@ -45,6 +45,7 @@ from ocs_ci.ocs import ocp, constants, defaults, bucket_utils
 from ocs_ci.helpers.helpers import wait_for_resource_state, get_secret_names
 from ocs_ci.utility.retry import retry
 from ocs_ci.utility.utils import exec_cmd, run_cmd, TimeoutSampler
+from ocs_ci.ocs.platform_nodes import PlatformNodesFactory
 from ocs_ci.ocs.node import get_node_objs
 
 logger = logging.getLogger(__name__)
@@ -1069,37 +1070,6 @@ def corrupt_ceph_monitors():
     )
 
 
-def verify_pods_running(pod_list, pod_type="pod", timeout=600):
-    """
-    Verify that a list of pods reach running state, with sandbox error recovery.
-
-    Args:
-        pod_list: List of pod objects to verify
-        pod_type: Type of pods for logging (e.g., "noobaa", "RGW", "MDS")
-        timeout: Maximum time to wait for each pod
-
-    Returns:
-        list: List of failed pod names (empty if all succeeded)
-    """
-    logger.info(f"Verifying {len(pod_list)} {pod_type} pods reach running state")
-    failed_pods = []
-
-    for pod_obj in pod_list:
-        logger.debug(f"Checking {pod_type} pod: {pod_obj.name}")
-        if not check_and_recover_sandbox_errors(pod_obj, timeout=timeout):
-            logger.error(f"{pod_type} pod {pod_obj.name} failed to reach running state")
-            failed_pods.append(pod_obj.name)
-
-    if failed_pods:
-        logger.error(
-            f"{pod_type} recovery failed: {len(failed_pods)} pods not running: {failed_pods}"
-        )
-    else:
-        logger.info(f"All {len(pod_list)} {pod_type} pods are running")
-
-    return failed_pods
-
-
 def check_and_recover_sandbox_errors(pod_obj, timeout=600):
     """
     Check if a pod has sandbox errors and recover by power cycling its node.
@@ -1142,12 +1112,14 @@ def check_and_recover_sandbox_errors(pod_obj, timeout=600):
         )
 
         has_sandbox_error = False
+        has_rwop_error = False
         error_messages = []
 
         for event in events.get("items", []):
             msg = event.get("message", "")
             reason = event.get("reason", "")
 
+            # Check for sandbox errors
             if any(
                 err in msg
                 for err in [
@@ -1160,18 +1132,38 @@ def check_and_recover_sandbox_errors(pod_obj, timeout=600):
                 has_sandbox_error = True
                 error_messages.append(f"{reason}: {msg[:150]}")
 
-        if not has_sandbox_error:
+            # Check for ReadWriteOncePod volume already in use error
+            if any(
+                err in msg
+                for err in [
+                    "ReadWriteOncePod access mode and is already in use",
+                    "volume is already exclusively attached",
+                ]
+            ):
+                has_rwop_error = True
+                error_messages.append(f"{reason}: {msg[:150]}")
+
+        if not has_sandbox_error and not has_rwop_error:
             logger.debug(
-                f"Pod {pod_name} has no sandbox errors, using standard recovery"
+                f"Pod {pod_name} has no sandbox or RWOP errors, using standard recovery"
             )
             return handle_multi_attach_error(pod_obj, timeout)
 
-        logger.warning(f"Pod {pod_name} on node {node_name} has sandbox errors:")
+        error_type = (
+            "sandbox/RWOP"
+            if (has_sandbox_error and has_rwop_error)
+            else ("sandbox" if has_sandbox_error else "ReadWriteOncePod")
+        )
+        logger.warning(f"Pod {pod_name} on node {node_name} has {error_type} errors:")
         for msg in error_messages[:3]:
             logger.warning(f"  - {msg}")
 
         logger.info(f"Recovering pod {pod_name} by restarting node {node_name}")
 
+        # Get platform-specific nodes object
+        nodes_platform = PlatformNodesFactory().get_nodes_platform()
+
+        # Get all node objects to find the target node
         node_objs = get_node_objs()
         target_node = None
         for n in node_objs:
@@ -1183,14 +1175,16 @@ def check_and_recover_sandbox_errors(pod_obj, timeout=600):
             logger.error(f"Could not find node object for {node_name}")
             return handle_multi_attach_error(pod_obj, timeout)
 
-        logger.info(f"Stopping node {node_name}...")
-        target_node.stop_nodes([target_node])
+        logger.info(
+            f"Stopping node {node_name} using platform: {nodes_platform.__class__.__name__}"
+        )
+        nodes_platform.stop_nodes([target_node])
 
         logger.info("Waiting 30s for node to stop...")
         time.sleep(30)
 
         logger.info(f"Starting node {node_name}...")
-        target_node.start_nodes([target_node])
+        nodes_platform.start_nodes([target_node])
 
         logger.info(f"Waiting for node {node_name} to become Ready...")
         ocp_node = OCP(kind=constants.NODE)
@@ -1220,6 +1214,37 @@ def check_and_recover_sandbox_errors(pod_obj, timeout=600):
     except Exception as e:
         logger.error(f"Error during sandbox error recovery for {pod_obj.name}: {e}")
         return handle_multi_attach_error(pod_obj, timeout)
+
+
+def verify_pods_running(pod_list, pod_type="pod", timeout=600):
+    """
+    Verify that a list of pods reach running state, with sandbox error recovery.
+
+    Args:
+        pod_list: List of pod objects to verify
+        pod_type: Type of pods for logging (e.g., "noobaa", "RGW", "MDS")
+        timeout: Maximum time to wait for each pod
+
+    Returns:
+        list: List of failed pod names (empty if all succeeded)
+    """
+    logger.info(f"Verifying {len(pod_list)} {pod_type} pods reach running state")
+    failed_pods = []
+
+    for pod_obj in pod_list:
+        logger.debug(f"Checking {pod_type} pod: {pod_obj.name}")
+        if not check_and_recover_sandbox_errors(pod_obj, timeout=timeout):
+            logger.error(f"{pod_type} pod {pod_obj.name} failed to reach running state")
+            failed_pods.append(pod_obj.name)
+
+    if failed_pods:
+        logger.error(
+            f"{pod_type} recovery failed: {len(failed_pods)} pods not running: {failed_pods}"
+        )
+    else:
+        logger.info(f"All {len(pod_list)} {pod_type} pods are running")
+
+    return failed_pods
 
 
 def handle_multi_attach_error(pod_obj, timeout=300):
@@ -1321,43 +1346,8 @@ def recover_mcg():
     logger.info("Waiting 120s for noobaa pods to respawn")
     time.sleep(120)
 
-    logger.info("Waiting for postgres cluster pods to spawn (timeout: 300s)")
-    max_wait_time = 300
-    start_time = time.time()
-    expected_pg_pods = 2
-    active_pg_pods = []
-
-    while time.time() - start_time < max_wait_time:
-        noobaa_db_pods = pod.get_pods_having_label(
-            constants.NOOBAA_DB_LABEL_419_AND_ABOVE,
-            config.ENV_DATA["cluster_namespace"],
-        )
-        active_pg_pods = [
-            p
-            for p in noobaa_db_pods
-            if p.get("metadata", {}).get("deletionTimestamp") is None
-        ]
-        if len(active_pg_pods) >= expected_pg_pods:
-            elapsed = int(time.time() - start_time)
-            logger.info(
-                f"All {len(active_pg_pods)} postgres cluster pods spawned after {elapsed}s"
-            )
-            break
-        logger.debug(
-            f"Postgres pods: active={len(active_pg_pods)}, total={len(noobaa_db_pods)}, "
-            f"expected={expected_pg_pods}, elapsed={int(time.time() - start_time)}s"
-        )
-        time.sleep(10)
-    else:
-        logger.warning(
-            f"Timeout waiting for postgres pods after {max_wait_time}s: "
-            f"found {len(active_pg_pods)}/{expected_pg_pods} expected"
-        )
-
     respawned_noobaa_pods = get_noobaa_pods()
-    logger.info(
-        f"Found {len(respawned_noobaa_pods)} noobaa pods to verify (includes postgres cluster)"
-    )
+    logger.info(f"Found {len(respawned_noobaa_pods)} noobaa pods to verify")
 
     failed_noobaa_pods = verify_pods_running(
         respawned_noobaa_pods, pod_type="noobaa", timeout=600

--- a/tests/cross_functional/kcs/test_monitor_recovery.py
+++ b/tests/cross_functional/kcs/test_monitor_recovery.py
@@ -32,13 +32,9 @@ from ocs_ci.ocs.resources.pod import (
     get_deployments_having_label,
     get_mds_pods,
     get_mgr_pods,
-    get_cephfsplugin_provisioner_pods,
-    get_rbdfsplugin_provisioner_pods,
     get_rgw_pods,
     get_noobaa_pods,
-    get_plugin_pods,
     get_ceph_tools_pod,
-    get_deployment_name,
     wait_for_storage_pods,
 )
 from ocs_ci.ocs.resources import pod
@@ -275,8 +271,6 @@ class TestMonitorRecovery(E2ETest):
         logger.test_step("Recover MCG by re-spinning noobaa pods")
         recover_mcg()
 
-        logger.test_step("Remove global ID reclaim warnings")
-        remove_global_id_reclaim()
         logger.test_step("Verify data integrity after recovery")
 
         logger.info("Checking current state of application pods before verification")
@@ -1155,7 +1149,7 @@ def _wait_for_replacement_pod(pod_obj, timeout, namespace):
     if last_segment.isdigit():
         prefix = pod_name
     else:
-        prefix = get_deployment_name(pod_name)
+        prefix = pod_name.rsplit("-", 1)[0]
     logger.info(
         f"Waiting up to {timeout}s for replacement of pod '{pod_obj.name}' "
         f"(name prefix: '{prefix}') to reach Running state"
@@ -1798,66 +1792,6 @@ def recover_mcg():
         logger.debug(
             f"Skipping RGW recovery on non-on-prem platform: {config.ENV_DATA['platform']}"
         )
-
-
-def remove_global_id_reclaim():
-    """
-    Removes global id warning by re-spinning client and mon pods
-
-    """
-    logger.info(
-        "Removing global ID reclaim warnings by re-spinning CSI, MDS, and monitor pods"
-    )
-
-    logger.info("Collecting CSI plugin and provisioner pods")
-    csi_pods = []
-    interfaces = [constants.CEPHBLOCKPOOL, constants.CEPHFILESYSTEM]
-    for interface in interfaces:
-        plugin_pods = get_plugin_pods(interface)
-        logger.debug(f"Found {len(plugin_pods)} plugin pods for interface: {interface}")
-        csi_pods += plugin_pods
-
-    cephfs_provisioner_pods = get_cephfsplugin_provisioner_pods()
-    rbd_provisioner_pods = get_rbdfsplugin_provisioner_pods()
-    logger.debug(f"Found {len(cephfs_provisioner_pods)} CephFS provisioner pods")
-    logger.debug(f"Found {len(rbd_provisioner_pods)} RBD provisioner pods")
-
-    csi_pods += cephfs_provisioner_pods
-    csi_pods += rbd_provisioner_pods
-    logger.info(f"Deleting {len(csi_pods)} CSI pods")
-    for csi_pod in csi_pods:
-        logger.debug(f"Deleting CSI pod: {csi_pod.name}")
-        csi_pod.delete(force=True)
-
-    logger.info("Deleting MDS pods")
-    mds_pods = get_mds_pods()
-    logger.info(f"Found {len(mds_pods)} MDS pods to delete")
-    for mds_pod in mds_pods:
-        logger.debug(f"Deleting MDS pod: {mds_pod.name}")
-        mds_pod.delete(force=True)
-
-    logger.info("Waiting for MDS pods to respawn and reach running state")
-    respawned_mds_pods = get_mds_pods()
-    for mds_pod in respawned_mds_pods:
-        logger.debug(f"Waiting for MDS pod: {mds_pod.name}")
-        wait_for_resource_state(resource=mds_pod, state=constants.STATUS_RUNNING)
-    logger.info(f"All {len(respawned_mds_pods)} MDS pods are running")
-
-    logger.info("Deleting monitor pods")
-    mon_pods = get_mon_pods(namespace=config.ENV_DATA["cluster_namespace"])
-    logger.info(f"Found {len(mon_pods)} monitor pods to delete")
-    for mon in mon_pods:
-        logger.debug(f"Deleting monitor pod: {mon.name}")
-        mon.delete(force=True)
-
-    logger.info("Waiting for monitor pods to respawn and reach running state")
-    respawned_mon_pods = get_mon_pods(namespace=config.ENV_DATA["cluster_namespace"])
-    for mon in respawned_mon_pods:
-        logger.debug(f"Waiting for monitor pod: {mon.name}")
-        wait_for_resource_state(resource=mon, state=constants.STATUS_RUNNING)
-    logger.info(f"All {len(respawned_mon_pods)} monitor pods are running")
-
-    logger.info("Global ID reclaim warning removal completed")
 
 
 def replace_mds_deployments():

--- a/tests/cross_functional/kcs/test_monitor_recovery.py
+++ b/tests/cross_functional/kcs/test_monitor_recovery.py
@@ -44,7 +44,8 @@ from ocs_ci.ocs.resources import pod
 from ocs_ci.ocs import ocp, constants, defaults, bucket_utils
 from ocs_ci.helpers.helpers import wait_for_resource_state, get_secret_names
 from ocs_ci.utility.retry import retry
-from ocs_ci.utility.utils import exec_cmd, run_cmd
+from ocs_ci.utility.utils import exec_cmd, run_cmd, TimeoutSampler
+from ocs_ci.ocs.node import get_node_objs
 
 logger = logging.getLogger(__name__)
 
@@ -655,7 +656,7 @@ class MonitorRecovery(object):
 
         for mon in other_mons:
             mon_id = mon.get().get("metadata").get("labels").get("ceph_daemon_id")
-            logger.info(f"Copying store.db to monitor: {mon.name} (mon-{mon_id})")
+            logger.debug(f"Copying store.db to monitor: {mon.name} (mon-{mon_id})")
 
             cmd = (
                 f"cp {self.backup_dir}/store.db "
@@ -690,7 +691,7 @@ class MonitorRecovery(object):
             revert_patch = f"replace --force -f {dep}"
             self.ocp_obj.exec_oc_cmd(revert_patch)
 
-            logger.info(
+            logger.debug(
                 f"Waiting for pods from deployment {dep_name} to reach running state"
             )
 
@@ -1068,6 +1069,159 @@ def corrupt_ceph_monitors():
     )
 
 
+def verify_pods_running(pod_list, pod_type="pod", timeout=600):
+    """
+    Verify that a list of pods reach running state, with sandbox error recovery.
+
+    Args:
+        pod_list: List of pod objects to verify
+        pod_type: Type of pods for logging (e.g., "noobaa", "RGW", "MDS")
+        timeout: Maximum time to wait for each pod
+
+    Returns:
+        list: List of failed pod names (empty if all succeeded)
+    """
+    logger.info(f"Verifying {len(pod_list)} {pod_type} pods reach running state")
+    failed_pods = []
+
+    for pod_obj in pod_list:
+        logger.debug(f"Checking {pod_type} pod: {pod_obj.name}")
+        if not check_and_recover_sandbox_errors(pod_obj, timeout=timeout):
+            logger.error(f"{pod_type} pod {pod_obj.name} failed to reach running state")
+            failed_pods.append(pod_obj.name)
+
+    if failed_pods:
+        logger.error(
+            f"{pod_type} recovery failed: {len(failed_pods)} pods not running: {failed_pods}"
+        )
+    else:
+        logger.info(f"All {len(pod_list)} {pod_type} pods are running")
+
+    return failed_pods
+
+
+def check_and_recover_sandbox_errors(pod_obj, timeout=600):
+    """
+    Check if a pod has sandbox errors and recover by power cycling its node.
+    After node recovery, delegates to handle_multi_attach_error for volume issues.
+
+    This is a lightweight helper specifically for recover_mcg() and ceph_fs_recovery()
+    to handle FailedCreatePodSandBox errors during pod recovery.
+
+    Args:
+        pod_obj: Pod object to check
+        timeout: Maximum time to wait for recovery (default: 600s)
+
+    Returns:
+        bool: True if pod reaches running state, False otherwise
+
+    """
+    try:
+        pod_name = pod_obj.name
+        namespace = pod_obj.namespace
+
+        pod_status = pod_obj.get().get("status", {})
+        phase = pod_status.get("phase")
+
+        if phase == constants.STATUS_RUNNING:
+            logger.debug(f"Pod {pod_name} is already running, no recovery needed")
+            return True
+
+        node_name = pod_obj.get().get("spec", {}).get("nodeName")
+
+        if not node_name:
+            logger.debug(f"Pod {pod_name} not scheduled to a node yet")
+            return handle_multi_attach_error(pod_obj, timeout)
+
+        logger.info(f"Pod {pod_name} is in phase '{phase}', checking for errors...")
+
+        ocp_pod = OCP(kind=constants.POD, namespace=namespace)
+        events = ocp_pod.exec_oc_cmd(
+            f"get events --field-selector involvedObject.name={pod_name} "
+            f"-n {namespace} -o json"
+        )
+
+        has_sandbox_error = False
+        error_messages = []
+
+        for event in events.get("items", []):
+            msg = event.get("message", "")
+            reason = event.get("reason", "")
+
+            if any(
+                err in msg
+                for err in [
+                    "FailedCreatePodSandBox",
+                    "DeadlineExceeded",
+                    "stream terminated",
+                    "context deadline exceeded",
+                ]
+            ):
+                has_sandbox_error = True
+                error_messages.append(f"{reason}: {msg[:150]}")
+
+        if not has_sandbox_error:
+            logger.debug(
+                f"Pod {pod_name} has no sandbox errors, using standard recovery"
+            )
+            return handle_multi_attach_error(pod_obj, timeout)
+
+        logger.warning(f"Pod {pod_name} on node {node_name} has sandbox errors:")
+        for msg in error_messages[:3]:
+            logger.warning(f"  - {msg}")
+
+        logger.info(f"Recovering pod {pod_name} by restarting node {node_name}")
+
+        node_objs = get_node_objs()
+        target_node = None
+        for n in node_objs:
+            if n.name == node_name:
+                target_node = n
+                break
+
+        if not target_node:
+            logger.error(f"Could not find node object for {node_name}")
+            return handle_multi_attach_error(pod_obj, timeout)
+
+        logger.info(f"Stopping node {node_name}...")
+        target_node.stop_nodes([target_node])
+
+        logger.info("Waiting 30s for node to stop...")
+        time.sleep(30)
+
+        logger.info(f"Starting node {node_name}...")
+        target_node.start_nodes([target_node])
+
+        logger.info(f"Waiting for node {node_name} to become Ready...")
+        ocp_node = OCP(kind=constants.NODE)
+        for sample in TimeoutSampler(
+            timeout=300, sleep=10, func=ocp_node.get, resource_name=node_name
+        ):
+            node_status = sample
+            conditions = node_status.get("status", {}).get("conditions", [])
+            for condition in conditions:
+                if (
+                    condition.get("type") == "Ready"
+                    and condition.get("status") == "True"
+                ):
+                    logger.info(f"Node {node_name} is Ready")
+                    break
+            else:
+                continue
+            break
+
+        logger.info("Waiting 60s for pod to stabilize after node restart...")
+        time.sleep(60)
+
+        logger.info("Node restart complete, checking for volume attachment issues...")
+
+        return handle_multi_attach_error(pod_obj, timeout)
+
+    except Exception as e:
+        logger.error(f"Error during sandbox error recovery for {pod_obj.name}: {e}")
+        return handle_multi_attach_error(pod_obj, timeout)
+
+
 def handle_multi_attach_error(pod_obj, timeout=300):
     """
     Handle multi-attach volume errors by deleting stale VolumeAttachment resources.
@@ -1200,28 +1354,17 @@ def recover_mcg():
             f"found {len(active_pg_pods)}/{expected_pg_pods} expected"
         )
 
-    logger.info("Verifying all noobaa pods reached running state")
     respawned_noobaa_pods = get_noobaa_pods()
     logger.info(
         f"Found {len(respawned_noobaa_pods)} noobaa pods to verify (includes postgres cluster)"
     )
-    failed_noobaa_pods = []
 
-    for noobaa_pod in respawned_noobaa_pods:
-        logger.debug(f"Checking noobaa pod: {noobaa_pod.name}")
-        if not handle_multi_attach_error(noobaa_pod, timeout=600):
-            logger.error(f"Noobaa pod {noobaa_pod.name} failed to reach running state")
-            failed_noobaa_pods.append(noobaa_pod.name)
+    failed_noobaa_pods = verify_pods_running(
+        respawned_noobaa_pods, pod_type="noobaa", timeout=600
+    )
 
     if failed_noobaa_pods:
-        logger.error(
-            f"MCG recovery failed: {len(failed_noobaa_pods)} noobaa pods not running: {failed_noobaa_pods}"
-        )
         raise AssertionError(f"NooBaa pod recovery failed: {failed_noobaa_pods}")
-
-    logger.info(
-        f"MCG noobaa pods recovery completed: all {len(respawned_noobaa_pods)} pods running"
-    )
 
     if config.ENV_DATA["platform"].lower() in constants.ON_PREM_PLATFORMS:
         logger.info("On-prem platform detected: recovering RGW pods")
@@ -1235,24 +1378,13 @@ def recover_mcg():
         logger.info("Waiting 120s for RGW pods to respawn")
         time.sleep(120)
 
-        logger.info("Verifying RGW pods reached running state")
-        failed_rgw_pods = []
         respawned_rgw_pods = get_rgw_pods()
-        for rgw_pod in respawned_rgw_pods:
-            logger.debug(f"Checking RGW pod: {rgw_pod.name}")
-            if not handle_multi_attach_error(rgw_pod, timeout=600):
-                logger.error(f"RGW pod {rgw_pod.name} failed to reach running state")
-                failed_rgw_pods.append(rgw_pod.name)
+        failed_rgw_pods = verify_pods_running(
+            respawned_rgw_pods, pod_type="RGW", timeout=600
+        )
 
         if failed_rgw_pods:
-            logger.error(
-                f"RGW recovery failed: {len(failed_rgw_pods)} RGW pods not running: {failed_rgw_pods}"
-            )
             raise AssertionError(f"RGW pod recovery failed: {failed_rgw_pods}")
-
-        logger.info(
-            f"RGW pods recovery completed: all {len(respawned_rgw_pods)} pods running"
-        )
     else:
         logger.debug(
             f"Skipping RGW recovery on non-on-prem platform: {config.ENV_DATA['platform']}"
@@ -1416,19 +1548,13 @@ def ceph_fs_recovery():
         f"Found {len(mds_pods)} active MDS pods to verify "
         f"(filtered out {len(all_mds_pods) - len(mds_pods)} terminating pods)"
     )
-    failed_mds_pods = []
-    for mds_pod in mds_pods:
-        logger.debug(f"Checking MDS pod: {mds_pod.name}")
-        if not handle_multi_attach_error(mds_pod, timeout=600):
-            logger.warning(f"MDS pod {mds_pod.name} did not reach running state")
-            failed_mds_pods.append(mds_pod.name)
+
+    failed_mds_pods = verify_pods_running(mds_pods, pod_type="MDS", timeout=600)
 
     if failed_mds_pods:
         logger.warning(
             f"{len(failed_mds_pods)} MDS pods did not reach running state: {failed_mds_pods}"
         )
-    else:
-        logger.info(f"All {len(mds_pods)} MDS pods are running after CephFS recovery")
 
 
 def get_spun_dc_pods(pod_list):

--- a/tests/cross_functional/kcs/test_monitor_recovery.py
+++ b/tests/cross_functional/kcs/test_monitor_recovery.py
@@ -39,6 +39,7 @@ from ocs_ci.ocs.resources.pod import (
     get_plugin_pods,
     get_ceph_tools_pod,
     wait_for_storage_pods,
+    wait_for_noobaa_pods_running,
 )
 from ocs_ci.ocs.resources import pod
 from ocs_ci.ocs import ocp, constants, defaults, bucket_utils
@@ -1465,53 +1466,140 @@ def handle_multi_attach_error(pod_obj, timeout=300):
 
 def recover_mcg():
     """
-    Recovery procedure for noobaa by re-spinning the pods after mon recovery.
-    Handles multi-attach errors by deleting stale VolumeAttachment resources.
+    Recovery procedure for NooBaa by re-spinning the pods after mon recovery
+    Simplified to use existing ocs-ci functions with expected pod count verification
 
     Raises:
-        AssertionError: If any NooBaa or RGW pods fail to reach running state
-
+        ResourceWrongStatusException: If any NooBaa or RGW pods fail to reach running state
     """
-    logger.info("Starting MCG recovery by re-spinning noobaa pods")
-    noobaa_pods = get_noobaa_pods()
-    logger.info(f"Found {len(noobaa_pods)} noobaa pods to respawn")
+    logger.info("Starting MCG recovery by re-spinning NooBaa pods")
 
-    for noobaa_pod in noobaa_pods:
-        logger.info(f"Force deleting noobaa pod: {noobaa_pod.name}")
-        noobaa_pod.delete(force=True)
-
-    logger.info("Waiting 120s for noobaa pods to respawn")
-    time.sleep(120)
-
-    respawned_noobaa_pods = get_noobaa_pods()
-    logger.info(f"Found {len(respawned_noobaa_pods)} noobaa pods to verify")
-
-    failed_noobaa_pods = verify_pods_running(
-        respawned_noobaa_pods, pod_type="noobaa", timeout=600
+    noobaa_pods_before = get_noobaa_pods()
+    expected_pod_count = len(noobaa_pods_before)
+    expected_pod_names = {pod.name for pod in noobaa_pods_before}
+    logger.info(
+        f"Found {expected_pod_count} NooBaa pods to respawn: {sorted(expected_pod_names)}"
     )
 
-    if failed_noobaa_pods:
-        raise AssertionError(f"NooBaa pod recovery failed: {failed_noobaa_pods}")
+    for idx, noobaa_pod in enumerate(noobaa_pods_before):
+        logger.info(
+            f"Force deleting NooBaa pod {idx+1}/{expected_pod_count}: {noobaa_pod.name}"
+        )
+        noobaa_pod.delete(force=True)
+
+        if idx < expected_pod_count - 1:
+            wait_time = 60
+            logger.info(f"Waiting {wait_time}s before deleting next NooBaa pod")
+            time.sleep(wait_time)
+
+    logger.info("Waiting 120s for NooBaa pods to fully respawn")
+    time.sleep(120)
+
+    max_count_retries = 5
+    retry_wait_time = 30
+
+    for retry_attempt in range(max_count_retries):
+        current_noobaa_pods = get_noobaa_pods()
+        current_pod_count = len(current_noobaa_pods)
+        current_pod_names = {pod.name for pod in current_noobaa_pods}
+
+        logger.info(
+            f"Pod count check attempt {retry_attempt + 1}/{max_count_retries}: "
+            f"Found {current_pod_count}/{expected_pod_count} NooBaa pods"
+        )
+
+        if current_pod_count >= expected_pod_count:
+            logger.info(
+                f"All {expected_pod_count} expected NooBaa pods found: {sorted(current_pod_names)}"
+            )
+            break
+
+        missing_pods = expected_pod_names - current_pod_names
+        logger.warning(
+            f"Missing {len(missing_pods)} NooBaa pods: {sorted(missing_pods)}. "
+            f"Waiting {retry_wait_time}s..."
+        )
+
+        if retry_attempt < max_count_retries - 1:
+            time.sleep(retry_wait_time)
+        else:
+            error_msg = (
+                f"NooBaa recovery failed: Expected {expected_pod_count} pods "
+                f"but only found {current_pod_count} after {max_count_retries} attempts. "
+                f"Missing pods: {sorted(missing_pods)}"
+            )
+            logger.error(error_msg)
+            raise ResourceWrongStatusException(error_msg)
+
+    try:
+        wait_for_noobaa_pods_running(timeout=600, sleep=10)
+        logger.info(
+            "All NooBaa pods verified running via wait_for_noobaa_pods_running()"
+        )
+    except Exception as e:
+        logger.warning(
+            f"wait_for_noobaa_pods_running() did not complete successfully: {e}. "
+            "Will attempt individual pod recovery."
+        )
+
+        current_noobaa_pods = get_noobaa_pods()
+        logger.info(f"Verifying {len(current_noobaa_pods)} NooBaa pods individually")
+
+        failed_noobaa_pods = verify_pods_running(
+            current_noobaa_pods, pod_type="NooBaa", timeout=600, parallel=False
+        )
+
+        if failed_noobaa_pods:
+            error_msg = (
+                f"NooBaa recovery failed: {len(failed_noobaa_pods)} pods did not reach "
+                f"running state after recovery attempts: {failed_noobaa_pods}"
+            )
+            logger.error(error_msg)
+            raise ResourceWrongStatusException(error_msg)
+
+    logger.info("NooBaa pods recovery completed successfully")
 
     if config.ENV_DATA["platform"].lower() in constants.ON_PREM_PLATFORMS:
         logger.info("On-prem platform detected: recovering RGW pods")
-        rgw_pods = get_rgw_pods()
-        logger.info(f"Found {len(rgw_pods)} RGW pods to respawn")
 
-        for rgw_pod in rgw_pods:
-            logger.info(f"Force deleting RGW pod: {rgw_pod.name}")
-            rgw_pod.delete(force=True)
+        rgw_pods_before = get_rgw_pods()
+        if not rgw_pods_before:
+            logger.debug("No RGW pods found, skipping RGW recovery")
+        else:
+            logger.info(f"Found {len(rgw_pods_before)} RGW pods to respawn")
 
-        logger.info("Waiting 120s for RGW pods to respawn")
-        time.sleep(120)
+            for idx, rgw_pod in enumerate(rgw_pods_before):
+                logger.info(
+                    f"Force deleting RGW pod {idx+1}/{len(rgw_pods_before)}: {rgw_pod.name}"
+                )
+                rgw_pod.delete(force=True)
 
-        respawned_rgw_pods = get_rgw_pods()
-        failed_rgw_pods = verify_pods_running(
-            respawned_rgw_pods, pod_type="RGW", timeout=600
-        )
+                if idx < len(rgw_pods_before) - 1:
+                    wait_time = 60
+                    logger.info(f"Waiting {wait_time}s before deleting next RGW pod")
+                    time.sleep(wait_time)
 
-        if failed_rgw_pods:
-            raise AssertionError(f"RGW pod recovery failed: {failed_rgw_pods}")
+            logger.info("Waiting 120s for RGW pods to fully respawn")
+            time.sleep(120)
+
+            respawned_rgw_pods = get_rgw_pods()
+            logger.info(f"Verifying {len(respawned_rgw_pods)} RGW pods")
+
+            failed_rgw_pods = verify_pods_running(
+                respawned_rgw_pods, pod_type="RGW", timeout=600
+            )
+
+            if failed_rgw_pods:
+                error_msg = (
+                    f"RGW recovery failed: {len(failed_rgw_pods)} pods did not reach "
+                    f"running state: {failed_rgw_pods}"
+                )
+                logger.error(error_msg)
+                raise ResourceWrongStatusException(error_msg)
+
+            logger.info(
+                f"RGW pods recovery completed - all {len(respawned_rgw_pods)} pods running"
+            )
     else:
         logger.debug(
             f"Skipping RGW recovery on non-on-prem platform: {config.ENV_DATA['platform']}"

--- a/tests/cross_functional/kcs/test_monitor_recovery.py
+++ b/tests/cross_functional/kcs/test_monitor_recovery.py
@@ -722,6 +722,18 @@ class MonitorRecovery(object):
                 logger.info(
                     f"MGR deployment {dep_name}: all {len(mgr_pods)} pods are running"
                 )
+            elif "rook-ceph-mds" in dep_name:
+                logger.debug("Waiting 30s before checking MDS pods")
+                time.sleep(30)
+                mds_pods = get_mds_pods()
+                for mds_pod in mds_pods:
+                    logger.debug(f"Waiting for MDS pod: {mds_pod.name}")
+                    wait_for_resource_state(
+                        resource=mds_pod, state=constants.STATUS_RUNNING, timeout=600
+                    )
+                logger.info(
+                    f"MDS deployment {dep_name}: all {len(mds_pods)} pods are running"
+                )
         logger.info("All deployments successfully reverted")
 
     def backup_deployments(self):

--- a/tests/cross_functional/kcs/test_monitor_recovery.py
+++ b/tests/cross_functional/kcs/test_monitor_recovery.py
@@ -36,8 +36,10 @@ from ocs_ci.ocs.resources.pod import (
     get_noobaa_pods,
     get_ceph_tools_pod,
     wait_for_storage_pods,
+    get_pod_obj,
+    cal_md5sum,
+    get_pods_having_label,
 )
-from ocs_ci.ocs.resources import pod
 from ocs_ci.ocs import ocp, constants, defaults, bucket_utils
 from ocs_ci.helpers.helpers import wait_for_resource_state, get_secret_names
 from ocs_ci.utility.retry import retry
@@ -141,7 +143,7 @@ class TestMonitorRecovery(E2ETest):
         self.md5sum = []
         for pod_obj in self.dc_pods:
             pod_obj.exec_cmd_on_pod(command=self.dd_cmd)
-            checksum = pod.cal_md5sum(pod_obj, self.filename)
+            checksum = cal_md5sum(pod_obj, self.filename)
             self.md5sum.append(checksum)
             logger.info(f"Pod {pod_obj.name}: checksum={checksum}")
         logger.info(f"Checksums before recovery: {self.md5sum}")
@@ -220,8 +222,7 @@ class TestMonitorRecovery(E2ETest):
             == "a"
         )
         logger.info(f"Copying mon-store to monitor: {mon_a.name}")
-        ocp_obj = MonitorRecovery()
-        ocp_obj._exec_oc_cmd(
+        mon_recovery._exec_oc_cmd(
             cmd=f"cp /tmp/monstore {constants.OPENSHIFT_STORAGE_NAMESPACE}/{mon_a.name}:/tmp/"
         )
 
@@ -233,6 +234,7 @@ class TestMonitorRecovery(E2ETest):
         logger.info(f"Keyrings extracted to: {file_path}")
 
         logger.test_step("Copy ceph daemon keyrings to mon-a pod")
+        # Re-fetch mon-a: the pod may have been replaced between steps
         mon_a = next(
             mon
             for mon in get_mon_pods(namespace=config.ENV_DATA["cluster_namespace"])
@@ -240,7 +242,7 @@ class TestMonitorRecovery(E2ETest):
             == "a"
         )
         logger.info(f"Copying keyring from {file_path} to monitor: {mon_a.name}")
-        ocp_obj._exec_oc_cmd(
+        mon_recovery._exec_oc_cmd(
             cmd=f"cp {file_path} {constants.OPENSHIFT_STORAGE_NAMESPACE}/{mon_a.name}:/tmp/keyring"
         )
 
@@ -288,7 +290,7 @@ class TestMonitorRecovery(E2ETest):
                 timeout=600,
                 sleep=10,
             )
-            checksum = pod.cal_md5sum(pod_obj, self.filename)
+            checksum = cal_md5sum(pod_obj, self.filename)
             new_md5_sum.append(checksum)
             logger.info(f"Pod {pod_obj.name}: checksum={checksum}")
 
@@ -676,76 +678,47 @@ class MonitorRecovery(object):
             deployment_paths (list): List of paths to deployment yamls
 
         """
+
+        def _verify_pod_type(dep_name, pod_type, get_pods_fn, timeout=600):
+            """Wait 30s then verify all pods of a given type are running."""
+            time.sleep(30)
+            pods = get_pods_fn()
+            logger.info(
+                f"Verifying {len(pods)} {pod_type} pods with sandbox error recovery"
+            )
+            failed = verify_pods_running(pods, pod_type=pod_type, timeout=timeout)
+            if failed:
+                raise AssertionError(
+                    f"{pod_type} deployment {dep_name} recovery failed: {failed}"
+                )
+            logger.info(
+                f"{pod_type} deployment {dep_name}: all {len(pods)} pods are running"
+            )
+
         logger.info(
             f"Reverting {len(deployment_paths)} deployments to original configuration"
         )
         for dep in deployment_paths:
             dep_name = dep.split("/")[-1].replace(".yaml", "")
             logger.info(f"Reverting deployment: {dep_name}")
-            revert_patch = f"replace --force -f {dep}"
-            self.ocp_obj.exec_oc_cmd(revert_patch)
-
-            logger.debug(
-                f"Waiting for pods from deployment {dep_name} to reach running state"
-            )
+            self.ocp_obj.exec_oc_cmd(f"replace --force -f {dep}")
 
             if "rook-ceph-mon" in dep_name:
-                logger.debug("Waiting 30s before validating monitor pods")
                 time.sleep(30)
-                logger.debug("Validating monitor pods are running")
                 validate_mon_pods()
                 logger.info(f"Monitor deployment {dep_name} pods are running")
             elif "rook-ceph-osd" in dep_name:
-                logger.debug("Waiting 30s before checking OSD pods")
-                time.sleep(30)
-                osd_pods = get_osd_pods()
-                logger.info(
-                    f"Verifying {len(osd_pods)} OSD pods with sandbox error recovery"
-                )
-                failed_osd_pods = verify_pods_running(
-                    osd_pods, pod_type="OSD", timeout=600
-                )
-                if failed_osd_pods:
-                    raise AssertionError(
-                        f"OSD deployment {dep_name} recovery failed: {failed_osd_pods}"
-                    )
-                logger.info(
-                    f"OSD deployment {dep_name}: all {len(osd_pods)} pods are running"
-                )
+                _verify_pod_type(dep_name, "OSD", get_osd_pods)
             elif "rook-ceph-mgr" in dep_name:
-                logger.debug("Waiting 30s before checking MGR pods")
-                time.sleep(30)
-                mgr_pods = get_mgr_pods(namespace=config.ENV_DATA["cluster_namespace"])
-                logger.info(
-                    f"Verifying {len(mgr_pods)} MGR pods with sandbox error recovery"
-                )
-                failed_mgr_pods = verify_pods_running(
-                    mgr_pods, pod_type="MGR", timeout=600
-                )
-                if failed_mgr_pods:
-                    raise AssertionError(
-                        f"MGR deployment {dep_name} recovery failed: {failed_mgr_pods}"
-                    )
-                logger.info(
-                    f"MGR deployment {dep_name}: all {len(mgr_pods)} pods are running"
+                _verify_pod_type(
+                    dep_name,
+                    "MGR",
+                    lambda: get_mgr_pods(
+                        namespace=config.ENV_DATA["cluster_namespace"]
+                    ),
                 )
             elif "rook-ceph-mds" in dep_name:
-                logger.debug("Waiting 30s before checking MDS pods")
-                time.sleep(30)
-                mds_pods = get_mds_pods()
-                logger.info(
-                    f"Verifying {len(mds_pods)} MDS pods with sandbox error recovery"
-                )
-                failed_mds_pods = verify_pods_running(
-                    mds_pods, pod_type="MDS", timeout=600
-                )
-                if failed_mds_pods:
-                    raise AssertionError(
-                        f"MDS deployment {dep_name} recovery failed: {failed_mds_pods}"
-                    )
-                logger.info(
-                    f"MDS deployment {dep_name}: all {len(mds_pods)} pods are running"
-                )
+                _verify_pod_type(dep_name, "MDS", get_mds_pods)
         logger.info("All deployments successfully reverted")
 
     def backup_deployments(self):
@@ -951,19 +924,22 @@ class MonitorRecovery(object):
             try:
                 wait_for_resource_state(resource=mds, state=constants.STATUS_RUNNING)
             except (CommandFailed, ResourceWrongStatusException):
-                # Pod may have been replaced (new name) during the deployment rollout.
-                # Confirm it is actually gone, then wait for the replacement to run.
-                if not _pod_exists(mds):
-                    logger.info(
-                        f"MDS pod {mds.name} no longer exists (replaced by deployment "
-                        "rollout) - waiting for replacement pod to reach Running state"
+                try:
+                    mds.get()
+                    raise
+                except CommandFailed as e:
+                    if "NotFound" not in str(e):
+                        raise
+                logger.info(
+                    f"MDS pod {mds.name} no longer exists (replaced by deployment "
+                    "rollout) - waiting for replacement pod to reach Running state"
+                )
+                ok, final_name = _wait_for_replacement_pod(mds, 300, mds.namespace)
+                if not ok:
+                    raise AssertionError(
+                        f"Replacement for MDS pod '{mds.name}' "
+                        f"(last seen: '{final_name}') did not reach Running state"
                     )
-                    if not _wait_for_replacement_pod(mds, 300, mds.namespace):
-                        raise AssertionError(
-                            f"Replacement for MDS pod {mds.name} did not reach Running state"
-                        )
-                    continue
-                raise
         logger.info(f"All {len(mds_pods)} MDS pods are running")
 
     @retry(CommandFailed, tries=10, delay=10, backoff=1)
@@ -1093,132 +1069,154 @@ def corrupt_ceph_monitors():
     )
 
 
-def is_pod_running(pod_obj):
+def _pod_name_prefix(pod_name):
     """
-    Check if pod is in Running phase
+    Derive the stable name prefix used to identify a replacement for *pod_name*.
 
-    Args:
-        pod_obj: Pod object to check
-
-    Returns:
-        bool: True if pod is running, False otherwise
     """
-    try:
-        phase = pod_obj.get().get("status", {}).get("phase")
-        return phase == constants.STATUS_RUNNING
-    except Exception:
-        return False
-
-
-def _pod_exists(pod_obj):
-    """
-    Check whether a pod still exists on the cluster.
-
-    Args:
-        pod_obj: Pod object to check
-
-    Returns:
-        bool: True if the pod exists (regardless of phase), False if NotFound
-    """
-    try:
-        pod_obj.get()
-        return True
-    except CommandFailed as e:
-        if "NotFound" in str(e):
-            return False
-        raise
-
-
-def _wait_for_replacement_pod(pod_obj, timeout, namespace):
-    """
-    Wait for the replacement of a deleted pod to reach Running state.
-
-    Derives the stable name prefix from the original pod's name and polls all
-    pods in the namespace until one with that prefix is Running.
-
-    Args:
-        pod_obj: The original (now-deleted) pod object — its name is read
-        timeout (int): Seconds to wait for the replacement pod
-        namespace (str): Namespace to search in
-
-    Returns:
-        bool: True if the replacement pod reaches Running, False otherwise
-    """
-    pod_name = pod_obj.name
     last_segment = pod_name.rsplit("-", 1)[-1]
     if last_segment.isdigit():
-        prefix = pod_name
-    else:
-        prefix = pod_name.rsplit("-", 1)[0]
-    logger.info(
-        f"Waiting up to {timeout}s for replacement of pod '{pod_obj.name}' "
-        f"(name prefix: '{prefix}') to reach Running state"
-    )
-
-    ocp_pod = OCP(kind=constants.POD, namespace=namespace)
-
-    def _replacement_is_running():
-        all_pods = ocp_pod.get().get("items", [])
-        for p in all_pods:
-            name = p.get("metadata", {}).get("name", "")
-            phase = p.get("status", {}).get("phase", "")
-            if name.startswith(prefix) and phase == constants.STATUS_RUNNING:
-                logger.info(f"Replacement pod '{name}' is Running")
-                return True
-        return False
-
-    try:
-        for result in TimeoutSampler(
-            timeout=timeout, sleep=10, func=_replacement_is_running
-        ):
-            if result:
-                return True
-    except TimeoutExpiredError:
-        logger.error(
-            f"Replacement pod for '{pod_obj.name}' (prefix='{prefix}') did not reach "
-            f"Running state within {timeout}s"
-        )
-        return False
-    return False
+        return pod_name
+    return pod_name.rsplit("-", 1)[0]
 
 
-def perform_node_restart(node_name, nodes_platform, node_objs):
+def _find_replacement_pod_name(deleted_name, prefix, namespace, timeout):
     """
-    Perform node restart operation using platform's restart_nodes_by_stop_and_start
+    Poll *namespace* until a pod whose name starts with *prefix* and is
+    **different** from *deleted_name* appears (any phase).
 
     Args:
-        node_name: Name of the node to restart
-        nodes_platform: Platform-specific nodes object
-        node_objs: List of node objects
+        deleted_name (str): Name of the pod that was deleted / disappeared.
+        prefix (str): Name prefix derived from *deleted_name*.
+        namespace (str): Namespace to search in.
+        timeout (int): Seconds to wait before giving up.
 
     Returns:
-        bool: True if restart successful, False otherwise
+        str | None: The new pod name, or ``None`` if not found in time.
     """
-    target_node = None
-    for n in node_objs:
-        if n.name == node_name:
-            target_node = n
-            break
+    ocp_pod = OCP(kind=constants.POD, namespace=namespace)
 
-    if not target_node:
-        logger.error(f"Could not find node object for {node_name}")
-        return False
-
-    logger.info(
-        f"Restarting node {node_name} using platform: {nodes_platform.__class__.__name__}"
-    )
+    def _new_pod_exists():
+        for p in ocp_pod.get().get("items", []):
+            name = p.get("metadata", {}).get("name", "")
+            if name.startswith(prefix) and name != deleted_name:
+                return name
+        return None
 
     try:
-        nodes_platform.restart_nodes_by_stop_and_start([target_node], wait=True)
-        logger.info(f"Node {node_name} restarted successfully")
-    except Exception as e:
-        logger.error(f"Failed to restart node {node_name}: {e}")
-        return False
+        for name in TimeoutSampler(timeout=timeout, sleep=10, func=_new_pod_exists):
+            if name:
+                logger.info(
+                    f"Replacement pod '{name}' appeared for deleted pod '{deleted_name}'"
+                )
+                return name
+    except TimeoutExpiredError:
+        pass
+    return None
 
-    logger.info("Waiting 60s for pods to stabilize after node restart...")
-    time.sleep(60)
 
-    return True
+def _wait_for_replacement_pod(pod_obj, timeout, namespace, max_attempts=3):
+    """
+    Wait for a replacement pod to reach Running state, with up to *max_attempts*
+    recovery cycles.
+
+    Each cycle:
+      1. Discovers the current replacement pod by name-prefix (skipping the
+         last-known deleted name — the name changes on every restart).
+      2. Calls ``check_and_recover_sandbox_errors`` on that replacement pod.
+      3. If the replacement itself disappears again (another restart), treats
+         *its* name as the new deleted name and repeats from step 1.
+
+    Args:
+        pod_obj: The original (now-deleted) pod object whose name seeds the
+                 prefix derivation.
+        timeout (int): Total seconds budget shared across all attempts.
+        namespace (str): Namespace to search in.
+        max_attempts (int): Maximum recovery cycles (default 3).
+
+    Returns:
+        tuple[bool, str]: ``(success, final_pod_name)`` where *final_pod_name*
+        is the name of the last replacement pod seen (original name if none
+        was ever found).
+    """
+    original_name = pod_obj.name
+    prefix = _pod_name_prefix(original_name)
+
+    logger.info(
+        f"Waiting up to {timeout}s for replacement of pod '{original_name}' "
+        f"(name prefix: '{prefix}', max attempts: {max_attempts})"
+    )
+
+    global_start = time.time()
+    deleted_name = original_name
+
+    for attempt in range(1, max_attempts + 1):
+        elapsed = time.time() - global_start
+        remaining = max(int(timeout - elapsed), 30)
+
+        # --- 1. Discover the replacement pod (name changed after restart) ------
+        logger.info(
+            f"Attempt {attempt}/{max_attempts}: looking for replacement of "
+            f"'{deleted_name}' (prefix='{prefix}', budget={remaining}s)"
+        )
+        new_name = _find_replacement_pod_name(
+            deleted_name, prefix, namespace, timeout=min(120, remaining)
+        )
+        if not new_name:
+            logger.error(
+                f"Attempt {attempt}/{max_attempts}: no replacement pod found for "
+                f"'{deleted_name}' (prefix='{prefix}') within {min(120, remaining)}s"
+            )
+            return False, deleted_name
+
+        # --- 2. Monitor / recover the replacement pod --------------------------
+        elapsed = time.time() - global_start
+        remaining = max(int(timeout - elapsed), 30)
+        logger.info(
+            f"Attempt {attempt}/{max_attempts}: monitoring replacement pod "
+            f"'{new_name}' (remaining budget: {remaining}s)"
+        )
+        try:
+            replacement_obj = get_pod_obj(name=new_name, namespace=namespace)
+        except Exception as e:
+            logger.warning(
+                f"Attempt {attempt}/{max_attempts}: could not get pod object "
+                f"for '{new_name}': {e} — will retry"
+            )
+            deleted_name = new_name
+            continue
+
+        ok = check_and_recover_sandbox_errors(
+            replacement_obj, timeout=remaining, max_recovery_attempts=1
+        )
+        if ok:
+            logger.info(
+                f"Replacement pod '{new_name}' reached Running state "
+                f"(attempt {attempt}/{max_attempts})"
+            )
+            return True, new_name
+
+        # --- 3. Replacement failed — check if it disappeared (another restart) -
+        elapsed = time.time() - global_start
+        remaining = int(timeout - elapsed)
+        if remaining <= 0 or attempt == max_attempts:
+            logger.error(
+                f"Attempt {attempt}/{max_attempts}: replacement pod '{new_name}' "
+                f"failed to reach Running state"
+            )
+            return False, new_name
+
+        logger.warning(
+            f"Attempt {attempt}/{max_attempts}: replacement pod '{new_name}' did not "
+            f"reach Running state — checking for another replacement..."
+        )
+        deleted_name = new_name
+
+    logger.error(
+        f"Original pod '{original_name}': replacement did not reach Running state "
+        f"after {max_attempts} attempt(s) (last pod: '{deleted_name}')"
+    )
+    return False, deleted_name
 
 
 def check_and_recover_sandbox_errors(
@@ -1244,9 +1242,12 @@ def check_and_recover_sandbox_errors(
         pod_name = pod_obj.name
         namespace = pod_obj.namespace
 
-        if is_pod_running(pod_obj):
-            logger.debug(f"Pod {pod_name} is already running, no recovery needed")
-            return True
+        try:
+            if pod_obj.get().get("status", {}).get("phase") == constants.STATUS_RUNNING:
+                logger.debug(f"Pod {pod_name} is already running, no recovery needed")
+                return True
+        except Exception:
+            pass
 
         try:
             pod_data = pod_obj.get()
@@ -1256,7 +1257,13 @@ def check_and_recover_sandbox_errors(
                     f"Pod {pod_name} no longer exists (replaced by a new pod) - "
                     "waiting for replacement pod to reach Running state"
                 )
-                return _wait_for_replacement_pod(pod_obj, timeout, namespace)
+                ok, final_name = _wait_for_replacement_pod(pod_obj, timeout, namespace)
+                if not ok:
+                    logger.error(
+                        f"Pod '{pod_name}': replacement pod '{final_name}' "
+                        f"failed to reach Running state"
+                    )
+                return ok
             raise
 
         node_name = pod_data.get("spec", {}).get("nodeName")
@@ -1326,11 +1333,26 @@ def check_and_recover_sandbox_errors(
                 logger.info(f"Recovering pod {pod_name} by restarting node {node_name}")
                 nodes_platform = PlatformNodesFactory().get_nodes_platform()
                 node_objs = get_node_objs()
-
-                if perform_node_restart(node_name, nodes_platform, node_objs):
+                target_node = next((n for n in node_objs if n.name == node_name), None)
+                if not target_node:
+                    logger.error(f"Could not find node object for {node_name}")
+                    return handle_multi_attach_error(pod_obj, timeout)
+                logger.info(
+                    f"Restarting node {node_name} using platform: "
+                    f"{nodes_platform.__class__.__name__}"
+                )
+                try:
+                    nodes_platform.restart_nodes_by_stop_and_start(
+                        [target_node], wait=True
+                    )
+                    logger.info(f"Node {node_name} restarted successfully")
+                    logger.info(
+                        "Waiting 60s for pods to stabilize after node restart..."
+                    )
+                    time.sleep(60)
                     _node_restart_tracker[node_name] = current_time
-                else:
-                    logger.error(f"Node restart failed for {node_name}")
+                except Exception as e:
+                    logger.error(f"Failed to restart node {node_name}: {e}")
                     return handle_multi_attach_error(pod_obj, timeout)
         else:
             logger.debug(f"Pod {pod_name} has no sandbox/RWOP errors initially")
@@ -1351,7 +1373,15 @@ def check_and_recover_sandbox_errors(
                         f"pod after node restart) - waiting for replacement pod "
                         f"(remaining timeout: {remaining}s)"
                     )
-                    return _wait_for_replacement_pod(pod_obj, remaining, namespace)
+                    ok, final_name = _wait_for_replacement_pod(
+                        pod_obj, remaining, namespace
+                    )
+                    if not ok:
+                        logger.error(
+                            f"Pod '{pod_name}': replacement pod '{final_name}' "
+                            f"failed to reach Running state"
+                        )
+                    return ok
                 raise
             phase = pod_obj.get().get("status", {}).get("phase")
 
@@ -1429,11 +1459,16 @@ def verify_pods_running(
     failed_pods = []
 
     def check_single_pod(pod_obj):
-        """Check a single pod and return its name if it fails"""
-        logger.debug(f"Checking {pod_type} pod: {pod_obj.name}")
+        """Check a single pod and return its name (or replacement name) if it fails"""
+        original_name = pod_obj.name
+        logger.debug(f"Checking {pod_type} pod: {original_name}")
         if not check_and_recover_sandbox_errors(pod_obj, timeout=timeout):
-            logger.error(f"{pod_type} pod {pod_obj.name} failed to reach running state")
-            return pod_obj.name
+            # check_and_recover_sandbox_errors already logs the replacement name;
+            # we surface the original name here so callers can correlate.
+            logger.error(
+                f"{pod_type} pod '{original_name}' failed to reach running state"
+            )
+            return original_name
         return None
 
     if parallel and len(pod_list) > 1:
@@ -1478,7 +1513,7 @@ def cleanup_stale_volume_attachments():
     logger.info("Cleaning up stale volume attachments")
     deleted_count = 0
     try:
-        va_ocp = OCP(kind="VolumeAttachment", namespace="")
+        va_ocp = OCP(kind="VolumeAttachment")
         attachments = va_ocp.get()
         if attachments and "items" in attachments:
             for attachment in attachments["items"]:
@@ -1613,64 +1648,44 @@ def recover_mcg():
     logger.info("Waiting 120s for NooBaa pods to fully respawn")
     time.sleep(120)
 
-    max_count_retries = 5
-    retry_wait_time = 30
+    # Wait for the minimum required pod types to appear (db-pg-cluster-2 is excluded
+    # because it is only created after db-pg-cluster-1 is fully running).
+    minimum_required_types = {
+        k: v for k, v in expected_pod_types.items() if k != "noobaa-db-pg-cluster-2"
+    }
+    minimum_required_count = sum(minimum_required_types.values())
 
-    # Check if we have at least 4 pods (excluding noobaa-db-pg-cluster-2)
-    # If noobaa-db-pg-cluster-1 is not running, noobaa-db-pg-cluster-2 won't be created
-    for retry_attempt in range(max_count_retries):
-        current_noobaa_pods = get_noobaa_pods()
-        current_pod_count = len(current_noobaa_pods)
-
+    def _minimum_pods_present():
+        current_pods = get_noobaa_pods()
         current_pod_types = {}
-        for pod_obj in current_noobaa_pods:
-            prefix = get_pod_type_prefix(pod_obj.name)
+        for p in current_pods:
+            prefix = get_pod_type_prefix(p.name)
             current_pod_types[prefix] = current_pod_types.get(prefix, 0) + 1
-
+        missing = [
+            f"{pt} ({current_pod_types.get(pt, 0)}/{cnt})"
+            for pt, cnt in minimum_required_types.items()
+            if current_pod_types.get(pt, 0) < cnt
+        ]
+        if missing:
+            logger.debug(f"NooBaa pods not yet ready — missing: {missing}")
+            return False
         logger.info(
-            f"Pod count check attempt {retry_attempt + 1}/{max_count_retries}: "
-            f"Found {current_pod_count}/{expected_pod_count} NooBaa pods by type: {current_pod_types}"
+            f"All minimum required NooBaa pod types present: {current_pod_types}"
         )
+        return True
 
-        # Check if we have the minimum required pods (excluding db-pg-cluster-2)
-        # Expected: noobaa-core, noobaa-endpoint, noobaa-operator, cnpg-controller-manager, noobaa-db-pg-cluster-1
-        minimum_required_types = {
-            k: v for k, v in expected_pod_types.items() if k != "noobaa-db-pg-cluster-2"
-        }
-        missing_types = []
-        for pod_type, expected_count in minimum_required_types.items():
-            current_count = current_pod_types.get(pod_type, 0)
-            if current_count < expected_count:
-                missing_types.append(f"{pod_type} ({current_count}/{expected_count})")
-
-        # If we have all minimum required pods (4 pods), proceed even if db-pg-cluster-2 is missing
-        if not missing_types and current_pod_count >= len(minimum_required_types):
-            logger.info(
-                f"Found {current_pod_count} NooBaa pods including all minimum required types: {current_pod_types}"
-            )
-            break
-
-        if missing_types:
-            logger.warning(
-                f"Missing or incomplete pod types: {missing_types}. "
-                f"Waiting {retry_wait_time}s..."
-            )
-        else:
-            logger.warning(
-                f"Pod count mismatch: {current_pod_count}/{len(minimum_required_types)} minimum required. "
-                f"Waiting {retry_wait_time}s..."
-            )
-
-        if retry_attempt < max_count_retries - 1:
-            time.sleep(retry_wait_time)
-        else:
-            error_msg = (
-                f"NooBaa recovery failed: Expected minimum {len(minimum_required_types)} pods "
-                f"but only found {current_pod_count} after {max_count_retries} attempts. "
-                f"Expected types: {minimum_required_types}, Current types: {current_pod_types}"
-            )
-            logger.error(error_msg)
-            raise ResourceWrongStatusException(error_msg)
+    try:
+        for ready in TimeoutSampler(timeout=150, sleep=30, func=_minimum_pods_present):
+            if ready:
+                break
+    except TimeoutExpiredError:
+        current_pods = get_noobaa_pods()
+        error_msg = (
+            f"NooBaa recovery failed: expected at least {minimum_required_count} pods "
+            f"({minimum_required_types}) but found {len(current_pods)} after 150s"
+        )
+        logger.error(error_msg)
+        raise ResourceWrongStatusException(error_msg)
 
     # Special handling for noobaa-db-pg-cluster-1 pod
     # If it's not running, noobaa-db-pg-cluster-2 won't be created
@@ -1803,12 +1818,15 @@ def replace_mds_deployments():
     """
     logger.info("Replacing MDS deployments to recover from CephFS reset")
 
-    mds_deployment_names = [
-        "rook-ceph-mds-ocs-storagecluster-cephfilesystem-a",
-        "rook-ceph-mds-ocs-storagecluster-cephfilesystem-b",
-    ]
-
     dep_ocp = OCP(kind=constants.DEPLOYMENT, namespace=defaults.ROOK_CLUSTER_NAMESPACE)
+    mds_deployments = get_deployments_having_label(
+        label=constants.MDS_APP_LABEL,
+        namespace=defaults.ROOK_CLUSTER_NAMESPACE,
+    )
+    mds_deployment_names = [d["metadata"]["name"] for d in mds_deployments]
+    logger.info(
+        f"Found {len(mds_deployment_names)} MDS deployments to replace: {mds_deployment_names}"
+    )
 
     with tempfile.TemporaryDirectory() as backup_dir:
         logger.info(
@@ -1857,7 +1875,7 @@ def ceph_fs_recovery():
     logger.info(
         f"Starting CephFS recovery for filesystem: {defaults.CEPHFILESYSTEM_NAME}"
     )
-    toolbox = pod.get_ceph_tools_pod()
+    toolbox = get_ceph_tools_pod()
     logger.debug(f"Using ceph tools pod: {toolbox.name}")
 
     try:
@@ -1938,12 +1956,12 @@ def get_spun_dc_pods(pod_list):
         label_selector = f"deploymentconfig={pod_label}"
         logger.debug(f"Searching for pods with label: {label_selector}")
 
-        pods_data = pod.get_pods_having_label(label_selector, pod_obj.namespace)
+        pods_data = get_pods_having_label(label_selector, pod_obj.namespace)
         for pod_data in pods_data:
             pod_name = pod_data.get("metadata").get("name")
             if "-deploy" not in pod_name and pod_name not in pod_obj.name:
                 logger.debug(f"Found re-spun pod: {pod_name}")
-                new_pods.append(pod.get_pod_obj(pod_name, pod_obj.namespace))
+                new_pods.append(get_pod_obj(pod_name, pod_obj.namespace))
 
     logger.info(f"Previous pods: {[pod_obj.name for pod_obj in pod_list]}")
     logger.info(f"Re-spun pods: {[pod_obj.name for pod_obj in new_pods]}")

--- a/tests/cross_functional/kcs/test_monitor_recovery.py
+++ b/tests/cross_functional/kcs/test_monitor_recovery.py
@@ -1,4 +1,5 @@
 import collections
+import datetime
 import logging
 import time
 from os.path import join
@@ -1096,8 +1097,7 @@ def _pod_name_prefix(pod_name):
 
 def _find_replacement_pod_name(deleted_name, prefix, namespace, timeout):
     """
-    Poll *namespace* until a pod whose name starts with *prefix* and is
-    **different** from *deleted_name* appears (any phase).
+    Poll *namespace* until a pod whose name starts with *prefix* appears (any phase).
 
     Args:
         deleted_name (str): Name of the pod that was deleted / disappeared.
@@ -1106,19 +1106,22 @@ def _find_replacement_pod_name(deleted_name, prefix, namespace, timeout):
         timeout (int): Seconds to wait before giving up.
 
     Returns:
-        str | None: The new pod name, or ``None`` if not found in time.
+        str | None: The (re)appearing pod name, or ``None`` if not found in time.
     """
     ocp_pod = OCP(kind=constants.POD, namespace=namespace)
 
-    def _new_pod_exists():
+    is_statefulset_pod = prefix == deleted_name
+
+    def _pod_exists():
         for p in ocp_pod.get().get("items", []):
             name = p.get("metadata", {}).get("name", "")
-            if name.startswith(prefix) and name != deleted_name:
-                return name
+            if name.startswith(prefix):
+                if is_statefulset_pod or name != deleted_name:
+                    return name
         return None
 
     try:
-        for name in TimeoutSampler(timeout=timeout, sleep=10, func=_new_pod_exists):
+        for name in TimeoutSampler(timeout=timeout, sleep=10, func=_pod_exists):
             if name:
                 logger.info(
                     f"Replacement pod '{name}' appeared for deleted pod '{deleted_name}'"
@@ -1133,13 +1136,6 @@ def _wait_for_replacement_pod(pod_obj, timeout, namespace, max_attempts=3):
     """
     Wait for a replacement pod to reach Running state, with up to *max_attempts*
     recovery cycles.
-
-    Each cycle:
-      1. Discovers the current replacement pod by name-prefix (skipping the
-         last-known deleted name — the name changes on every restart).
-      2. Calls ``check_and_recover_sandbox_errors`` on that replacement pod.
-      3. If the replacement itself disappears again (another restart), treats
-         *its* name as the new deleted name and repeats from step 1.
 
     Args:
         pod_obj: The original (now-deleted) pod object whose name seeds the
@@ -1168,7 +1164,6 @@ def _wait_for_replacement_pod(pod_obj, timeout, namespace, max_attempts=3):
         elapsed = time.time() - global_start
         remaining = max(int(timeout - elapsed), 30)
 
-        # --- 1. Discover the replacement pod (name changed after restart) ------
         logger.info(
             f"Attempt {attempt}/{max_attempts}: looking for replacement of "
             f"'{deleted_name}' (prefix='{prefix}', budget={remaining}s)"
@@ -1183,7 +1178,6 @@ def _wait_for_replacement_pod(pod_obj, timeout, namespace, max_attempts=3):
             )
             return False, deleted_name
 
-        # --- 2. Monitor / recover the replacement pod --------------------------
         elapsed = time.time() - global_start
         remaining = max(int(timeout - elapsed), 30)
         logger.info(
@@ -1210,7 +1204,6 @@ def _wait_for_replacement_pod(pod_obj, timeout, namespace, max_attempts=3):
             )
             return True, new_name
 
-        # --- 3. Replacement failed — check if it disappeared (another restart) -
         elapsed = time.time() - global_start
         remaining = int(timeout - elapsed)
         if remaining <= 0 or attempt == max_attempts:
@@ -1271,7 +1264,7 @@ def check_and_recover_sandbox_errors(
                     f"Pod {pod_name} no longer exists (replaced by a new pod) - "
                     "waiting for replacement pod to reach Running state"
                 )
-                ok, final_name = _wait_for_replacement_pod(pod_obj, timeout, namespace)
+                ok, final_name = _wait_for_replacement_pod(pod_obj, 600, namespace)
                 if not ok:
                     logger.error(
                         f"Pod '{pod_name}': replacement pod '{final_name}' "
@@ -1374,22 +1367,18 @@ def check_and_recover_sandbox_errors(
         logger.info(f"Monitoring pod {pod_name} for up to {timeout}s...")
         start_time = time.time()
         last_check = 0
-        check_interval = 120
+        check_interval = 30
 
         while time.time() - start_time < timeout:
             try:
                 pod_obj.reload()
             except CommandFailed as e:
                 if "NotFound" in str(e):
-                    remaining = max(int(timeout - (time.time() - start_time)), 30)
                     logger.info(
                         f"Pod {pod_name} no longer exists during monitoring (replaced by a new "
-                        f"pod after node restart) - waiting for replacement pod "
-                        f"(remaining timeout: {remaining}s)"
+                        f"pod after node restart) - waiting for replacement pod (600s budget)"
                     )
-                    ok, final_name = _wait_for_replacement_pod(
-                        pod_obj, remaining, namespace
-                    )
+                    ok, final_name = _wait_for_replacement_pod(pod_obj, 600, namespace)
                     if not ok:
                         logger.error(
                             f"Pod '{pod_name}': replacement pod '{final_name}' "
@@ -1415,26 +1404,48 @@ def check_and_recover_sandbox_errors(
 
                     for event in events.get("items", []):
                         msg = event.get("message", "")
-                        if any(err in msg for err in ALL_POD_ERROR_PATTERNS):
-                            logger.warning(f"New error detected: {msg[:150]}")
+                        if not any(err in msg for err in ALL_POD_ERROR_PATTERNS):
+                            continue
 
-                            if _attempt >= max_recovery_attempts:
-                                logger.error(
-                                    f"Pod {pod_name} still has errors after {max_recovery_attempts} "
-                                    "recovery attempts, giving up on automatic recovery"
+                        event_time_str = (
+                            event.get("lastTimestamp") or event.get("eventTime") or ""
+                        )
+                        if event_time_str:
+                            try:
+                                event_dt = datetime.datetime.fromisoformat(
+                                    event_time_str.rstrip("Z")
+                                ).replace(tzinfo=datetime.timezone.utc)
+                                monitor_start_dt = datetime.datetime.fromtimestamp(
+                                    start_time, tz=datetime.timezone.utc
                                 )
-                                return False
+                                if event_dt < monitor_start_dt:
+                                    logger.debug(
+                                        f"Ignoring stale event (ts={event_time_str}): "
+                                        f"{msg[:100]}"
+                                    )
+                                    continue
+                            except Exception:
+                                pass
 
-                            logger.info(
-                                f"Triggering recovery for newly detected error "
-                                f"(attempt {_attempt + 1}/{max_recovery_attempts})..."
+                        logger.warning(f"New error detected: {msg[:150]}")
+
+                        if _attempt >= max_recovery_attempts:
+                            logger.error(
+                                f"Pod {pod_name} still has errors after {max_recovery_attempts} "
+                                "recovery attempts, giving up on automatic recovery"
                             )
-                            return check_and_recover_sandbox_errors(
-                                pod_obj,
-                                int(timeout - elapsed),
-                                max_recovery_attempts,
-                                _attempt + 1,
-                            )
+                            return False
+
+                        logger.info(
+                            f"Triggering recovery for newly detected error "
+                            f"(attempt {_attempt + 1}/{max_recovery_attempts})..."
+                        )
+                        return check_and_recover_sandbox_errors(
+                            pod_obj,
+                            600,
+                            max_recovery_attempts,
+                            _attempt + 1,
+                        )
                 except Exception as e:
                     logger.debug(f"Error checking events: {e}")
 
@@ -1477,8 +1488,6 @@ def verify_pods_running(
         original_name = pod_obj.name
         logger.debug(f"Checking {pod_type} pod: {original_name}")
         if not check_and_recover_sandbox_errors(pod_obj, timeout=timeout):
-            # check_and_recover_sandbox_errors already logs the replacement name;
-            # we surface the original name here so callers can correlate.
             logger.error(
                 f"{pod_type} pod '{original_name}' failed to reach running state"
             )

--- a/tests/cross_functional/kcs/test_monitor_recovery.py
+++ b/tests/cross_functional/kcs/test_monitor_recovery.py
@@ -156,6 +156,19 @@ class TestMonitorRecovery(E2ETest):
                     logger.warning(
                         f"Error force-deleting pods for label name={pod_label}: {e}"
                     )
+
+                # Clean up any stale VolumeAttachments for this pod's PVC.
+                try:
+                    pvc_obj = getattr(dc_pod, "pvc", None)
+                    if pvc_obj:
+                        pv_name = pvc_obj.backed_pv_obj.name
+                        _delete_volume_attachments_for_pv(pv_name)
+                except Exception as e:
+                    logger.warning(
+                        f"Teardown: could not clean VolumeAttachments for "
+                        f"{dc_pod.name}: {e}"
+                    )
+
             try:
                 logger.info("Teardown: archiving ceph crash warnings")
                 get_ceph_tools_pod().exec_ceph_cmd(
@@ -343,11 +356,9 @@ class TestMonitorRecovery(E2ETest):
         new_md5_sum = []
         logger.info("Waiting for pods to respawn and calculating checksums")
         for pod_obj in get_spun_dc_pods(self.dc_pods):
-            pod_obj.ocp.wait_for_resource(
-                condition=constants.STATUS_RUNNING,
-                resource_name=pod_obj.name,
-                timeout=600,
-                sleep=10,
+            assert check_and_recover_sandbox_errors(pod_obj, timeout=600), (
+                f"Pod {pod_obj.name} failed to reach Running state "
+                "after recovery — cannot verify data integrity"
             )
             checksum = cal_md5sum(pod_obj, self.filename)
             new_md5_sum.append(checksum)
@@ -886,9 +897,9 @@ class MonitorRecovery(object):
             formatted_data.append(pod_name)
             for block in keyring_data:
                 if block == "[client.admin]" and "[mon.]" in keyring_data:
-                    logger.info(
-                        "Skipping adding the [client.admin] details present in rook-ceph-mons-keyring"
-                        "as the secret details are already fecthed with rook-ceph-admin-keyring"
+                    logger.debug(
+                        "Skipping [client.admin] from rook-ceph-mons-keyring — "
+                        "already extracted via rook-ceph-admin-keyring"
                     )
                     break
                 key = None
@@ -1175,6 +1186,10 @@ def _find_replacement_pod_name(deleted_name, prefix, namespace, timeout):
                 return name
     except TimeoutExpiredError:
         pass
+    logger.error(
+        f"No replacement pod found for '{deleted_name}' "
+        f"(prefix='{prefix}') within {timeout}s"
+    )
     return None
 
 
@@ -1275,22 +1290,28 @@ def _wait_for_replacement_pod(pod_obj, timeout, namespace, max_attempts=3):
 def _classify_pod_errors(pod_obj):
     """
     Run ``oc describe pod`` and classify which error types are present in the
-    Events section.  Returns a tuple of three booleans:
-    ``(has_multi_attach, has_sandbox, has_rwop)``.
+    Events section.  Returns a 4-tuple:
+    ``(has_multi_attach, has_sandbox, has_rwop, events_text)``.
 
     """
+    logger.debug(f"Classifying pod errors for: {pod_obj.name}")
     try:
         describe_out = pod_obj.ocp.exec_oc_cmd(
             f"describe pod {pod_obj.name}", out_yaml_format=False
         )
     except Exception:
         logger.exception(f"Failed to describe pod {pod_obj.name}")
-        return False, False, False
+        return False, False, False, ""
 
     has_multi_attach = any(p in describe_out for p in MULTI_ATTACH_PATTERNS)
     has_sandbox = any(p in describe_out for p in SANDBOX_ERROR_PATTERNS)
     has_rwop = any(p in describe_out for p in RWOP_ERROR_PATTERNS)
-    return has_multi_attach, has_sandbox, has_rwop
+
+    events_idx = describe_out.find("\nEvents:")
+    events_text = (
+        describe_out[events_idx:].strip() if events_idx != -1 else describe_out[-2000:]
+    )
+    return has_multi_attach, has_sandbox, has_rwop, events_text
 
 
 def check_and_recover_sandbox_errors(
@@ -1351,13 +1372,16 @@ def check_and_recover_sandbox_errors(
 
         logger.info(f"Pod {pod_name} is in phase '{phase}', checking for errors...")
 
-        has_multi_attach, has_sandbox, has_rwop = _classify_pod_errors(pod_obj)
+        has_multi_attach, has_sandbox, has_rwop, events_text = _classify_pod_errors(
+            pod_obj
+        )
 
         if has_multi_attach:
             logger.warning(
                 f"Pod {pod_name} has Multi-Attach error — resolving via "
                 "VolumeAttachment cleanup (no node restart)"
             )
+            logger.warning(f"Pod {pod_name} events:\n{events_text}")
             handle_multi_attach_error(pod_obj, timeout=30)
             return check_and_recover_sandbox_errors(
                 pod_obj, 600, max_recovery_attempts, _attempt, _session_start
@@ -1372,6 +1396,7 @@ def check_and_recover_sandbox_errors(
             logger.warning(
                 f"Pod {pod_name} on node {node_name} has {error_type} errors"
             )
+            logger.warning(f"Pod {pod_name} events:\n{events_text}")
 
             current_time = time.time()
             should_restart_node = True
@@ -1455,13 +1480,14 @@ def check_and_recover_sandbox_errors(
             if elapsed - last_check >= check_interval:
                 logger.debug(f"Checking for errors after {int(elapsed)}s...")
                 try:
-                    has_ma, has_sb, has_rw = _classify_pod_errors(pod_obj)
+                    has_ma, has_sb, has_rw, events_text = _classify_pod_errors(pod_obj)
 
                     if has_ma:
                         logger.warning(
                             f"Multi-Attach error detected during monitoring for pod "
                             f"{pod_name} — resolving via VolumeAttachment cleanup"
                         )
+                        logger.warning(f"Pod {pod_name} events:\n{events_text}")
                         handle_multi_attach_error(pod_obj, timeout=30)
                         return check_and_recover_sandbox_errors(
                             pod_obj,
@@ -1502,15 +1528,22 @@ def check_and_recover_sandbox_errors(
                 f"Pod {pod_name} timed out after {timeout}s — checking for errors "
                 f"before retry (attempt {_attempt + 1}/{max_recovery_attempts})"
             )
-            has_ma, has_sb, has_rw = _classify_pod_errors(pod_obj)
+            has_ma, has_sb, has_rw, events_text = _classify_pod_errors(pod_obj)
             if has_ma or has_sb or has_rw:
-                logger.warning("Errors still present after timeout — retrying recovery")
+                logger.warning(
+                    f"Errors still present after timeout — retrying recovery\n{events_text}"
+                )
                 return check_and_recover_sandbox_errors(
                     pod_obj,
                     600,
                     max_recovery_attempts,
                     _attempt + 1,
                     _session_start,
+                )
+            elif events_text:
+                logger.warning(
+                    f"Pod {pod_name} timed out with no recognised error pattern — "
+                    f"last known events:\n{events_text}"
                 )
 
         logger.error(f"Pod {pod_name} failed to reach running state after {timeout}s")

--- a/tests/cross_functional/kcs/test_monitor_recovery.py
+++ b/tests/cross_functional/kcs/test_monitor_recovery.py
@@ -107,24 +107,47 @@ class TestMonitorRecovery(E2ETest):
 
         def finalizer():
             """
-            Teardown to clean up test resources
+            Teardown to clean up test resources.
             """
             logger.test_step("Teardown: Clean up test resources")
             for dc_pod in getattr(self, "dc_pods", []):
+                pod_label = dc_pod.labels.get("name") or dc_pod.labels.get(
+                    "deploymentconfig"
+                )
+                if not pod_label:
+                    continue
+                namespace = dc_pod.namespace
+
                 try:
-                    pod_label = dc_pod.labels.get("name") or dc_pod.labels.get(
-                        "deploymentconfig"
-                    )
-                    if pod_label:
-                        logger.info(f"Deleting deployment: {pod_label}")
-                        deploy_ocp = ocp.OCP(
-                            kind="Deployment", namespace=dc_pod.namespace
+                    logger.info(f"Deleting deployment: {pod_label}")
+                    deploy_ocp = ocp.OCP(kind="Deployment", namespace=namespace)
+                    deploy_ocp.delete(resource_name=pod_label)
+                    deploy_ocp.wait_for_delete(resource_name=pod_label)
+                except Exception as e:
+                    logger.warning(f"Failed to delete deployment {pod_label}: {e}")
+
+                try:
+                    pod_ocp = ocp.OCP(kind="Pod", namespace=namespace)
+                    result = pod_ocp.get(selector=f"name={pod_label}")
+                    for item in (result or {}).get("items", []):
+                        pod_name = item.get("metadata", {}).get("name", "")
+                        if not pod_name:
+                            continue
+                        logger.info(
+                            f"Force deleting pod {pod_name} to release volume mount"
                         )
-                        deploy_ocp.delete(resource_name=pod_label)
-                        deploy_ocp.wait_for_delete(resource_name=pod_label)
+                        try:
+                            pod_ocp.delete(
+                                resource_name=pod_name, wait=False, force=True
+                            )
+                        except Exception as pod_e:
+                            if "NotFound" not in str(pod_e):
+                                logger.warning(
+                                    f"Could not force-delete pod {pod_name}: {pod_e}"
+                                )
                 except Exception as e:
                     logger.warning(
-                        f"Failed to delete deployment for pod {dc_pod.name}: {e}"
+                        f"Error force-deleting pods for label name={pod_label}: {e}"
                     )
             try:
                 logger.info("Teardown: archiving ceph crash warnings")

--- a/tests/cross_functional/kcs/test_monitor_recovery.py
+++ b/tests/cross_functional/kcs/test_monitor_recovery.py
@@ -118,6 +118,14 @@ class TestMonitorRecovery(E2ETest):
                     logger.warning(
                         f"Failed to delete deployment for pod {dc_pod.name}: {e}"
                     )
+            try:
+                logger.info("Teardown: archiving ceph crash warnings")
+                get_ceph_tools_pod().exec_ceph_cmd(
+                    ceph_cmd="ceph crash archive-all", format=None
+                )
+                logger.info("Teardown: ceph crashes archived")
+            except Exception as e:
+                logger.warning(f"Teardown: failed to archive ceph crashes: {e}")
 
         request.addfinalizer(finalizer)
 
@@ -176,8 +184,9 @@ class TestMonitorRecovery(E2ETest):
         https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.8/html/troubleshooting_openshift_container_storage/restoring-the-monitor-pods-in-openshift-container-storage_rhocs
 
         """
+        logger.info("Starting monitor recovery test procedure")
         mon_recovery = MonitorRecovery()
-        logger.info(
+        logger.debug(
             f"Monitor recovery initialized with backup dir: {mon_recovery.backup_dir}"
         )
 
@@ -1357,7 +1366,7 @@ def check_and_recover_sandbox_errors(
                     time.sleep(60)
                     _node_restart_tracker[node_name] = current_time
                 except Exception as e:
-                    logger.error(f"Failed to restart node {node_name}: {e}")
+                    logger.exception(f"Failed to restart node {node_name}: {e}")
                     return handle_multi_attach_error(pod_obj, timeout)
         else:
             logger.debug(f"Pod {pod_name} has no sandbox/RWOP errors initially")
@@ -1437,7 +1446,7 @@ def check_and_recover_sandbox_errors(
         return False
 
     except Exception as e:
-        logger.error(f"Error during sandbox error recovery for {pod_obj.name}: {e}")
+        logger.exception(f"Error during sandbox error recovery for {pod_obj.name}: {e}")
         return handle_multi_attach_error(pod_obj, timeout)
 
 
@@ -1488,7 +1497,7 @@ def verify_pods_running(
                         failed_pods.append(result)
                 except Exception as e:
                     pod = futures[future]
-                    logger.error(
+                    logger.exception(
                         f"Exception while checking {pod_type} pod {pod.name}: {e}"
                     )
                     failed_pods.append(pod.name)
@@ -1594,10 +1603,41 @@ def handle_multi_attach_error(pod_obj, timeout=300):
         logger.info(f"Pod {pod_obj.name} is running")
         return True
     except Exception as e:
-        logger.error(
+        logger.exception(
             f"Pod {pod_obj.name} failed to reach running state after {timeout}s: {e}"
         )
         return False
+
+
+def _wait_for_noobaa_pod_type(prefix, timeout, description):
+    """
+    Poll get_noobaa_pods() until a pod whose name starts with *prefix* appears,
+    then return that pod object.
+
+    Args:
+        prefix (str): Name prefix to match (e.g. "cnpg-controller-manager").
+        timeout (int): Seconds to wait before giving up.
+        description (str): Human-readable name used in log messages.
+
+    Returns:
+        Pod | None: The first matching pod object, or None if not found in time.
+    """
+    logger.info(
+        f"Polling for {description} pod to appear (prefix={prefix!r}, timeout={timeout}s)"
+    )
+    try:
+        for pods in TimeoutSampler(
+            timeout=timeout,
+            sleep=15,
+            func=lambda: [p for p in get_noobaa_pods() if p.name.startswith(prefix)],
+        ):
+            if pods:
+                logger.info(f"Found {description} pod: {pods[0].name}")
+                return pods[0]
+    except TimeoutExpiredError:
+        pass
+    logger.error(f"{description} pod did not appear within {timeout}s")
+    return None
 
 
 def recover_mcg():
@@ -1610,49 +1650,107 @@ def recover_mcg():
     logger.info("Starting MCG recovery by re-spinning NooBaa pods")
 
     noobaa_pods_before = get_noobaa_pods()
+    expected_pod_count = len(noobaa_pods_before)
     logger.info(
-        f"Found {len(noobaa_pods_before)} NooBaa pods to respawn: "
+        f"Found {expected_pod_count} NooBaa pods to respawn: "
         f"{[p.name for p in noobaa_pods_before]}"
     )
+
     for noobaa_pod in noobaa_pods_before:
         logger.info(f"Force deleting NooBaa pod: {noobaa_pod.name}")
         noobaa_pod.delete(force=True)
 
-    logger.info("Waiting for noobaa-db-pg-cluster-1 to reach Running (timeout 300s)")
-    db_pg_1_pod = None
-    try:
-        for db_pg_1_pods in TimeoutSampler(
-            timeout=300,
-            sleep=15,
-            func=lambda: [
-                p
-                for p in get_noobaa_pods()
-                if p.name.startswith("noobaa-db-pg-cluster-1")
-            ],
-        ):
-            if db_pg_1_pods:
-                db_pg_1_pod = db_pg_1_pods[0]
-                break
-    except TimeoutExpiredError:
+    logger.info(
+        "Waiting for noobaa-operator to appear and reach Running (timeout 600s)"
+    )
+    operator_pod = _wait_for_noobaa_pod_type(
+        prefix="noobaa-operator", timeout=600, description="noobaa-operator"
+    )
+    if operator_pod is None:
         raise ResourceWrongStatusException(
-            "noobaa-db-pg-cluster-1 pod did not appear within 300s"
+            "noobaa-operator pod did not appear within 600s"
         )
-    assert db_pg_1_pod is not None, "noobaa-db-pg-cluster-1 pod not set after wait"
-    failed = verify_pods_running(
+    failed_operator = verify_pods_running(
+        [operator_pod], pod_type="NooBaa operator", timeout=600, parallel=False
+    )
+    if failed_operator:
+        raise ResourceWrongStatusException(
+            f"noobaa-operator did not reach Running state within 600s: {failed_operator}"
+        )
+    logger.info("noobaa-operator is in Running state")
+
+    logger.info(
+        "Waiting for cnpg-controller-manager to appear and reach Running (timeout 600s)"
+    )
+    cnpg_pod = _wait_for_noobaa_pod_type(
+        prefix="cnpg-controller-manager",
+        timeout=600,
+        description="cnpg-controller-manager",
+    )
+    if cnpg_pod is None:
+        raise ResourceWrongStatusException(
+            "cnpg-controller-manager pod did not appear within 600s"
+        )
+    failed_cnpg = verify_pods_running(
+        [cnpg_pod], pod_type="NooBaa CNPG controller", timeout=600, parallel=False
+    )
+    if failed_cnpg:
+        raise ResourceWrongStatusException(
+            f"cnpg-controller-manager did not reach Running state within 600s: {failed_cnpg}"
+        )
+    logger.info("cnpg-controller-manager is in Running state")
+
+    logger.info(
+        "Waiting for noobaa-db-pg-cluster-1 to appear and reach Running (timeout 600s)"
+    )
+    db_pg_1_pod = _wait_for_noobaa_pod_type(
+        prefix="noobaa-db-pg-cluster-1",
+        timeout=600,
+        description="noobaa-db-pg-cluster-1",
+    )
+    if db_pg_1_pod is None:
+        raise ResourceWrongStatusException(
+            "noobaa-db-pg-cluster-1 pod did not appear within 600s after cnpg-controller-manager"
+            " was Running. Check CNPG cluster resource status."
+        )
+    failed_db1 = verify_pods_running(
         [db_pg_1_pod], pod_type="NooBaa DB cluster-1", timeout=600, parallel=False
     )
-    if failed:
+    if failed_db1:
         raise ResourceWrongStatusException(
-            f"noobaa-db-pg-cluster-1 did not reach Running state within 600s: {failed}"
+            f"noobaa-db-pg-cluster-1 did not reach Running state within 600s: {failed_db1}"
         )
     logger.info("noobaa-db-pg-cluster-1 is in Running state")
 
-    logger.info("Waiting 300s for operator to create dependent NooBaa pods")
-    time.sleep(300)
+    logger.info(
+        f"Waiting for remaining NooBaa pods to appear "
+        f"(expected ~{expected_pod_count}, timeout 300s)"
+    )
+    try:
+        for current_pods in TimeoutSampler(
+            timeout=300,
+            sleep=15,
+            func=get_noobaa_pods,
+        ):
+            if len(current_pods) >= expected_pod_count:
+                logger.info(
+                    f"All {len(current_pods)} expected NooBaa pods have appeared: "
+                    f"{[p.name for p in current_pods]}"
+                )
+                break
+            logger.debug(
+                f"Waiting for NooBaa pods: {len(current_pods)}/{expected_pod_count} present"
+            )
+    except TimeoutExpiredError:
+        current_pods = get_noobaa_pods()
+        logger.warning(
+            f"Only {len(current_pods)}/{expected_pod_count} NooBaa pods appeared after 300s: "
+            f"{[p.name for p in current_pods]} — proceeding to verify what is present"
+        )
 
     current_noobaa_pods = get_noobaa_pods()
     logger.info(
-        f"Verifying {len(current_noobaa_pods)} NooBaa pods are running: "
+        f"Verifying {len(current_noobaa_pods)} NooBaa pods reach Running state: "
         f"{[p.name for p in current_noobaa_pods]}"
     )
     failed_noobaa_pods = verify_pods_running(
@@ -1678,16 +1776,9 @@ def recover_mcg():
         else:
             logger.info(f"Found {len(rgw_pods_before)} RGW pods to respawn")
 
-            for idx, rgw_pod in enumerate(rgw_pods_before):
-                logger.info(
-                    f"Force deleting RGW pod {idx+1}/{len(rgw_pods_before)}: {rgw_pod.name}"
-                )
+            for rgw_pod in rgw_pods_before:
+                logger.info(f"Force deleting RGW pod: {rgw_pod.name}")
                 rgw_pod.delete(force=True)
-
-                if idx < len(rgw_pods_before) - 1:
-                    wait_time = 60
-                    logger.info(f"Waiting {wait_time}s before deleting next RGW pod")
-                    time.sleep(wait_time)
 
             logger.info("Waiting 120s for RGW pods to fully respawn")
             time.sleep(120)

--- a/tests/cross_functional/kcs/test_monitor_recovery.py
+++ b/tests/cross_functional/kcs/test_monitor_recovery.py
@@ -64,7 +64,14 @@ RWOP_ERROR_PATTERNS = [
     "volume is already exclusively attached",
 ]
 
-ALL_POD_ERROR_PATTERNS = SANDBOX_ERROR_PATTERNS + RWOP_ERROR_PATTERNS
+MULTI_ATTACH_PATTERNS = [
+    "Multi-Attach error",
+    "Volume is already exclusively attached to one node",
+]
+
+ALL_POD_ERROR_PATTERNS = (
+    SANDBOX_ERROR_PATTERNS + RWOP_ERROR_PATTERNS + MULTI_ATTACH_PATTERNS
+)
 
 _node_restart_tracker = {}
 NODE_RESTART_COOLDOWN = 300
@@ -292,7 +299,16 @@ class TestMonitorRecovery(E2ETest):
         logger.info("Force deleting original dc pods to trigger re-spawn")
         for pod_obj in self.dc_pods:
             logger.debug(f"Force deleting pod: {pod_obj.name}")
-            pod_obj.delete(force=True)
+            try:
+                pod_obj.delete(force=True)
+            except Exception as e:
+                if "NotFound" in str(e):
+                    logger.info(
+                        f"Pod {pod_obj.name} already gone (replaced during recovery), "
+                        "skipping delete"
+                    )
+                else:
+                    raise
 
         new_md5_sum = []
         logger.info("Waiting for pods to respawn and calculating checksums")
@@ -1290,6 +1306,7 @@ def check_and_recover_sandbox_errors(
 
         has_sandbox_error = False
         has_rwop_error = False
+        has_multi_attach_error = False
         error_messages = []
 
         for event in events.get("items", []):
@@ -1303,6 +1320,19 @@ def check_and_recover_sandbox_errors(
             if any(err in msg for err in RWOP_ERROR_PATTERNS):
                 has_rwop_error = True
                 error_messages.append(f"{reason}: {msg[:150]}")
+
+            if any(err in msg for err in MULTI_ATTACH_PATTERNS):
+                has_multi_attach_error = True
+                error_messages.append(f"{reason}: {msg[:150]}")
+
+        if has_multi_attach_error:
+            logger.warning(
+                f"Pod {pod_name} has Multi-Attach error — resolving via "
+                "VolumeAttachment cleanup (no node restart)"
+            )
+            for msg in error_messages[:3]:
+                logger.warning(f"  - {msg}")
+            return handle_multi_attach_error(pod_obj, timeout)
 
         if has_sandbox_error or has_rwop_error:
             error_type = (
@@ -1362,7 +1392,9 @@ def check_and_recover_sandbox_errors(
                     logger.exception(f"Failed to restart node {node_name}: {e}")
                     return handle_multi_attach_error(pod_obj, timeout)
         else:
-            logger.debug(f"Pod {pod_name} has no sandbox/RWOP errors initially")
+            logger.debug(
+                f"Pod {pod_name} has no sandbox/RWOP/multi-attach errors initially"
+            )
 
         logger.info(f"Monitoring pod {pod_name} for up to {timeout}s...")
         start_time = time.time()
@@ -1428,6 +1460,15 @@ def check_and_recover_sandbox_errors(
                                 pass
 
                         logger.warning(f"New error detected: {msg[:150]}")
+
+                        if any(err in msg for err in MULTI_ATTACH_PATTERNS):
+                            logger.warning(
+                                f"Multi-Attach error detected during monitoring for "
+                                f"pod {pod_name} — resolving via VolumeAttachment "
+                                "cleanup (no node restart)"
+                            )
+                            remaining = max(int(timeout - elapsed), 60)
+                            return handle_multi_attach_error(pod_obj, remaining)
 
                         if _attempt >= max_recovery_attempts:
                             logger.error(

--- a/tests/cross_functional/kcs/test_monitor_recovery.py
+++ b/tests/cross_functional/kcs/test_monitor_recovery.py
@@ -1,5 +1,4 @@
 import collections
-import datetime
 import logging
 import time
 from os.path import join
@@ -68,10 +67,6 @@ MULTI_ATTACH_PATTERNS = [
     "Multi-Attach error",
     "Volume is already exclusively attached to one node",
 ]
-
-ALL_POD_ERROR_PATTERNS = (
-    SANDBOX_ERROR_PATTERNS + RWOP_ERROR_PATTERNS + MULTI_ATTACH_PATTERNS
-)
 
 _node_restart_tracker = {}
 NODE_RESTART_COOLDOWN = 300
@@ -1277,37 +1272,54 @@ def _wait_for_replacement_pod(pod_obj, timeout, namespace, max_attempts=3):
     return False, deleted_name
 
 
+def _classify_pod_errors(pod_obj):
+    """
+    Run ``oc describe pod`` and classify which error types are present in the
+    Events section.  Returns a tuple of three booleans:
+    ``(has_multi_attach, has_sandbox, has_rwop)``.
+
+    """
+    try:
+        describe_out = pod_obj.ocp.exec_oc_cmd(
+            f"describe pod {pod_obj.name}", out_yaml_format=False
+        )
+    except Exception:
+        logger.exception(f"Failed to describe pod {pod_obj.name}")
+        return False, False, False
+
+    has_multi_attach = any(p in describe_out for p in MULTI_ATTACH_PATTERNS)
+    has_sandbox = any(p in describe_out for p in SANDBOX_ERROR_PATTERNS)
+    has_rwop = any(p in describe_out for p in RWOP_ERROR_PATTERNS)
+    return has_multi_attach, has_sandbox, has_rwop
+
+
 def check_and_recover_sandbox_errors(
     pod_obj, timeout=600, max_recovery_attempts=3, _attempt=0, _session_start=None
 ):
     """
-    Check if a pod has sandbox errors and recover by power cycling its node.
-    After node recovery, continues monitoring for pod readiness with periodic error checks.
+    Check if a pod has sandbox / RWOP / Multi-Attach errors and recover.
 
-    This handles FailedCreatePodSandBox and ReadWriteOncePod errors during pod recovery.
+    Recovery strategy (in priority order):
+    - Multi-Attach  → delete the stale VolumeAttachment
+    - Sandbox/RWOP  → power-cycle the pod's node
+
+    After taking a recovery action the function re-enters itself to monitor
+    the pod until it reaches Running or until ``max_recovery_attempts`` is
+    exhausted.
 
     Args:
         pod_obj: Pod object to check
         timeout: Maximum time to wait for recovery (default: 600s)
         max_recovery_attempts: Maximum number of recovery attempts (default: 3)
-        _attempt: Internal counter for recursion depth
-        _session_start: Unix timestamp of the first call in this session.
-            Used to filter stale events that pre-date the entire monitoring
-            session.
+        _attempt: Internal recursion counter (do not pass from outside)
+        _session_start: Unused; kept for call-site compatibility
 
     Returns:
         bool: True if pod reaches running state, False otherwise
-
     """
     try:
         pod_name = pod_obj.name
         namespace = pod_obj.namespace
-        # Anchor the stale-event cutoff to the very first call in this session.
-        # Subsequent recursions inherit this timestamp unchanged so that errors
-        # that occurred after session start are never silently dropped.
-        if _session_start is None:
-            _session_start = time.time()
-        entry_time = _session_start
 
         try:
             pod_data = pod_obj.get()
@@ -1339,75 +1351,28 @@ def check_and_recover_sandbox_errors(
 
         logger.info(f"Pod {pod_name} is in phase '{phase}', checking for errors...")
 
-        ocp_pod = OCP(kind=constants.POD, namespace=namespace)
-        events = ocp_pod.exec_oc_cmd(
-            f"get events --field-selector involvedObject.name={pod_name} "
-            f"-n {namespace} -o json"
-        )
+        has_multi_attach, has_sandbox, has_rwop = _classify_pod_errors(pod_obj)
 
-        has_sandbox_error = False
-        has_rwop_error = False
-        has_multi_attach_error = False
-        error_messages = []
-
-        entry_dt = datetime.datetime.fromtimestamp(entry_time, tz=datetime.timezone.utc)
-
-        for event in events.get("items", []):
-            msg = event.get("message", "")
-            reason = event.get("reason", "")
-
-            # Skip events that pre-date this function call — they are stale
-            # (e.g. a Multi-Attach event that already triggered VA deletion on
-            # a previous recursion; the VA is gone but the event lingers).
-            event_time_str = event.get("lastTimestamp") or event.get("eventTime") or ""
-            if event_time_str:
-                try:
-                    event_dt = datetime.datetime.fromisoformat(
-                        event_time_str.rstrip("Z")
-                    ).replace(tzinfo=datetime.timezone.utc)
-                    if event_dt < entry_dt:
-                        logger.debug(
-                            f"Skipping stale event (ts={event_time_str}): {msg[:80]}"
-                        )
-                        continue
-                except Exception:
-                    pass
-
-            if any(err in msg for err in SANDBOX_ERROR_PATTERNS):
-                has_sandbox_error = True
-                error_messages.append(f"{reason}: {msg[:150]}")
-            elif any(err in msg for err in RWOP_ERROR_PATTERNS):
-                has_rwop_error = True
-                error_messages.append(f"{reason}: {msg[:150]}")
-            elif any(err in msg for err in MULTI_ATTACH_PATTERNS):
-                has_multi_attach_error = True
-                error_messages.append(f"{reason}: {msg[:150]}")
-
-        if has_multi_attach_error:
+        if has_multi_attach:
             logger.warning(
                 f"Pod {pod_name} has Multi-Attach error — resolving via "
                 "VolumeAttachment cleanup (no node restart)"
             )
-            for msg in error_messages[:3]:
-                logger.warning(f"  - {msg}")
             handle_multi_attach_error(pod_obj, timeout=30)
             return check_and_recover_sandbox_errors(
                 pod_obj, 600, max_recovery_attempts, _attempt, _session_start
             )
 
-        if has_sandbox_error or has_rwop_error:
+        if has_sandbox or has_rwop:
             error_type = (
                 "sandbox/RWOP"
-                if (has_sandbox_error and has_rwop_error)
-                else ("sandbox" if has_sandbox_error else "ReadWriteOncePod")
+                if (has_sandbox and has_rwop)
+                else ("sandbox" if has_sandbox else "ReadWriteOncePod")
             )
             logger.warning(
-                f"Pod {pod_name} on node {node_name} has {error_type} errors:"
+                f"Pod {pod_name} on node {node_name} has {error_type} errors"
             )
-            for msg in error_messages[:3]:
-                logger.warning(f"  - {msg}")
 
-            # Check if node was recently restarted to avoid redundant restarts
             current_time = time.time()
             should_restart_node = True
 
@@ -1490,62 +1455,32 @@ def check_and_recover_sandbox_errors(
             if elapsed - last_check >= check_interval:
                 logger.debug(f"Checking for errors after {int(elapsed)}s...")
                 try:
-                    events = ocp_pod.exec_oc_cmd(
-                        f"get events --field-selector involvedObject.name={pod_name} "
-                        f"-n {namespace} -o json"
-                    )
+                    has_ma, has_sb, has_rw = _classify_pod_errors(pod_obj)
 
-                    for event in events.get("items", []):
-                        msg = event.get("message", "")
-                        if not any(err in msg for err in ALL_POD_ERROR_PATTERNS):
-                            continue
-
-                        event_time_str = (
-                            event.get("lastTimestamp") or event.get("eventTime") or ""
+                    if has_ma:
+                        logger.warning(
+                            f"Multi-Attach error detected during monitoring for pod "
+                            f"{pod_name} — resolving via VolumeAttachment cleanup"
                         )
-                        if event_time_str:
-                            try:
-                                event_dt = datetime.datetime.fromisoformat(
-                                    event_time_str.rstrip("Z")
-                                ).replace(tzinfo=datetime.timezone.utc)
-                                monitor_start_dt = datetime.datetime.fromtimestamp(
-                                    start_time, tz=datetime.timezone.utc
-                                )
-                                if event_dt < monitor_start_dt:
-                                    logger.debug(
-                                        f"Ignoring stale event (ts={event_time_str}): "
-                                        f"{msg[:100]}"
-                                    )
-                                    continue
-                            except Exception:
-                                pass
+                        handle_multi_attach_error(pod_obj, timeout=30)
+                        return check_and_recover_sandbox_errors(
+                            pod_obj,
+                            600,
+                            max_recovery_attempts,
+                            _attempt,
+                            _session_start,
+                        )
 
-                        logger.warning(f"New error detected: {msg[:150]}")
-
-                        if any(err in msg for err in MULTI_ATTACH_PATTERNS):
-                            logger.warning(
-                                f"Multi-Attach error detected during monitoring for "
-                                f"pod {pod_name} — resolving via VolumeAttachment "
-                                "cleanup then re-entering sandbox recovery"
-                            )
-                            handle_multi_attach_error(pod_obj, timeout=30)
-                            return check_and_recover_sandbox_errors(
-                                pod_obj,
-                                600,
-                                max_recovery_attempts,
-                                _attempt,
-                                _session_start,
-                            )
-
+                    if has_sb or has_rw:
                         if _attempt >= max_recovery_attempts:
                             logger.error(
-                                f"Pod {pod_name} still has errors after {max_recovery_attempts} "
-                                "recovery attempts, giving up on automatic recovery"
+                                f"Pod {pod_name} still has errors after "
+                                f"{max_recovery_attempts} recovery attempts, "
+                                "giving up on automatic recovery"
                             )
                             return False
-
                         logger.info(
-                            f"Triggering recovery for newly detected error "
+                            f"New error detected — triggering recovery "
                             f"(attempt {_attempt + 1}/{max_recovery_attempts})..."
                         )
                         return check_and_recover_sandbox_errors(
@@ -1556,7 +1491,7 @@ def check_and_recover_sandbox_errors(
                             _session_start,
                         )
                 except Exception as e:
-                    logger.debug(f"Error checking events: {e}")
+                    logger.debug(f"Error classifying pod errors: {e}")
 
                 last_check = elapsed
 
@@ -1567,26 +1502,16 @@ def check_and_recover_sandbox_errors(
                 f"Pod {pod_name} timed out after {timeout}s — checking for errors "
                 f"before retry (attempt {_attempt + 1}/{max_recovery_attempts})"
             )
-            try:
-                events = ocp_pod.exec_oc_cmd(
-                    f"get events --field-selector involvedObject.name={pod_name} "
-                    f"-n {namespace} -o json"
+            has_ma, has_sb, has_rw = _classify_pod_errors(pod_obj)
+            if has_ma or has_sb or has_rw:
+                logger.warning("Errors still present after timeout — retrying recovery")
+                return check_and_recover_sandbox_errors(
+                    pod_obj,
+                    600,
+                    max_recovery_attempts,
+                    _attempt + 1,
+                    _session_start,
                 )
-                for event in events.get("items", []):
-                    msg = event.get("message", "")
-                    if any(err in msg for err in ALL_POD_ERROR_PATTERNS):
-                        logger.warning(
-                            f"Error found after timeout, retrying recovery: {msg[:150]}"
-                        )
-                        return check_and_recover_sandbox_errors(
-                            pod_obj,
-                            600,
-                            max_recovery_attempts,
-                            _attempt + 1,
-                            _session_start,
-                        )
-            except Exception as e:
-                logger.debug(f"Error checking events after timeout: {e}")
 
         logger.error(f"Pod {pod_name} failed to reach running state after {timeout}s")
         return False

--- a/tests/cross_functional/kcs/test_monitor_recovery.py
+++ b/tests/cross_functional/kcs/test_monitor_recovery.py
@@ -103,12 +103,36 @@ class TestMonitorRecovery(E2ETest):
             """
             logger.test_step("Teardown: Clean up test resources")
             logger.info("Force deleting test pods to release PVCs")
+            pods_to_delete = list(self.dc_pods)
             for dc_pod in self.dc_pods:
                 try:
-                    logger.debug(f"Force deleting pod: {dc_pod.name}")
-                    dc_pod.delete(force=True, wait=False)
+                    pod_label = dc_pod.labels.get("name") or dc_pod.labels.get(
+                        "deploymentconfig"
+                    )
+                    if pod_label:
+                        label_key = (
+                            "name" if dc_pod.labels.get("name") else "deploymentconfig"
+                        )
+                        current_pods_data = get_pods_having_label(
+                            f"{label_key}={pod_label}", dc_pod.namespace
+                        )
+                        for pod_data in current_pods_data:
+                            current_pod_name = pod_data.get("metadata", {}).get("name")
+                            if current_pod_name and current_pod_name != dc_pod.name:
+                                pods_to_delete.append(
+                                    get_pod_obj(current_pod_name, dc_pod.namespace)
+                                )
                 except Exception as e:
-                    logger.warning(f"Failed to delete pod {dc_pod.name}: {e}")
+                    logger.warning(
+                        f"Failed to look up current pods for {dc_pod.name}: {e}"
+                    )
+
+            for pod_obj in pods_to_delete:
+                try:
+                    logger.debug(f"Force deleting pod: {pod_obj.name}")
+                    pod_obj.delete(force=True, wait=False)
+                except Exception as e:
+                    logger.warning(f"Failed to delete pod {pod_obj.name}: {e}")
 
             logger.info("Waiting 30s for pods to terminate")
             time.sleep(30)
@@ -275,15 +299,14 @@ class TestMonitorRecovery(E2ETest):
 
         logger.test_step("Verify data integrity after recovery")
 
-        logger.info("Checking current state of application pods before verification")
-        current_dc_pods = get_spun_dc_pods(self.dc_pods)
-        for pod_obj in current_dc_pods:
+        logger.info("Force deleting original dc pods to trigger re-spawn")
+        for pod_obj in self.dc_pods:
             logger.debug(f"Force deleting pod: {pod_obj.name}")
             pod_obj.delete(force=True)
 
         new_md5_sum = []
         logger.info("Waiting for pods to respawn and calculating checksums")
-        for pod_obj in get_spun_dc_pods(current_dc_pods):
+        for pod_obj in get_spun_dc_pods(self.dc_pods):
             pod_obj.ocp.wait_for_resource(
                 condition=constants.STATUS_RUNNING,
                 resource_name=pod_obj.name,

--- a/tests/cross_functional/kcs/test_monitor_recovery.py
+++ b/tests/cross_functional/kcs/test_monitor_recovery.py
@@ -1278,7 +1278,7 @@ def _wait_for_replacement_pod(pod_obj, timeout, namespace, max_attempts=3):
 
 
 def check_and_recover_sandbox_errors(
-    pod_obj, timeout=600, max_recovery_attempts=3, _attempt=0
+    pod_obj, timeout=600, max_recovery_attempts=3, _attempt=0, _session_start=None
 ):
     """
     Check if a pod has sandbox errors and recover by power cycling its node.
@@ -1289,8 +1289,11 @@ def check_and_recover_sandbox_errors(
     Args:
         pod_obj: Pod object to check
         timeout: Maximum time to wait for recovery (default: 600s)
-        max_recovery_attempts: Maximum number of recovery attempts (default: 2)
-        _attempt: Internal counter for recursion depth (do not set manually)
+        max_recovery_attempts: Maximum number of recovery attempts (default: 3)
+        _attempt: Internal counter for recursion depth
+        _session_start: Unix timestamp of the first call in this session.
+            Used to filter stale events that pre-date the entire monitoring
+            session.
 
     Returns:
         bool: True if pod reaches running state, False otherwise
@@ -1299,13 +1302,12 @@ def check_and_recover_sandbox_errors(
     try:
         pod_name = pod_obj.name
         namespace = pod_obj.namespace
-
-        try:
-            if pod_obj.get().get("status", {}).get("phase") == constants.STATUS_RUNNING:
-                logger.debug(f"Pod {pod_name} is already running, no recovery needed")
-                return True
-        except Exception:
-            pass
+        # Anchor the stale-event cutoff to the very first call in this session.
+        # Subsequent recursions inherit this timestamp unchanged so that errors
+        # that occurred after session start are never silently dropped.
+        if _session_start is None:
+            _session_start = time.time()
+        entry_time = _session_start
 
         try:
             pod_data = pod_obj.get()
@@ -1324,13 +1326,17 @@ def check_and_recover_sandbox_errors(
                 return ok
             raise
 
+        phase = pod_data.get("status", {}).get("phase")
+        if phase == constants.STATUS_RUNNING:
+            logger.debug(f"Pod {pod_name} is already running, no recovery needed")
+            return True
+
         node_name = pod_data.get("spec", {}).get("nodeName")
 
         if not node_name:
             logger.debug(f"Pod {pod_name} not scheduled to a node yet")
             return handle_multi_attach_error(pod_obj, timeout)
 
-        phase = pod_data.get("status", {}).get("phase")
         logger.info(f"Pod {pod_name} is in phase '{phase}', checking for errors...")
 
         ocp_pod = OCP(kind=constants.POD, namespace=namespace)
@@ -1344,19 +1350,36 @@ def check_and_recover_sandbox_errors(
         has_multi_attach_error = False
         error_messages = []
 
+        entry_dt = datetime.datetime.fromtimestamp(entry_time, tz=datetime.timezone.utc)
+
         for event in events.get("items", []):
             msg = event.get("message", "")
             reason = event.get("reason", "")
 
+            # Skip events that pre-date this function call — they are stale
+            # (e.g. a Multi-Attach event that already triggered VA deletion on
+            # a previous recursion; the VA is gone but the event lingers).
+            event_time_str = event.get("lastTimestamp") or event.get("eventTime") or ""
+            if event_time_str:
+                try:
+                    event_dt = datetime.datetime.fromisoformat(
+                        event_time_str.rstrip("Z")
+                    ).replace(tzinfo=datetime.timezone.utc)
+                    if event_dt < entry_dt:
+                        logger.debug(
+                            f"Skipping stale event (ts={event_time_str}): {msg[:80]}"
+                        )
+                        continue
+                except Exception:
+                    pass
+
             if any(err in msg for err in SANDBOX_ERROR_PATTERNS):
                 has_sandbox_error = True
                 error_messages.append(f"{reason}: {msg[:150]}")
-
-            if any(err in msg for err in RWOP_ERROR_PATTERNS):
+            elif any(err in msg for err in RWOP_ERROR_PATTERNS):
                 has_rwop_error = True
                 error_messages.append(f"{reason}: {msg[:150]}")
-
-            if any(err in msg for err in MULTI_ATTACH_PATTERNS):
+            elif any(err in msg for err in MULTI_ATTACH_PATTERNS):
                 has_multi_attach_error = True
                 error_messages.append(f"{reason}: {msg[:150]}")
 
@@ -1369,7 +1392,7 @@ def check_and_recover_sandbox_errors(
                 logger.warning(f"  - {msg}")
             handle_multi_attach_error(pod_obj, timeout=30)
             return check_and_recover_sandbox_errors(
-                pod_obj, 600, max_recovery_attempts, _attempt
+                pod_obj, 600, max_recovery_attempts, _attempt, _session_start
             )
 
         if has_sandbox_error or has_rwop_error:
@@ -1507,7 +1530,11 @@ def check_and_recover_sandbox_errors(
                             )
                             handle_multi_attach_error(pod_obj, timeout=30)
                             return check_and_recover_sandbox_errors(
-                                pod_obj, 600, max_recovery_attempts, _attempt
+                                pod_obj,
+                                600,
+                                max_recovery_attempts,
+                                _attempt,
+                                _session_start,
                             )
 
                         if _attempt >= max_recovery_attempts:
@@ -1526,6 +1553,7 @@ def check_and_recover_sandbox_errors(
                             600,
                             max_recovery_attempts,
                             _attempt + 1,
+                            _session_start,
                         )
                 except Exception as e:
                     logger.debug(f"Error checking events: {e}")
@@ -1533,6 +1561,32 @@ def check_and_recover_sandbox_errors(
                 last_check = elapsed
 
             time.sleep(10)
+
+        if _attempt < max_recovery_attempts:
+            logger.info(
+                f"Pod {pod_name} timed out after {timeout}s — checking for errors "
+                f"before retry (attempt {_attempt + 1}/{max_recovery_attempts})"
+            )
+            try:
+                events = ocp_pod.exec_oc_cmd(
+                    f"get events --field-selector involvedObject.name={pod_name} "
+                    f"-n {namespace} -o json"
+                )
+                for event in events.get("items", []):
+                    msg = event.get("message", "")
+                    if any(err in msg for err in ALL_POD_ERROR_PATTERNS):
+                        logger.warning(
+                            f"Error found after timeout, retrying recovery: {msg[:150]}"
+                        )
+                        return check_and_recover_sandbox_errors(
+                            pod_obj,
+                            600,
+                            max_recovery_attempts,
+                            _attempt + 1,
+                            _session_start,
+                        )
+            except Exception as e:
+                logger.debug(f"Error checking events after timeout: {e}")
 
         logger.error(f"Pod {pod_name} failed to reach running state after {timeout}s")
         return False

--- a/tests/cross_functional/kcs/test_monitor_recovery.py
+++ b/tests/cross_functional/kcs/test_monitor_recovery.py
@@ -99,45 +99,25 @@ class TestMonitorRecovery(E2ETest):
 
         def finalizer():
             """
-            Teardown: Force delete pods and clean up volume attachments
+            Teardown to clean up test resources
             """
             logger.test_step("Teardown: Clean up test resources")
-            logger.info("Force deleting test pods to release PVCs")
-            pods_to_delete = list(self.dc_pods)
-            for dc_pod in self.dc_pods:
+            for dc_pod in getattr(self, "dc_pods", []):
                 try:
                     pod_label = dc_pod.labels.get("name") or dc_pod.labels.get(
                         "deploymentconfig"
                     )
                     if pod_label:
-                        label_key = (
-                            "name" if dc_pod.labels.get("name") else "deploymentconfig"
+                        logger.info(f"Deleting deployment: {pod_label}")
+                        deploy_ocp = ocp.OCP(
+                            kind="Deployment", namespace=dc_pod.namespace
                         )
-                        current_pods_data = get_pods_having_label(
-                            f"{label_key}={pod_label}", dc_pod.namespace
-                        )
-                        for pod_data in current_pods_data:
-                            current_pod_name = pod_data.get("metadata", {}).get("name")
-                            if current_pod_name and current_pod_name != dc_pod.name:
-                                pods_to_delete.append(
-                                    get_pod_obj(current_pod_name, dc_pod.namespace)
-                                )
+                        deploy_ocp.delete(resource_name=pod_label)
+                        deploy_ocp.wait_for_delete(resource_name=pod_label)
                 except Exception as e:
                     logger.warning(
-                        f"Failed to look up current pods for {dc_pod.name}: {e}"
+                        f"Failed to delete deployment for pod {dc_pod.name}: {e}"
                     )
-
-            for pod_obj in pods_to_delete:
-                try:
-                    logger.debug(f"Force deleting pod: {pod_obj.name}")
-                    pod_obj.delete(force=True, wait=False)
-                except Exception as e:
-                    logger.warning(f"Failed to delete pod {pod_obj.name}: {e}")
-
-            logger.info("Waiting 30s for pods to terminate")
-            time.sleep(30)
-
-            cleanup_stale_volume_attachments()
 
         request.addfinalizer(finalizer)
 

--- a/tests/cross_functional/kcs/test_monitor_recovery.py
+++ b/tests/cross_functional/kcs/test_monitor_recovery.py
@@ -129,6 +129,7 @@ class TestMonitorRecovery(E2ETest):
                 try:
                     pod_ocp = ocp.OCP(kind="Pod", namespace=namespace)
                     result = pod_ocp.get(selector=f"name={pod_label}")
+                    pod_names_to_wait = []
                     for item in (result or {}).get("items", []):
                         pod_name = item.get("metadata", {}).get("name", "")
                         if not pod_name:
@@ -140,11 +141,22 @@ class TestMonitorRecovery(E2ETest):
                             pod_ocp.delete(
                                 resource_name=pod_name, wait=False, force=True
                             )
+                            pod_names_to_wait.append(pod_name)
                         except Exception as pod_e:
                             if "NotFound" not in str(pod_e):
                                 logger.warning(
                                     f"Could not force-delete pod {pod_name}: {pod_e}"
                                 )
+                    for pod_name in pod_names_to_wait:
+                        logger.info(f"Waiting for pod {pod_name} to terminate")
+                        try:
+                            pod_ocp.wait_for_delete(resource_name=pod_name, timeout=120)
+                            logger.info(f"Pod {pod_name} terminated")
+                        except Exception as wait_e:
+                            logger.warning(
+                                f"Pod {pod_name} did not terminate within 120s: "
+                                f"{wait_e} — continuing anyway"
+                            )
                 except Exception as e:
                     logger.warning(
                         f"Error force-deleting pods for label name={pod_label}: {e}"
@@ -1355,7 +1367,10 @@ def check_and_recover_sandbox_errors(
             )
             for msg in error_messages[:3]:
                 logger.warning(f"  - {msg}")
-            return handle_multi_attach_error(pod_obj, timeout)
+            handle_multi_attach_error(pod_obj, timeout=30)
+            return check_and_recover_sandbox_errors(
+                pod_obj, 600, max_recovery_attempts, _attempt
+            )
 
         if has_sandbox_error or has_rwop_error:
             error_type = (
@@ -1426,7 +1441,7 @@ def check_and_recover_sandbox_errors(
 
         while time.time() - start_time < timeout:
             try:
-                pod_obj.reload()
+                pod_data = pod_obj.get()
             except CommandFailed as e:
                 if "NotFound" in str(e):
                     logger.info(
@@ -1441,7 +1456,7 @@ def check_and_recover_sandbox_errors(
                         )
                     return ok
                 raise
-            phase = pod_obj.get().get("status", {}).get("phase")
+            phase = pod_data.get("status", {}).get("phase")
 
             if phase == constants.STATUS_RUNNING:
                 logger.info(f"Pod {pod_name} is running")
@@ -1488,10 +1503,12 @@ def check_and_recover_sandbox_errors(
                             logger.warning(
                                 f"Multi-Attach error detected during monitoring for "
                                 f"pod {pod_name} — resolving via VolumeAttachment "
-                                "cleanup (no node restart)"
+                                "cleanup then re-entering sandbox recovery"
                             )
-                            remaining = max(int(timeout - elapsed), 60)
-                            return handle_multi_attach_error(pod_obj, remaining)
+                            handle_multi_attach_error(pod_obj, timeout=30)
+                            return check_and_recover_sandbox_errors(
+                                pod_obj, 600, max_recovery_attempts, _attempt
+                            )
 
                         if _attempt >= max_recovery_attempts:
                             logger.error(
@@ -1590,53 +1607,66 @@ def verify_pods_running(
     return failed_pods
 
 
-def cleanup_stale_volume_attachments():
+def _delete_volume_attachments_for_pv(pv_name):
     """
-    Clean up all unattached VolumeAttachment resources.
+    Delete all VolumeAttachment objects whose spec.source.persistentVolumeName
+    matches *pv_name*, regardless of their ``status.attached`` value.
+
+    Args:
+        pv_name (str): The PersistentVolume name extracted from the Multi-Attach
+            error message (e.g. ``pvc-6c090725-...``).
 
     Returns:
-        int: Number of VolumeAttachments deleted
+        int: Number of VolumeAttachment objects deleted.
     """
-    logger.info("Cleaning up stale volume attachments")
+    logger.info(f"Deleting VolumeAttachment(s) for PV: {pv_name}")
     deleted_count = 0
     try:
         va_ocp = OCP(kind="VolumeAttachment")
         attachments = va_ocp.get()
-        if attachments and "items" in attachments:
-            for attachment in attachments["items"]:
-                if not attachment.get("status", {}).get("attached", False):
-                    va_name = attachment["metadata"]["name"]
-                    logger.debug(f"Deleting unattached VolumeAttachment: {va_name}")
-                    try:
-                        va_ocp.delete(resource_name=va_name)
-                        deleted_count += 1
-                    except Exception as e:
-                        logger.warning(
-                            f"Failed to delete VolumeAttachment {va_name}: {e}"
-                        )
-            if deleted_count > 0:
-                logger.info(f"Deleted {deleted_count} stale volume attachments")
-            else:
-                logger.debug("No stale volume attachments found")
+        for attachment in (attachments or {}).get("items", []):
+            spec_pv = (
+                attachment.get("spec", {})
+                .get("source", {})
+                .get("persistentVolumeName", "")
+            )
+            if spec_pv == pv_name:
+                va_name = attachment["metadata"]["name"]
+                attached = attachment.get("status", {}).get("attached", False)
+                logger.info(
+                    f"Deleting VolumeAttachment {va_name} "
+                    f"(attached={attached}, pv={pv_name})"
+                )
+                try:
+                    va_ocp.delete(resource_name=va_name)
+                    deleted_count += 1
+                except Exception as e:
+                    logger.warning(f"Failed to delete VolumeAttachment {va_name}: {e}")
     except Exception:
-        logger.exception("Failed to cleanup stale volume attachments")
-
+        logger.exception(f"Failed to delete VolumeAttachments for PV {pv_name}")
+    if deleted_count:
+        logger.info(f"Deleted {deleted_count} VolumeAttachment(s) for PV {pv_name}")
+    else:
+        logger.info(
+            f"No VolumeAttachment found for PV {pv_name} — "
+            "already gone or already cleaned up"
+        )
     return deleted_count
 
 
 def handle_multi_attach_error(pod_obj, timeout=300):
     """
-    Handle multi-attach volume errors by deleting stale VolumeAttachment resources.
+    Resolve a Multi-Attach volume error by deleting the specific VolumeAttachment
+    that is blocking the pod, then optionally waiting for the pod to reach Running.
 
     Args:
-        pod_obj: Pod object that may have multi-attach error
-        timeout: Maximum time to wait for pod to become running (default: 300s)
+        pod_obj: Pod object that has a Multi-Attach error.
+        timeout (int): Maximum time to wait for pod to become Running (default: 300s).
 
     Returns:
-        bool: True if pod is running, False otherwise
-
+        bool: True if pod is Running, False otherwise.
     """
-    logger.debug(f"Checking pod {pod_obj.name} for multi-attach errors")
+    logger.info(f"Resolving Multi-Attach error for pod: {pod_obj.name}")
 
     try:
         pod_describe = pod_obj.ocp.exec_oc_cmd(
@@ -1644,27 +1674,39 @@ def handle_multi_attach_error(pod_obj, timeout=300):
         )
 
         if "Multi-Attach error" in pod_describe:
-            logger.warning(f"Multi-attach error detected for pod: {pod_obj.name}")
-
-            pvc_match = re.search(
+            pv_match = re.search(
                 r'Multi-Attach error for volume "([^"]+)"', pod_describe
             )
-            if pvc_match:
-                pvc_id = pvc_match.group(1)
-                logger.info(f"Identified PVC with multi-attach error: {pvc_id}")
-
-                deleted_count = cleanup_stale_volume_attachments()
-                if deleted_count > 0:
-                    logger.info("Waiting 10s for VolumeAttachment cleanup to propagate")
-                    time.sleep(10)
+            if pv_match:
+                pv_name = pv_match.group(1)
+                logger.info(f"Pod {pod_obj.name}: Multi-Attach error on PV {pv_name}")
+                deleted = _delete_volume_attachments_for_pv(pv_name)
+                if deleted:
+                    logger.info("VolumeAttachment deleted; waiting 15s to propagate")
+                    time.sleep(15)
+                else:
+                    logger.warning(
+                        f"No VolumeAttachment deleted for PV {pv_name}; "
+                        "pod may recover on its own or need manual intervention"
+                    )
             else:
                 logger.warning(
-                    "Multi-attach error detected but could not extract PVC ID from pod description"
+                    f"Pod {pod_obj.name}: Multi-Attach error in describe but "
+                    "could not extract PV name"
                 )
+        else:
+            logger.debug(
+                f"Pod {pod_obj.name}: no Multi-Attach error in describe output"
+            )
     except Exception:
-        logger.exception(
-            f"Error while checking pod {pod_obj.name} for multi-attach errors"
+        logger.exception(f"Error resolving Multi-Attach error for pod {pod_obj.name}")
+
+    if timeout <= 30:
+        logger.debug(
+            f"Short-circuit: skipping wait for pod {pod_obj.name} "
+            f"(timeout={timeout}s, caller will re-enter full monitoring)"
         )
+        return False
 
     logger.debug(
         f"Waiting for pod {pod_obj.name} to reach running state (timeout: {timeout}s)"
@@ -1799,6 +1841,7 @@ def recover_mcg():
         f"Waiting for remaining NooBaa pods to appear "
         f"(expected ~{expected_pod_count}, timeout 300s)"
     )
+    current_pods = get_noobaa_pods()
     try:
         for current_pods in TimeoutSampler(
             timeout=300,
@@ -1821,13 +1864,12 @@ def recover_mcg():
             f"{[p.name for p in current_pods]} — proceeding to verify what is present"
         )
 
-    current_noobaa_pods = get_noobaa_pods()
     logger.info(
-        f"Verifying {len(current_noobaa_pods)} NooBaa pods reach Running state: "
-        f"{[p.name for p in current_noobaa_pods]}"
+        f"Verifying {len(current_pods)} NooBaa pods reach Running state: "
+        f"{[p.name for p in current_pods]}"
     )
     failed_noobaa_pods = verify_pods_running(
-        current_noobaa_pods, pod_type="NooBaa", timeout=600, parallel=False
+        current_pods, pod_type="NooBaa", timeout=600, parallel=False
     )
 
     if failed_noobaa_pods:

--- a/tests/cross_functional/kcs/test_monitor_recovery.py
+++ b/tests/cross_functional/kcs/test_monitor_recovery.py
@@ -967,9 +967,10 @@ def _exec_cmd_on_pod(cmd, pod_obj):
     pod_obj.exec_cmd_on_pod(cmd)
 
 
+@retry(CommandFailed, tries=10, delay=5, backoff=1)
 def insert_delay(mon_dep):
     """
-    Inserts delay on a monitor
+    Inserts delay on a monitor.
 
     Args:
         mon_dep (str): Name of a monitor deployment
@@ -988,6 +989,7 @@ def insert_delay(mon_dep):
     logger.debug(f"Successfully updated initialDelaySeconds for {mon_dep}")
 
 
+@retry(CommandFailed, tries=10, delay=5, backoff=1)
 def update_mon_initial_delay():
     """
     Inserts delay on all monitors

--- a/tests/cross_functional/kcs/test_monitor_recovery.py
+++ b/tests/cross_functional/kcs/test_monitor_recovery.py
@@ -1225,7 +1225,7 @@ def _wait_for_replacement_pod(pod_obj, timeout, namespace, max_attempts=3):
 
 
 def check_and_recover_sandbox_errors(
-    pod_obj, timeout=600, max_recovery_attempts=2, _attempt=0
+    pod_obj, timeout=600, max_recovery_attempts=3, _attempt=0
 ):
     """
     Check if a pod has sandbox errors and recover by power cycling its node.
@@ -1602,7 +1602,7 @@ def handle_multi_attach_error(pod_obj, timeout=300):
 
 def recover_mcg():
     """
-    Recovery procedure for NooBaa by re-spinning the pods after mon recovery
+    Recovery procedure for NooBaa by re-spinning the pods after mon recovery.
 
     Raises:
         ResourceWrongStatusException: If any NooBaa or RGW pods fail to reach running state
@@ -1610,149 +1610,51 @@ def recover_mcg():
     logger.info("Starting MCG recovery by re-spinning NooBaa pods")
 
     noobaa_pods_before = get_noobaa_pods()
-    expected_pod_count = len(noobaa_pods_before)
-
-    NOOBAA_POD_PREFIXES = [
-        "noobaa-db-pg-cluster-1",
-        "noobaa-db-pg-cluster-2",
-        "cnpg-controller-manager",
-        "noobaa-core",
-        "noobaa-endpoint",
-        "noobaa-operator",
-    ]
-
-    def get_pod_type_prefix(pod_name):
-        """Extract pod type prefix from pod name using known prefixes"""
-        for prefix in NOOBAA_POD_PREFIXES:
-            if pod_name.startswith(prefix):
-                return prefix
-        logger.warning(f"Unknown NooBaa pod type: {pod_name}")
-        parts = pod_name.rsplit("-", 2)
-        return parts[0] if len(parts) > 1 else pod_name
-
-    expected_pod_types = {}
-    for pod_obj in noobaa_pods_before:
-        prefix = get_pod_type_prefix(pod_obj.name)
-        expected_pod_types[prefix] = expected_pod_types.get(prefix, 0) + 1
-
     logger.info(
-        f"Found {expected_pod_count} NooBaa pods to respawn by type: {expected_pod_types}"
+        f"Found {len(noobaa_pods_before)} NooBaa pods to respawn: "
+        f"{[p.name for p in noobaa_pods_before]}"
     )
-
-    for idx, noobaa_pod in enumerate(noobaa_pods_before):
-        logger.info(
-            f"Force deleting NooBaa pod {idx+1}/{expected_pod_count}: {noobaa_pod.name}"
-        )
+    for noobaa_pod in noobaa_pods_before:
+        logger.info(f"Force deleting NooBaa pod: {noobaa_pod.name}")
         noobaa_pod.delete(force=True)
 
-        if idx < expected_pod_count - 1:
-            wait_time = 60
-            logger.info(f"Waiting {wait_time}s before deleting next NooBaa pod")
-            time.sleep(wait_time)
-
-    logger.info("Waiting 120s for NooBaa pods to fully respawn")
-    time.sleep(120)
-
-    # Wait for the minimum required pod types to appear (db-pg-cluster-2 is excluded
-    # because it is only created after db-pg-cluster-1 is fully running).
-    minimum_required_types = {
-        k: v for k, v in expected_pod_types.items() if k != "noobaa-db-pg-cluster-2"
-    }
-    minimum_required_count = sum(minimum_required_types.values())
-
-    def _minimum_pods_present():
-        current_pods = get_noobaa_pods()
-        current_pod_types = {}
-        for p in current_pods:
-            prefix = get_pod_type_prefix(p.name)
-            current_pod_types[prefix] = current_pod_types.get(prefix, 0) + 1
-        missing = [
-            f"{pt} ({current_pod_types.get(pt, 0)}/{cnt})"
-            for pt, cnt in minimum_required_types.items()
-            if current_pod_types.get(pt, 0) < cnt
-        ]
-        if missing:
-            logger.debug(f"NooBaa pods not yet ready — missing: {missing}")
-            return False
-        logger.info(
-            f"All minimum required NooBaa pod types present: {current_pod_types}"
-        )
-        return True
-
+    logger.info("Waiting for noobaa-db-pg-cluster-1 to reach Running (timeout 300s)")
+    db_pg_1_pod = None
     try:
-        for ready in TimeoutSampler(timeout=150, sleep=30, func=_minimum_pods_present):
-            if ready:
+        for db_pg_1_pods in TimeoutSampler(
+            timeout=300,
+            sleep=15,
+            func=lambda: [
+                p
+                for p in get_noobaa_pods()
+                if p.name.startswith("noobaa-db-pg-cluster-1")
+            ],
+        ):
+            if db_pg_1_pods:
+                db_pg_1_pod = db_pg_1_pods[0]
                 break
     except TimeoutExpiredError:
-        current_pods = get_noobaa_pods()
-        error_msg = (
-            f"NooBaa recovery failed: expected at least {minimum_required_count} pods "
-            f"({minimum_required_types}) but found {len(current_pods)} after 150s"
+        raise ResourceWrongStatusException(
+            "noobaa-db-pg-cluster-1 pod did not appear within 300s"
         )
-        logger.error(error_msg)
-        raise ResourceWrongStatusException(error_msg)
+    assert db_pg_1_pod is not None, "noobaa-db-pg-cluster-1 pod not set after wait"
+    failed = verify_pods_running(
+        [db_pg_1_pod], pod_type="NooBaa DB cluster-1", timeout=600, parallel=False
+    )
+    if failed:
+        raise ResourceWrongStatusException(
+            f"noobaa-db-pg-cluster-1 did not reach Running state within 600s: {failed}"
+        )
+    logger.info("noobaa-db-pg-cluster-1 is in Running state")
 
-    # Special handling for noobaa-db-pg-cluster-1 pod
-    # If it's not running, noobaa-db-pg-cluster-2 won't be created
-    logger.info("Checking if noobaa-db-pg-cluster-1 needs recovery")
-    db_pg_1_pods = [
-        p for p in get_noobaa_pods() if p.name.startswith("noobaa-db-pg-cluster-1")
-    ]
-
-    if db_pg_1_pods:
-        db_pg_1_pod = db_pg_1_pods[0]
-        logger.info(f"Found noobaa-db-pg-cluster-1 pod: {db_pg_1_pod.name}")
-
-        try:
-            if (
-                db_pg_1_pod.get().get("status", {}).get("phase")
-                != constants.STATUS_RUNNING
-            ):
-                logger.info(
-                    f"noobaa-db-pg-cluster-1 pod {db_pg_1_pod.name} is not running, attempting recovery"
-                )
-
-                failed_pods = verify_pods_running(
-                    [db_pg_1_pod], pod_type="NooBaa DB", timeout=600, parallel=False
-                )
-
-                if not failed_pods:
-                    logger.info("noobaa-db-pg-cluster-1 pod recovered successfully")
-
-                    logger.info("Waiting 180s for noobaa-db-pg-cluster-2 to be created")
-                    time.sleep(180)
-
-                    db_pods = [
-                        p
-                        for p in get_noobaa_pods()
-                        if p.name.startswith("noobaa-db-pg-cluster-")
-                    ]
-                    logger.info(f"Verifying {len(db_pods)} NooBaa DB pods are running")
-
-                    failed_db_pods = verify_pods_running(
-                        db_pods, pod_type="NooBaa DB", timeout=300, parallel=False
-                    )
-
-                    if failed_db_pods:
-                        logger.warning(
-                            f"Some NooBaa DB pods failed recovery: {failed_db_pods}"
-                        )
-                    else:
-                        logger.info("Both NooBaa DB pods are running successfully")
-                else:
-                    logger.warning(
-                        f"noobaa-db-pg-cluster-1 pod recovery failed: {failed_pods}"
-                    )
-            else:
-                logger.info("noobaa-db-pg-cluster-1 pod is already running")
-        except Exception as e:
-            logger.warning(f"Error during noobaa-db-pg-cluster-1 recovery check: {e}")
-    else:
-        logger.warning("noobaa-db-pg-cluster-1 pod not found")
+    logger.info("Waiting 300s for operator to create dependent NooBaa pods")
+    time.sleep(300)
 
     current_noobaa_pods = get_noobaa_pods()
-    logger.info(f"Verifying {len(current_noobaa_pods)} NooBaa pods are running")
-
+    logger.info(
+        f"Verifying {len(current_noobaa_pods)} NooBaa pods are running: "
+        f"{[p.name for p in current_noobaa_pods]}"
+    )
     failed_noobaa_pods = verify_pods_running(
         current_noobaa_pods, pod_type="NooBaa", timeout=600, parallel=False
     )

--- a/tests/cross_functional/kcs/test_monitor_recovery.py
+++ b/tests/cross_functional/kcs/test_monitor_recovery.py
@@ -1952,14 +1952,20 @@ def get_spun_dc_pods(pod_list):
     new_pods = []
 
     for pod_obj in pod_list:
-        pod_label = pod_obj.labels.get("deploymentconfig")
-        label_selector = f"deploymentconfig={pod_label}"
+        pod_label = pod_obj.labels.get("name") or pod_obj.labels.get("deploymentconfig")
+        if not pod_label:
+            logger.warning(
+                f"Pod {pod_obj.name} has no 'name' or 'deploymentconfig' label, skipping"
+            )
+            continue
+        label_key = "name" if pod_obj.labels.get("name") else "deploymentconfig"
+        label_selector = f"{label_key}={pod_label}"
         logger.debug(f"Searching for pods with label: {label_selector}")
 
         pods_data = get_pods_having_label(label_selector, pod_obj.namespace)
         for pod_data in pods_data:
             pod_name = pod_data.get("metadata").get("name")
-            if "-deploy" not in pod_name and pod_name not in pod_obj.name:
+            if "-deploy" not in pod_name and pod_name != pod_obj.name:
                 logger.debug(f"Found re-spun pod: {pod_name}")
                 new_pods.append(get_pod_obj(pod_name, pod_obj.namespace))
 


### PR DESCRIPTION
Fixes: #14384

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Tests
- Refactored the end-to-end monitor recovery workflow to better stage tools into monitor/OSD pods, regenerate `monstore`, rebuild `store.db` on the primary monitor, and distribute the rebuilt database to the remaining monitors.
- Improved recovery validation and failure detection, including pod readiness checks, enhanced logging, and stricter handling of keyring and monitor map inputs.

## Refactor
- Reworked keyring collection to aggregate from cluster secrets and OSD pod files into the expected merged keyring format.
- Strengthened MCG recovery behavior with more resilient multi-attach cleanup and improved deployment patch/rollback sequencing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->