### PR TITLE
A new test cases for noobaa bucket error state improvements

### DIFF
--- a/ocs_ci/ocs/bucket_utils.py
+++ b/ocs_ci/ocs/bucket_utils.py
@@ -3651,6 +3651,76 @@ def get_noobaa_bucket_replication_metrics_in_prometheus(
         )
 
 
+def get_bucket_mode(mcg_obj, bucket_name):
+    """
+    Get the current mode of a bucket from NooBaa.
+
+    Args:
+        mcg_obj (MCG): MCG object
+        bucket_name (str): Name of the bucket
+
+    Returns:
+        str: The bucket mode (e.g. "OPTIMAL", "EXCEEDING_QUOTA")
+    """
+    bucket_info = mcg_obj.get_bucket_info(bucket_name)
+    if bucket_info:
+        logger.debug(f"Bucket info for {bucket_name}: {bucket_info}")
+        return bucket_info.get("mode", "UNKNOWN")
+    logger.warning(f"Bucket {bucket_name} not found in NooBaa system")
+    return "UNKNOWN"
+
+
+def wait_for_bucket_mode(mcg_obj, bucket_name, expected_mode, timeout=600, sleep=15):
+    """
+    Poll NooBaa until the bucket enters the expected mode or timeout.
+
+    Args:
+        mcg_obj (MCG): MCG object
+        bucket_name (str): Name of the bucket
+        expected_mode (str): Expected bucket mode (e.g. "EXCEEDING_QUOTA")
+            or "!OPTIMAL" to wait for any non-OPTIMAL mode
+            (UNKNOWN is excluded to avoid false positives on lookup failures)
+        timeout (int): Timeout in seconds (default: 600)
+        sleep (int): Poll interval in seconds (default: 15)
+
+    Returns:
+        str: The actual bucket mode once matched
+
+    Raises:
+        AssertionError: If the bucket does not reach the expected mode
+            within the timeout
+    """
+    check_not_optimal = expected_mode == "!OPTIMAL"
+    last_mode = "UNKNOWN"
+
+    try:
+        for mode in TimeoutSampler(
+            timeout=timeout,
+            sleep=sleep,
+            func=get_bucket_mode,
+            mcg_obj=mcg_obj,
+            bucket_name=bucket_name,
+        ):
+            last_mode = mode
+            if check_not_optimal and mode not in ("OPTIMAL", "UNKNOWN"):
+                logger.info(f"Bucket {bucket_name} entered non-OPTIMAL mode: {mode}")
+                return mode
+            elif not check_not_optimal and mode == expected_mode:
+                logger.info(f"Bucket {bucket_name} entered expected mode: {mode}")
+                return mode
+    except TimeoutExpiredError:
+        if check_not_optimal:
+            assert False, (
+                f"Bucket {bucket_name} is still OPTIMAL after "
+                f"{timeout}s (last mode: {last_mode})"
+            )
+        else:
+            assert False, (
+                f"Expected bucket mode {expected_mode} for {bucket_name}, "
+                f"got {last_mode} after {timeout}s"
+            )
+
+
 def get_bucket_status_value(mcg_obj, bucket_name, key):
     """
     Helper function returning specific bucket status value by key

--- a/tests/functional/object/mcg/test_noobaa_bucket_error_state_mode.py
+++ b/tests/functional/object/mcg/test_noobaa_bucket_error_state_mode.py
@@ -449,7 +449,7 @@ class TestNooBaaBucketErrorStateMode:
             alerts = wait_for_alert_firing(
                 api=prometheus_api,
                 alert_name=alert_name,
-                timeout=600,
+                timeout=900,
                 expected_message_substr="EXCEEDING_QUOTA",
             )
 

--- a/tests/functional/object/mcg/test_noobaa_bucket_error_state_mode.py
+++ b/tests/functional/object/mcg/test_noobaa_bucket_error_state_mode.py
@@ -78,7 +78,7 @@ class TestNooBaaBucketErrorStateMode:
             2. Upload ~2.5GB to exceed the quota
             3. Wait for bucket mode to propagate
             4. Verify bucket mode is EXCEEDING_QUOTA via NooBaa
-            5. Clean up
+            5. Clean up (tmp files, bucket objects, bucket)
 
         Args:
             mcg_obj (MCG): MCG object with S3 connection credentials
@@ -90,12 +90,13 @@ class TestNooBaaBucketErrorStateMode:
         bucket = MCGCLIBucket(bucket_name, mcg=mcg_obj, quota="2Gi")
         logger.info(f"Created bucket {bucket_name} with 2Gi quota")
 
+        local_dir = f"/tmp/{bucket_name}"
         try:
             try:
                 write_random_test_objects_to_bucket(
                     io_pod=awscli_pod,
                     bucket_to_write=bucket_name,
-                    file_dir=f"/tmp/{bucket_name}",
+                    file_dir=local_dir,
                     amount=5,
                     bs="500M",
                     mcg_obj=mcg_obj,
@@ -109,6 +110,7 @@ class TestNooBaaBucketErrorStateMode:
 
             wait_for_bucket_mode(mcg_obj, bucket_name, "EXCEEDING_QUOTA")
         finally:
+            awscli_pod.exec_cmd_on_pod(f"rm -rf {local_dir}", out_yaml_format=False)
             try:
                 rm_object_recursive(awscli_pod, bucket_name, mcg_obj)
             except CommandFailed:
@@ -133,10 +135,10 @@ class TestNooBaaBucketErrorStateMode:
         Steps:
             1. Create a data bucket with a PV pool backing store (17Gi)
             2. Upload data so NooBaa tracks objects against the store
-            3. Force-delete the PV pool pod to trigger resource error
-            4. Wait for bucket to detect the resource error
-            5. Verify bucket mode is NOT_ENOUGH_HEALTHY_RESOURCES
-            6. Clean up
+            3. Clean up tmp files from awscli pod
+            4. Force-delete the PV pool pod to trigger resource error
+            5. Wait for bucket to detect the resource error
+            6. Verify bucket mode is NOT_ENOUGH_HEALTHY_RESOURCES
 
         Args:
             mcg_obj (MCG): MCG object with S3 connection credentials
@@ -159,14 +161,16 @@ class TestNooBaaBucketErrorStateMode:
             f"PV pool backing store {backingstore.name}"
         )
 
+        local_dir = f"/tmp/{bucket.name}"
         write_random_test_objects_to_bucket(
             io_pod=awscli_pod,
             bucket_to_write=bucket.name,
-            file_dir=f"/tmp/{bucket.name}",
+            file_dir=local_dir,
             amount=2,
             bs="50M",
             mcg_obj=mcg_obj,
         )
+        awscli_pod.exec_cmd_on_pod(f"rm -rf {local_dir}", out_yaml_format=False)
         logger.info(
             f"Uploaded ~100MB to bucket {bucket.name} "
             f"so NooBaa tracks objects against the backing store"
@@ -203,10 +207,10 @@ class TestNooBaaBucketErrorStateMode:
             1. Create 2 namespace stores backed by AWS target buckets
             2. Create a namespace bucket using Multi policy
             3. Upload data so NooBaa tracks objects against the stores
-            4. Delete the target bucket of one namespace store
-            5. Wait for bucket to detect the resource error
-            6. Verify bucket mode is NOT_ENOUGH_HEALTHY_RESOURCES
-            7. Clean up
+            4. Clean up tmp files from awscli pod
+            5. Delete the target bucket of one namespace store
+            6. Wait for bucket to detect the resource error
+            7. Verify bucket mode is NOT_ENOUGH_HEALTHY_RESOURCES
 
         Args:
             mcg_obj (MCG): MCG object with S3 connection credentials
@@ -234,14 +238,16 @@ class TestNooBaaBucketErrorStateMode:
         logger.info(f"Created namespace stores: {[ns.name for ns in ns_stores]}")
         logger.info(f"Created namespace bucket {ns_bucket.name} with Multi policy")
 
+        local_dir = f"/tmp/{ns_bucket.name}"
         write_random_test_objects_to_bucket(
             io_pod=awscli_pod,
             bucket_to_write=ns_bucket.name,
-            file_dir=f"/tmp/{ns_bucket.name}",
+            file_dir=local_dir,
             amount=2,
             bs="50M",
             mcg_obj=mcg_obj,
         )
+        awscli_pod.exec_cmd_on_pod(f"rm -rf {local_dir}", out_yaml_format=False)
         logger.info(
             f"Uploaded ~100MB to namespace bucket {ns_bucket.name} "
             f"so NooBaa tracks objects against the namespace stores"
@@ -277,7 +283,7 @@ class TestNooBaaBucketErrorStateMode:
             2. Upload data in 4GB increments, checking mode after each
             3. Log all observed mode transitions
             4. Verify bucket reaches a capacity error mode
-            5. Clean up
+            5. Clean up tmp test file from awscli pod
 
         Args:
             mcg_obj (MCG): MCG object with S3 connection credentials
@@ -316,62 +322,68 @@ class TestNooBaaBucketErrorStateMode:
         file_num = 0
         final_mode = None
 
-        awscli_pod.exec_cmd_on_pod("dd if=/dev/zero of=/tmp/testfile bs=1M count=4000")
+        testfile = "/tmp/testfile"
+        awscli_pod.exec_cmd_on_pod(f"dd if=/dev/zero of={testfile} bs=1M count=4000")
         logger.info("Created 4GB test file for gradual upload")
 
-        for chunk in range(1, 7):
-            file_num += 1
-            logger.info(
-                f"Uploading chunk {chunk}/6 (~4GB) to bucket {bucket.name} "
-                f"(total so far: ~{chunk * 4}GB, PV pool: 17Gi)"
-            )
-            try:
-                copy_objects(
-                    awscli_pod,
-                    "/tmp/testfile",
-                    f"s3://{bucket.name}/testfile{file_num}",
-                    s3_obj=mcg_obj,
+        try:
+            for chunk in range(1, 7):
+                file_num += 1
+                logger.info(
+                    f"Uploading chunk {chunk}/6 (~4GB) to bucket {bucket.name} "
+                    f"(total so far: ~{chunk * 4}GB, PV pool: 17Gi)"
                 )
-            except CommandFailed:
-                logger.warning(
-                    f"Upload of chunk {chunk} failed "
-                    f"(expected when exceeding capacity)"
+                try:
+                    copy_objects(
+                        awscli_pod,
+                        testfile,
+                        f"s3://{bucket.name}/testfile{file_num}",
+                        s3_obj=mcg_obj,
+                    )
+                except CommandFailed:
+                    logger.warning(
+                        f"Upload of chunk {chunk} failed "
+                        f"(expected when exceeding capacity)"
+                    )
+
+                mode = get_bucket_mode(mcg_obj, bucket.name)
+                logger.info(
+                    f"After chunk {chunk}: bucket mode = {mode} "
+                    f"(uploaded ~{chunk * 4}GB / 17Gi)"
                 )
 
-            mode = get_bucket_mode(mcg_obj, bucket.name)
+                if mode != "OPTIMAL" and mode not in observed_modes:
+                    observed_modes.append(mode)
+                    logger.info(f"New non-OPTIMAL mode observed: {mode}")
+
+                if mode in capacity_error_modes:
+                    final_mode = mode
+                    logger.info(
+                        f"Bucket {bucket.name} entered capacity error mode: {mode}"
+                    )
+                    break
+
+            if not final_mode:
+                logger.info(
+                    "Bucket still OPTIMAL after all uploads, "
+                    "waiting for mode to propagate"
+                )
+                final_mode = wait_for_bucket_mode(
+                    mcg_obj, bucket.name, "NOT_ENOUGH_HEALTHY_RESOURCES"
+                )
+                if final_mode and final_mode not in observed_modes:
+                    observed_modes.append(final_mode)
+
             logger.info(
-                f"After chunk {chunk}: bucket mode = {mode} "
-                f"(uploaded ~{chunk * 4}GB / 17Gi)"
+                f"Capacity test complete. "
+                f"Observed mode transitions: {observed_modes}. "
+                f"Final mode: {final_mode}"
             )
-
-            if mode != "OPTIMAL" and mode not in observed_modes:
-                observed_modes.append(mode)
-                logger.info(f"New non-OPTIMAL mode observed: {mode}")
-
-            if mode in capacity_error_modes:
-                final_mode = mode
-                logger.info(f"Bucket {bucket.name} entered capacity error mode: {mode}")
-                break
-
-        if not final_mode:
-            logger.info(
-                "Bucket still OPTIMAL after all uploads, "
-                "waiting for mode to propagate"
-            )
-            final_mode = wait_for_bucket_mode(
-                mcg_obj, bucket.name, "NOT_ENOUGH_HEALTHY_RESOURCES"
-            )
-            if final_mode and final_mode not in observed_modes:
-                observed_modes.append(final_mode)
-
-        logger.info(
-            f"Capacity test complete. "
-            f"Observed mode transitions: {observed_modes}. "
-            f"Final mode: {final_mode}"
-        )
-        assert (
-            final_mode in capacity_error_modes
-        ), f"Expected one of {capacity_error_modes}, got {final_mode}"
+            assert (
+                final_mode in capacity_error_modes
+            ), f"Expected one of {capacity_error_modes}, got {final_mode}"
+        finally:
+            awscli_pod.exec_cmd_on_pod(f"rm -f {testfile}", out_yaml_format=False)
 
     # ------------------------------------------------------------------
     # Alert verification test
@@ -393,8 +405,9 @@ class TestNooBaaBucketErrorStateMode:
             2. Upload ~2.5GB to exceed the quota
             3. Verify bucket enters EXCEEDING_QUOTA mode
             4. Wait for NooBaaBucketErrorState alert to fire (~5 min)
-            5. Verify alert contains bucket_mode=EXCEEDING_QUOTA
-            6. Clean up
+            5. Filter alerts by bucket_name and verify
+               bucket_mode=EXCEEDING_QUOTA
+            6. Clean up (tmp files, bucket objects, bucket)
 
         Args:
             mcg_obj (MCG): MCG object with S3 connection credentials
@@ -407,12 +420,13 @@ class TestNooBaaBucketErrorStateMode:
         bucket = MCGCLIBucket(bucket_name, mcg=mcg_obj, quota="2Gi")
         logger.info(f"Created bucket {bucket_name} with 2Gi quota")
 
+        local_dir = f"/tmp/{bucket_name}"
         try:
             try:
                 write_random_test_objects_to_bucket(
                     io_pod=awscli_pod,
                     bucket_to_write=bucket_name,
-                    file_dir=f"/tmp/{bucket_name}",
+                    file_dir=local_dir,
                     amount=5,
                     bs="500M",
                     mcg_obj=mcg_obj,
@@ -439,22 +453,27 @@ class TestNooBaaBucketErrorStateMode:
                 expected_message_substr="EXCEEDING_QUOTA",
             )
 
-            alert_labels = alerts[0]["labels"]
-            logger.info(f"Alert {alert_name} fired with labels: {alert_labels}")
-            assert alert_labels.get("bucket_mode") == "EXCEEDING_QUOTA", (
-                f"Expected bucket_mode=EXCEEDING_QUOTA in alert labels, "
-                f"got bucket_mode={alert_labels.get('bucket_mode')}"
+            matching_alert = next(
+                (
+                    alert
+                    for alert in alerts
+                    if alert.get("labels", {}).get("bucket_name") == bucket_name
+                    and alert.get("labels", {}).get("bucket_mode") == "EXCEEDING_QUOTA"
+                ),
+                None,
             )
-            assert alert_labels.get("bucket_name") == bucket_name, (
-                f"Expected bucket_name={bucket_name} in alert labels, "
-                f"got bucket_name={alert_labels.get('bucket_name')}"
+            assert matching_alert, (
+                f"No '{alert_name}' firing instance found for "
+                f"bucket_name={bucket_name} with bucket_mode=EXCEEDING_QUOTA"
             )
+            alert_labels = matching_alert["labels"]
             logger.info(
                 f"Alert {alert_name} verified: "
                 f"bucket_name={alert_labels.get('bucket_name')}, "
                 f"bucket_mode={alert_labels.get('bucket_mode')}"
             )
         finally:
+            awscli_pod.exec_cmd_on_pod(f"rm -rf {local_dir}", out_yaml_format=False)
             try:
                 rm_object_recursive(awscli_pod, bucket_name, mcg_obj)
             except CommandFailed:

--- a/tests/functional/object/mcg/test_noobaa_bucket_error_state_mode.py
+++ b/tests/functional/object/mcg/test_noobaa_bucket_error_state_mode.py
@@ -11,10 +11,9 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_disconnected_cluster,
     skipif_managed_service,
     skipif_mcg_only,
-    skipif_ocs_version,
     tier2,
 )
-from ocs_ci.ocs import constants
+from ocs_ci.ocs.constants import DEFAULT_STORAGECLASS_RBD
 from ocs_ci.ocs.bucket_utils import (
     copy_objects,
     get_bucket_mode,
@@ -37,7 +36,6 @@ logger = logging.getLogger(__name__)
 @post_upgrade
 @runs_on_provider
 @skipif_disconnected_cluster
-@skipif_ocs_version("<4.22")
 class TestNooBaaBucketErrorStateMode:
     """
     Tests for RHSTOR-7732: verify that NooBaa buckets enter the
@@ -165,7 +163,7 @@ class TestNooBaaBucketErrorStateMode:
         """
         bucketclass_dict = {
             "interface": "OC",
-            "backingstore_dict": {"pv": [(1, 17, constants.DEFAULT_STORAGECLASS_RBD)]},
+            "backingstore_dict": {"pv": [(1, 17, DEFAULT_STORAGECLASS_RBD)]},
         }
         bucket = bucket_factory(
             amount=1,
@@ -324,7 +322,7 @@ class TestNooBaaBucketErrorStateMode:
 
         bucketclass_dict = {
             "interface": "OC",
-            "backingstore_dict": {"pv": [(1, 17, constants.DEFAULT_STORAGECLASS_RBD)]},
+            "backingstore_dict": {"pv": [(1, 17, DEFAULT_STORAGECLASS_RBD)]},
         }
         bucket = bucket_factory(
             amount=1,

--- a/tests/functional/object/mcg/test_noobaa_bucket_error_state_mode.py
+++ b/tests/functional/object/mcg/test_noobaa_bucket_error_state_mode.py
@@ -1,18 +1,18 @@
 import logging
 
+import pytest
+
 from ocs_ci.framework.pytest_customization.marks import (
+    mcg,
     post_upgrade,
     red_squad,
-    skipif_ocs_version,
-    skipif_mcg_only,
-)
-from ocs_ci.framework.testlib import (
     runs_on_provider,
     skipif_aws_creds_are_missing,
     skipif_disconnected_cluster,
     skipif_managed_service,
+    skipif_mcg_only,
+    skipif_ocs_version,
     tier2,
-    mcg,
 )
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.bucket_utils import (
@@ -63,26 +63,20 @@ class TestNooBaaBucketErrorStateMode:
     """
 
     # ------------------------------------------------------------------
-    # Quota error mode tests (EXCEEDING_QUOTA)
+    # Shared fixtures
     # ------------------------------------------------------------------
 
-    # TODO: Replace with actual Polarion ID
-    # @polarion_id("OCS-XXXXX")
-    def test_data_bucket_quota_error_mode(self, mcg_obj, awscli_pod):
+    @pytest.fixture()
+    def quota_exceeded_bucket(self, request, mcg_obj, awscli_pod):
         """
-        Trigger a quota-related bucket mode on a data bucket and verify
-        that the bucket enters EXCEEDING_QUOTA mode.
+        Create a data bucket with a 2Gi quota, upload ~2.5GB to exceed
+        it, and wait for the bucket to enter EXCEEDING_QUOTA mode.
+        Cleanup (tmp files, bucket objects, bucket) is handled via
+        request.addfinalizer.
 
-        Steps:
-            1. Create a data bucket with a 2Gi quota
-            2. Upload ~2.5GB to exceed the quota
-            3. Wait for bucket mode to propagate
-            4. Verify bucket mode is EXCEEDING_QUOTA via NooBaa
-            5. Clean up (tmp files, bucket objects, bucket)
-
-        Args:
-            mcg_obj (MCG): MCG object with S3 connection credentials
-            awscli_pod (Pod): Pod running the AWSCLI tools
+        Returns:
+            tuple: (bucket_name, bucket) — the bucket in EXCEEDING_QUOTA
+                mode, ready for further assertions.
         """
         bucket_name = create_unique_resource_name(
             resource_description="bucket", resource_type="quota"
@@ -91,31 +85,55 @@ class TestNooBaaBucketErrorStateMode:
         logger.info(f"Created bucket {bucket_name} with 2Gi quota")
 
         local_dir = f"/tmp/{bucket_name}"
-        try:
-            try:
-                write_random_test_objects_to_bucket(
-                    io_pod=awscli_pod,
-                    bucket_to_write=bucket_name,
-                    file_dir=local_dir,
-                    amount=5,
-                    bs="500M",
-                    mcg_obj=mcg_obj,
-                )
-            except CommandFailed:
-                logger.warning("Some uploads failed as expected when exceeding quota")
-            logger.info(
-                f"Uploaded data to bucket {bucket_name} "
-                f"(quota 2Gi) to trigger EXCEEDING_QUOTA"
-            )
 
-            wait_for_bucket_mode(mcg_obj, bucket_name, "EXCEEDING_QUOTA")
-        finally:
+        def finalizer():
             awscli_pod.exec_cmd_on_pod(f"rm -rf {local_dir}", out_yaml_format=False)
             try:
                 rm_object_recursive(awscli_pod, bucket_name, mcg_obj)
             except CommandFailed:
                 logger.warning(f"Cleanup of bucket {bucket_name} objects failed")
             bucket.delete()
+
+        request.addfinalizer(finalizer)
+
+        try:
+            write_random_test_objects_to_bucket(
+                io_pod=awscli_pod,
+                bucket_to_write=bucket_name,
+                file_dir=local_dir,
+                amount=5,
+                bs="500M",
+                mcg_obj=mcg_obj,
+            )
+        except CommandFailed:
+            logger.warning("Some uploads failed as expected when exceeding quota")
+        logger.info(
+            f"Uploaded data to bucket {bucket_name} "
+            f"(quota 2Gi) to trigger EXCEEDING_QUOTA"
+        )
+
+        wait_for_bucket_mode(mcg_obj, bucket_name, "EXCEEDING_QUOTA")
+        return bucket_name, bucket
+
+    # ------------------------------------------------------------------
+    # Quota error mode tests (EXCEEDING_QUOTA)
+    # ------------------------------------------------------------------
+
+    # TODO: Replace with actual Polarion ID
+    # @polarion_id("OCS-XXXXX")
+    def test_data_bucket_quota_error_mode(self, quota_exceeded_bucket):
+        """
+        Trigger a quota-related bucket mode on a data bucket and verify
+        that the bucket enters EXCEEDING_QUOTA mode.
+
+        The quota_exceeded_bucket fixture creates a 2Gi-quota bucket,
+        uploads ~2.5GB to exceed it, and verifies the bucket reaches
+        EXCEEDING_QUOTA mode. Cleanup is handled by the fixture.
+
+        Args:
+            quota_exceeded_bucket (tuple): (bucket_name, bucket) already
+                in EXCEEDING_QUOTA mode
+        """
 
     # ------------------------------------------------------------------
     # Resource error mode tests (NOT_ENOUGH_HEALTHY_RESOURCES)
@@ -391,91 +409,59 @@ class TestNooBaaBucketErrorStateMode:
 
     # TODO: Replace with actual Polarion ID
     # @polarion_id("OCS-XXXXX")
-    def test_bucket_error_state_alert(self, mcg_obj, awscli_pod, threading_lock):
+    def test_bucket_error_state_alert(self, quota_exceeded_bucket, threading_lock):
         """
         Verify that the NooBaaBucketErrorState Prometheus alert fires
         with the correct bucket_mode label when a bucket enters an
         error state.
 
-        Uses a quota-exceeded scenario (fastest to trigger) and waits
-        for the alert to fire after 5+ minutes.
+        Uses quota_exceeded_bucket fixture (fastest to trigger) and
+        waits for the alert to fire after 5+ minutes. Cleanup is
+        handled by the fixture.
 
         Steps:
-            1. Create a data bucket with a 2Gi quota
-            2. Upload ~2.5GB to exceed the quota
-            3. Verify bucket enters EXCEEDING_QUOTA mode
-            4. Wait for NooBaaBucketErrorState alert to fire (~5 min)
-            5. Filter alerts by bucket_name and verify
+            1. Receive a bucket already in EXCEEDING_QUOTA mode
+            2. Wait for NooBaaBucketErrorState alert to fire (~5 min)
+            3. Filter alerts by bucket_name and verify
                bucket_mode=EXCEEDING_QUOTA
-            6. Clean up (tmp files, bucket objects, bucket)
 
         Args:
-            mcg_obj (MCG): MCG object with S3 connection credentials
-            awscli_pod (Pod): Pod running the AWSCLI tools
+            quota_exceeded_bucket (tuple): (bucket_name, bucket) already
+                in EXCEEDING_QUOTA mode
             threading_lock: Threading lock for Prometheus API
         """
-        bucket_name = create_unique_resource_name(
-            resource_description="bucket", resource_type="alert-quota"
+        bucket_name, _ = quota_exceeded_bucket
+
+        logger.info(
+            f"Bucket {bucket_name} is in EXCEEDING_QUOTA mode, "
+            f"waiting for Prometheus alert to fire (5+ minutes)"
         )
-        bucket = MCGCLIBucket(bucket_name, mcg=mcg_obj, quota="2Gi")
-        logger.info(f"Created bucket {bucket_name} with 2Gi quota")
 
-        local_dir = f"/tmp/{bucket_name}"
-        try:
-            try:
-                write_random_test_objects_to_bucket(
-                    io_pod=awscli_pod,
-                    bucket_to_write=bucket_name,
-                    file_dir=local_dir,
-                    amount=5,
-                    bs="500M",
-                    mcg_obj=mcg_obj,
-                )
-            except CommandFailed:
-                logger.warning("Some uploads failed as expected when exceeding quota")
-            logger.info(
-                f"Uploaded data to bucket {bucket_name} "
-                f"(quota 2Gi) to trigger EXCEEDING_QUOTA"
-            )
+        prometheus_api = PrometheusAPI(threading_lock=threading_lock)
+        alert_name = "NooBaaBucketErrorState"
+        alerts = wait_for_alert_firing(
+            api=prometheus_api,
+            alert_name=alert_name,
+            timeout=900,
+            expected_message_substr="EXCEEDING_QUOTA",
+        )
 
-            wait_for_bucket_mode(mcg_obj, bucket_name, "EXCEEDING_QUOTA")
-            logger.info(
-                f"Bucket {bucket_name} is in EXCEEDING_QUOTA mode, "
-                f"waiting for Prometheus alert to fire (5+ minutes)"
-            )
-
-            prometheus_api = PrometheusAPI(threading_lock=threading_lock)
-            alert_name = "NooBaaBucketErrorState"
-            alerts = wait_for_alert_firing(
-                api=prometheus_api,
-                alert_name=alert_name,
-                timeout=900,
-                expected_message_substr="EXCEEDING_QUOTA",
-            )
-
-            matching_alert = next(
-                (
-                    alert
-                    for alert in alerts
-                    if alert.get("labels", {}).get("bucket_name") == bucket_name
-                    and alert.get("labels", {}).get("bucket_mode") == "EXCEEDING_QUOTA"
-                ),
-                None,
-            )
-            assert matching_alert, (
-                f"No '{alert_name}' firing instance found for "
-                f"bucket_name={bucket_name} with bucket_mode=EXCEEDING_QUOTA"
-            )
-            alert_labels = matching_alert["labels"]
-            logger.info(
-                f"Alert {alert_name} verified: "
-                f"bucket_name={alert_labels.get('bucket_name')}, "
-                f"bucket_mode={alert_labels.get('bucket_mode')}"
-            )
-        finally:
-            awscli_pod.exec_cmd_on_pod(f"rm -rf {local_dir}", out_yaml_format=False)
-            try:
-                rm_object_recursive(awscli_pod, bucket_name, mcg_obj)
-            except CommandFailed:
-                logger.warning(f"Cleanup of bucket {bucket_name} objects failed")
-            bucket.delete()
+        matching_alert = next(
+            (
+                alert
+                for alert in alerts
+                if alert.get("labels", {}).get("bucket_name") == bucket_name
+                and alert.get("labels", {}).get("bucket_mode") == "EXCEEDING_QUOTA"
+            ),
+            None,
+        )
+        assert matching_alert, (
+            f"No '{alert_name}' firing instance found for "
+            f"bucket_name={bucket_name} with bucket_mode=EXCEEDING_QUOTA"
+        )
+        alert_labels = matching_alert["labels"]
+        logger.info(
+            f"Alert {alert_name} verified: "
+            f"bucket_name={alert_labels.get('bucket_name')}, "
+            f"bucket_mode={alert_labels.get('bucket_mode')}"
+        )

--- a/tests/functional/object/mcg/test_noobaa_bucket_error_state_mode.py
+++ b/tests/functional/object/mcg/test_noobaa_bucket_error_state_mode.py
@@ -1,0 +1,462 @@
+import logging
+
+from ocs_ci.framework.pytest_customization.marks import (
+    post_upgrade,
+    red_squad,
+    skipif_ocs_version,
+    skipif_mcg_only,
+)
+from ocs_ci.framework.testlib import (
+    runs_on_provider,
+    skipif_aws_creds_are_missing,
+    skipif_disconnected_cluster,
+    skipif_managed_service,
+    tier2,
+    mcg,
+)
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.bucket_utils import (
+    copy_objects,
+    get_bucket_mode,
+    rm_object_recursive,
+    wait_for_bucket_mode,
+    write_random_test_objects_to_bucket,
+)
+from ocs_ci.ocs.exceptions import CommandFailed
+from ocs_ci.ocs.resources.objectbucket import MCGCLIBucket
+from ocs_ci.ocs.resources.pod import get_noobaa_pvpool_pods
+from ocs_ci.helpers.helpers import create_unique_resource_name
+from ocs_ci.utility.prometheus import PrometheusAPI, wait_for_alert_firing
+
+logger = logging.getLogger(__name__)
+
+
+@mcg
+@red_squad
+@tier2
+@post_upgrade
+@runs_on_provider
+@skipif_disconnected_cluster
+@skipif_ocs_version("<4.22")
+class TestNooBaaBucketErrorStateMode:
+    """
+    Tests for RHSTOR-7732: verify that NooBaa buckets enter the
+    expected error modes (bucket_mode) when specific failure
+    conditions are triggered.
+
+    Each test triggers an error condition on a bucket, then verifies
+    via NooBaa's get_bucket_info that the bucket enters the expected
+    error mode.
+
+    Covers three error categories:
+    - Quota-related (data buckets): EXCEEDING_QUOTA
+    - Resource-related (data and namespace buckets):
+      NOT_ENOUGH_HEALTHY_RESOURCES
+    - Capacity-related (data buckets): capacity exhaustion modes
+
+    Also verifies that the NooBaaBucketErrorState Prometheus alert
+    fires with the correct bucket_mode label.
+
+    Note: Namespace buckets are only tested for resource errors,
+    as they act as proxies and do not enforce quota or track
+    capacity internally.
+    """
+
+    # ------------------------------------------------------------------
+    # Quota error mode tests (EXCEEDING_QUOTA)
+    # ------------------------------------------------------------------
+
+    # TODO: Replace with actual Polarion ID
+    # @polarion_id("OCS-XXXXX")
+    def test_data_bucket_quota_error_mode(self, mcg_obj, awscli_pod):
+        """
+        Trigger a quota-related bucket mode on a data bucket and verify
+        that the bucket enters EXCEEDING_QUOTA mode.
+
+        Steps:
+            1. Create a data bucket with a 2Gi quota
+            2. Upload ~2.5GB to exceed the quota
+            3. Wait for bucket mode to propagate
+            4. Verify bucket mode is EXCEEDING_QUOTA via NooBaa
+            5. Clean up
+
+        Args:
+            mcg_obj (MCG): MCG object with S3 connection credentials
+            awscli_pod (Pod): Pod running the AWSCLI tools
+        """
+        bucket_name = create_unique_resource_name(
+            resource_description="bucket", resource_type="quota"
+        )
+        bucket = MCGCLIBucket(bucket_name, mcg=mcg_obj, quota="2Gi")
+        logger.info(f"Created bucket {bucket_name} with 2Gi quota")
+
+        try:
+            try:
+                write_random_test_objects_to_bucket(
+                    io_pod=awscli_pod,
+                    bucket_to_write=bucket_name,
+                    file_dir=f"/tmp/{bucket_name}",
+                    amount=5,
+                    bs="500M",
+                    mcg_obj=mcg_obj,
+                )
+            except CommandFailed:
+                logger.warning("Some uploads failed as expected when exceeding quota")
+            logger.info(
+                f"Uploaded data to bucket {bucket_name} "
+                f"(quota 2Gi) to trigger EXCEEDING_QUOTA"
+            )
+
+            wait_for_bucket_mode(mcg_obj, bucket_name, "EXCEEDING_QUOTA")
+        finally:
+            try:
+                rm_object_recursive(awscli_pod, bucket_name, mcg_obj)
+            except CommandFailed:
+                logger.warning(f"Cleanup of bucket {bucket_name} objects failed")
+            bucket.delete()
+
+    # ------------------------------------------------------------------
+    # Resource error mode tests (NOT_ENOUGH_HEALTHY_RESOURCES)
+    # ------------------------------------------------------------------
+
+    @skipif_mcg_only
+    # TODO: Replace with actual Polarion ID
+    # @polarion_id("OCS-XXXXX")
+    def test_data_bucket_resource_error_mode(self, mcg_obj, awscli_pod, bucket_factory):
+        """
+        Trigger a resource-related bucket mode on a data bucket and
+        verify the bucket enters NOT_ENOUGH_HEALTHY_RESOURCES mode.
+
+        Uses a PV pool backing store and force-deletes its pool pod
+        to simulate a resource failure.
+
+        Steps:
+            1. Create a data bucket with a PV pool backing store (17Gi)
+            2. Upload data so NooBaa tracks objects against the store
+            3. Force-delete the PV pool pod to trigger resource error
+            4. Wait for bucket to detect the resource error
+            5. Verify bucket mode is NOT_ENOUGH_HEALTHY_RESOURCES
+            6. Clean up
+
+        Args:
+            mcg_obj (MCG): MCG object with S3 connection credentials
+            awscli_pod (Pod): Pod running the AWSCLI tools
+            bucket_factory (func): Factory for creating MCG buckets
+        """
+        bucketclass_dict = {
+            "interface": "OC",
+            "backingstore_dict": {"pv": [(1, 17, constants.DEFAULT_STORAGECLASS_RBD)]},
+        }
+        bucket = bucket_factory(
+            amount=1,
+            interface=bucketclass_dict["interface"],
+            bucketclass=bucketclass_dict,
+        )[0]
+        backingstore = bucket.bucketclass.backingstores[0]
+
+        logger.info(
+            f"Created data bucket {bucket.name} with "
+            f"PV pool backing store {backingstore.name}"
+        )
+
+        write_random_test_objects_to_bucket(
+            io_pod=awscli_pod,
+            bucket_to_write=bucket.name,
+            file_dir=f"/tmp/{bucket.name}",
+            amount=2,
+            bs="50M",
+            mcg_obj=mcg_obj,
+        )
+        logger.info(
+            f"Uploaded ~100MB to bucket {bucket.name} "
+            f"so NooBaa tracks objects against the backing store"
+        )
+
+        pool_pods = get_noobaa_pvpool_pods(backingstore.name)
+        assert pool_pods, f"No pool pods found for backing store {backingstore.name}"
+        for pod in pool_pods:
+            logger.info(
+                f"Deleting pool pod {pod.name} of backing store "
+                f"{backingstore.name} to trigger resource error"
+            )
+            pod.delete(force=True)
+
+        wait_for_bucket_mode(mcg_obj, bucket.name, "NOT_ENOUGH_HEALTHY_RESOURCES")
+
+    @skipif_managed_service
+    @skipif_aws_creds_are_missing
+    # TODO: Replace with actual Polarion ID
+    # @polarion_id("OCS-XXXXX")
+    def test_ns_bucket_resource_error_mode(
+        self,
+        mcg_obj,
+        awscli_pod,
+        bucket_factory,
+        namespace_store_factory,
+        cld_mgr,
+    ):
+        """
+        Trigger a resource-related bucket mode on a namespace bucket
+        and verify the bucket enters NOT_ENOUGH_HEALTHY_RESOURCES mode.
+
+        Steps:
+            1. Create 2 namespace stores backed by AWS target buckets
+            2. Create a namespace bucket using Multi policy
+            3. Upload data so NooBaa tracks objects against the stores
+            4. Delete the target bucket of one namespace store
+            5. Wait for bucket to detect the resource error
+            6. Verify bucket mode is NOT_ENOUGH_HEALTHY_RESOURCES
+            7. Clean up
+
+        Args:
+            mcg_obj (MCG): MCG object with S3 connection credentials
+            awscli_pod (Pod): Pod running the AWSCLI tools
+            bucket_factory (func): Factory for creating MCG buckets
+            namespace_store_factory (func): Factory for creating namespace stores
+            cld_mgr (CloudManager): Cloud manager for cloud operations
+        """
+        nss_tup = ("oc", {"aws": [(2, "us-east-2")]})
+        ns_stores = namespace_store_factory(*nss_tup)
+
+        bucketclass_dict = {
+            "interface": "OC",
+            "namespace_policy_dict": {
+                "type": "Multi",
+                "namespacestores": ns_stores,
+            },
+        }
+        ns_bucket = bucket_factory(
+            amount=1,
+            interface=bucketclass_dict["interface"],
+            bucketclass=bucketclass_dict,
+        )[0]
+
+        logger.info(f"Created namespace stores: {[ns.name for ns in ns_stores]}")
+        logger.info(f"Created namespace bucket {ns_bucket.name} with Multi policy")
+
+        write_random_test_objects_to_bucket(
+            io_pod=awscli_pod,
+            bucket_to_write=ns_bucket.name,
+            file_dir=f"/tmp/{ns_bucket.name}",
+            amount=2,
+            bs="50M",
+            mcg_obj=mcg_obj,
+        )
+        logger.info(
+            f"Uploaded ~100MB to namespace bucket {ns_bucket.name} "
+            f"so NooBaa tracks objects against the namespace stores"
+        )
+
+        target_uls_name = ns_stores[0].uls_name
+        logger.info(
+            f"Deleting target bucket {target_uls_name} of "
+            f"namespace store {ns_stores[0].name}"
+        )
+        cld_mgr.aws_client.delete_uls(target_uls_name)
+
+        wait_for_bucket_mode(mcg_obj, ns_bucket.name, "NOT_ENOUGH_HEALTHY_RESOURCES")
+
+    # ------------------------------------------------------------------
+    # Capacity error mode tests
+    # ------------------------------------------------------------------
+
+    @skipif_mcg_only
+    # TODO: Replace with actual Polarion ID
+    # @polarion_id("OCS-XXXXX")
+    def test_data_bucket_capacity_error_mode(self, mcg_obj, awscli_pod, bucket_factory):
+        """
+        Gradually fill a data bucket's PV pool backing store and track
+        bucket mode transitions through capacity error states.
+
+        Uploads data in 4GB increments, checking the bucket mode after
+        each upload to capture intermediate modes (e.g. LOW_CAPACITY,
+        NO_CAPACITY) before the final NOT_ENOUGH_HEALTHY_RESOURCES.
+
+        Steps:
+            1. Create a data bucket backed by a small PV pool (17Gi)
+            2. Upload data in 4GB increments, checking mode after each
+            3. Log all observed mode transitions
+            4. Verify bucket reaches a capacity error mode
+            5. Clean up
+
+        Args:
+            mcg_obj (MCG): MCG object with S3 connection credentials
+            awscli_pod (Pod): Pod running the AWSCLI tools
+            bucket_factory (func): Factory for creating MCG buckets
+        """
+        capacity_error_modes = {
+            "LOW_CAPACITY",
+            "TIER_LOW_CAPACITY",
+            "NO_CAPACITY",
+            "TIER_NO_CAPACITY",
+            "NOT_ENOUGH_HEALTHY_RESOURCES",
+            "TIER_NOT_ENOUGH_HEALTHY_RESOURCES",
+            "NOT_ENOUGH_RESOURCES",
+            "TIER_NOT_ENOUGH_RESOURCES",
+            "NO_RESOURCES",
+        }
+
+        bucketclass_dict = {
+            "interface": "OC",
+            "backingstore_dict": {"pv": [(1, 17, constants.DEFAULT_STORAGECLASS_RBD)]},
+        }
+        bucket = bucket_factory(
+            amount=1,
+            interface=bucketclass_dict["interface"],
+            bucketclass=bucketclass_dict,
+        )[0]
+        backingstore = bucket.bucketclass.backingstores[0]
+
+        logger.info(
+            f"Created data bucket {bucket.name} with "
+            f"17Gi PV pool backing store {backingstore.name}"
+        )
+
+        observed_modes = []
+        file_num = 0
+        final_mode = None
+
+        awscli_pod.exec_cmd_on_pod("dd if=/dev/zero of=/tmp/testfile bs=1M count=4000")
+        logger.info("Created 4GB test file for gradual upload")
+
+        for chunk in range(1, 7):
+            file_num += 1
+            logger.info(
+                f"Uploading chunk {chunk}/6 (~4GB) to bucket {bucket.name} "
+                f"(total so far: ~{chunk * 4}GB, PV pool: 17Gi)"
+            )
+            try:
+                copy_objects(
+                    awscli_pod,
+                    "/tmp/testfile",
+                    f"s3://{bucket.name}/testfile{file_num}",
+                    s3_obj=mcg_obj,
+                )
+            except CommandFailed:
+                logger.warning(
+                    f"Upload of chunk {chunk} failed "
+                    f"(expected when exceeding capacity)"
+                )
+
+            mode = get_bucket_mode(mcg_obj, bucket.name)
+            logger.info(
+                f"After chunk {chunk}: bucket mode = {mode} "
+                f"(uploaded ~{chunk * 4}GB / 17Gi)"
+            )
+
+            if mode != "OPTIMAL" and mode not in observed_modes:
+                observed_modes.append(mode)
+                logger.info(f"New non-OPTIMAL mode observed: {mode}")
+
+            if mode in capacity_error_modes:
+                final_mode = mode
+                logger.info(f"Bucket {bucket.name} entered capacity error mode: {mode}")
+                break
+
+        if not final_mode:
+            logger.info(
+                "Bucket still OPTIMAL after all uploads, "
+                "waiting for mode to propagate"
+            )
+            final_mode = wait_for_bucket_mode(
+                mcg_obj, bucket.name, "NOT_ENOUGH_HEALTHY_RESOURCES"
+            )
+            if final_mode and final_mode not in observed_modes:
+                observed_modes.append(final_mode)
+
+        logger.info(
+            f"Capacity test complete. "
+            f"Observed mode transitions: {observed_modes}. "
+            f"Final mode: {final_mode}"
+        )
+        assert (
+            final_mode in capacity_error_modes
+        ), f"Expected one of {capacity_error_modes}, got {final_mode}"
+
+    # ------------------------------------------------------------------
+    # Alert verification test
+    # ------------------------------------------------------------------
+
+    # TODO: Replace with actual Polarion ID
+    # @polarion_id("OCS-XXXXX")
+    def test_bucket_error_state_alert(self, mcg_obj, awscli_pod, threading_lock):
+        """
+        Verify that the NooBaaBucketErrorState Prometheus alert fires
+        with the correct bucket_mode label when a bucket enters an
+        error state.
+
+        Uses a quota-exceeded scenario (fastest to trigger) and waits
+        for the alert to fire after 5+ minutes.
+
+        Steps:
+            1. Create a data bucket with a 2Gi quota
+            2. Upload ~2.5GB to exceed the quota
+            3. Verify bucket enters EXCEEDING_QUOTA mode
+            4. Wait for NooBaaBucketErrorState alert to fire (~5 min)
+            5. Verify alert contains bucket_mode=EXCEEDING_QUOTA
+            6. Clean up
+
+        Args:
+            mcg_obj (MCG): MCG object with S3 connection credentials
+            awscli_pod (Pod): Pod running the AWSCLI tools
+            threading_lock: Threading lock for Prometheus API
+        """
+        bucket_name = create_unique_resource_name(
+            resource_description="bucket", resource_type="alert-quota"
+        )
+        bucket = MCGCLIBucket(bucket_name, mcg=mcg_obj, quota="2Gi")
+        logger.info(f"Created bucket {bucket_name} with 2Gi quota")
+
+        try:
+            try:
+                write_random_test_objects_to_bucket(
+                    io_pod=awscli_pod,
+                    bucket_to_write=bucket_name,
+                    file_dir=f"/tmp/{bucket_name}",
+                    amount=5,
+                    bs="500M",
+                    mcg_obj=mcg_obj,
+                )
+            except CommandFailed:
+                logger.warning("Some uploads failed as expected when exceeding quota")
+            logger.info(
+                f"Uploaded data to bucket {bucket_name} "
+                f"(quota 2Gi) to trigger EXCEEDING_QUOTA"
+            )
+
+            wait_for_bucket_mode(mcg_obj, bucket_name, "EXCEEDING_QUOTA")
+            logger.info(
+                f"Bucket {bucket_name} is in EXCEEDING_QUOTA mode, "
+                f"waiting for Prometheus alert to fire (5+ minutes)"
+            )
+
+            prometheus_api = PrometheusAPI(threading_lock=threading_lock)
+            alert_name = "NooBaaBucketErrorState"
+            alerts = wait_for_alert_firing(
+                api=prometheus_api,
+                alert_name=alert_name,
+                timeout=600,
+                expected_message_substr="EXCEEDING_QUOTA",
+            )
+
+            alert_labels = alerts[0]["labels"]
+            logger.info(f"Alert {alert_name} fired with labels: {alert_labels}")
+            assert alert_labels.get("bucket_mode") == "EXCEEDING_QUOTA", (
+                f"Expected bucket_mode=EXCEEDING_QUOTA in alert labels, "
+                f"got bucket_mode={alert_labels.get('bucket_mode')}"
+            )
+            assert alert_labels.get("bucket_name") == bucket_name, (
+                f"Expected bucket_name={bucket_name} in alert labels, "
+                f"got bucket_name={alert_labels.get('bucket_name')}"
+            )
+            logger.info(
+                f"Alert {alert_name} verified: "
+                f"bucket_name={alert_labels.get('bucket_name')}, "
+                f"bucket_mode={alert_labels.get('bucket_mode')}"
+            )
+        finally:
+            try:
+                rm_object_recursive(awscli_pod, bucket_name, mcg_obj)
+            except CommandFailed:
+                logger.warning(f"Cleanup of bucket {bucket_name} objects failed")
+            bucket.delete()

--- a/tests/functional/object/mcg/test_noobaa_bucket_error_state_mode.py
+++ b/tests/functional/object/mcg/test_noobaa_bucket_error_state_mode.py
@@ -203,7 +203,9 @@ class TestNooBaaBucketErrorStateMode:
             )
             pod.delete(force=True)
 
-        wait_for_bucket_mode(mcg_obj, bucket.name, "NOT_ENOUGH_HEALTHY_RESOURCES")
+        wait_for_bucket_mode(
+            mcg_obj, bucket.name, "NOT_ENOUGH_HEALTHY_RESOURCES", timeout=900
+        )
 
     @skipif_managed_service
     @skipif_aws_creds_are_missing


### PR DESCRIPTION
Note : this is the same test that was added in https://github.com/red-hat-storage/ocs-ci/pull/15287 just create on a clean updated master. 

Summary

Add 5 tests verifying that NooBaa data buckets and namespace buckets enter the expected error modes (bucket_mode) when specific failure conditions are triggered, and that the NooBaaBucketErrorState Prometheus alert fires with the correct bucket_mode label.

Related epic: [RHSTOR-7732](https://redhat.atlassian.net/browse/RHSTOR-7732)

Background

The NooBaaBucketErrorState alert was improved to include bucket_mode in its message and description, making the alert actionable by indicating the reason for the error. These tests verify that buckets correctly transition to the expected error modes when quota, resource, or capacity failures occur, and that the Prometheus alert propagates the bucket_mode correctly.

Test Cases:

test_data_bucket_quota_error_mode (Data Bucket) — EXCEEDING_QUOTA
Flow:

Create a data bucket with a 2Gi quota
Upload ~2.5GB (5 files x 500MB) to exceed the quota
Poll bucket mode via NooBaa's get_bucket_info
Verify bucket enters EXCEEDING_QUOTA mode
How to trigger: Uploading data beyond the bucket's configured quota causes NooBaa to flag the bucket as EXCEEDING_QUOTA.

test_data_bucket_resource_error_mode (Data Bucket) — NOT_ENOUGH_HEALTHY_RESOURCES
Flow:

Create a data bucket with a PV pool backing store (17Gi)
Upload ~100MB so NooBaa tracks objects against the backing store
Force-delete the PV pool pod to make the resource unavailable
Poll bucket mode via NooBaa's get_bucket_info
Verify bucket enters NOT_ENOUGH_HEALTHY_RESOURCES mode
How to trigger: Killing the PV pool pod removes the backing store's agent. NooBaa detects the missing pool node and marks the bucket as NOT_ENOUGH_HEALTHY_RESOURCES.

test_ns_bucket_resource_error_mode (Namespace Bucket) — NOT_ENOUGH_HEALTHY_RESOURCES
Flow:

Create 2 AWS-backed namespace stores
Create a namespace bucket with Multi policy using both stores
Upload ~100MB so NooBaa tracks objects against the namespace stores
Delete the underlying AWS target bucket of one namespace store
Poll bucket mode via NooBaa's get_bucket_info
Verify bucket enters NOT_ENOUGH_HEALTHY_RESOURCES mode
How to trigger: Deleting the AWS target bucket makes one namespace store unavailable. NooBaa detects the missing resource and marks the bucket as NOT_ENOUGH_HEALTHY_RESOURCES.

test_data_bucket_capacity_error_mode (Data Bucket) — NOT_ENOUGH_HEALTHY_RESOURCES
Flow:

Create a data bucket with a PV pool backing store (17Gi)
Upload data gradually in 4GB chunks, checking bucket mode after each chunk
Log all observed mode transitions (to capture any intermediate modes like LOW_CAPACITY or NO_CAPACITY)
Verify bucket enters a capacity error mode (any of: LOW_CAPACITY, NO_CAPACITY, NOT_ENOUGH_HEALTHY_RESOURCES, etc.)
How to trigger: Filling the PV pool beyond its capacity exhausts the storage. NooBaa detects the backing store has no free space and marks the bucket as NOT_ENOUGH_HEALTHY_RESOURCES.

test_bucket_error_state_alert — Prometheus Alert Verification
Flow:

Create a data bucket with a 2Gi quota
Upload ~2.5GB to exceed the quota
Wait for bucket to enter EXCEEDING_QUOTA mode
Wait for the NooBaaBucketErrorState Prometheus alert to fire (~5 min delay)
Verify the alert's labels contain bucket_mode=EXCEEDING_QUOTA and the correct bucket_name
Clean up
How to trigger: Uses the quota-exceeded scenario (fastest to trigger) and verifies that the improved alert propagates the bucket_mode into the Prometheus alert labels.

Note: Namespace bucket quota and capacity tests were intentionally excluded — NS buckets act as proxies and don't keep metadata internally, so quota is never enforced and capacity exhaustion cannot be triggered. Confirmed by Eran Tamir on [RHSTOR-7732](https://redhat.atlassian.net/browse/RHSTOR-7732).

Validation:

Each test verifies via NooBaa's get_bucket_info that the bucket enters the expected error mode after the failure condition is triggered. The alert test additionally validates the Prometheus alert labels. Full bucket info is logged before assertions to aid debugging if mode values change.

Markers:

https://github.com/tier2, @mcg, @red_squad, @runs_on_provider
@skipif_disconnected_cluster, @skipif_ocs_version("<4.22")
AWS-dependent tests additionally have @skipif_managed_service, @skipif_aws_creds_are_missing
PV pool tests additionally have @skipif_mcg_only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added helper utilities to read a bucket’s current operational mode (with safe default behavior) and to wait until it reaches an expected mode, including a “any non-OPTIMAL” option with tailored timeout assertions.
* **Tests**
  * Expanded functional coverage for NooBaa bucket error-state transitions: quota exhaustion, resource failures (data PV-backed and AWS-backed namespace), and capacity exhaustion.
  * Verifies the related Prometheus alert is emitted with matching `bucket_name` and `bucket_mode`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->