### PR TITLE
Wait for VM/DataVolume/PVC cleanup in vm clone teardown

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1077,7 +1077,9 @@ def ceph_pool_factory_fixture(request, replica=3, compression=None, pool_name=No
 
         for instance in instances:
             try:
+                log.info(f"Deleting CephBlockPool {instance.name}")
                 instance.delete(wait=False)
+                log.info(f"Delete request sent for CephBlockPool {instance.name}")
 
                 try:
                     radosns_obj = ocp.OCP(
@@ -1129,7 +1131,18 @@ def ceph_pool_factory_fixture(request, replica=3, compression=None, pool_name=No
                     raise
 
             try:
-                instance.ocp.wait_for_delete(instance.name)
+                log.info(f"Waiting for CephBlockPool {instance.name} to be deleted")
+                instance.ocp.wait_for_delete(
+                    resource_name=instance.name,
+                    timeout=300,
+                )
+                log.info(f"CephBlockPool {instance.name} deleted successfully")
+            except TimeoutError:
+                log.error(f"Timeout waiting for CephBlockPool {instance.name} deletion")
+                log.error(
+                    f"Describe output: {instance.ocp.describe(resource_name=instance.name)}"
+                )
+                raise
             except CommandFailed as wait_ex:
                 if "NotFound" in str(wait_ex) or skip_resource_not_found_error:
                     log.info(f"Resource {instance.name} already deleted or not found")


### PR DESCRIPTION
## Problem

test_vm_snap_of_clone intermittently fails during teardown with:

- Timeout waiting for CephBlockPool deletion
- PoolDeletionIsBlocked
- PoolNotEmpty

The cloned VM teardown deleted the VM and PVC without waiting for
resource cleanup to complete. For DataVolume-backed clones, the
DataVolume was not explicitly cleaned up.

## Fix

- Wait for cloned VM deletion.
- Delete and wait for DataVolume deletion when present.
- Delete and wait for PVC deletion.
- Skip storage cleanup if VM deletion times out.

This ensures storage resources are cleaned up before CephBlockPool
teardown begins and reduces the chance of PoolNotEmpty failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved reliability of Ceph block pool fixture teardown by making deletion more deterministic: the fixture now logs the delete request, explicitly waits for the pool’s resource deletion with a 300s timeout, and on timeout surfaces detailed pool diagnostics before re-raising the error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->