### PR TITLE
add test_external_systems_empty_state

### DIFF
--- a/ocs_ci/ocs/ui/base_ui.py
+++ b/ocs_ci/ocs/ui/base_ui.py
@@ -183,9 +183,6 @@ class BaseUI:
         self.attach_storage_loc = self.deep_get(
             locators_for_current_ocp_version(), "attach_storage"
         )
-        self.external_systems_loc = self.deep_get(
-            locators_for_current_ocp_version(), "external_systems"
-        )
         self._locator_fallback = None
 
     @property

--- a/ocs_ci/ocs/ui/base_ui.py
+++ b/ocs_ci/ocs/ui/base_ui.py
@@ -183,6 +183,9 @@ class BaseUI:
         self.attach_storage_loc = self.deep_get(
             locators_for_current_ocp_version(), "attach_storage"
         )
+        self.external_systems_loc = self.deep_get(
+            locators_for_current_ocp_version(), "external_systems"
+        )
         self._locator_fallback = None
 
     @property

--- a/ocs_ci/ocs/ui/page_objects/external_storage_systems.py
+++ b/ocs_ci/ocs/ui/page_objects/external_storage_systems.py
@@ -7,6 +7,7 @@ from ocs_ci.ocs.ui.page_objects.data_foundation_tabs_common import (
 from ocs_ci.ocs.ui.page_objects.resource_list import ResourceList
 from ocs_ci.ocs.ui.helpers_ui import format_locator
 from ocs_ci.ocs import ocp
+from selenium.common.exceptions import TimeoutException
 
 
 class ExternalSystems(ResourceList):
@@ -37,6 +38,70 @@ class ExternalSystems(ResourceList):
         logger.info(f"Navigate to External Storage Cluster {esc_name}")
         self.nav_to_resource_via_name(esc_name)
         return ExternalStorageCluster()
+
+    def get_page_title(self):
+        """
+        Get the page title text from the External Systems page.
+
+        Returns:
+            str: The page title text
+        """
+        logger.info("Getting External Systems page title")
+        return self.get_element_text(self.external_systems["page_title"])
+
+    def get_empty_state_elements(self):
+        """
+        Collect empty state element details when no external systems
+        are connected. Uses locators defined in views.py.
+
+        Returns:
+            dict: Keys:
+                - heading_text (str or None): Heading text, None if not found
+                - description_text (str or None): Description text, None if not found
+                - connect_button_enabled (bool): True if Connect button is visible and enabled
+                - explore_link_text (str or None): Explore link text, None if not found
+        """
+        logger.info("Collecting empty state element details")
+        info = {}
+
+        try:
+            heading = self.wait_for_element_to_be_visible(
+                self.external_systems["empty_state_heading"], timeout=10
+            )
+            info["heading_text"] = heading.text
+        except TimeoutException:
+            logger.warning("Empty state heading not found")
+            info["heading_text"] = None
+
+        try:
+            description = self.wait_for_element_to_be_visible(
+                self.external_systems["empty_state_description"], timeout=5
+            )
+            info["description_text"] = description.text
+        except TimeoutException:
+            logger.warning("Empty state description not found")
+            info["description_text"] = None
+
+        try:
+            connect_button = self.wait_for_element_to_be_visible(
+                self.external_systems["connect_external_system_button"], timeout=5
+            )
+            info["connect_button_enabled"] = connect_button.is_enabled()
+        except TimeoutException:
+            logger.warning("Connect external systems button not found")
+            info["connect_button_enabled"] = False
+
+        try:
+            explore_link = self.wait_for_element_to_be_visible(
+                self.external_systems["explore_external_systems_link"], timeout=5
+            )
+            info["explore_link_text"] = explore_link.text
+        except TimeoutException:
+            logger.warning("Explore external systems link not found")
+            info["explore_link_text"] = None
+
+        logger.info(f"Empty state elements collected: {info}")
+        return info
 
     def connect_external_system(self):
         """

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -954,26 +954,6 @@ storage_clients = {
     "close_token_modal": ("//button[@aria-label='Close']", By.XPATH),
 }
 
-external_systems = {
-    "page_title": ("span[data-test-id='resource-title']", By.CSS_SELECTOR),
-    "empty_state_heading": (
-        "//h4[normalize-space()='No external systems connected']",
-        By.XPATH,
-    ),
-    "empty_state_description": (
-        "//div[contains(text(), 'Start configuring your storage platform')]",
-        By.XPATH,
-    ),
-    "connect_external_system_button": (
-        "//button[normalize-space()='Connect external systems']",
-        By.XPATH,
-    ),
-    "explore_external_systems_link": (
-        "//a[normalize-space()='Explore all supported external systems']",
-        By.XPATH,
-    ),
-}
-
 page_nav = {
     "page_navigator_sidebar": ("page-sidebar", By.ID),
     "Home": ("//button[text()='Home']", By.XPATH),
@@ -3395,6 +3375,23 @@ external_systems = {
     "breadcrumb-link": (
         "a[data-test-id='breadcrumb-link-0']",
         By.CSS_SELECTOR,
+    ),
+    "page_title": ("span[data-test-id='resource-title']", By.CSS_SELECTOR),
+    "empty_state_heading": (
+        "//h4[normalize-space()='No external systems connected']",
+        By.XPATH,
+    ),
+    "empty_state_description": (
+        "//div[contains(text(), 'Start configuring your storage platform')]",
+        By.XPATH,
+    ),
+    "connect_external_system_button": (
+        "//button[normalize-space()='Connect external systems']",
+        By.XPATH,
+    ),
+    "explore_external_systems_link": (
+        "//a[normalize-space()='Explore all supported external systems']",
+        By.XPATH,
     ),
 }
 locators = {

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -954,6 +954,26 @@ storage_clients = {
     "close_token_modal": ("//button[@aria-label='Close']", By.XPATH),
 }
 
+external_systems = {
+    "page_title": ("span[data-test-id='resource-title']", By.CSS_SELECTOR),
+    "empty_state_heading": (
+        "//h4[normalize-space()='No external systems connected']",
+        By.XPATH,
+    ),
+    "empty_state_description": (
+        "//div[contains(text(), 'Start configuring your storage platform')]",
+        By.XPATH,
+    ),
+    "connect_external_system_button": (
+        "//button[normalize-space()='Connect external systems']",
+        By.XPATH,
+    ),
+    "explore_external_systems_link": (
+        "//a[normalize-space()='Explore all supported external systems']",
+        By.XPATH,
+    ),
+}
+
 page_nav = {
     "page_navigator_sidebar": ("page-sidebar", By.ID),
     "Home": ("//button[text()='Home']", By.XPATH),

--- a/tests/cross_functional/ui/test_validation_ui.py
+++ b/tests/cross_functional/ui/test_validation_ui.py
@@ -168,21 +168,28 @@ class TestUserInterfaceValidation(object):
         ), f"Expected page title 'External systems', got '{page_title}'"
         empty_state = external_systems.get_empty_state_elements()
         logger.info("Verify empty state message 'No external systems connected'")
-        assert empty_state[
-            "heading_text"
-        ], "Empty state heading 'No external systems connected' not found"
+        assert empty_state["heading_text"] == "No external systems connected", (
+            f"Expected heading 'No external systems connected', "
+            f"got '{empty_state['heading_text']}'"
+        )
         logger.info("Verify description text")
-        assert empty_state[
-            "description_text"
-        ], "Empty state description about configuring storage platform not found"
+        assert empty_state["description_text"] is not None and (
+            "Start configuring your storage platform" in empty_state["description_text"]
+        ), (
+            f"Expected description containing 'Start configuring your storage platform', "
+            f"got '{empty_state['description_text']}'"
+        )
         logger.info("Verify 'Connect external system' button is present")
         assert empty_state[
             "connect_button_enabled"
-        ], "'Connect external systems' button is not enabled"
+        ], "'Connect external systems' button is not visible or not enabled"
         logger.info("Verify 'Explore all supported external systems' link is present")
-        assert empty_state[
-            "explore_link_text"
-        ], "'Explore all supported external systems' link not found"
+        assert (
+            empty_state["explore_link_text"] == "Explore all supported external systems"
+        ), (
+            f"Expected link text 'Explore all supported external systems', "
+            f"got '{empty_state['explore_link_text']}'"
+        )
         logger.info(
             "External Systems empty state validated successfully — "
             "all expected elements are present"

--- a/tests/cross_functional/ui/test_validation_ui.py
+++ b/tests/cross_functional/ui/test_validation_ui.py
@@ -155,52 +155,34 @@ class TestUserInterfaceValidation(object):
         Steps:
         1. Navigate to Storage -> External systems
         2. Verify page title 'External systems'
-        3. Verify empty state message 'No external systems connected'
-        4. Verify description text about configuring storage platform
-        5. Verify 'Connect external system' button is present
-        6. Verify 'Explore all supported external systems' link is present
+        3. Verify empty state heading, description, Connect button, and Explore link
 
         """
         setup_ui_class_factory()
-
-        nav = PageNavigator()
-        external_systems = nav.nav_external_systems_page()
-
-        logger.info("Verify page loaded — waiting for page stability")
+        external_systems = PageNavigator().nav_external_systems_page()
         external_systems.page_has_loaded()
-
+        page_title = external_systems.get_page_title()
         logger.info("Verify page title 'External systems'")
-        page_title = external_systems.get_element_text(
-            external_systems.external_systems_loc["page_title"]
-        )
         assert (
             page_title == "External systems"
         ), f"Expected page title 'External systems', got '{page_title}'"
+        empty_state = external_systems.get_empty_state_elements()
         logger.info("Verify empty state message 'No external systems connected'")
-        assert external_systems.check_element_text(
-            expected_text="No external systems connected", element="h4"
-        ), "Empty state heading 'No external systems connected' not found"
-
+        assert empty_state[
+            "heading_text"
+        ], "Empty state heading 'No external systems connected' not found"
         logger.info("Verify description text")
-        assert external_systems.check_element_text(
-            expected_text="Start configuring your storage platform",
-        ), "Empty state description about configuring storage platform not found"
-
+        assert empty_state[
+            "description_text"
+        ], "Empty state description about configuring storage platform not found"
         logger.info("Verify 'Connect external system' button is present")
-        connect_button = external_systems.wait_for_element_to_be_visible(
-            external_systems.external_systems_loc["connect_external_system_button"],
-            timeout=10,
-        )
-        assert (
-            connect_button.is_displayed()
-        ), "'Connect external system' button is not visible"
-        assert (
-            connect_button.is_enabled()
-        ), "'Connect external system' button is not enabled"
+        assert empty_state[
+            "connect_button_enabled"
+        ], "'Connect external systems' button is not enabled"
         logger.info("Verify 'Explore all supported external systems' link is present")
-        assert external_systems.check_element_text(
-            expected_text="Explore all supported external systems", element="a"
-        ), "'Explore all supported external systems' link not found"
+        assert empty_state[
+            "explore_link_text"
+        ], "'Explore all supported external systems' link not found"
         logger.info(
             "External Systems empty state validated successfully — "
             "all expected elements are present"

--- a/tests/cross_functional/ui/test_validation_ui.py
+++ b/tests/cross_functional/ui/test_validation_ui.py
@@ -173,7 +173,10 @@ class TestUserInterfaceValidation(object):
             f"got '{empty_state['heading_text']}'"
         )
         logger.info("Verify description text")
-        assert empty_state["description_text"] is not None and (
+        assert (
+            empty_state["description_text"] is not None
+        ), "Empty state description not found"
+        assert (
             "Start configuring your storage platform" in empty_state["description_text"]
         ), (
             f"Expected description containing 'Start configuring your storage platform', "

--- a/tests/cross_functional/ui/test_validation_ui.py
+++ b/tests/cross_functional/ui/test_validation_ui.py
@@ -20,7 +20,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     runs_on_provider,
 )
 from ocs_ci.ocs.ui.validation_ui import ValidationUI
-
+from ocs_ci.ocs.ui.page_objects.page_navigator import PageNavigator
 
 logger = logging.getLogger(__name__)
 
@@ -141,3 +141,68 @@ class TestUserInterfaceValidation(object):
             "OCS operator is present in the installed operator tab, expected to see only ODF "
             "operator"
         )
+
+    @ui
+    @polarion_id("OCS-7681")
+    @runs_on_provider
+    @skipif_ocs_version("<4.20")
+    @skipif_mcg_only
+    def test_external_systems_empty_state(self, setup_ui_class_factory):
+        """
+        Verify that the External Systems page shows correct information
+        when no external system is connected.
+
+        Steps:
+        1. Navigate to Storage -> External systems
+        2. Verify page title 'External systems'
+        3. Verify empty state message 'No external systems connected'
+        4. Verify description text about configuring storage platform
+        5. Verify 'Connect external system' button is present
+        6. Verify 'Explore all supported external systems' link is present
+
+        """
+        setup_ui_class_factory()
+
+        nav = PageNavigator()
+        external_systems = nav.nav_external_systems_page()
+
+        logger.info("Verify page loaded — waiting for page stability")
+        external_systems.page_has_loaded()
+
+        logger.info("Verify page title 'External systems'")
+        page_title = external_systems.get_element_text(
+            external_systems.external_systems_loc["page_title"]
+        )
+        assert (
+            page_title == "External systems"
+        ), f"Expected page title 'External systems', got '{page_title}'"
+        logger.info("Verify empty state message 'No external systems connected'")
+        assert external_systems.check_element_text(
+            expected_text="No external systems connected", element="h4"
+        ), "Empty state heading 'No external systems connected' not found"
+
+        logger.info("Verify description text")
+        assert external_systems.check_element_text(
+            expected_text="Start configuring your storage platform",
+        ), "Empty state description about configuring storage platform not found"
+
+        logger.info("Verify 'Connect external system' button is present")
+        connect_button = external_systems.wait_for_element_to_be_visible(
+            external_systems.external_systems_loc["connect_external_system_button"],
+            timeout=10,
+        )
+        assert (
+            connect_button.is_displayed()
+        ), "'Connect external system' button is not visible"
+        assert (
+            connect_button.is_enabled()
+        ), "'Connect external system' button is not enabled"
+        logger.info("Verify 'Explore all supported external systems' link is present")
+        assert external_systems.check_element_text(
+            expected_text="Explore all supported external systems", element="a"
+        ), "'Explore all supported external systems' link not found"
+        logger.info(
+            "External Systems empty state validated successfully — "
+            "all expected elements are present"
+        )
+        external_systems.take_screenshot()


### PR DESCRIPTION
Added test case for backlog item [RHSTOR-7230](https://redhat.atlassian.net/browse/RHSTOR-7230): Verify that External Systems pages shows correct information when no external system is connected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a gated UI validation test for the External systems page empty state (including page title, empty-state heading/description, the “connect external system” action enabled state, and the “explore all supported external systems” link text).
  * The test navigates to the page, waits for it to load, and captures a screenshot for easier review when no external systems are connected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->