### PR TITLE
Adding certificate pull for ceph reef

### DIFF
--- a/conf/README.md
+++ b/conf/README.md
@@ -535,8 +535,11 @@ Configuration specific to external Ceph cluster
     * `key` - Admin keyring value used for the external Ceph cluster
 * `external_cluster_details` - base64 encoded data of json output from exporter script
 * `rgw_secure` - boolean parameter which defines if external Ceph cluster RGW is secured using SSL
-* `rgw_cert_ca` - URL for the RGW signing CA when external Ceph is **below 19.0**, or as a **fallback** if cephadm CA fetch fails on 19.0+
-* For external Ceph **19.0 and newer**, ocs-ci runs ``ceph orch certmgr cert get cephadm_root_ca_cert`` via ``cephadm shell`` on the ``_admin`` node (``get_external_cluster_client("_admin")``, falling back to ``node1``) instead of using ``rgw_cert_ca``, unless that command fails
+* `rgw_cert_ca` - URL for the RGW signing CA, used as a **fallback** when automatic certificate retrieval fails
+* For external Ceph **19.0+ (Squid and newer)**: ocs-ci runs ``ceph orch certmgr cert get cephadm_root_ca_cert`` via ``cephadm shell`` on the ``_admin`` node to fetch the cephadm root CA certificate
+* For external Ceph **18.x (Reef)**: ocs-ci fetches the certificate directly from the RGW server endpoint using ``openssl s_client``, since cephadm certmgr is not available in this version
+* For external Ceph **below 18.0**: Falls back to downloading from ``rgw_cert_ca`` URL
+* All methods fall back to ``rgw_cert_ca`` URL if the automatic fetch fails
 * `use_rbd_namespace` - boolean parameter to use RBD namespace in pool
 * `rbd_namespace` - Name of RBD namespace to use in pool
 

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -25,6 +25,7 @@ from ocs_ci.deployment.helpers.external_cluster_helpers import (
     ExternalCluster,
     get_external_cluster_client,
     get_and_apply_rgw_cert_ca,
+    _external_ceph_semantic_version_or_none,
 )
 from ocs_ci.deployment.helpers.mcg_helpers import (
     mcg_only_post_deployment_checks,
@@ -2071,7 +2072,20 @@ class Deployment(object):
         )
         templating.dump_data_to_temp_yaml(cluster_data, cluster_data_yaml.name)
         run_cmd(f"oc apply -f {cluster_data_yaml.name}", timeout=2400)
-        external_cluster.disable_certificate_check()
+
+        # Disable certificate check only for Ceph 19.0+ (Squid)
+        # The mgr/cephadm/certificate_check_period config option doesn't exist in earlier versions
+        ceph_version = _external_ceph_semantic_version_or_none()
+        if ceph_version and ceph_version >= version.get_semantic_version(
+            "19.0", only_major_minor=True
+        ):
+            external_cluster.disable_certificate_check()
+        else:
+            logger.info(
+                f"Skipping disable_certificate_check for Ceph version {ceph_version} "
+                "(only supported on Ceph 19.0+)"
+            )
+
         self.external_post_deploy_validation()
 
         # enable secure connection mode for in-transit encryption

--- a/ocs_ci/deployment/helpers/external_cluster_helpers.py
+++ b/ocs_ci/deployment/helpers/external_cluster_helpers.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 import json
 import logging
 import re
+import shlex
 import tempfile
 import uuid
 import os
@@ -407,12 +408,22 @@ class ExternalCluster(object):
             str: PEM-encoded certificate
 
         Raises:
-            ExternalClusterExporterRunFailed: If certificate fetch fails
+            ExternalClusterExporterRunFailed: If certificate fetch fails or endpoint format is invalid
 
         """
+        # Validate RGW endpoint format to prevent command injection
+        # Expected format: host:port or [ipv6]:port
+        endpoint_pattern = r"^\[?[A-Za-z0-9:._-]+\]?:\d{1,5}$"
+        if not re.fullmatch(endpoint_pattern, rgw_endpoint):
+            raise ExternalClusterExporterRunFailed(
+                f"Invalid RGW endpoint format: {rgw_endpoint}. "
+                f"Expected format: 'host:port' or '[ipv6]:port'"
+            )
+
         # Use openssl s_client to fetch the server certificate
+        # Use shlex.quote() to safely escape the endpoint parameter
         cmd = (
-            f"echo | openssl s_client -connect {rgw_endpoint} -showcerts 2>/dev/null | "
+            f"echo | openssl s_client -connect {shlex.quote(rgw_endpoint)} -showcerts 2>/dev/null | "
             f"openssl x509 -outform PEM"
         )
 
@@ -1728,9 +1739,7 @@ def get_and_apply_rgw_cert_ca(apply=True):
                 "Could not determine Ceph version, falling back to rgw_cert_ca URL"
             )
         else:
-            logger.info(
-                f"Ceph version {ceph_version} < 18.0, using rgw_cert_ca URL"
-            )
+            logger.info(f"Ceph version {ceph_version} < 18.0, using rgw_cert_ca URL")
         download_file(
             config.EXTERNAL_MODE["rgw_cert_ca"],
             rgw_cert_ca_path,

--- a/ocs_ci/deployment/helpers/external_cluster_helpers.py
+++ b/ocs_ci/deployment/helpers/external_cluster_helpers.py
@@ -44,7 +44,7 @@ from ocs_ci.utility.utils import (
     upload_file,
     encode,
     decode,
-    download_file,
+    download_with_retries,
     exec_cmd,
     wait_for_machineconfigpool_status,
     create_config_ini_file,
@@ -1700,10 +1700,15 @@ def get_and_apply_rgw_cert_ca(apply=True):
             logger.warning(
                 "cephadm CA fetch failed (%s); falling back to rgw_cert_ca URL", exc
             )
-            download_file(
+            downloaded = download_with_retries(
                 config.EXTERNAL_MODE["rgw_cert_ca"],
                 rgw_cert_ca_path,
             )
+            if not downloaded:
+                raise CommandFailed(
+                    f"Failed to download RGW CA cert from "
+                    f"{config.EXTERNAL_MODE['rgw_cert_ca']}"
+                )
 
     # Ceph 18.x (Reef): Fetch directly from RGW server
     elif ceph_version and ceph_version >= version.get_semantic_version(
@@ -1727,10 +1732,15 @@ def get_and_apply_rgw_cert_ca(apply=True):
                 "RGW server certificate fetch failed (%s); falling back to rgw_cert_ca URL",
                 exc,
             )
-            download_file(
+            downloaded = download_with_retries(
                 config.EXTERNAL_MODE["rgw_cert_ca"],
                 rgw_cert_ca_path,
             )
+            if not downloaded:
+                raise CommandFailed(
+                    f"Failed to download RGW CA cert from "
+                    f"{config.EXTERNAL_MODE['rgw_cert_ca']}"
+                )
 
     # Older versions or version detection failed: Use rgw_cert_ca URL
     else:
@@ -1740,10 +1750,15 @@ def get_and_apply_rgw_cert_ca(apply=True):
             )
         else:
             logger.info(f"Ceph version {ceph_version} < 18.0, using rgw_cert_ca URL")
-        download_file(
+        downloaded = download_with_retries(
             config.EXTERNAL_MODE["rgw_cert_ca"],
             rgw_cert_ca_path,
         )
+        if not downloaded:
+            raise CommandFailed(
+                f"Failed to download RGW CA cert from "
+                f"{config.EXTERNAL_MODE['rgw_cert_ca']}"
+            )
 
     # configure the CA cert to be trusted by the OCP cluster
     if apply:

--- a/ocs_ci/deployment/helpers/external_cluster_helpers.py
+++ b/ocs_ci/deployment/helpers/external_cluster_helpers.py
@@ -393,6 +393,42 @@ class ExternalCluster(object):
             )
         return pem if pem.endswith("\n") else f"{pem}\n"
 
+    def fetch_rgw_server_certificate(self, rgw_endpoint):
+        """
+        Fetch the actual certificate presented by the RGW server for Ceph < 19.0.
+
+        For Reef (18.x), cephadm doesn't have certmgr, so we extract the cert
+        directly from the RGW server endpoint using openssl s_client.
+
+        Args:
+            rgw_endpoint (str): RGW endpoint (e.g., "10.1.112.76:443")
+
+        Returns:
+            str: PEM-encoded certificate
+
+        Raises:
+            ExternalClusterExporterRunFailed: If certificate fetch fails
+
+        """
+        # Use openssl s_client to fetch the server certificate
+        cmd = (
+            f"echo | openssl s_client -connect {rgw_endpoint} -showcerts 2>/dev/null | "
+            f"openssl x509 -outform PEM"
+        )
+
+        ret, out, err = self.rhcs_conn.exec_cmd(cmd)
+        if ret != 0 or not out or "BEGIN CERTIFICATE" not in out:
+            raise ExternalClusterExporterRunFailed(
+                f"Failed to fetch RGW server certificate from {rgw_endpoint}: {err}"
+            )
+
+        pem = out.strip()
+        if not pem.endswith("\n"):
+            pem = f"{pem}\n"
+
+        logger.info(f"Fetched RGW server certificate from {rgw_endpoint} (Ceph < 19.0)")
+        return pem
+
     def get_rgw_endpoint_api_port(self):
         """
         Fetches rgw endpoint api port.
@@ -1614,7 +1650,8 @@ def try_embed_rgw_ca_pem_in_mcg_cli_resources(service_ca_data, sts_dict):
 def get_and_apply_rgw_cert_ca(apply=True):
     """
     Obtain the RGW TLS CA: for external Ceph **19.0+**, fetch ``cephadm_root_ca_cert``
-    from the ``_admin`` node via SSH; otherwise download from ``rgw_cert_ca`` URL.
+    from the ``_admin`` node via SSH; for Ceph **18.x (Reef)**, fetch the certificate
+    directly from the RGW server; otherwise download from ``rgw_cert_ca`` URL.
 
     Args:
         apply (bool): if True, the certificate is applied as trusted CA by the OCP cluster
@@ -1631,7 +1668,12 @@ def get_and_apply_rgw_cert_ca(apply=True):
     ).name
     config.EXTERNAL_MODE.pop("embedded_external_rgw_ca_pem", None)
 
-    if external_rgw_ca_should_use_cephadm_fetch():
+    ceph_version = _external_ceph_semantic_version_or_none()
+
+    # Ceph 19.0+ (Squid): Use cephadm certmgr
+    if ceph_version and ceph_version >= version.get_semantic_version(
+        "19.0", only_major_minor=True
+    ):
         try:
             host, user, password, ssh_key = get_external_cluster_client("_admin")
             pem = ExternalCluster(
@@ -1651,11 +1693,49 @@ def get_and_apply_rgw_cert_ca(apply=True):
                 config.EXTERNAL_MODE["rgw_cert_ca"],
                 rgw_cert_ca_path,
             )
+
+    # Ceph 18.x (Reef): Fetch directly from RGW server
+    elif ceph_version and ceph_version >= version.get_semantic_version(
+        "18.0", only_major_minor=True
+    ):
+        try:
+            rgw_endpoint = get_rgw_endpoint()
+            ext = get_external_cluster_instance()
+            rgw_port = ext.get_rgw_endpoint_api_port()
+            rgw_full_endpoint = f"{rgw_endpoint}:{rgw_port}"
+
+            pem = ext.fetch_rgw_server_certificate(rgw_full_endpoint)
+            with open(rgw_cert_ca_path, "w", encoding="utf-8") as pem_fd:
+                pem_fd.write(pem)
+            config.EXTERNAL_MODE["embedded_external_rgw_ca_pem"] = pem
+            logger.info(
+                f"Using server certificate from RGW endpoint {rgw_full_endpoint} (Ceph 18.x)"
+            )
+        except Exception as exc:
+            logger.warning(
+                "RGW server certificate fetch failed (%s); falling back to rgw_cert_ca URL",
+                exc,
+            )
+            download_file(
+                config.EXTERNAL_MODE["rgw_cert_ca"],
+                rgw_cert_ca_path,
+            )
+
+    # Older versions or version detection failed: Use rgw_cert_ca URL
     else:
+        if ceph_version is None:
+            logger.warning(
+                "Could not determine Ceph version, falling back to rgw_cert_ca URL"
+            )
+        else:
+            logger.info(
+                f"Ceph version {ceph_version} < 18.0, using rgw_cert_ca URL"
+            )
         download_file(
             config.EXTERNAL_MODE["rgw_cert_ca"],
             rgw_cert_ca_path,
         )
+
     # configure the CA cert to be trusted by the OCP cluster
     if apply:
         ssl_certs.configure_trusted_ca_bundle(ca_cert_path=rgw_cert_ca_path)


### PR DESCRIPTION
fixes: https://github.com/red-hat-storage/ocs-ci/issues/15410

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified external mode RGW TLS certificate handling, including Ceph 19.0+ and Ceph 18.x retrieval flows, plus consistent fallback behavior when automatic retrieval fails.

* **New Features**
  * Enhanced external Ceph RGW certificate retrieval across supported versions, including embedding the retrieved certificate when available and automatically falling back to the configured certificate source.

* **Bug Fixes**
  * Adjusted external cluster deployment to disable Ceph certificate checking only when the detected external Ceph version supports it (no longer disabled unconditionally).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->