### PR TITLE
Apply OCS-CI logging guidelines to blue squad test cases

### DIFF
--- a/tests/functional/monitoring/libtest/test_workload_example.py
+++ b/tests/functional/monitoring/libtest/test_workload_example.py
@@ -36,21 +36,32 @@ def test_start_fio_job(
     Start a fio job performing IO load, check that it's running, and keep
     it running even after the test finishes.
     """
+    logger.info(f"Starting test: Start continuous fio workload in {TEST_NS}")
+
+    logger.test_step("Create dedicated project for continuous workload")
     # creating project directly to set it's name and prevent it's deletion
     project = ocp.OCP(kind="Project", namespace=TEST_NS)
     project.new_project(TEST_NS)
+    logger.info(f"Created project: {TEST_NS}")
 
+    logger.test_step("Configure fio workload parameters")
     # size of the volume for fio
     pvc_size = 10  # GiB
-
     # test uses cephfs based volume, could be either parametrized or we can
     # try to start more jobs
     storage_class_name = "ocs-storagecluster-cephfs"
+    logger.info(
+        f"PVC configuration: size={pvc_size}Gi, storage_class={storage_class_name}"
+    )
 
     # fio config file: random mixed read and write IO will be running for one
     # day (we expect that the other test will stop it), only 1/2 of the volume
     # is used, we don't need to utilize the PV 100%
     fio_size = int(pvc_size / 2)  # GiB
+    logger.info(
+        f"Fio workload size: {fio_size}G (50% of PVC), runtime: 24h, pattern: randrw"
+    )
+
     fio_conf = textwrap.dedent(
         f"""
         [readwrite]
@@ -64,26 +75,39 @@ def test_start_fio_job(
         runtime=24h
         """
     )
+    logger.debug(f"Fio configuration:\n{fio_conf}")
 
+    logger.test_step("Create Job configuration file")
     # put the dicts together into yaml file of the Job
     fio_configmap_dict["data"]["workload.fio"] = fio_conf
     fio_pvc_dict["spec"]["storageClassName"] = storage_class_name
     fio_pvc_dict["spec"]["resources"]["requests"]["storage"] = f"{pvc_size}Gi"
     fio_objs = [fio_pvc_dict, fio_configmap_dict, fio_job_dict]
     job_file = ObjectConfFile("fio_continuous", fio_objs, project, tmp_path)
+    logger.info("Job configuration created with PVC, ConfigMap, and Job objects")
 
+    logger.test_step("Deploy and start fio Job")
     # deploy the Job to the cluster and start it
     job_file.create()
+    logger.info("Fio Job deployed to cluster")
 
+    logger.test_step("Wait for pod to be running")
     # wait for a pod for the job to be deployed and running
     ocp_pod = ocp.OCP(kind="Pod", namespace=project.namespace)
+    logger.info(f"Waiting for pod in namespace {project.namespace} (timeout: 300s)")
+
     try:
         ocp_pod.wait_for_resource(
             resource_count=1, condition=constants.STATUS_RUNNING, timeout=300, sleep=30
         )
+        logger.info("Pod is running successfully")
     except TimeoutExpiredError:
-        logger.error("pod for fio job wasn't deployed properly")
+        logger.error(
+            "Pod for fio job wasn't deployed properly - timeout waiting for Running state"
+        )
         raise
+
+    logger.info("Test passed: Continuous fio workload started and running")
 
 
 @blue_squad
@@ -93,18 +117,34 @@ def test_stop_fio_job():
     """
     Check that the job is still running.
     """
+    logger.info(f"Starting test: Verify and stop continuous fio workload in {TEST_NS}")
+
+    logger.test_step("Verify fio pod is still running")
     # check that the pod of the job is still running
     ocp_pod = ocp.OCP(kind="Pod", namespace=TEST_NS)
+    logger.info(f"Checking for running pod in namespace {TEST_NS} (timeout: 300s)")
+
     try:
         ocp_pod.wait_for_resource(
             resource_count=1, condition=constants.STATUS_RUNNING, timeout=300, sleep=30
         )
+        logger.info("Pod is still running as expected")
     except TimeoutExpiredError:
-        logger.error("pod for fio job wasn't deployed properly")
+        logger.error(
+            f"Pod for fio job in {TEST_NS} is not running - workload may have stopped prematurely"
+        )
         raise
 
     # TODO: check the activity of the job during it's whole run could via
     # prometheus query (make sure it was really running)
+    logger.debug(
+        "TODO: Add Prometheus query validation to verify job was actively running"
+    )
 
+    logger.test_step("Delete project to stop workload")
     # TODO: delete the project properly
+    logger.info(f"Deleting project {TEST_NS} (timeout: 600s)")
     run_cmd(cmd=f"oc delete project/{TEST_NS}", timeout=600)
+    logger.info(f"Project {TEST_NS} deleted successfully")
+
+    logger.info("Test passed: Continuous fio workload verified and stopped")

--- a/tests/functional/monitoring/libtest/test_workload_fixture.py
+++ b/tests/functional/monitoring/libtest/test_workload_fixture.py
@@ -62,67 +62,140 @@ def test_workload_rbd(workload_storageutilization_50p_rbd, threading_lock):
     Note that this test is valid only on 3 osd cluster with all pools using
     3 way replication.
     """
+    logger.info(
+        "Starting test: Validate RBD workload utilization metrics via Prometheus"
+    )
+
+    logger.test_step("Initialize Prometheus API and retrieve workload period")
     prometheus = PrometheusAPI(threading_lock=threading_lock)
+    start_time = workload_storageutilization_50p_rbd["start"]
+    end_time = workload_storageutilization_50p_rbd["stop"]
+    logger.info(f"Workload period: start={start_time}, end={end_time}")
+
+    logger.test_step("Query Prometheus for OSD bytes used during workload")
     # Asking for values of `ceph_osd_stat_bytes_used` for every 15s in
     # when the workload fixture was utilizing 50% of the OCS storage.
     result_used = prometheus.query_range(
         query="ceph_osd_stat_bytes_used",
-        start=workload_storageutilization_50p_rbd["start"],
-        end=workload_storageutilization_50p_rbd["stop"],
+        start=start_time,
+        end=end_time,
         step=15,
     )
+    logger.info(f"OSD bytes used query returned {len(result_used)} time series")
+
+    logger.test_step("Query Prometheus for total OSD capacity")
     # This time, we are asking for total OCS capacity, in the same format
     # as in previous case (for each OSD).
     result_total = prometheus.query_range(
         query="ceph_osd_stat_bytes",
-        start=workload_storageutilization_50p_rbd["start"],
-        end=workload_storageutilization_50p_rbd["stop"],
+        start=start_time,
+        end=end_time,
         step=15,
     )
+    logger.info(f"OSD capacity query returned {len(result_total)} time series")
+
+    logger.test_step("Validate OSD capacity consistency")
     # Check test assumption that ceph_osd_stat_bytes hasn't changed for each
     # OSD, and that each OSD has the same size.
     osd_stat_bytes = []
-    for metric in result_total:
+    for i, metric in enumerate(result_total, 1):
         values = []
         for ts, value in metric["values"]:
             values.append(value)
-        assert all(value == values[0] for value in values)
+
+        values_consistent = all(value == values[0] for value in values)
+        logger.debug(
+            f"OSD {i}/{len(result_total)}: capacity consistent across time = {values_consistent}"
+        )
+        logger.assertion(
+            f"OSD {i} capacity constant over time: expected=True, actual={values_consistent}"
+        )
+        assert values_consistent, f"OSD {i} capacity changed during measurement"
+
         osd_stat_bytes.append(values[0])
-    assert all(value == osd_stat_bytes[0] for value in osd_stat_bytes)
+
+    all_osds_same_size = all(value == osd_stat_bytes[0] for value in osd_stat_bytes)
+    logger.assertion(
+        f"All OSDs have same capacity: expected=True, actual={all_osds_same_size}, "
+        f"capacity={osd_stat_bytes[0]}"
+    )
+    assert all_osds_same_size, "OSDs have different capacities"
+    logger.info(
+        f"All {len(osd_stat_bytes)} OSDs have consistent capacity: {osd_stat_bytes[0]} bytes"
+    )
+
+    logger.test_step("Calculate expected utilization based on workload target")
     # Compute expected value of'ceph_osd_stat_bytes_used, based on percentage
     # utilized by the fixture.
     percentage = workload_storageutilization_50p_rbd["result"]["target_p"]
     expected_value = int(osd_stat_bytes[0]) * percentage
+    tolerance = 0.10  # 10% error margin
+    logger.info(
+        f"Expected OSD utilization: {expected_value} bytes ({percentage*100}% of capacity), "
+        f"tolerance: ±{tolerance*100}%"
+    )
+
+    logger.test_step("Validate actual OSD utilization matches expected value")
     # Now we can check the actual usage values from Prometheus.
     at_least_one_value_out_of_range = False
+    total_values_checked = 0
+    values_in_range = 0
+    values_out_of_range = 0
+
     for metric in result_used:
         name = metric["metric"]["__name__"]
         daemon = metric["metric"]["ceph_daemon"]
-        logger.info(f"metric {name} from {daemon}")
+        logger.info(f"Validating metric {name} from {daemon}")
+
         # We are skipping the 1st 10% of the values, as it could take some
         # additional time for all the data to be written everywhere, and
         # during this time utilization value still grows.
         start_index = int(len(metric["values"]) * 0.1)
-        logger.info(f"ignoring first {start_index} values")
+        total_value_count = len(metric["values"])
+        logger.debug(
+            f"Skipping first {start_index}/{total_value_count} values (warmup period)"
+        )
+
         for ts, value in metric["values"][:start_index]:
             value = int(value)
             dt = datetime.utcfromtimestamp(ts)
-            logger.info(f"ignoring value {value} B at {dt}")
+            logger.debug(f"Ignoring warmup value {value} B at {dt}")
+
         for ts, value in metric["values"][start_index:]:
             value = int(value)
             dt = datetime.utcfromtimestamp(ts)
+            total_values_checked += 1
+
             # checking the value, with 10% error margin in each direction
-            if expected_value * 0.90 <= value <= expected_value * 1.10:
-                logger.info(f"value {value} B at {dt} is withing expected range")
+            if (
+                expected_value * (1 - tolerance)
+                <= value
+                <= expected_value * (1 + tolerance)
+            ):
+                values_in_range += 1
+                logger.debug(f"Value {value} B at {dt} is within expected range")
             else:
+                values_out_of_range += 1
                 logger.error(
-                    (
-                        f"value {value} B at {dt} is outside of expected range"
-                        f" {expected_value} B +- 10%"
-                    )
+                    f"Value {value} B at {dt} is outside of expected range "
+                    f"{expected_value} B ± {tolerance*100}%"
                 )
                 at_least_one_value_out_of_range = True
-    assert not at_least_one_value_out_of_range
+
+    logger.info(
+        f"Utilization validation summary: {values_in_range}/{total_values_checked} values in range, "
+        f"{values_out_of_range} out of range"
+    )
+
+    logger.assertion(
+        f"All utilization values within expected range: "
+        f"expected=0 out of range, actual={values_out_of_range} out of range"
+    )
+    assert (
+        not at_least_one_value_out_of_range
+    ), f"{values_out_of_range} values were outside expected range"
+
+    logger.info("Test passed: RBD workload utilization validated successfully")
 
 
 @blue_squad
@@ -135,7 +208,9 @@ def test_workload_rbd_in_some_other_way(workload_storageutilization_50p_rbd):
     this and the previous test are using the same workload. You can check this
     by plotting ``ceph_osd_stat_bytes_used`` value via OCP Prometheus.
     """
-    logger.info(workload_storageutilization_50p_rbd)
+    logger.info("Starting test: Demonstrate reuse of RBD workload fixture")
+    logger.info(f"Workload fixture data: {workload_storageutilization_50p_rbd}")
+    logger.info("Test passed: RBD workload fixture reused successfully")
 
 
 @blue_squad
@@ -145,7 +220,9 @@ def test_workload_cephfs(workload_storageutilization_50p_cephfs):
     """
     Purpose of this test is to make another workload fixture executed as well.
     """
-    logger.info(workload_storageutilization_50p_cephfs)
+    logger.info("Starting test: Execute CephFS workload fixture")
+    logger.info(f"Workload fixture data: {workload_storageutilization_50p_cephfs}")
+    logger.info("Test passed: CephFS workload fixture executed")
 
 
 @blue_squad
@@ -159,8 +236,16 @@ def test_workload_rbd_cephfs(
     it can be used to reproduce issue with workload_fio_storageutilization
     fixtures, see https://github.com/red-hat-storage/ocs-ci/issues/1327
     """
-    logger.info(workload_storageutilization_50p_rbd)
-    logger.info(workload_storageutilization_50p_cephfs)
+    logger.info(
+        "Starting test: Execute both RBD and CephFS workload fixtures (regression test for issue #1327)"
+    )
+    logger.info(f"RBD workload fixture data: {workload_storageutilization_50p_rbd}")
+    logger.info(
+        f"CephFS workload fixture data: {workload_storageutilization_50p_cephfs}"
+    )
+    logger.info(
+        "Test passed: Both RBD and CephFS workload fixtures executed successfully"
+    )
 
 
 @blue_squad
@@ -177,5 +262,11 @@ def test_workload_rbd_cephfs_minimal(
     Mostly usefull as a libtest and regression test for
     https://github.com/red-hat-storage/ocs-ci/issues/1327
     """
-    logger.info(workload_storageutilization_05p_rbd)
-    logger.info(workload_storageutilization_05p_cephfs)
+    logger.info(
+        "Starting test: Execute minimal RBD and CephFS workload fixtures (5% capacity, regression test for issue #1327)"
+    )
+    logger.info(f"RBD 5% workload fixture data: {workload_storageutilization_05p_rbd}")
+    logger.info(
+        f"CephFS 5% workload fixture data: {workload_storageutilization_05p_cephfs}"
+    )
+    logger.info("Test passed: Minimal workload fixtures executed successfully")

--- a/tests/functional/monitoring/pagerduty/alerts/test_ceph.py
+++ b/tests/functional/monitoring/pagerduty/alerts/test_ceph.py
@@ -12,7 +12,7 @@ from ocs_ci.ocs import constants
 from ocs_ci.utility import pagerduty
 
 
-log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 @blue_squad
@@ -30,20 +30,32 @@ def deprecated_test_corrupt_pg_pd(measure_corrupt_pg):
     on one OSD is corrupted and that this incident is cleared when the corrupted
     ceph pool is removed.
     """
+    logger.test_step("Initialize PagerDuty API client")
     api = pagerduty.PagerDutyAPI()
 
-    # get incidents from time when manager deployment was scaled down
+    logger.test_step("Retrieve PagerDuty incidents from corrupted PG time window")
     incidents = measure_corrupt_pg.get("pagerduty_incidents")
     target_label = constants.ALERT_CLUSTERERRORSTATE
+    logger.info(f"Target alert label: {target_label}")
+    logger.info(f"Number of incidents retrieved: {len(incidents) if incidents else 0}")
 
+    logger.test_step("Verify high-urgency incident exists for ClusterErrorState alert")
     # TODO(fbalak): check the whole string in summary and incident alerts
-    assert pagerduty.check_incident_list(
+    incident_found = pagerduty.check_incident_list(
         summary=target_label,
         incidents=incidents,
         urgency="high",
     )
+    logger.assertion(
+        f"ClusterErrorState incident check: expected=True, actual={incident_found}, "
+        f"urgency=high, alert={target_label}"
+    )
+    assert incident_found, f"No high-urgency incident found for {target_label}"
+
+    logger.test_step("Verify incident is cleared after corrupted pool removal")
     api.check_incident_cleared(
         summary=target_label,
         measure_end_time=measure_corrupt_pg.get("stop"),
         pagerduty_service_ids=[pagerduty.get_pagerduty_service_id()],
     )
+    logger.info("Incident verified as cleared in PagerDuty")

--- a/tests/functional/monitoring/pagerduty/alerts/test_deployment_status.py
+++ b/tests/functional/monitoring/pagerduty/alerts/test_deployment_status.py
@@ -1,4 +1,4 @@
-import loggerging
+import logging
 import pytest
 
 from ocs_ci.framework.pytest_customization.marks import blue_squad
@@ -14,7 +14,7 @@ from ocs_ci.ocs import constants
 from ocs_ci.utility import pagerduty
 
 
-logger = loggerging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 @blue_squad

--- a/tests/functional/monitoring/pagerduty/alerts/test_deployment_status.py
+++ b/tests/functional/monitoring/pagerduty/alerts/test_deployment_status.py
@@ -1,4 +1,4 @@
-import logging
+import loggerging
 import pytest
 
 from ocs_ci.framework.pytest_customization.marks import blue_squad
@@ -14,7 +14,7 @@ from ocs_ci.ocs import constants
 from ocs_ci.utility import pagerduty
 
 
-log = logging.getLogger(__name__)
+logger = loggerging.getLogger(__name__)
 
 
 @blue_squad
@@ -29,26 +29,44 @@ def deprecated_test_ceph_manager_stopped_pd(measure_stop_ceph_mgr):
     is unavailable and that this incident is cleared when the manager
     is back online.
     """
-    api = pagerduty.PagerDutyAPI()
+    logger.info("Starting test: Verify Ceph manager stopped PagerDuty incidents")
 
-    # get incidents from time when manager deployment was scaled down
+    logger.test_step("Initialize PagerDuty API and retrieve incidents")
+    api = pagerduty.PagerDutyAPI()
     incidents = measure_stop_ceph_mgr.get("pagerduty_incidents")
-    for target_label in [
+    logger.info(f"Number of incidents retrieved: {len(incidents) if incidents else 0}")
+
+    target_labels = [
         constants.ALERT_MGRISABSENT,
         constants.ALERT_MGRISMISSINGREPLICAS,
-    ]:
+    ]
+    logger.info(f"Checking {len(target_labels)} alert types")
+
+    logger.test_step("Validate and verify clearance for each manager alert")
+    for i, target_label in enumerate(target_labels, 1):
+        logger.info(f"Processing alert {i}/{len(target_labels)}: {target_label}")
 
         # TODO(fbalak): check the whole string in summary and incident alerts
-        assert pagerduty.check_incident_list(
+        logger.debug(f"Checking incident list for {target_label} with urgency=high")
+        incident_found = pagerduty.check_incident_list(
             summary=target_label,
             incidents=incidents,
             urgency="high",
         )
+        logger.assertion(
+            f"Incident check for {target_label}: expected=True, actual={incident_found}"
+        )
+        assert incident_found, f"No high-urgency incident found for {target_label}"
+
+        logger.debug(f"Verifying incident {target_label} is cleared")
         api.check_incident_cleared(
             summary=target_label,
             measure_end_time=measure_stop_ceph_mgr.get("stop"),
             pagerduty_service_ids=[pagerduty.get_pagerduty_service_id()],
         )
+        logger.info(f"Alert {target_label} verified and cleared successfully")
+
+    logger.info("Test passed: All Ceph manager incidents triggered and cleared")
 
 
 @blue_squad
@@ -63,32 +81,60 @@ def deprecated_test_ceph_osd_stopped_pd(measure_stop_ceph_osd):
     is unavailable and that these incidents are cleared when the osd
     is back online.
     """
+    logger.info("Starting test: Verify Ceph OSD stopped PagerDuty incidents")
+
+    logger.test_step("Initialize PagerDuty API and retrieve incidents")
     api = pagerduty.PagerDutyAPI()
-
-    # get incidents from time when osd deployment was scaled down
     incidents = measure_stop_ceph_osd.get("pagerduty_incidents")
+    logger.info(f"Number of incidents retrieved: {len(incidents) if incidents else 0}")
 
+    logger.test_step("Verify at least one OSD-related incident exists")
     # check that at least one of incidents CephOSDDisdUnavailable or
     # CephOSDDiskNotResponding is correctly raised
-    assert pagerduty.check_incident_list(
+    logger.debug(f"Checking for {constants.ALERT_OSDDISKUNAVAILABLE}")
+    disk_unavailable = pagerduty.check_incident_list(
         summary=constants.ALERT_OSDDISKUNAVAILABLE,
         incidents=incidents,
         urgency="high",
-    ) or pagerduty.check_incident_list(
+    )
+    logger.debug(f"Checking for {constants.ALERT_OSDDISKNOTRESPONDING}")
+    disk_not_responding = pagerduty.check_incident_list(
         summary=constants.ALERT_OSDDISKNOTRESPONDING,
         incidents=incidents,
         urgency="high",
     )
+
+    osd_incident_found = disk_unavailable or disk_not_responding
+    logger.assertion(
+        f"OSD incident check: disk_unavailable={disk_unavailable}, "
+        f"disk_not_responding={disk_not_responding}, at_least_one=expected"
+    )
+    assert osd_incident_found, (
+        f"No high-urgency OSD incident found. "
+        f"Expected {constants.ALERT_OSDDISKUNAVAILABLE} or {constants.ALERT_OSDDISKNOTRESPONDING}"
+    )
+    logger.info(
+        f"OSD incident found: unavailable={disk_unavailable}, not_responding={disk_not_responding}"
+    )
+
+    logger.test_step("Verify both OSD alert types are cleared")
+    logger.debug(f"Verifying {constants.ALERT_OSDDISKUNAVAILABLE} is cleared")
     api.check_incident_cleared(
         summary=constants.ALERT_OSDDISKUNAVAILABLE,
         measure_end_time=measure_stop_ceph_osd.get("stop"),
         pagerduty_service_ids=[pagerduty.get_pagerduty_service_id()],
     )
+    logger.info(f"{constants.ALERT_OSDDISKUNAVAILABLE} cleared successfully")
+
+    logger.debug(f"Verifying {constants.ALERT_OSDDISKNOTRESPONDING} is cleared")
     api.check_incident_cleared(
         summary=constants.ALERT_OSDDISKNOTRESPONDING,
         measure_end_time=measure_stop_ceph_osd.get("stop"),
         pagerduty_service_ids=[pagerduty.get_pagerduty_service_id()],
     )
+    logger.info(f"{constants.ALERT_OSDDISKNOTRESPONDING} cleared successfully")
+
+    logger.info("Test passed: Ceph OSD incidents triggered and cleared")
 
 
 @blue_squad
@@ -104,25 +150,39 @@ def depricated_test_stop_worker_nodes_pd(measure_stop_worker_nodes):
     nodes are unavailable and that these incidents are cleared when those nodes
     are back online.
     """
+    logger.info("Starting test: Verify worker node stopped PagerDuty incidents")
+
+    logger.test_step("Initialize PagerDuty API and retrieve incidents")
     api = pagerduty.PagerDutyAPI()
-
-    # get incidents from time when node is down
     incidents = measure_stop_worker_nodes.get("pagerduty_incidents")
+    logger.info(f"Number of incidents retrieved: {len(incidents) if incidents else 0}")
 
+    logger.test_step("Validate and verify clearance for NodeDown alert")
     # check that incident CephNodeDown is correctly raised
     for target_label in [
         constants.ALERT_NODEDOWN,
     ]:
-        assert pagerduty.check_incident_list(
+        logger.info(f"Checking incident for alert: {target_label}")
+
+        incident_found = pagerduty.check_incident_list(
             summary=target_label,
             incidents=incidents,
             urgency="high",
         )
+        logger.assertion(
+            f"Incident check for {target_label}: expected=True, actual={incident_found}"
+        )
+        assert incident_found, f"No high-urgency incident found for {target_label}"
+
+        logger.debug(f"Verifying incident {target_label} is cleared")
         api.check_incident_cleared(
             summary=target_label,
             measure_end_time=measure_stop_worker_nodes.get("stop"),
             pagerduty_service_ids=[pagerduty.get_pagerduty_service_id()],
         )
+        logger.info(f"Alert {target_label} verified and cleared successfully")
+
+    logger.info("Test passed: Worker node incidents triggered and cleared")
 
 
 @blue_squad
@@ -137,31 +197,48 @@ def deprecated_test_ceph_monitor_stopped_pd(measure_stop_ceph_mon):
     is unavailable and that these incidents are cleared when the monitor
     is back online.
     """
+    logger.info("Starting test: Verify Ceph monitor stopped PagerDuty incidents")
+
+    logger.test_step("Initialize PagerDuty API and retrieve incidents")
     api = pagerduty.PagerDutyAPI()
-
-    # get incidents from time when monitor deployment was scaled down
     incidents = measure_stop_ceph_mon.get("pagerduty_incidents")
+    logger.info(f"Number of incidents retrieved: {len(incidents) if incidents else 0}")
 
-    # check that incidents CephMonQuorumAtRisk and CephClusterWarningState
-    # alert are correctly raised
-    for target_label in [
+    target_labels = [
         constants.ALERT_MONQUORUMATRISK,
         constants.ALERT_CLUSTERWARNINGSTATE,
-    ]:
-        assert pagerduty.check_incident_list(
+    ]
+    logger.info(f"Checking {len(target_labels)} alert types")
+
+    logger.test_step("Validate and verify clearance for each monitor alert")
+    # check that incidents CephMonQuorumAtRisk and CephClusterWarningState
+    # alert are correctly raised
+    for i, target_label in enumerate(target_labels, 1):
+        logger.info(f"Processing alert {i}/{len(target_labels)}: {target_label}")
+
+        incident_found = pagerduty.check_incident_list(
             summary=target_label,
             incidents=incidents,
             urgency="high",
         )
+        logger.assertion(
+            f"Incident check for {target_label}: expected=True, actual={incident_found}"
+        )
+        assert incident_found, f"No high-urgency incident found for {target_label}"
+
         # adding 1 extra minute to wait for clearing of the alert
         # CephMonQuorumAtRisk alert takes longer time to be cleared
         time_min = 480
+        logger.debug(f"Verifying {target_label} is cleared (timeout={time_min}min)")
         api.check_incident_cleared(
             summary=target_label,
             measure_end_time=measure_stop_ceph_mon.get("stop"),
             time_min=time_min,
             pagerduty_service_ids=[pagerduty.get_pagerduty_service_id()],
         )
+        logger.info(f"Alert {target_label} verified and cleared successfully")
+
+    logger.info("Test passed: All Ceph monitor incidents triggered and cleared")
 
 
 @blue_squad
@@ -177,20 +254,34 @@ def deprecated_test_ceph_mons_quorum_lost_pd(measure_stop_ceph_mon):
     except one are unavailable and that these incidents are cleared when the
     monitor is back online.
     """
+    logger.info("Starting test: Verify Ceph monitor quorum lost PagerDuty incidents")
+
+    logger.test_step("Initialize PagerDuty API and retrieve incidents")
     api = pagerduty.PagerDutyAPI()
-
-    # get incidents from time when monitor deployments were scaled down
     incidents = measure_stop_ceph_mon.get("pagerduty_incidents")
+    logger.info(f"Number of incidents retrieved: {len(incidents) if incidents else 0}")
 
+    logger.test_step("Validate MonQuorumLost incident and verify clearance")
     # check that incident CephMonQuorumLost is correctly raised
     target_label = constants.ALERT_MONQUORUMLOST
-    assert pagerduty.check_incident_list(
+    logger.info(f"Checking incident for alert: {target_label}")
+
+    incident_found = pagerduty.check_incident_list(
         summary=target_label,
         incidents=incidents,
         urgency="high",
     )
+    logger.assertion(
+        f"Incident check for {target_label}: expected=True, actual={incident_found}"
+    )
+    assert incident_found, f"No high-urgency incident found for {target_label}"
+
+    logger.debug(f"Verifying incident {target_label} is cleared")
     api.check_incident_cleared(
         summary=target_label,
         measure_end_time=measure_stop_ceph_mon.get("stop"),
         pagerduty_service_ids=[pagerduty.get_pagerduty_service_id()],
     )
+    logger.info(f"Alert {target_label} verified and cleared successfully")
+
+    logger.info("Test passed: Monitor quorum lost incident triggered and cleared")

--- a/tests/functional/monitoring/prometheus/alerts/test_alert_mds_cache_high_usage.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_alert_mds_cache_high_usage.py
@@ -1,4 +1,4 @@
-import loggerging
+import logging
 import pytest
 import time
 
@@ -26,7 +26,7 @@ from ocs_ci.ocs.resources.pod import (
 from ocs_ci.utility.utils import ceph_health_check
 from ocs_ci.utility import prometheus
 
-logger = loggerging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 # sleep timer (in seconds) for scale up, resource deletion & alert verification

--- a/tests/functional/monitoring/prometheus/alerts/test_alert_mds_cache_high_usage.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_alert_mds_cache_high_usage.py
@@ -1,4 +1,4 @@
-import logging
+import loggerging
 import pytest
 import time
 
@@ -26,7 +26,7 @@ from ocs_ci.ocs.resources.pod import (
 from ocs_ci.utility.utils import ceph_health_check
 from ocs_ci.utility import prometheus
 
-log = logging.getLogger(__name__)
+logger = loggerging.getLogger(__name__)
 
 
 # sleep timer (in seconds) for scale up, resource deletion & alert verification
@@ -45,34 +45,48 @@ def run_metadata_io_with_cephfs(deployment_pod_factory):
     4. Run meta_data_io.py on fedora pod
 
     """
+    logger.test_step("Identify worker nodes excluding MDS nodes")
     access_mode = constants.ACCESS_MODE_RWX
     file = constants.METAIO
     interface = constants.CEPHFILESYSTEM
     active_mds_node = cluster.get_active_mds_info()["node_name"]
     sr_mds_node = cluster.get_mds_standby_replay_info()["node_name"]
     worker_nodes = get_worker_nodes()
+    logger.info(f"Active MDS node: {active_mds_node}")
+    logger.info(f"Standby-replay MDS node: {sr_mds_node}")
+
     target_node = []
+    logger.info("Verifying Ceph cluster health")
     ceph_health_check()
+
     for node in worker_nodes:
         if (node != active_mds_node) and (node != sr_mds_node):
             target_node.append(node)
+    logger.info(f"Selected target node for pods: {target_node[0]}")
+
+    logger.test_step("Create 3 CephFS pods and start metadata IO workload")
     for dc_pod in range(3):
-        log.info("Create fedora dc pod")
+        logger.info(f"Creating pod {dc_pod + 1}/3 with CephFS PVC")
         pod_obj = deployment_pod_factory(
             size="30",
             access_mode=access_mode,
             interface=interface,
             node_name=target_node[0],
         )
-        log.info("Copy meta_data_io.py to fedora pod ")
+        logger.debug(f"Pod created: {pod_obj.name} in namespace {pod_obj.namespace}")
+
+        logger.debug(f"Copying {file} to pod {pod_obj.name}")
         cmd = f"oc cp {file} {pod_obj.namespace}/{pod_obj.name}:/"
         helpers.run_cmd(cmd=cmd)
-        log.info("meta_data_io.py copied successfully ")
-        log.info("Run meta data IO on fedora pod ")
+        logger.debug("meta_data_io.py copied successfully")
+
+        logger.debug(f"Starting metadata IO on pod {pod_obj.name}")
         metaio_executor = ThreadPoolExecutor(max_workers=1)
         metaio_executor.submit(
             pod_obj.exec_sh_cmd_on_pod, command="python3 meta_data_io.py"
         )
+
+    logger.info("All 3 pods created and metadata IO started in background")
 
 
 @tier2
@@ -87,7 +101,9 @@ class TestMdsMemoryAlerts(E2ETest):
             This function will call a function to clear the mds memory usage gradually
 
             """
+            logger.test_step("Cleanup: Bring down MDS memory usage gradually")
             cluster.bring_down_mds_memory_usage_gradually()
+            logger.info("MDS memory usage cleared successfully")
 
         request.addfinalizer(finalizer)
 
@@ -101,12 +117,16 @@ class TestMdsMemoryAlerts(E2ETest):
 
         """
         cache_alert = constants.ALERT_MDSCACHEUSAGEHIGH
+        logger.info(f"Validating {cache_alert} alert")
 
         api = prometheus.PrometheusAPI(threading_lock=threading_lock)
-        log.info("Wait for an alert to be triggered....")
+        logger.info(f"Waiting for {cache_alert} alert to be triggered (sleep={timer}s)")
         alerts = api.wait_for_alert(name=cache_alert, state="firing", sleep=timer)
+        logger.info(f"Alert detected: {len(alerts) if alerts else 0} instances")
 
         active_mds = cluster.get_active_mds_info()["mds_daemon"]
+        logger.info(f"Active MDS daemon: {active_mds}")
+
         message = f"High MDS cache usage for the daemon mds.{active_mds}."
         description = (
             f"MDS cache usage for the daemon mds.{active_mds} has exceeded above 95% of the requested value."
@@ -118,6 +138,11 @@ class TestMdsMemoryAlerts(E2ETest):
         )
         state = ["firing"]
         severity = "error"
+
+        logger.debug(f"Expected message: {message}")
+        logger.debug(f"Expected severity: {severity}")
+        logger.debug(f"Expected state: {state}")
+
         prometheus.check_alert_list(
             label=cache_alert,
             msg=message,
@@ -127,7 +152,7 @@ class TestMdsMemoryAlerts(E2ETest):
             severity=severity,
             alerts=alerts,
         )
-        log.info("Alert verified successfully")
+        logger.info(f"Alert {cache_alert} verified successfully")
         return True
 
     @pytest.mark.polarion_id("OCS-5570")
@@ -138,10 +163,19 @@ class TestMdsMemoryAlerts(E2ETest):
         This function verifies the mds cache alert triggered or not.
 
         """
-        log.info(
-            "Metadata IO started in the background. Script will look for the MDS alert now."
+        logger.info("Starting test: Verify MDS cache high usage alert is triggered")
+        logger.info(
+            "Metadata IO started in the background. Monitoring for MDS cache alert"
         )
-        assert self.active_mds_alert_values(threading_lock)
+
+        logger.test_step("Validate MDS cache high usage alert is triggered")
+        alert_validated = self.active_mds_alert_values(threading_lock)
+        logger.assertion(
+            f"MDS cache alert validation: expected=True, actual={alert_validated}"
+        )
+        assert alert_validated, "MDS cache high usage alert validation failed"
+
+        logger.info("Test passed: MDS cache alert triggered successfully")
 
     @pytest.mark.polarion_id("OCS-5571")
     def deprecated_test_mds_cache_alert_with_active_node_drain(
@@ -151,26 +185,47 @@ class TestMdsMemoryAlerts(E2ETest):
         This function verifies the mds cache alert when the active mds running node drained.
 
         """
-        log.info(
-            "Metadata IO started in the background. Script will look for the MDS alert now."
+        logger.info(
+            "Starting test: Verify MDS cache alert persists after draining active MDS node"
         )
-        log.info("Validating the alert now")
-        assert self.active_mds_alert_values(threading_lock)
+        logger.info(
+            "Metadata IO started in the background. Monitoring for MDS cache alert"
+        )
+
+        logger.test_step("Validate initial MDS cache high usage alert")
+        alert_validated = self.active_mds_alert_values(threading_lock)
+        logger.assertion(
+            f"Initial alert validation: expected=True, actual={alert_validated}"
+        )
+        assert alert_validated, "Initial MDS cache alert validation failed"
+
+        logger.test_step("Drain active MDS node and verify alert persists")
         node_name = cluster.get_active_mds_info()["node_name"]
-        log.info("Unschedule active mds running node")
+        logger.info(f"Active MDS running on node: {node_name}")
+
+        logger.info(f"Unscheduling node {node_name}")
         unschedule_nodes([node_name])
-        log.info(f"node {node_name} unscheduled successfully")
-        log.info("Drain node operation")
+        logger.info(f"Node {node_name} unscheduled successfully")
+
+        logger.info(f"Draining node {node_name}")
         drain_nodes([node_name])
-        log.info(f"node {node_name} drained successfully")
-        log.info("Make the node schedule-able")
+        logger.info(f"Node {node_name} drained successfully")
+
+        logger.info(f"Making node {node_name} schedulable again")
         schedule_nodes([node_name])
-        log.info(f"Scheduled the node {node_name}")
-        log.info(
-            f"Script will sleep for {timer}  seconds minutes before validating the alert"
-        )
+        logger.info(f"Node {node_name} scheduled successfully")
+
+        logger.info(f"Waiting {timer}s before re-validating alert")
         time.sleep(timer)
-        assert self.active_mds_alert_values(threading_lock)
+
+        logger.test_step("Re-validate MDS cache alert after node drain")
+        alert_validated = self.active_mds_alert_values(threading_lock)
+        logger.assertion(
+            f"Alert after node drain: expected=True, actual={alert_validated}"
+        )
+        assert alert_validated, "Alert validation failed after node drain"
+
+        logger.info("Test passed: MDS cache alert persisted correctly after node drain")
 
     @pytest.mark.polarion_id("OCS-5572")
     def deprecated_test_alert_by_restarting_operator_and_ceph_pods(
@@ -183,38 +238,38 @@ class TestMdsMemoryAlerts(E2ETest):
         3. Deleting the OSD pod running on the active mds node
 
         """
-        log.info(
+        logger.info(
             "Metadata IO started in the background. Script will look for the MDS alert now."
         )
         assert self.active_mds_alert_values(threading_lock)
 
         active_mds_node_name = cluster.get_active_mds_info()["node_name"]
-        log.info("Restart the rook-operator pod")
+        logger.info("Restart the rook-operator pod")
         operator_pod_obj = get_operator_pods()
         delete_pods(pod_objs=operator_pod_obj)
         POD_OBJ.wait_for_resource(
             condition=constants.STATUS_RUNNING,
             selector=constants.OPERATOR_LABEL,
         )
-        log.info("Validating the alert after the rook-operator pod restart")
+        logger.info("Validating the alert after the rook-operator pod restart")
         assert self.active_mds_alert_values(threading_lock)
 
-        log.info("Find mon pod on active mds running node and delete it.")
+        logger.info("Find mon pod on active mds running node and delete it.")
         mon_pod_objs = get_mon_pods()
         for pod_obj in mon_pod_objs:
             mon_pod_running_node_name = pod_obj.data["spec"].get("nodeName")
             if mon_pod_running_node_name == active_mds_node_name:
                 delete_pods([pod_obj])
-        log.info("Validating the alert after the mon pod restart")
+        logger.info("Validating the alert after the mon pod restart")
         assert self.active_mds_alert_values(threading_lock)
 
-        log.info("Find OSD pod on active mds running node and delete it.")
+        logger.info("Find OSD pod on active mds running node and delete it.")
         osd_pod_objs = get_osd_pods()
         for pod_obj in osd_pod_objs:
             osd_pod_running_node_name = pod_obj.data["spec"].get("nodeName")
             if osd_pod_running_node_name == active_mds_node_name:
                 delete_pods([pod_obj])
-        log.info("Validating the alert after the OSD pod restart")
+        logger.info("Validating the alert after the OSD pod restart")
         assert self.active_mds_alert_values(threading_lock)
 
     @pytest.mark.polarion_id("OCS-5576")
@@ -227,7 +282,7 @@ class TestMdsMemoryAlerts(E2ETest):
 
         """
         assert self.active_mds_alert_values(threading_lock)
-        log.info("Bring down the prometheus")
+        logger.info("Bring down the prometheus")
         list_of_prometheus_pod_obj = get_prometheus_pods()
         delete_pods(list_of_prometheus_pod_obj)
         assert self.active_mds_alert_values(threading_lock)
@@ -240,33 +295,54 @@ class TestMdsMemoryAlerts(E2ETest):
         This test function verifies the mds cache alert with active mds scale down and up
 
         """
-        log.info(
-            "Metadata IO started in the background. Script will look for the MDS alert now."
+        logger.info(
+            "Starting test: Verify MDS cache alert persists after active MDS scale down/up"
         )
-        assert self.active_mds_alert_values(threading_lock)
+        logger.info(
+            "Metadata IO started in the background. Monitoring for MDS cache alert"
+        )
 
+        logger.test_step("Validate initial MDS cache high usage alert")
+        alert_validated = self.active_mds_alert_values(threading_lock)
+        logger.assertion(
+            f"Initial alert validation: expected=True, actual={alert_validated}"
+        )
+        assert alert_validated, "Initial MDS cache alert validation failed"
+
+        logger.test_step("Scale down active MDS deployment and scale back up")
         active_mds = cluster.get_active_mds_info()["mds_daemon"]
         active_mds_pod = cluster.get_active_mds_info()["active_pod"]
         deployment_name = "rook-ceph-mds-" + active_mds
+        logger.info(f"Active MDS daemon: {active_mds}, deployment: {deployment_name}")
 
-        log.info(f"Scale down {deployment_name} to 0")
+        logger.info(f"Scaling down {deployment_name} to 0 replicas")
         helpers.modify_deployment_replica_count(
             deployment_name=deployment_name, replica_count=0
         )
         POD_OBJ.wait_for_delete(resource_name=active_mds_pod)
-        log.info(f"Scale up {deployment_name} to 1")
+
+        logger.info(f"Scaling up {deployment_name} to 1 replica")
         helpers.modify_deployment_replica_count(
             deployment_name=deployment_name, replica_count=1
         )
-        log.info(
-            f" Script will be in sleep for {timer}  seconds to make sure mds scale up completed."
-        )
+        logger.info(f"Waiting {timer}s for MDS scale up to complete")
         time.sleep(timer)
+
+        logger.info("Waiting for all MDS pods to reach Running state")
         mds_pods = cluster.get_mds_pods()
         for pod in mds_pods:
             helpers.wait_for_resource_state(resource=pod, state=state)
 
-        assert self.active_mds_alert_values(threading_lock)
+        logger.test_step("Re-validate MDS cache alert after scale operations")
+        alert_validated = self.active_mds_alert_values(threading_lock)
+        logger.assertion(
+            f"Alert after MDS scale: expected=True, actual={alert_validated}"
+        )
+        assert alert_validated, "Alert validation failed after MDS scale operations"
+
+        logger.info(
+            "Test passed: MDS cache alert persisted correctly after scale down/up"
+        )
 
     @pytest.mark.polarion_id("OCS-5578")
     def deprecated_test_mds_cache_alert_with_sr_node_scaledown(
@@ -276,7 +352,7 @@ class TestMdsMemoryAlerts(E2ETest):
         This test function verifies the mds cache alert with standby-replay mds scale down and up
 
         """
-        log.info(
+        logger.info(
             "Metadata IO started in the background. Script will look for the MDS alert now."
         )
         assert self.active_mds_alert_values(threading_lock)
@@ -306,7 +382,7 @@ class TestMdsMemoryAlerts(E2ETest):
         This test function verifies the mds cache alert with both active and standby-replay mds scale down and up
 
         """
-        log.info(
+        logger.info(
             "Metadata IO started in the background. Script will look for the MDS alert now."
         )
         assert self.active_mds_alert_values(threading_lock)
@@ -319,24 +395,24 @@ class TestMdsMemoryAlerts(E2ETest):
         sr_mds_pod = cluster.get_mds_standby_replay_info()["standby_replay_pod"]
         mds_dc_pods = [active_mds_dc, sr_mds_dc]
 
-        log.info(f"Scale down {active_mds_dc} to 0")
+        logger.info(f"Scale down {active_mds_dc} to 0")
         helpers.modify_deployment_replica_count(
             deployment_name=active_mds_dc, replica_count=0
         )
         POD_OBJ.wait_for_delete(resource_name=active_mds_pod)
 
-        log.info(f"Scale down {sr_mds_dc} to 0")
+        logger.info(f"Scale down {sr_mds_dc} to 0")
         helpers.modify_deployment_replica_count(
             deployment_name=sr_mds_dc, replica_count=0
         )
         POD_OBJ.wait_for_delete(resource_name=sr_mds_pod)
 
         for mds_pod_obj in mds_dc_pods:
-            log.info(f"Scale up {mds_pod_obj} to 1")
+            logger.info(f"Scale up {mds_pod_obj} to 1")
             helpers.modify_deployment_replica_count(
                 deployment_name=mds_pod_obj, replica_count=1
             )
-        log.info(
+        logger.info(
             f" Script will be in sleep for {timer} seconds to make sure both mds scale up completed."
         )
         time.sleep(timer)

--- a/tests/functional/monitoring/prometheus/alerts/test_alert_mds_cpu_high_usage.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_alert_mds_cpu_high_usage.py
@@ -1,4 +1,4 @@
-import logging
+import loggerging
 import pytest
 
 from concurrent.futures import ThreadPoolExecutor
@@ -14,7 +14,7 @@ from ocs_ci.ocs import cluster, constants
 from ocs_ci.utility import prometheus
 from ocs_ci.utility.utils import ceph_health_check_base
 
-log = logging.getLogger(__name__)
+logger = loggerging.getLogger(__name__)
 
 
 @pytest.fixture(scope="function")
@@ -30,24 +30,31 @@ def run_file_creator_io_with_cephfs(deployment_pod_factory):
     access_mode = constants.ACCESS_MODE_RWX
     file = constants.FILE_CREATOR_IO
     interface = constants.CEPHFILESYSTEM
-    log.info("Checking for Ceph Health OK")
-    ceph_health_check_base()
 
+    logger.test_step("Verify Ceph cluster health before starting IO workload")
+    ceph_health_check_base()
+    logger.info("Ceph cluster health verified as OK")
+
+    logger.test_step("Create 10 CephFS pods and start file creator IO workload")
     for dc_pod in range(10):
-        log.info(f"Creating {interface} based PVC")
-        log.info("Creating fedora dc pod")
+        logger.info(f"Creating pod {dc_pod + 1}/10 with {interface} PVC")
         pod_obj = deployment_pod_factory(
             size="15", access_mode=access_mode, interface=interface
         )
-        log.info("Copying file_creator_io.py to fedora pod ")
+        logger.debug(f"Pod created: {pod_obj.name} in namespace {pod_obj.namespace}")
+
+        logger.debug(f"Copying {file} to pod {pod_obj.name}")
         cmd = f"oc cp {file} {pod_obj.namespace}/{pod_obj.name}:/"
         helpers.run_cmd(cmd=cmd)
-        log.info("file_creator_io.py copied successfully ")
-        log.info("Running file creator IO on fedora pod ")
+        logger.debug("file_creator_io.py copied successfully")
+
+        logger.debug(f"Starting file creator IO on pod {pod_obj.name}")
         metaio_executor = ThreadPoolExecutor(max_workers=1)
         metaio_executor.submit(
             pod_obj.exec_sh_cmd_on_pod, command="python3 file_creator_io.py"
         )
+
+    logger.info("All 10 pods created and file creator IO started in background")
 
 
 def active_mds_alert_values(threading_lock):
@@ -55,11 +62,18 @@ def active_mds_alert_values(threading_lock):
     This function validates the mds alerts using prometheus api
 
     """
+    logger.test_step("Get active MDS pod information")
     active_mds_pod = cluster.get_active_mds_info()["active_pod"]
     cpu_alert = constants.ALERT_MDSCPUUSAGEHIGH
+    logger.info(f"Active MDS pod: {active_mds_pod}")
+    logger.info(f"Monitoring for alert: {cpu_alert}")
 
+    logger.test_step("Wait for MDS CPU high usage alert to trigger")
     api = prometheus.PrometheusAPI(threading_lock=threading_lock)
     alert_list = api.wait_for_alert(name=cpu_alert, state="pending")
+    logger.info(f"Alert detected: {len(alert_list) if alert_list else 0} instances")
+
+    logger.test_step("Validate alert details match expected values")
     message = f"Ceph metadata server pod ({active_mds_pod}) has high cpu usage"
     description = (
         f"Ceph metadata server pod ({active_mds_pod}) has high cpu usage"
@@ -74,6 +88,10 @@ def active_mds_alert_values(threading_lock):
     severity = "warning"
     state = ["pending"]
 
+    logger.debug(f"Expected message: {message}")
+    logger.debug(f"Expected severity: {severity}")
+    logger.debug(f"Expected state: {state}")
+
     prometheus.check_alert_list(
         label=cpu_alert,
         msg=message,
@@ -83,7 +101,11 @@ def active_mds_alert_values(threading_lock):
         severity=severity,
         alerts=alert_list,
     )
-    log.info("Alert verified successfully")
+    logger.assertion(
+        f"Alert validation: alert={cpu_alert}, severity={severity}, "
+        f"state={state}, validation=passed"
+    )
+    logger.info("Alert verified successfully")
     return True
 
 
@@ -100,7 +122,9 @@ class TestMdsCpuAlerts(E2ETest):
             This function will call a function to clear the mds memory usage gradually
 
             """
+            logger.test_step("Cleanup: Bring down MDS memory usage gradually")
             cluster.bring_down_mds_memory_usage_gradually()
+            logger.info("MDS memory usage cleared successfully")
 
         request.addfinalizer(finalizer)
 
@@ -117,8 +141,19 @@ class TestMdsCpuAlerts(E2ETest):
         threading_lock: to pass the threading lock in alert validation function
 
         """
-        log.info(
-            "File creation IO started in the background."
-            " Script will look for MDSCPUUsageHigh  alert"
+        logger.info("Starting test: Verify MDS CPU high usage alert is triggered")
+        logger.info(
+            "File creation IO started in the background. "
+            "Monitoring for MDSCPUUsageHigh alert"
         )
-        assert active_mds_alert_values(threading_lock)
+
+        logger.test_step("Validate MDSCPUUsageHigh alert is triggered and correct")
+        alert_validated = active_mds_alert_values(threading_lock)
+        logger.assertion(
+            f"MDS CPU alert validation: expected=True, actual={alert_validated}"
+        )
+        assert alert_validated, "MDS CPU high usage alert validation failed"
+
+        logger.info(
+            "Test passed: MDS CPU high usage alert triggered and validated successfully"
+        )

--- a/tests/functional/monitoring/prometheus/alerts/test_alert_mds_cpu_high_usage.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_alert_mds_cpu_high_usage.py
@@ -1,4 +1,4 @@
-import loggerging
+import logging
 import pytest
 
 from concurrent.futures import ThreadPoolExecutor
@@ -14,7 +14,7 @@ from ocs_ci.ocs import cluster, constants
 from ocs_ci.utility import prometheus
 from ocs_ci.utility.utils import ceph_health_check_base
 
-logger = loggerging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="function")

--- a/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
@@ -1,4 +1,4 @@
-import logging
+import loggerging
 import pytest
 import time
 
@@ -28,7 +28,7 @@ from ocs_ci.ocs.resources import pod
 from ocs_ci.ocs.node import wait_for_nodes_status
 from ocs_ci.utility.utils import ceph_health_check
 
-log = logging.getLogger(__name__)
+logger = loggerging.getLogger(__name__)
 
 OCP_POD_OBJ = ocp.OCP(
     kind=constants.POD, namespace=config.ENV_DATA["cluster_namespace"]
@@ -59,11 +59,11 @@ def set_xattr_with_high_cpu_usage(
         PVC: The PVC object created for extended attribute operations
 
     """
-    log.info("setting extended attributes value for multiple files in MDS server ")
+    logger.test_step("Set up CephFS PVC and pod for extended attribute operations")
     active_mds_node_name = cluster.get_active_mds_info()["node_name"]
     file = constants.EXTENDED_ATTRIBUTES
+    logger.info(f"Active MDS node: {active_mds_node_name}")
 
-    # Creating PVC to attach POD to it
     pvc_obj = pvc_factory(
         interface=constants.CEPHFILESYSTEM,
         access_mode=constants.ACCESS_MODE_RWX,
@@ -71,18 +71,23 @@ def set_xattr_with_high_cpu_usage(
         status=constants.STATUS_BOUND,
         project=OCP(kind="Project", namespace=config.ENV_DATA["cluster_namespace"]),
     )
+    logger.info(f"Created CephFS PVC: {pvc_obj.name}")
 
     pod_obj = deployment_pod_factory(
         interface=constants.CEPHFILESYSTEM,
         pvc=pvc_obj,
         node_name=active_mds_node_name,
     )
+    logger.info(f"Created pod: {pod_obj.name} on node {active_mds_node_name}")
 
+    logger.test_step("Perform extended attribute operations to generate MDS load")
     perform_xattr_only_operations(file=file, pod_obj=pod_obj)
-
+    logger.info(
+        "Extended attribute operations started, waiting 120s for load generation"
+    )
     time.sleep(120)
 
-    log.info("Reducing MDS CPU resources to trigger MDS xattr latency alert")
+    logger.test_step("Reduce MDS CPU resources to trigger xattr latency alert")
     storagecluster_obj.patch(
         resource_name=constants.DEFAULT_STORAGE_CLUSTER,
         params=(
@@ -92,6 +97,7 @@ def set_xattr_with_high_cpu_usage(
         ),
         format_type="merge",
     )
+    logger.info("MDS resources reduced to CPU=250m, Memory=512Mi")
 
     return pvc_obj
 
@@ -111,7 +117,8 @@ def MDSxattr_alert_values(threading_lock, timeout):
         bool: True if alert is found and validated successfully, False otherwise
 
     """
-    return prometheus.validate_alert(
+    logger.info(f"Validating {constants.ALERT_MDSXATTR} alert (timeout: {timeout}s)")
+    result = prometheus.validate_alert(
         threading_lock=threading_lock,
         alert_constant=constants.ALERT_MDSXATTR,
         message="There is a latency in setting the 'xattr' values for Ceph Metadata Servers.",
@@ -127,6 +134,11 @@ def MDSxattr_alert_values(threading_lock, timeout):
         state="pending",
         timeout=timeout,
     )
+    if result:
+        logger.info(f"{constants.ALERT_MDSXATTR} alert validated successfully")
+    else:
+        logger.error(f"{constants.ALERT_MDSXATTR} alert validation failed")
+    return result
 
 
 def ceph_not_health_error():
@@ -138,13 +150,15 @@ def ceph_not_health_error():
               False if health check fails or raises an exception
 
     """
+    logger.debug("Checking Ceph cluster health (tries=45, delay=60s)")
     try:
         ceph_health_check(
             namespace=config.ENV_DATA["cluster_namespace"], tries=45, delay=60
         )
+        logger.info("Ceph health check passed")
         return True
     except Exception as ex:
-        log.warning(f"Ceph health check failed: {ex}")
+        logger.warning(f"Ceph health check failed: {ex}")
         return False
 
 
@@ -168,9 +182,10 @@ def verify_alert_cleared(threading_lock):
     Args:
         threading_lock: Threading lock for Prometheus API calls
     """
+    logger.test_step("Restore MDS resources and verify alert cleared")
     api = prometheus.PrometheusAPI(threading_lock=threading_lock)
 
-    log.info("Restoring MDS CPU and memory resources to default values to clear alert")
+    logger.info("Restoring MDS CPU and memory resources to default values")
     storagecluster_obj.patch(
         resource_name=constants.DEFAULT_STORAGE_CLUSTER,
         params=(
@@ -180,13 +195,17 @@ def verify_alert_cleared(threading_lock):
         ),
         format_type="merge",
     )
+    logger.info("MDS resources restored to CPU=2, Memory=6Gi")
 
-    # waiting for sometime for load distribution
+    logger.info("Waiting 400s for load distribution and alert clearance")
     time.sleep(400)
     test_end_time = int(time.time())
+
+    logger.info(f"Checking {constants.ALERT_MDSXATTR} alert is cleared")
     api.check_alert_cleared(
         label=constants.ALERT_MDSXATTR, measure_end_time=test_end_time, time_min=600
     )
+    logger.info(f"{constants.ALERT_MDSXATTR} alert cleared successfully")
 
 
 def recover_mds_pods_if_not_running():
@@ -220,32 +239,33 @@ def recover_mds_pods_if_not_running():
     ]
 
     if not deployments_to_scale:
-        log.info("No MDS deployments needed scaling")
+        logger.info("No MDS deployments needed scaling")
         return
 
-    log.info(f"Found {len(deployments_to_scale)} MDS deployment(s) at 0 replicas")
+    logger.info(f"Found {len(deployments_to_scale)} MDS deployment(s) at 0 replicas")
 
-    # Scale up each deployment from 0 to 1
+    logger.test_step("Scale up MDS deployments from 0 to 1 replica")
     for deployment in deployments_to_scale:
         deployment_name = deployment["metadata"]["name"]
         try:
             helpers.modify_deployment_replica_count(
                 deployment_name=deployment_name, replica_count=1
             )
-            log.info(f"Successfully scaled {deployment_name} to 1 replica")
-        except Exception as e:
-            log.error(f"Failed to scale MDS deployment {deployment_name}: {e}")
+            logger.info(f"Successfully scaled {deployment_name} to 1 replica")
+        except Exception:
+            logger.exception(f"Failed to scale MDS deployment {deployment_name}")
             raise AssertionError(
                 f"Teardown failed: Could not scale MDS deployment {deployment_name} from 0 to 1"
             )
 
+    logger.info("Waiting for MDS pods to reach Running state")
     pod.wait_for_pods_to_be_running(
         namespace=config.ENV_DATA["cluster_namespace"],
         selector=constants.MDS_APP_LABEL,
         timeout=180,
         sleep=10,
     )
-    log.info("All MDS pods are running successfully")
+    logger.info("All MDS pods are running successfully")
 
 
 @blue_squad
@@ -285,9 +305,8 @@ class TestMdsXattrAlerts(E2ETest):
             Alert verification is done at the end of each test method.
 
             """
-
-            log.info(
-                "Restoring MDS CPU and memory resources to default values in teardown"
+            logger.test_step(
+                "Cleanup: Restore MDS CPU and memory resources to defaults"
             )
             storagecluster_obj.patch(
                 resource_name=constants.DEFAULT_STORAGE_CLUSTER,
@@ -298,6 +317,7 @@ class TestMdsXattrAlerts(E2ETest):
                 ),
                 format_type="merge",
             )
+            logger.info("MDS resources restored to CPU=2, Memory=6Gi in teardown")
 
         request.addfinalizer(finalizer)
 
@@ -320,13 +340,22 @@ class TestMdsXattrAlerts(E2ETest):
             4. Verify alert is cleared after test completion
 
         """
-        log.info(
-            "Setting extended attributes and file creation IO started in the background."
-            " Script will look for CephXattrSetLatency  alert"
+        logger.info("Starting test: Verify MDS xattr latency alert is triggered")
+        logger.info(
+            "Extended attributes operations started. "
+            "Monitoring for CephXattrSetLatency alert"
         )
-        assert MDSxattr_alert_values(threading_lock, timeout=1200)
+
+        logger.test_step("Wait for and validate CephXattrSetLatency alert")
+        alert_validated = MDSxattr_alert_values(threading_lock, timeout=1200)
+        logger.assertion(
+            f"MDS xattr alert validation: expected=True, actual={alert_validated}"
+        )
+        assert alert_validated, "CephXattrSetLatency alert validation failed"
 
         verify_alert_cleared(threading_lock)
+
+        logger.info("Test passed: MDS xattr alert triggered and cleared successfully")
 
     @tier4c
     @pytest.mark.polarion_id("OCS-7734")
@@ -352,23 +381,35 @@ class TestMdsXattrAlerts(E2ETest):
             9. Verify alert is cleared after test completion
 
         """
-        log.info(
-            "Setting extended attributes and file creation IO started in the background."
-            " Script will look for CephXattrSetLatency  alert"
+        logger.info(
+            "Starting test: Verify alert persistence after restarting operator and metrics pods"
         )
-        assert MDSxattr_alert_values(threading_lock, timeout=1200)
+        logger.info(
+            "Extended attributes operations started. "
+            "Monitoring for CephXattrSetLatency alert"
+        )
 
-        log.info("Restart the rook-operator pod")
+        logger.test_step("Wait for and validate initial CephXattrSetLatency alert")
+        alert_validated = MDSxattr_alert_values(threading_lock, timeout=1200)
+        logger.assertion(
+            f"Initial alert validation: expected=True, actual={alert_validated}"
+        )
+        assert alert_validated, "Initial CephXattrSetLatency alert validation failed"
+
+        logger.test_step("Restart rook-operator pod and re-validate alert")
         operator_pod_obj = get_operator_pods()
         delete_pods(pod_objs=operator_pod_obj)
         OCP_POD_OBJ.wait_for_resource(
             condition=constants.STATUS_RUNNING,
             selector=constants.OPERATOR_LABEL,
         )
-        log.info("Validating the alert after the rook-operator pod restart")
-        assert MDSxattr_alert_values(threading_lock, timeout=1200)
+        alert_validated = MDSxattr_alert_values(threading_lock, timeout=1200)
+        logger.assertion(
+            f"Alert after operator restart: expected=True, actual={alert_validated}"
+        )
+        assert alert_validated, "Alert validation failed after operator restart"
 
-        log.info("Respin the ocs-metrics-exporter pod")
+        logger.test_step("Restart ocs-metrics-exporter pod and re-validate alert")
         metrics_pods = get_pods_having_label(
             label="app.kubernetes.io/name=ocs-metrics-exporter",
             namespace=config.ENV_DATA["cluster_namespace"],
@@ -377,11 +418,11 @@ class TestMdsXattrAlerts(E2ETest):
         assert metrics_pods, "No ocs-metrics-exporter pods found"
         metrics_pod = metrics_pods[0]
         metrics_pod_name = metrics_pod["metadata"]["name"]
-        log.info(f"Initial ocs-metrics-exporter pod: {metrics_pod_name}")
+        logger.info(f"Initial ocs-metrics-exporter pod: {metrics_pod_name}")
 
         OCP_POD_OBJ.delete(resource_name=metrics_pod_name)
 
-        log.info("Wait for ocs-metrics-exporter pod to come up")
+        logger.info("Wait for ocs-metrics-exporter pod to come up")
         assert OCP_POD_OBJ.wait_for_resource(
             condition="Running",
             selector="app.kubernetes.io/name=ocs-metrics-exporter",
@@ -389,10 +430,17 @@ class TestMdsXattrAlerts(E2ETest):
             timeout=600,
         )
 
-        log.info("Validating the alert after ocs-metrics-exporter pod restart")
-        assert MDSxattr_alert_values(threading_lock, timeout=1200)
+        alert_validated = MDSxattr_alert_values(threading_lock, timeout=1200)
+        logger.assertion(
+            f"Alert after metrics-exporter restart: expected=True, actual={alert_validated}"
+        )
+        assert alert_validated, "Alert validation failed after metrics-exporter restart"
 
         verify_alert_cleared(threading_lock)
+
+        logger.info(
+            "Test passed: Alert persisted correctly after operator and metrics pod restarts"
+        )
 
     @tier2
     @pytest.mark.polarion_id("OCS-7735")
@@ -413,20 +461,37 @@ class TestMdsXattrAlerts(E2ETest):
             5. Re-validate the alert after Prometheus recovery (timeout: 300s)
             6. Verify alert is cleared after test completion
         """
-
-        log.info(
-            "Setting extended attributes and file creation IO started in the background."
-            " Script will look for CephXattrSetLatency  alert"
+        logger.info(
+            "Starting test: Verify alert recovery after Prometheus pod failures"
         )
-        assert MDSxattr_alert_values(threading_lock, timeout=1200)
+        logger.info(
+            "Extended attributes operations started. "
+            "Monitoring for CephXattrSetLatency alert"
+        )
 
-        log.info("Bring down the prometheus")
+        logger.test_step("Wait for and validate initial CephXattrSetLatency alert")
+        alert_validated = MDSxattr_alert_values(threading_lock, timeout=1200)
+        logger.assertion(
+            f"Initial alert validation: expected=True, actual={alert_validated}"
+        )
+        assert alert_validated, "Initial CephXattrSetLatency alert validation failed"
+
+        logger.test_step("Delete Prometheus pods and re-validate alert after recovery")
+        logger.info("Deleting Prometheus pods to simulate failure")
         list_of_prometheus_pod_obj = get_prometheus_pods()
         delete_pods(list_of_prometheus_pod_obj)
 
-        assert MDSxattr_alert_values(threading_lock, timeout=300)
+        alert_validated = MDSxattr_alert_values(threading_lock, timeout=300)
+        logger.assertion(
+            f"Alert after Prometheus recovery: expected=True, actual={alert_validated}"
+        )
+        assert alert_validated, "Alert validation failed after Prometheus recovery"
 
         verify_alert_cleared(threading_lock)
+
+        logger.info(
+            "Test passed: Alert recovered successfully after Prometheus pod failures"
+        )
 
     @tier4c
     @pytest.mark.polarion_id("OCS-7736")
@@ -457,40 +522,61 @@ class TestMdsXattrAlerts(E2ETest):
             """
             Teardown to ensure MDS deployments are scaled up and pods are running.
             """
+            logger.test_step("Cleanup: Recover MDS deployments if needed")
             recover_mds_pods_if_not_running()
 
         request.addfinalizer(finalizer)
 
-        log.info(
-            "Setting extended attributes and file creation IO started in the background."
-            " Script will look for CephXattrSetLatency  alert"
+        logger.info(
+            "Starting test: Verify alert persistence after active MDS scale down/up"
         )
-        assert MDSxattr_alert_values(threading_lock, timeout=1200)
+        logger.info(
+            "Extended attributes operations started. "
+            "Monitoring for CephXattrSetLatency alert"
+        )
 
+        logger.test_step("Wait for and validate initial CephXattrSetLatency alert")
+        alert_validated = MDSxattr_alert_values(threading_lock, timeout=1200)
+        logger.assertion(
+            f"Initial alert validation: expected=True, actual={alert_validated}"
+        )
+        assert alert_validated, "Initial CephXattrSetLatency alert validation failed"
+
+        logger.test_step("Scale down active MDS deployment and scale back up")
         active_mds = cluster.get_active_mds_info()["mds_daemon"]
         active_mds_pod = cluster.get_active_mds_info()["active_pod"]
         deployment_name = "rook-ceph-mds-" + active_mds
+        logger.info(f"Active MDS daemon: {active_mds}, deployment: {deployment_name}")
 
-        log.info(f"Scale down {deployment_name} to 0")
+        logger.info(f"Scaling down {deployment_name} to 0 replicas")
         helpers.modify_deployment_replica_count(
             deployment_name=deployment_name, replica_count=0
         )
         OCP_POD_OBJ.wait_for_delete(resource_name=active_mds_pod)
-        log.info(f"Scale up {deployment_name} to 1")
+        logger.info(f"Scaling up {deployment_name} to 1 replica")
         helpers.modify_deployment_replica_count(
             deployment_name=deployment_name, replica_count=1
         )
-        log.info(
-            " Script will be in sleep for 60 seconds to make sure mds scale up completed."
-        )
+        logger.info("Waiting 60s for MDS scale up to complete")
         time.sleep(60)
+
+        logger.info("Waiting for all MDS pods to reach Running state")
         mds_pods = get_mds_pods()
         for pd in mds_pods:
             helpers.wait_for_resource_state(resource=pd, state=constants.STATUS_RUNNING)
 
-        assert MDSxattr_alert_values(threading_lock, timeout=60)
+        logger.test_step("Re-validate alert after MDS scale operations")
+        alert_validated = MDSxattr_alert_values(threading_lock, timeout=60)
+        logger.assertion(
+            f"Alert after MDS scale: expected=True, actual={alert_validated}"
+        )
+        assert alert_validated, "Alert validation failed after MDS scale operations"
 
         verify_alert_cleared(threading_lock)
+
+        logger.info(
+            "Test passed: Alert persisted correctly after active MDS scale down/up"
+        )
 
     @tier2
     @pytest.mark.polarion_id("OCS-7737")
@@ -528,16 +614,29 @@ class TestMdsXattrAlerts(E2ETest):
             """
             Teardown to ensure MDS deployments are scaled up and pods are running.
             """
+            logger.test_step("Cleanup: Recover MDS deployments if needed")
             recover_mds_pods_if_not_running()
 
         request.addfinalizer(finalizer)
 
-        log.info(
-            "Setting extended attributes and file creation IO started in the background."
-            " Script will look for CephXattrSetLatency  alert"
+        logger.info(
+            "Starting test: Verify alert persistence after both active and standby MDS scale down/up"
         )
-        assert MDSxattr_alert_values(threading_lock, timeout=1200)
+        logger.info(
+            "Extended attributes operations started. "
+            "Monitoring for CephXattrSetLatency alert"
+        )
 
+        logger.test_step("Wait for and validate initial CephXattrSetLatency alert")
+        alert_validated = MDSxattr_alert_values(threading_lock, timeout=1200)
+        logger.assertion(
+            f"Initial alert validation: expected=True, actual={alert_validated}"
+        )
+        assert alert_validated, "Initial CephXattrSetLatency alert validation failed"
+
+        logger.test_step(
+            "Scale down both active and standby MDS deployments, then scale back up"
+        )
         active_mds = cluster.get_active_mds_info()["mds_daemon"]
         standby_mds = cluster.get_mds_standby_replay_info()["mds_daemon"]
         active_mds_d = "rook-ceph-mds-" + active_mds
@@ -545,36 +644,47 @@ class TestMdsXattrAlerts(E2ETest):
         active_mds_pod = cluster.get_active_mds_info()["active_pod"]
         standby_mds_pod = cluster.get_mds_standby_replay_info()["standby_replay_pod"]
         mds_dc_pods = [active_mds_d, standby_mds_d]
+        logger.info(f"Active MDS: {active_mds_d}, Standby MDS: {standby_mds_d}")
 
-        log.info(f"Scale down {active_mds_d} to 0")
+        logger.info(f"Scaling down {active_mds_d} to 0 replicas")
         helpers.modify_deployment_replica_count(
             deployment_name=active_mds_d, replica_count=0
         )
         OCP_POD_OBJ.wait_for_delete(resource_name=active_mds_pod)
 
-        log.info(f"Scale down {standby_mds_d} to 0")
+        logger.info(f"Scaling down {standby_mds_d} to 0 replicas")
         helpers.modify_deployment_replica_count(
             deployment_name=standby_mds_d, replica_count=0
         )
         OCP_POD_OBJ.wait_for_delete(resource_name=standby_mds_pod)
 
         for mds_pod_obj in mds_dc_pods:
-            log.info(f"Scale up {mds_pod_obj} to 1")
+            logger.info(f"Scaling up {mds_pod_obj} to 1 replica")
             helpers.modify_deployment_replica_count(
                 deployment_name=mds_pod_obj, replica_count=1
             )
-        log.info(
-            " Script will be in sleep for 60 seconds to make sure both mds scale up completed."
-        )
+        logger.info("Waiting 60s for both MDS scale up operations to complete")
         time.sleep(60)
 
+        logger.info("Waiting for all MDS pods to reach Running state")
         mds_pods = get_mds_pods()
         for pd in mds_pods:
             helpers.wait_for_resource_state(resource=pd, state=constants.STATUS_RUNNING)
 
-        assert MDSxattr_alert_values(threading_lock, timeout=1200)
+        logger.test_step("Re-validate alert after both MDS scale operations")
+        alert_validated = MDSxattr_alert_values(threading_lock, timeout=1200)
+        logger.assertion(
+            f"Alert after both MDS scale: expected=True, actual={alert_validated}"
+        )
+        assert (
+            alert_validated
+        ), "Alert validation failed after both MDS scale operations"
 
         verify_alert_cleared(threading_lock)
+
+        logger.info(
+            "Test passed: Alert persisted correctly after both MDS scale down/up"
+        )
 
     @tier4b
     @pytest.mark.polarion_id("OCS-7738")
@@ -605,30 +715,60 @@ class TestMdsXattrAlerts(E2ETest):
 
         def finalizer():
             """Teardown to ensure all nodes are up and cluster is healthy after test"""
+            logger.test_step(
+                "Cleanup: Restart any stopped nodes and verify cluster health"
+            )
             nodes.restart_nodes_by_stop_and_start_teardown()
+            cluster_healthy = is_cluster_healthy()
+            logger.assertion(
+                f"Cluster health after teardown: expected=True, actual={cluster_healthy}"
+            )
             assert (
-                is_cluster_healthy()
+                cluster_healthy
             ), "Cluster is not healthy after node restart in teardown"
 
         request.addfinalizer(finalizer)
 
-        log.info(
-            "Setting extended attributes and file creation IO started in the background."
-            " Script will look for CephXattrSetLatency  alert"
+        logger.info(
+            "Starting test: Verify alert persistence after active MDS node restart"
         )
-        assert MDSxattr_alert_values(threading_lock, timeout=1200)
+        logger.info(
+            "Extended attributes operations started. "
+            "Monitoring for CephXattrSetLatency alert"
+        )
 
+        logger.test_step("Wait for and validate initial CephXattrSetLatency alert")
+        alert_validated = MDSxattr_alert_values(threading_lock, timeout=1200)
+        logger.assertion(
+            f"Initial alert validation: expected=True, actual={alert_validated}"
+        )
+        assert alert_validated, "Initial CephXattrSetLatency alert validation failed"
+
+        logger.test_step(
+            "Restart node running active MDS pod and verify cluster health"
+        )
         active_mds_pod_obj = cluster.get_active_mds_info()["active_pod_obj"]
-        log.info("Restart active mds running node")
         active_mds_node = pod.get_pod_node(active_mds_pod_obj)
+        logger.info(f"Restarting node: {active_mds_node.name}")
         nodes.restart_nodes([active_mds_node])
         wait_for_nodes_status(
             [active_mds_node.name], constants.STATUS_READY, timeout=420
         )
-        assert (
-            is_cluster_healthy()
-        ), "Cluster is not healthy after active MDS node restart"
+        cluster_healthy = is_cluster_healthy()
+        logger.assertion(
+            f"Cluster health after node restart: expected=True, actual={cluster_healthy}"
+        )
+        assert cluster_healthy, "Cluster is not healthy after active MDS node restart"
 
-        assert MDSxattr_alert_values(threading_lock, timeout=1200)
+        logger.test_step("Re-validate alert after node restart")
+        alert_validated = MDSxattr_alert_values(threading_lock, timeout=1200)
+        logger.assertion(
+            f"Alert after node restart: expected=True, actual={alert_validated}"
+        )
+        assert alert_validated, "Alert validation failed after node restart"
 
         verify_alert_cleared(threading_lock)
+
+        logger.info(
+            "Test passed: Alert persisted correctly after active MDS node restart"
+        )

--- a/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_alert_mds_xattr_latency.py
@@ -1,4 +1,4 @@
-import loggerging
+import logging
 import pytest
 import time
 
@@ -28,7 +28,7 @@ from ocs_ci.ocs.resources import pod
 from ocs_ci.ocs.node import wait_for_nodes_status
 from ocs_ci.utility.utils import ceph_health_check
 
-logger = loggerging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 OCP_POD_OBJ = ocp.OCP(
     kind=constants.POD, namespace=config.ENV_DATA["cluster_namespace"]

--- a/tests/functional/monitoring/prometheus/alerts/test_alerting_works.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_alerting_works.py
@@ -13,7 +13,7 @@ import ocs_ci.utility.prometheus
 from ocs_ci.utility.utils import TimeoutIterator
 from ocs_ci.ocs.monitoring import validate_no_prometheus_rule_failures
 
-log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 @blue_squad
@@ -22,14 +22,28 @@ def test_alerting_works(threading_lock):
     """
     If alerting works then there is at least one alert.
     """
+    logger.info("Starting test: Verify Prometheus alerting is working")
+
+    logger.test_step("Query Prometheus for active alerts")
     prometheus = ocs_ci.utility.prometheus.PrometheusAPI(threading_lock=threading_lock)
     alerts_response = prometheus.get(
         "alerts", payload={"silenced": False, "inhibited": False}
     )
-    assert alerts_response.ok is True
+
+    logger.assertion(
+        f"Prometheus API response: expected=ok, actual={'ok' if alerts_response.ok else 'failed'}"
+    )
+    assert alerts_response.ok is True, "Prometheus API request failed"
+
+    logger.test_step("Verify at least one alert exists")
     alerts = alerts_response.json()["data"]["alerts"]
-    log.info(f"Prometheus Alerts: {alerts}")
-    assert len(alerts) > 0
+    logger.info(f"Number of alerts found: {len(alerts)}")
+    logger.debug(f"Prometheus Alerts: {alerts}")
+
+    logger.assertion(f"Alert count: expected>0, actual={len(alerts)}")
+    assert len(alerts) > 0, "No alerts found - alerting may not be working"
+
+    logger.info("Test passed: Prometheus alerting is functioning correctly")
 
 
 @provider_mode
@@ -43,23 +57,47 @@ def test_prometheus_rule_failures(threading_lock):
     This test is extended to check for many-to-many matching errors in Prometheus logs (more in DFBUGS-2571).
     If such error message found PrometheusRuleFailures alert must fire as well.
     """
+    logger.info("Starting test: Verify no Prometheus rule failures")
+
+    logger.test_step(
+        "Poll for Prometheus rule validation (timeout: 120s, interval: 30s)"
+    )
     no_prometheus_rule_failures = False
+    iteration = 0
     for no_prometheus_rule_failures in TimeoutIterator(
         timeout=120,
         sleep=30,
         func=validate_no_prometheus_rule_failures,
         func_kwargs={"threading_lock": threading_lock},
     ):
+        iteration += 1
+        logger.debug(
+            f"Validation iteration {iteration}: "
+            f"no_failures={no_prometheus_rule_failures}"
+        )
         if no_prometheus_rule_failures:
+            logger.info(
+                f"All Prometheus rules validated successfully after iteration {iteration}"
+            )
             break
+
+    logger.assertion(
+        f"Prometheus rule validation: expected=True, actual={no_prometheus_rule_failures}"
+    )
     assert no_prometheus_rule_failures, "Not all prometheus rule checks passed"
+
+    logger.info("Test passed: No Prometheus rule failures detected")
 
 
 def setup_module(module):
+    logger.info("Setting up module: Storing original user for cleanup")
     ocs_obj = OCP()
     module.original_user = ocs_obj.get_user_name()
+    logger.info(f"Original user stored: {module.original_user}")
 
 
 def teardown_module(module):
+    logger.info("Tearing down module: Restoring original user")
     ocs_obj = OCP()
     ocs_obj.login_as_user(module.original_user)
+    logger.info(f"Restored user: {module.original_user}")

--- a/tests/functional/monitoring/prometheus/alerts/test_capacity.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_capacity.py
@@ -13,7 +13,7 @@ from ocs_ci.ocs import constants
 from ocs_ci.utility import prometheus
 from ocs_ci.ocs.ocp import OCP
 
-log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 @blue_squad
@@ -31,54 +31,83 @@ def test_rbd_capacity_workload_alerts(
     Test that there are appropriate alerts when ceph cluster is utilized
     via RBD interface.
     """
+    logger.info("Starting test: Verify capacity alerts during RBD utilization workload")
+
+    logger.test_step("Initialize Prometheus API and retrieve workload data")
     api = prometheus.PrometheusAPI(threading_lock=threading_lock)
     measure_start_time = workload_storageutilization_97p_rbd.get("start")
     measure_end_time = workload_storageutilization_97p_rbd.get("stop")
+    logger.info(
+        f"Measurement period: start={measure_start_time}, end={measure_end_time}"
+    )
 
     # Check utilization on 97%
     alerts = workload_storageutilization_97p_rbd.get("prometheus_alerts")
-    if config.ENV_DATA.get("ocs_version") >= "4.21":
+    logger.info(f"Number of alerts retrieved: {len(alerts) if alerts else 0}")
+    ocs_version = config.ENV_DATA.get("ocs_version")
+    logger.info(f"OCS version: {ocs_version}")
+
+    if ocs_version >= "4.21":
+        logger.test_step("Check disk utilization metrics (OCS 4.21+)")
+
         disk_util_query = (
             "max by (ceph_daemon, device, instance, managedBy) ("
             'label_replace(ceph_disk_occupation{job="rook-ceph-mgr"}, "device", "$1", "device", "/dev/(.*)") '
             "* on (instance, device) group_left () "
             'max by (instance, device) (rate(node_disk_io_time_seconds_total{job="node-exporter"}[5m]))) * 100'
         )
-        log.info("Querying Prometheus for disk utilization metrics")
+        logger.debug(f"Disk utilization query: {disk_util_query}")
+        logger.info("Querying Prometheus for disk utilization metrics")
+
         disk_util_results = api.query_range(
             query=disk_util_query,
             start=measure_start_time,
             end=measure_end_time,
             step=60,
         )
+        logger.info(f"Query returned {len(disk_util_results)} disk metric time series")
+
         high_util_disks = []
         max_utilization_per_disk = {}
-        for result in disk_util_results:
+
+        logger.debug(f"Analyzing {len(disk_util_results)} disks for utilization")
+        for i, result in enumerate(disk_util_results, 1):
             metric_info = result.get("metric", {})
             device_id = f"{metric_info.get('ceph_daemon', 'unknown')}-{metric_info.get('device', 'unknown')}"
             values = result.get("values", [])
+
             if not values:
-                log.warning(f"No values found for disk {device_id}")
+                logger.warning(
+                    f"Disk {i}/{len(disk_util_results)} ({device_id}): No values found"
+                )
                 continue
+
             max_util = max(float(value) for timestamp, value in values)
             max_utilization_per_disk[device_id] = {
                 "metric": metric_info,
                 "max_utilization": max_util,
             }
-            log.info(f"Disk {device_id}: max utilization = {max_util:.2f}%")
+
+            logger.debug(
+                f"Disk {i}/{len(disk_util_results)} ({device_id}): max utilization = {max_util:.2f}%"
+            )
+
             if max_util > 90:
                 high_util_disks.append(
                     {"metric": metric_info, "max_utilization": max_util}
                 )
-                log.info(
+                logger.info(
                     f"High disk utilization detected: {device_id} = {max_util:.2f}%"
                 )
 
+        logger.info(f"Summary: {len(high_util_disks)} disks with utilization > 90%")
+
         if high_util_disks:
-            log.info(
-                f"Disk utilization > 90% detected."
+            logger.info(
+                f"Disk utilization > 90% detected. "
                 f"Verifying {constants.ALERT_ODF_DISK_UTILIZATION_HIGH} alert is present."
             )
+
             disk_alert_found = False
             for alert in alerts:
                 if alert.get("labels").get(
@@ -87,30 +116,40 @@ def test_rbd_capacity_workload_alerts(
                     alert.get("state") == "pending" or alert.get("state") == "firing"
                 ):
                     disk_alert_found = True
-                    log.info(
-                        f"{constants.ALERT_ODF_DISK_UTILIZATION_HIGH} alert found in state: {alert.get('state')}"
+                    alert_state = alert.get("state")
+                    logger.info(
+                        f"{constants.ALERT_ODF_DISK_UTILIZATION_HIGH} alert found in state: {alert_state}"
                     )
                     break
+
+            logger.assertion(
+                f"Disk utilization alert present: expected=True (high util disks={len(high_util_disks)}), "
+                f"actual={disk_alert_found}"
+            )
 
             assert disk_alert_found, (
                 f"Disk utilization > 90% detected but {constants.ALERT_ODF_DISK_UTILIZATION_HIGH} "
                 f"alert not found in pending or firing state. "
                 f"High utilization disks: {high_util_disks}"
             )
+            logger.info("Disk utilization alert validated successfully")
         else:
-            log.info(
+            logger.info(
                 "No disks with utilization > 90% detected. Skipping disk utilization alert check."
             )
     else:
-        log.info(
-            "OCS version is less than 4.21. Skipping disk utilization alert check."
+        logger.info(
+            f"OCS version {ocs_version} is less than 4.21. Skipping disk utilization alert check."
         )
 
-    if config.ENV_DATA.get("ocs_version") == "4.2":
+    logger.test_step("Validate cluster capacity alerts")
+
+    if ocs_version == "4.2":
         nearfull_message = "Storage cluster is nearing full. Expansion is required."
         criticallfull_mesage = (
             "Storage cluster is critically full and needs immediate expansion"
         )
+        logger.debug("Using OCS 4.2 alert messages")
     else:
         # since OCS 4.3
         nearfull_message = (
@@ -121,8 +160,9 @@ def test_rbd_capacity_workload_alerts(
             "Storage cluster is critically full and needs immediate data "
             "deletion or cluster expansion."
         )
+        logger.debug("Using OCS 4.3+ alert messages")
 
-    for target_label, target_msg, target_states, target_severity in [
+    alert_configs = [
         (
             constants.ALERT_CLUSTERNEARFULL,
             nearfull_message,
@@ -135,7 +175,23 @@ def test_rbd_capacity_workload_alerts(
             ["pending", "firing"],
             "error",
         ),
-    ]:
+    ]
+    logger.info(f"Checking {len(alert_configs)} capacity alert types")
+
+    # the time to wait is increased because it takes more time for Ceph
+    # cluster to delete all data
+    pg_wait = 300
+    logger.debug(f"Alert clearance timeout: {pg_wait}min")
+
+    for i, (target_label, target_msg, target_states, target_severity) in enumerate(
+        alert_configs, 1
+    ):
+        logger.info(
+            f"Processing alert {i}/{len(alert_configs)}: {target_label} "
+            f"(severity: {target_severity})"
+        )
+
+        logger.debug(f"Validating {target_label} with states={target_states}")
         prometheus.check_alert_list(
             label=target_label,
             msg=target_msg,
@@ -144,12 +200,15 @@ def test_rbd_capacity_workload_alerts(
             severity=target_severity,
             ignore_more_occurences=True,
         )
-        # the time to wait is increased because it takes more time for Ceph
-        # cluster to delete all data
-        pg_wait = 300
+        logger.info(f"Alert {target_label} validated successfully")
+
+        logger.debug(f"Verifying {target_label} is cleared (timeout={pg_wait}min)")
         api.check_alert_cleared(
             label=target_label, measure_end_time=measure_end_time, time_min=pg_wait
         )
+        logger.info(f"Alert {target_label} cleared successfully")
+
+    logger.info("Test passed: RBD capacity alerts validated successfully")
 
 
 @blue_squad
@@ -166,17 +225,30 @@ def test_cephfs_capacity_workload_alerts(
     """
     Test that there are appropriate alerts when ceph cluster is utilized.
     """
+    logger.info(
+        "Starting test: Verify capacity alerts during CephFS utilization workload"
+    )
+
+    logger.test_step("Initialize Prometheus API and retrieve workload data")
     api = prometheus.PrometheusAPI(threading_lock=threading_lock)
     measure_end_time = workload_storageutilization_97p_cephfs.get("stop")
+    logger.info(f"Measurement end time: {measure_end_time}")
 
     # Check utilization on 97%
     alerts = workload_storageutilization_97p_cephfs.get("prometheus_alerts")
+    logger.info(f"Number of alerts retrieved: {len(alerts) if alerts else 0}")
 
-    if config.ENV_DATA.get("ocs_version") == "4.2":
+    logger.test_step("Validate cluster capacity alerts")
+
+    ocs_version = config.ENV_DATA.get("ocs_version")
+    logger.info(f"OCS version: {ocs_version}")
+
+    if ocs_version == "4.2":
         nearfull_message = "Storage cluster is nearing full. Expansion is required."
         criticallfull_mesage = (
             "Storage cluster is critically full and needs immediate expansion"
         )
+        logger.debug("Using OCS 4.2 alert messages")
     else:
         # since OCS 4.3
         nearfull_message = (
@@ -187,8 +259,9 @@ def test_cephfs_capacity_workload_alerts(
             "Storage cluster is critically full and needs immediate data "
             "deletion or cluster expansion."
         )
+        logger.debug("Using OCS 4.3+ alert messages")
 
-    for target_label, target_msg, target_states, target_severity in [
+    alert_configs = [
         (
             constants.ALERT_CLUSTERNEARFULL,
             nearfull_message,
@@ -201,7 +274,23 @@ def test_cephfs_capacity_workload_alerts(
             ["pending", "firing"],
             "error",
         ),
-    ]:
+    ]
+    logger.info(f"Checking {len(alert_configs)} capacity alert types")
+
+    # the time to wait is increased because it takes more time for Ceph
+    # cluster to delete all data
+    pg_wait = 300
+    logger.debug(f"Alert clearance timeout: {pg_wait}min")
+
+    for i, (target_label, target_msg, target_states, target_severity) in enumerate(
+        alert_configs, 1
+    ):
+        logger.info(
+            f"Processing alert {i}/{len(alert_configs)}: {target_label} "
+            f"(severity: {target_severity})"
+        )
+
+        logger.debug(f"Validating {target_label} with states={target_states}")
         prometheus.check_alert_list(
             label=target_label,
             msg=target_msg,
@@ -210,19 +299,26 @@ def test_cephfs_capacity_workload_alerts(
             severity=target_severity,
             ignore_more_occurences=True,
         )
-        # the time to wait is increased because it takes more time for Ceph
-        # cluster to delete all data
-        pg_wait = 300
+        logger.info(f"Alert {target_label} validated successfully")
+
+        logger.debug(f"Verifying {target_label} is cleared (timeout={pg_wait}min)")
         api.check_alert_cleared(
             label=target_label, measure_end_time=measure_end_time, time_min=pg_wait
         )
+        logger.info(f"Alert {target_label} cleared successfully")
+
+    logger.info("Test passed: CephFS capacity alerts validated successfully")
 
 
 def setup_module(module):
+    logger.info("Setting up module: Storing original user for cleanup")
     ocs_obj = OCP()
     module.original_user = ocs_obj.get_user_name()
+    logger.info(f"Original user stored: {module.original_user}")
 
 
 def teardown_module(module):
+    logger.info("Tearing down module: Restoring original user")
     ocs_obj = OCP()
     ocs_obj.login_as_user(module.original_user)
+    logger.info(f"Restored user: {module.original_user}")

--- a/tests/functional/monitoring/prometheus/alerts/test_ceph.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_ceph.py
@@ -24,7 +24,7 @@ from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.resources.pod import get_osd_pods
 from ocs_ci.utility import prometheus
 
-log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 @blue_squad
@@ -40,10 +40,16 @@ def test_corrupt_pg_alerts(measure_corrupt_pg, threading_lock):
     is unavailable and that this alert is cleared when the manager
     is back online.
     """
-    api = prometheus.PrometheusAPI(threading_lock=threading_lock)
+    logger.info(
+        "Starting test: Verify corrupt placement group alerts trigger and clear"
+    )
 
+    logger.test_step("Initialize Prometheus API and retrieve alerts")
+    api = prometheus.PrometheusAPI(threading_lock=threading_lock)
     alerts = measure_corrupt_pg.get("prometheus_alerts")
-    for target_label, target_msg, target_states, target_severity in [
+    logger.info(f"Number of alerts retrieved: {len(alerts) if alerts else 0}")
+
+    alert_configs = [
         (
             constants.ALERT_PGREPAIRTAKINGTOOLONG,
             "Self heal problems detected",
@@ -56,7 +62,24 @@ def test_corrupt_pg_alerts(measure_corrupt_pg, threading_lock):
             ["pending", "firing"],
             "error",
         ),
-    ]:
+    ]
+    logger.info(f"Checking {len(alert_configs)} alert types")
+
+    logger.test_step("Validate and verify clearance for each alert")
+    # the time to wait is increased because it takes more time for Ceph
+    # cluster to resolve its issues
+    pg_wait = 360
+    logger.debug(f"PG clearance timeout: {pg_wait}min")
+
+    for i, (target_label, target_msg, target_states, target_severity) in enumerate(
+        alert_configs, 1
+    ):
+        logger.info(
+            f"Processing alert {i}/{len(alert_configs)}: {target_label} "
+            f"(severity: {target_severity})"
+        )
+
+        logger.debug(f"Validating {target_label} with states={target_states}")
         prometheus.check_alert_list(
             label=target_label,
             msg=target_msg,
@@ -64,14 +87,17 @@ def test_corrupt_pg_alerts(measure_corrupt_pg, threading_lock):
             states=target_states,
             severity=target_severity,
         )
-        # the time to wait is increased because it takes more time for Ceph
-        # cluster to resolve its issues
-        pg_wait = 360
+        logger.info(f"Alert {target_label} validated successfully")
+
+        logger.debug(f"Verifying {target_label} is cleared (timeout={pg_wait}min)")
         api.check_alert_cleared(
             label=target_label,
             measure_end_time=measure_corrupt_pg.get("stop"),
             time_min=pg_wait,
         )
+        logger.info(f"Alert {target_label} cleared successfully")
+
+    logger.info("Test passed: All corrupt PG alerts triggered and cleared as expected")
 
 
 @provider_mode
@@ -90,17 +116,26 @@ def deprecated_test_ceph_health(
     utilization monitor and for Ceph Error state is used measure_corrupt_pg
     utilization.
     """
+    logger.info("Starting test: Verify Ceph health alerts (warning and error states)")
+
+    logger.test_step("Initialize Prometheus API and calculate clearance timeout")
     api = prometheus.PrometheusAPI(threading_lock=threading_lock)
     # the time to wait is increased because it takes more time for Ceph
     # cluster to resolve its issues
     health_wait = 420
     stop_time = max(measure_stop_ceph_osd.get("stop"), measure_corrupt_pg.get("stop"))
+    logger.info(f"Health clearance timeout: {health_wait}min, stop_time: {stop_time}")
 
+    logger.test_step("Validate ClusterWarningState alert from OSD stop")
     alerts = measure_stop_ceph_osd.get("prometheus_alerts")
+    logger.info(f"OSD stop alerts retrieved: {len(alerts) if alerts else 0}")
+
     target_label = constants.ALERT_CLUSTERWARNINGSTATE
     target_msg = "Storage cluster is in degraded state"
     target_states = ["pending", "firing"]
     target_severity = "warning"
+    logger.info(f"Checking alert: {target_label} (severity: {target_severity})")
+
     prometheus.check_alert_list(
         label=target_label,
         msg=target_msg,
@@ -108,17 +143,26 @@ def deprecated_test_ceph_health(
         states=target_states,
         severity=target_severity,
     )
+    logger.info(f"Alert {target_label} validated successfully")
+
+    logger.debug(f"Verifying {target_label} is cleared")
     api.check_alert_cleared(
         label=target_label,
         measure_end_time=stop_time,
         time_min=health_wait,
     )
+    logger.info(f"Alert {target_label} cleared successfully")
 
+    logger.test_step("Validate ClusterErrorState alert from corrupt PG")
     alerts = measure_corrupt_pg.get("prometheus_alerts")
+    logger.info(f"Corrupt PG alerts retrieved: {len(alerts) if alerts else 0}")
+
     target_label = constants.ALERT_CLUSTERERRORSTATE
     target_msg = "Storage cluster is in error state"
     target_states = ["pending", "firing"]
     target_severity = "error"
+    logger.info(f"Checking alert: {target_label} (severity: {target_severity})")
+
     prometheus.check_alert_list(
         label=target_label,
         msg=target_msg,
@@ -126,11 +170,17 @@ def deprecated_test_ceph_health(
         states=target_states,
         severity=target_severity,
     )
+    logger.info(f"Alert {target_label} validated successfully")
+
+    logger.debug(f"Verifying {target_label} is cleared")
     api.check_alert_cleared(
         label=target_label,
         measure_end_time=stop_time,
         time_min=health_wait,
     )
+    logger.info(f"Alert {target_label} cleared successfully")
+
+    logger.info("Test passed: Ceph health alerts triggered and cleared correctly")
 
 
 @runs_on_provider
@@ -140,30 +190,45 @@ class TestCephOSDSlowOps(object):
         """
         Set preconditions to trigger CephOSDSlowOps
         """
+        logger.info("Setting up test: Configure preconditions for CephOSDSlowOps")
+
         self.test_pass = None
         reduced_osd_complaint_time = 0.02
 
+        logger.test_step("Reduce OSD complaint time to trigger slow ops alert")
+        logger.info(f"Setting osd_op_complaint_time to {reduced_osd_complaint_time}s")
         set_osd_op_complaint_time(reduced_osd_complaint_time)
 
+        logger.test_step("Calculate storage capacity and timeout parameters")
         ceph_cluster = CephCluster()
 
         self.full_osd_ratio = round(get_full_ratio_from_osd_dump(), 2)
         self.full_osd_threshold = self.full_osd_ratio * 100
+        logger.info(
+            f"Full OSD ratio: {self.full_osd_ratio}, threshold: {self.full_osd_threshold}%"
+        )
 
         # max possible cap to reach CephOSDSlowOps is to fill storage up to threshold; alert should appear much earlier
         pvc_size = ceph_cluster.get_ceph_free_capacity() * self.full_osd_ratio
+        logger.info(f"Target PVC size calculated: {pvc_size} GiB")
 
         # assuming storageutilization speed reduced to less than 1, estimation timeout to fill the storage
         # will be reduced by number of osds. That should be more than enough to trigger an alert,
         # otherwise the failure is legitimate
-        storageutilization_min_mbps = config.ENV_DATA[
-            "fio_storageutilization_min_mbps"
-        ] / len(get_osd_pods())
+        osd_count = len(get_osd_pods())
+        storageutilization_min_mbps = (
+            config.ENV_DATA["fio_storageutilization_min_mbps"] / osd_count
+        )
         self.timeout_sec = get_timeout(storageutilization_min_mbps, int(pvc_size))
+        logger.info(
+            f"Calculated timeout: {self.timeout_sec}s (OSDs: {osd_count}, min_mbps: {storageutilization_min_mbps})"
+        )
 
+        logger.test_step("Create PVCs for workload")
         access_modes = [constants.ACCESS_MODE_RWO, constants.ACCESS_MODE_RWX]
-
         num_of_load_objs = 2
+        logger.info(f"Creating {num_of_load_objs} PVCs with CephFS interface")
+
         self.pvc_objs = multi_pvc_factory(
             interface=constants.CEPHFILESYSTEM,
             size=pvc_size / num_of_load_objs,
@@ -172,15 +237,28 @@ class TestCephOSDSlowOps(object):
             num_of_pvc=num_of_load_objs,
             wait_each=True,
         )
+        logger.info(f"Created {len(self.pvc_objs)} PVCs successfully")
+
+        logger.test_step("Create pods and start IO workload")
         self.pod_objs = []
 
-        for pvc_obj in self.pvc_objs:
+        for i, pvc_obj in enumerate(self.pvc_objs, 1):
+            logger.debug(f"Creating pod {i}/{num_of_load_objs} for PVC {pvc_obj.name}")
             pod_obj = pod_factory(
                 interface=constants.CEPHFILESYSTEM, pvc=pvc_obj, replica_count=3
             )
             self.pod_objs.append(pod_obj)
+
             file_name = pod_obj.name
-            pod_obj.fillup_fs(size=f"{round(pvc_size * 1024)}M", fio_filename=file_name)
+            fillup_size = f"{round(pvc_size * 1024)}M"
+            logger.debug(
+                f"Filling up filesystem on pod {pod_obj.name} with {fillup_size}"
+            )
+            pod_obj.fillup_fs(size=fillup_size, fio_filename=file_name)
+
+            logger.debug(
+                f"Starting IO workload on pod {pod_obj.name} (runtime: {self.timeout_sec}s)"
+            )
             pod_obj.run_io(
                 storage_type="fs",
                 size="3G",
@@ -189,22 +267,34 @@ class TestCephOSDSlowOps(object):
             )
 
         self.start_workload_time = time.perf_counter()
+        logger.info(f"All {len(self.pod_objs)} pods created and workload started")
 
         def finalizer():
             """
             Set default values for:
               osd_op_complaint_time=30.000000
             """
+            logger.info(
+                "Tearing down test: Restoring OSD settings and cleaning resources"
+            )
+
             # set the osd_op_complaint_time to selected monitor back to default value
+            logger.debug(
+                f"Restoring osd_op_complaint_time to {constants.DEFAULT_OSD_OP_COMPLAINT_TIME}"
+            )
             set_osd_op_complaint_time(constants.DEFAULT_OSD_OP_COMPLAINT_TIME)
 
             # delete resources
+            logger.debug(f"Deleting {len(self.pod_objs)} pods")
             for pod_obj in self.pod_objs:
                 pod_obj.delete()
                 pod_obj.delete(wait=True)
 
+            logger.debug(f"Deleting {len(self.pvc_objs)} PVCs")
             for pvc_obj in self.pvc_objs:
                 pvc_obj.delete(wait=True)
+
+            logger.info("Cleanup completed successfully")
 
         request.addfinalizer(finalizer)
 
@@ -226,65 +316,106 @@ class TestCephOSDSlowOps(object):
         2.2 If CephOSDSlowOps has not been fired while the storage filled up to full_ratio % or time to fill up the
         storage ends - fail the test
         """
+        logger.info(
+            "Starting test: Verify CephOSDSlowOps alert triggers during storage utilization"
+        )
+        logger.info(
+            f"Test conditions - Full OSD threshold: {self.full_osd_threshold}%, "
+            f"Timeout: {self.timeout_sec}s"
+        )
 
+        logger.test_step(
+            "Initialize Prometheus API and monitor for CephOSDSlowOps alert"
+        )
         api = prometheus.PrometheusAPI(threading_lock=threading_lock)
 
+        target_alert = constants.ALERT_CEPHOSDSLOWOPS
+        target_msg = "OSD requests are taking too long to process."
+        target_states = ["firing"]
+        target_severity = "warning"
+        logger.info(
+            f"Monitoring for alert: {target_alert} (severity: {target_severity})"
+        )
+
+        iteration = 0
         while get_percent_used_capacity() < self.full_osd_threshold:
+            iteration += 1
             time_passed_sec = time.perf_counter() - self.start_workload_time
+            current_utilization = round(get_percent_used_capacity(), 1)
+
+            logger.debug(
+                f"Iteration {iteration}: utilization={current_utilization}%, "
+                f"elapsed={round(time_passed_sec)}s, timeout={round(self.timeout_sec)}s"
+            )
+
             if time_passed_sec > self.timeout_sec:
+                logger.error(
+                    f"Timeout exceeded: {round(time_passed_sec)}s > {round(self.timeout_sec)}s "
+                    f"at {current_utilization}% utilization"
+                )
                 pytest.fail("failed to fill the storage in calculated time")
 
             delay_time = 60
-            log.info(f"sleep {delay_time}s")
+            logger.debug(f"Sleeping {delay_time}s before next check")
             time.sleep(delay_time)
 
+            logger.debug("Querying Prometheus for current alerts")
             alerts_response = api.get(
                 "alerts", payload={"silenced": False, "inhibited": False}
             )
             if not alerts_response.ok:
-                log.error(f"got bad response from Prometheus: {alerts_response.text}")
-                continue
-            prometheus_alerts = alerts_response.json()["data"]["alerts"]
-            log.info(f"Prometheus Alerts: {prometheus_alerts}")
-            for target_label, target_msg, target_states, target_severity in [
-                (
-                    constants.ALERT_CEPHOSDSLOWOPS,
-                    "OSD requests are taking too long to process.",
-                    ["firing"],
-                    "warning",
+                logger.error(
+                    f"got bad response from Prometheus: {alerts_response.text}"
                 )
-            ]:
-                try:
-                    prometheus.check_alert_list(
-                        label=target_label,
-                        msg=target_msg,
-                        alerts=prometheus_alerts,
-                        states=target_states,
-                        severity=target_severity,
-                        ignore_more_occurences=True,
-                    )
-                    self.test_pass = True
-                except AssertionError:
-                    log.info(
-                        "workload storage utilization job did not finish\n"
-                        f"current utilization {round(get_percent_used_capacity(), 1)}p\n"
-                        f"time passed since start workload: {round(time.perf_counter() - self.start_workload_time)}s\n"
-                        f"timeout = {round(self.timeout_sec)}s"
-                    )
+                continue
+
+            prometheus_alerts = alerts_response.json()["data"]["alerts"]
+            logger.debug(f"Prometheus returned {len(prometheus_alerts)} alerts")
+
+            try:
+                prometheus.check_alert_list(
+                    label=target_alert,
+                    msg=target_msg,
+                    alerts=prometheus_alerts,
+                    states=target_states,
+                    severity=target_severity,
+                    ignore_more_occurences=True,
+                )
+                logger.info(
+                    f"Alert {target_alert} detected successfully at {current_utilization}% "
+                    f"utilization after {round(time_passed_sec)}s"
+                )
+                self.test_pass = True
+            except AssertionError:
+                logger.debug(
+                    f"Alert {target_alert} not yet fired - "
+                    f"utilization: {current_utilization}%, "
+                    f"elapsed: {round(time_passed_sec)}s"
+                )
+
             if self.test_pass:
+                logger.info("Test passed: CephOSDSlowOps alert triggered as expected")
                 break
         else:
-            # if test got to this point, the alert was found, test PASS
+            # if test got to this point without detecting the alert, fail
+            logger.error(
+                f"Failed to detect {target_alert} alert. "
+                f"Storage filled to {self.full_osd_ratio * 100}% without alert firing"
+            )
             pytest.fail(
                 f"failed to get 'CephOSDSlowOps' while workload filled up the storage to {self.full_osd_ratio} percents"
             )
 
 
 def setup_module(module):
+    logger.info("Setting up module: Storing original user for cleanup")
     ocs_obj = OCP()
     module.original_user = ocs_obj.get_user_name()
+    logger.info(f"Original user stored: {module.original_user}")
 
 
 def teardown_module(module):
+    logger.info("Tearing down module: Restoring original user")
     ocs_obj = OCP()
     ocs_obj.login_as_user(module.original_user)
+    logger.info(f"Restored user: {module.original_user}")

--- a/tests/functional/monitoring/prometheus/alerts/test_deployment_status.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_deployment_status.py
@@ -1,4 +1,4 @@
-import loggerging
+import logging
 import pytest
 
 from ocs_ci.framework.pytest_customization.marks import blue_squad, provider_mode
@@ -13,7 +13,7 @@ from ocs_ci.utility import prometheus
 from ocs_ci.ocs.ocp import OCP
 
 
-logger = loggerging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 @provider_mode

--- a/tests/functional/monitoring/prometheus/alerts/test_deployment_status.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_deployment_status.py
@@ -1,4 +1,4 @@
-import logging
+import loggerging
 import pytest
 
 from ocs_ci.framework.pytest_customization.marks import blue_squad, provider_mode
@@ -13,7 +13,7 @@ from ocs_ci.utility import prometheus
 from ocs_ci.ocs.ocp import OCP
 
 
-log = logging.getLogger(__name__)
+logger = loggerging.getLogger(__name__)
 
 
 @provider_mode
@@ -28,14 +28,20 @@ def test_ceph_manager_stopped(measure_stop_ceph_mgr, threading_lock):
     is unavailable and that this alert is cleared when the manager
     is back online.
     """
-    api = prometheus.PrometheusAPI(threading_lock=threading_lock)
+    logger.info("Starting test: Verify Ceph manager stopped alert triggers and clears")
 
-    # get alerts from time when manager deployment was scaled down
+    logger.test_step("Initialize Prometheus API and retrieve alerts")
+    api = prometheus.PrometheusAPI(threading_lock=threading_lock)
     alerts = measure_stop_ceph_mgr.get("prometheus_alerts")
     target_label = constants.ALERT_MGRISABSENT
     target_msg = "Storage metrics collector service not available anymore."
     states = ["pending", "firing"]
 
+    logger.info(f"Target alert: {target_label}")
+    logger.info(f"Number of alerts retrieved: {len(alerts) if alerts else 0}")
+    logger.debug(f"Expected states: {states}, severity: critical")
+
+    logger.test_step("Validate MgrIsAbsent alert is present with correct properties")
     prometheus.check_alert_list(
         label=target_label,
         msg=target_msg,
@@ -43,8 +49,16 @@ def test_ceph_manager_stopped(measure_stop_ceph_mgr, threading_lock):
         states=states,
         severity="critical",
     )
-    api.check_alert_cleared(
-        label=target_label, measure_end_time=measure_stop_ceph_mgr.get("stop")
+    logger.info(f"Alert {target_label} validated successfully")
+
+    logger.test_step("Verify alert is cleared after manager recovery")
+    stop_time = measure_stop_ceph_mgr.get("stop")
+    logger.info(f"Checking alert clearance after time: {stop_time}")
+    api.check_alert_cleared(label=target_label, measure_end_time=stop_time)
+    logger.info(f"Alert {target_label} cleared successfully")
+
+    logger.info(
+        "Test passed: Ceph manager stopped alert triggered and cleared as expected"
     )
 
 
@@ -60,11 +74,14 @@ def test_ceph_monitor_stopped(measure_stop_ceph_mon, threading_lock):
     when there is even number of ceph monitors and that this alert
     is cleared when monitors are back online.
     """
-    api = prometheus.PrometheusAPI(threading_lock=threading_lock)
+    logger.info("Starting test: Verify Ceph monitor stopped alerts trigger and clear")
 
-    # get alerts from time when manager deployment was scaled down
+    logger.test_step("Initialize Prometheus API and retrieve alerts")
+    api = prometheus.PrometheusAPI(threading_lock=threading_lock)
     alerts = measure_stop_ceph_mon.get("prometheus_alerts")
-    for target_label, target_msg, target_states, target_severity in [
+    logger.info(f"Number of alerts retrieved: {len(alerts) if alerts else 0}")
+
+    alert_configs = [
         (
             constants.ALERT_MONQUORUMATRISK,
             "Storage quorum at risk",
@@ -77,7 +94,19 @@ def test_ceph_monitor_stopped(measure_stop_ceph_mon, threading_lock):
             ["pending"],
             "warning",
         ),
-    ]:
+    ]
+    logger.info(f"Checking {len(alert_configs)} alert types")
+
+    logger.test_step("Validate and verify clearance for each monitor alert")
+    for i, (target_label, target_msg, target_states, target_severity) in enumerate(
+        alert_configs, 1
+    ):
+        logger.info(
+            f"Processing alert {i}/{len(alert_configs)}: {target_label} "
+            f"(severity: {target_severity})"
+        )
+
+        logger.debug(f"Validating {target_label} with states={target_states}")
         prometheus.check_alert_list(
             label=target_label,
             msg=target_msg,
@@ -85,9 +114,17 @@ def test_ceph_monitor_stopped(measure_stop_ceph_mon, threading_lock):
             states=target_states,
             severity=target_severity,
         )
+        logger.info(f"Alert {target_label} validated successfully")
+
+        logger.debug(f"Verifying {target_label} is cleared")
         api.check_alert_cleared(
             label=target_label, measure_end_time=measure_stop_ceph_mon.get("stop")
         )
+        logger.info(f"Alert {target_label} cleared successfully")
+
+    logger.info(
+        "Test passed: All Ceph monitor alerts triggered and cleared as expected"
+    )
 
 
 @provider_mode
@@ -103,14 +140,22 @@ def test_ceph_mons_quorum_lost(measure_stop_ceph_mon, threading_lock):
     Test to verify that CephMonQuorumLost alert is seen and
     that this alert is cleared when monitors are back online.
     """
-    api = prometheus.PrometheusAPI(threading_lock=threading_lock)
+    logger.info(
+        "Starting test: Verify Ceph monitor quorum lost alert triggers and clears"
+    )
 
-    # get alerts from time when manager deployment was scaled down
+    logger.test_step("Initialize Prometheus API and retrieve alerts")
+    api = prometheus.PrometheusAPI(threading_lock=threading_lock)
     alerts = measure_stop_ceph_mon.get("prometheus_alerts")
     target_label = constants.ALERT_MONQUORUMLOST
     target_msg = "Storage quorum is lost"
     target_states = ["pending", "firing"]
 
+    logger.info(f"Target alert: {target_label}")
+    logger.info(f"Number of alerts retrieved: {len(alerts) if alerts else 0}")
+    logger.debug(f"Expected states: {target_states}, severity: critical")
+
+    logger.test_step("Validate MonQuorumLost alert is present with correct properties")
     prometheus.check_alert_list(
         label=target_label,
         msg=target_msg,
@@ -118,8 +163,16 @@ def test_ceph_mons_quorum_lost(measure_stop_ceph_mon, threading_lock):
         states=target_states,
         severity="critical",
     )
-    api.check_alert_cleared(
-        label=target_label, measure_end_time=measure_stop_ceph_mon.get("stop")
+    logger.info(f"Alert {target_label} validated successfully")
+
+    logger.test_step("Verify alert is cleared after monitors recovery")
+    stop_time = measure_stop_ceph_mon.get("stop")
+    logger.info(f"Checking alert clearance after time: {stop_time}")
+    api.check_alert_cleared(label=target_label, measure_end_time=stop_time)
+    logger.info(f"Alert {target_label} cleared successfully")
+
+    logger.info(
+        "Test passed: Monitor quorum lost alert triggered and cleared as expected"
     )
 
 
@@ -133,11 +186,14 @@ def test_ceph_osd_stopped(measure_stop_ceph_osd, threading_lock):
     Test that there is appropriate alert related to situation when ceph osd
     is down. Alert is cleared when osd disk is back online.
     """
-    api = prometheus.PrometheusAPI(threading_lock=threading_lock)
+    logger.info("Starting test: Verify Ceph OSD stopped alerts trigger and clear")
 
-    # get alerts from time when manager deployment was scaled down
+    logger.test_step("Initialize Prometheus API and retrieve alerts")
+    api = prometheus.PrometheusAPI(threading_lock=threading_lock)
     alerts = measure_stop_ceph_osd.get("prometheus_alerts")
-    for target_label, target_msg, target_states, target_severity, ignore in [
+    logger.info(f"Number of alerts retrieved: {len(alerts) if alerts else 0}")
+
+    alert_configs = [
         (
             constants.ALERT_OSDDISKNOTRESPONDING,
             "Disk not responding",
@@ -159,7 +215,28 @@ def test_ceph_osd_stopped(measure_stop_ceph_osd, threading_lock):
             "warning",
             True,
         ),
-    ]:
+    ]
+    logger.info(f"Checking {len(alert_configs)} alert types")
+
+    logger.test_step("Validate and verify clearance for each OSD alert")
+    # the time to wait is increased because it takes more time for osd pod
+    # to be ready than for other pods
+    osd_up_wait = 360
+    logger.debug(f"OSD clearance timeout: {osd_up_wait}min")
+
+    for i, (
+        target_label,
+        target_msg,
+        target_states,
+        target_severity,
+        ignore,
+    ) in enumerate(alert_configs, 1):
+        logger.info(
+            f"Processing alert {i}/{len(alert_configs)}: {target_label} "
+            f"(severity: {target_severity}, ignore_more: {ignore})"
+        )
+
+        logger.debug(f"Validating {target_label} with states={target_states}")
         prometheus.check_alert_list(
             label=target_label,
             msg=target_msg,
@@ -168,21 +245,28 @@ def test_ceph_osd_stopped(measure_stop_ceph_osd, threading_lock):
             severity=target_severity,
             ignore_more_occurences=ignore,
         )
-        # the time to wait is increased because it takes more time for osd pod
-        # to be ready than for other pods
-        osd_up_wait = 360
+        logger.info(f"Alert {target_label} validated successfully")
+
+        logger.debug(f"Verifying {target_label} is cleared (timeout={osd_up_wait}min)")
         api.check_alert_cleared(
             label=target_label,
             measure_end_time=measure_stop_ceph_osd.get("stop"),
             time_min=osd_up_wait,
         )
+        logger.info(f"Alert {target_label} cleared successfully")
+
+    logger.info("Test passed: All Ceph OSD alerts triggered and cleared as expected")
 
 
 def setup_module(module):
+    logger.info("Setting up module: Storing original user for cleanup")
     ocs_obj = OCP()
     module.original_user = ocs_obj.get_user_name()
+    logger.info(f"Original user stored: {module.original_user}")
 
 
 def teardown_module(module):
+    logger.info("Tearing down module: Restoring original user")
     ocs_obj = OCP()
     ocs_obj.login_as_user(module.original_user)
+    logger.info(f"Restored user: {module.original_user}")

--- a/tests/functional/monitoring/prometheus/alerts/test_encryption.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_encryption.py
@@ -13,7 +13,7 @@ from ocs_ci.utility import prometheus
 from ocs_ci.ocs.ocp import OCP
 
 
-log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 @blue_squad
@@ -28,10 +28,16 @@ def test_kms_unavailable(measure_rewrite_kms_endpoint, threading_lock):
     this alert is cleared when the KMS endpoint is back online.
 
     """
+    logger.info("Starting test: Verify KMS unavailable alert triggers and clears")
+
+    logger.test_step("Initialize Prometheus API and retrieve alerts")
     api = prometheus.PrometheusAPI(threading_lock=threading_lock)
 
     # get alerts from time when manager deployment was scaled down
     alerts = measure_rewrite_kms_endpoint.get("prometheus_alerts")
+    logger.info(f"Number of alerts retrieved: {len(alerts) if alerts else 0}")
+
+    logger.test_step("Prepare alert validation parameters")
     target_label = constants.ALERT_KMSSERVERCONNECTIONALERT
     config_namespace = config.ENV_DATA["cluster_namespace"]
     config_cluster = config.ENV_DATA["storage_cluster_name"]
@@ -40,26 +46,48 @@ def test_kms_unavailable(measure_rewrite_kms_endpoint, threading_lock):
         f"KMS config in namespace:cluster {config_namespace}:{config_cluster}."
     )
     states = ["pending", "firing"]
+    severity = "error"
 
+    logger.info(f"Target alert: {target_label}")
+    logger.info(f"Namespace: {config_namespace}, Cluster: {config_cluster}")
+    logger.debug(f"Expected states: {states}, severity: {severity}")
+
+    logger.test_step("Validate KMS server connection alert is present")
     prometheus.check_alert_list(
         label=target_label,
         msg=target_msg,
         alerts=alerts,
         states=states,
-        severity="error",
+        severity=severity,
     )
+    logger.info(f"Alert {target_label} validated successfully")
+
+    logger.test_step("Verify alert is cleared after KMS endpoint restoration")
+    stop_time = measure_rewrite_kms_endpoint.get("stop")
+    clearance_timeout = 300
+    logger.info(
+        f"Checking alert clearance (stop_time: {stop_time}, timeout: {clearance_timeout}min)"
+    )
+
     api.check_alert_cleared(
         label=target_label,
-        measure_end_time=measure_rewrite_kms_endpoint.get("stop"),
-        time_min=300,
+        measure_end_time=stop_time,
+        time_min=clearance_timeout,
     )
+    logger.info(f"Alert {target_label} cleared successfully")
+
+    logger.info("Test passed: KMS unavailable alert triggered and cleared as expected")
 
 
 def setup_module(module):
+    logger.info("Setting up module: Storing original user for cleanup")
     ocs_obj = OCP()
     module.original_user = ocs_obj.get_user_name()
+    logger.info(f"Original user stored: {module.original_user}")
 
 
 def teardown_module(module):
+    logger.info("Tearing down module: Restoring original user")
     ocs_obj = OCP()
     ocs_obj.login_as_user(module.original_user)
+    logger.info(f"Restored user: {module.original_user}")

--- a/tests/functional/monitoring/prometheus/alerts/test_hpa.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_hpa.py
@@ -25,16 +25,23 @@ def test_hpa_maxreplica_alert(threading_lock):
     """
     Test to verify that no HPA max replica alert is triggered
     """
-    api = prometheus.PrometheusAPI(threading_lock=threading_lock)
+    logger.info("Starting test: Verify no HPA max replica mismatch alerts")
 
-    logger.info(
-        f"Verifying whether {constants.ALERT_KUBEHPAREPLICASMISMATCH} "
-        f"has not been triggered"
+    logger.test_step("Initialize Prometheus API and check for HPA alerts")
+    api = prometheus.PrometheusAPI(threading_lock=threading_lock)
+    target_alert = constants.ALERT_KUBEHPAREPLICASMISMATCH
+    logger.info(f"Checking for alert: {target_alert} (timeout=10s)")
+
+    alerts = api.wait_for_alert(name=target_alert, timeout=10, sleep=1)
+
+    logger.test_step("Verify no HPA replica mismatch alerts are present")
+    alert_count = len(alerts)
+    logger.assertion(
+        f"Alert count for {target_alert}: expected=0, actual={alert_count}"
     )
-    alerts = api.wait_for_alert(
-        name=constants.ALERT_KUBEHPAREPLICASMISMATCH, timeout=10, sleep=1
-    )
-    if len(alerts) > 0:
-        assert (
-            False
-        ), f"Failed: There should be no {constants.ALERT_KUBEHPAREPLICASMISMATCH} alert"
+
+    if alert_count > 0:
+        logger.debug(f"Unexpected alerts found: {alerts}")
+        assert False, f"Failed: There should be no {target_alert} alert"
+
+    logger.info("Test passed: No HPA max replica mismatch alerts detected")

--- a/tests/functional/monitoring/prometheus/alerts/test_noobaa.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_noobaa.py
@@ -18,7 +18,7 @@ from ocs_ci.ocs import constants
 from ocs_ci.utility import prometheus, version
 from ocs_ci.ocs.ocp import OCP
 
-log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 @mcg
@@ -33,12 +33,23 @@ def test_noobaa_bucket_quota(measure_noobaa_exceed_bucket_quota, threading_lock)
     """
     Test that there are appropriate alerts when NooBaa Bucket Quota is reached.
     """
+    logger.info("Starting test: Verify NooBaa bucket quota alerts trigger and clear")
+
+    logger.test_step("Initialize Prometheus API and retrieve alerts")
     api = prometheus.PrometheusAPI(threading_lock=threading_lock)
 
     alerts = measure_noobaa_exceed_bucket_quota.get("prometheus_alerts")
+    logger.info(f"Number of alerts retrieved: {len(alerts) if alerts else 0}")
+
+    logger.test_step("Determine expected alerts based on OCS version")
+    ocs_version = version.get_semantic_ocs_version_from_config()
+    logger.info(f"OCS version: {ocs_version}")
 
     # since version 4.5 all NooBaa alerts have defined Pending state
-    if version.get_semantic_ocs_version_from_config() < version.VERSION_4_5:
+    if ocs_version < version.VERSION_4_5:
+        logger.debug(
+            "Using OCS < 4.5 alert configuration (no pending state for some alerts)"
+        )
         expected_alerts = [
             (
                 constants.ALERT_BUCKETREACHINGQUOTASTATE,
@@ -59,7 +70,8 @@ def test_noobaa_bucket_quota(measure_noobaa_exceed_bucket_quota, threading_lock)
                 "warning",
             ),
         ]
-    elif version.get_semantic_ocs_version_from_config() < version.VERSION_4_13:
+    elif ocs_version < version.VERSION_4_13:
+        logger.debug("Using OCS 4.5-4.12 alert configuration (with pending states)")
         expected_alerts = [
             (
                 constants.ALERT_BUCKETREACHINGQUOTASTATE,
@@ -81,6 +93,7 @@ def test_noobaa_bucket_quota(measure_noobaa_exceed_bucket_quota, threading_lock)
             ),
         ]
     else:
+        logger.debug("Using OCS >= 4.13 alert configuration (size quota alerts)")
         expected_alerts = [
             (
                 constants.ALERT_BUCKETREACHINGSIZEQUOTASTATE,
@@ -102,7 +115,24 @@ def test_noobaa_bucket_quota(measure_noobaa_exceed_bucket_quota, threading_lock)
             ),
         ]
 
-    for target_label, target_msg, target_states, target_severity in expected_alerts:
+    logger.info(f"Checking {len(expected_alerts)} NooBaa bucket quota alert types")
+
+    logger.test_step("Validate and verify clearance for each bucket quota alert")
+    # the time to wait is increased because it takes more time for OCS
+    # cluster to resolve its issues
+    pg_wait = 480
+    stop_time = measure_noobaa_exceed_bucket_quota.get("stop")
+    logger.debug(f"Alert clearance timeout: {pg_wait}min, stop_time: {stop_time}")
+
+    for i, (target_label, target_msg, target_states, target_severity) in enumerate(
+        expected_alerts, 1
+    ):
+        logger.info(
+            f"Processing alert {i}/{len(expected_alerts)}: {target_label} "
+            f"(severity: {target_severity})"
+        )
+
+        logger.debug(f"Validating {target_label} with states={target_states}")
         prometheus.check_alert_list(
             label=target_label,
             msg=target_msg,
@@ -110,14 +140,17 @@ def test_noobaa_bucket_quota(measure_noobaa_exceed_bucket_quota, threading_lock)
             states=target_states,
             severity=target_severity,
         )
-        # the time to wait is increased because it takes more time for OCS
-        # cluster to resolve its issues
-        pg_wait = 480
+        logger.info(f"Alert {target_label} validated successfully")
+
+        logger.debug(f"Verifying {target_label} is cleared (timeout={pg_wait}min)")
         api.check_alert_cleared(
             label=target_label,
-            measure_end_time=measure_noobaa_exceed_bucket_quota.get("stop"),
+            measure_end_time=stop_time,
             time_min=pg_wait,
         )
+        logger.info(f"Alert {target_label} cleared successfully")
+
+    logger.info("Test passed: NooBaa bucket quota alerts validated successfully")
 
 
 @mcg
@@ -133,10 +166,17 @@ def test_noobaa_ns_bucket(measure_noobaa_ns_target_bucket_deleted, threading_loc
     Test that there are appropriate alerts when target bucket used of
     namespace store used in namespace bucket is deleted.
     """
+    logger.info(
+        "Starting test: Verify NooBaa namespace bucket alerts when target bucket deleted"
+    )
+
+    logger.test_step("Initialize Prometheus API and retrieve alerts")
     api = prometheus.PrometheusAPI(threading_lock=threading_lock)
 
     alerts = measure_noobaa_ns_target_bucket_deleted.get("prometheus_alerts")
+    logger.info(f"Number of alerts retrieved: {len(alerts) if alerts else 0}")
 
+    logger.test_step("Define expected namespace bucket error alerts")
     expected_alerts = [
         (
             constants.ALERT_NAMESPACEBUCKETERRORSTATE,
@@ -151,8 +191,24 @@ def test_noobaa_ns_bucket(measure_noobaa_ns_target_bucket_deleted, threading_loc
             "warning",
         ),
     ]
+    logger.info(f"Checking {len(expected_alerts)} namespace bucket alert types")
 
-    for target_label, target_msg, target_states, target_severity in expected_alerts:
+    logger.test_step("Validate and verify clearance for each namespace bucket alert")
+    # the time to wait is increased because it takes more time for NooBaa
+    # to clear the alert
+    pg_wait = 600
+    stop_time = measure_noobaa_ns_target_bucket_deleted.get("stop")
+    logger.debug(f"Alert clearance timeout: {pg_wait}min, stop_time: {stop_time}")
+
+    for i, (target_label, target_msg, target_states, target_severity) in enumerate(
+        expected_alerts, 1
+    ):
+        logger.info(
+            f"Processing alert {i}/{len(expected_alerts)}: {target_label} "
+            f"(severity: {target_severity})"
+        )
+
+        logger.debug(f"Validating {target_label} with states={target_states}")
         prometheus.check_alert_list(
             label=target_label,
             msg=target_msg,
@@ -160,14 +216,17 @@ def test_noobaa_ns_bucket(measure_noobaa_ns_target_bucket_deleted, threading_loc
             states=target_states,
             severity=target_severity,
         )
-        # the time to wait is increased because it takes more time for NooBaa
-        # to clear the alert
-        pg_wait = 600
+        logger.info(f"Alert {target_label} validated successfully")
+
+        logger.debug(f"Verifying {target_label} is cleared (timeout={pg_wait}min)")
         api.check_alert_cleared(
             label=target_label,
-            measure_end_time=measure_noobaa_ns_target_bucket_deleted.get("stop"),
+            measure_end_time=stop_time,
             time_min=pg_wait,
         )
+        logger.info(f"Alert {target_label} cleared successfully")
+
+    logger.info("Test passed: NooBaa namespace bucket alerts validated successfully")
 
 
 @mcg
@@ -180,22 +239,48 @@ def test_noobaa_prometheus_rules_exist():
     """
     Verify that the NooBaa PrometheusRule CR exists and contains rule groups.
     """
+    logger.info(
+        "Starting test: Verify NooBaa PrometheusRule CR exists and contains rule groups"
+    )
+
+    logger.test_step("Retrieve NooBaa PrometheusRule CR")
+    namespace = config.ENV_DATA["cluster_namespace"]
+    rule_name = "noobaa-prometheus-rules"
+    logger.info(f"Looking for PrometheusRule: {rule_name} in namespace {namespace}")
+
     prometheus_rule = OCP(
         api_version="monitoring.coreos.com/v1",
         kind="PrometheusRule",
-        namespace=config.ENV_DATA["cluster_namespace"],
+        namespace=namespace,
     )
-    rule = prometheus_rule.get(resource_name="noobaa-prometheus-rules")
+    rule = prometheus_rule.get(resource_name=rule_name)
+    logger.debug(f"Retrieved PrometheusRule CR: {rule_name}")
+
+    logger.test_step("Validate rule groups are present")
     groups = rule.get("spec", {}).get("groups", [])
-    log.info(f"Found {len(groups)} rule groups: " f"{[g['name'] for g in groups]}")
-    assert groups, "noobaa-prometheus-rules PrometheusRule CR has no rule groups"
+    group_count = len(groups)
+    group_names = [g["name"] for g in groups]
+
+    logger.info(f"Found {group_count} rule groups: {group_names}")
+
+    has_groups = group_count > 0
+    logger.assertion(
+        f"PrometheusRule has rule groups: expected>0, actual={group_count}, has_groups={has_groups}"
+    )
+    assert has_groups, "noobaa-prometheus-rules PrometheusRule CR has no rule groups"
+
+    logger.info("Test passed: NooBaa PrometheusRule CR validated successfully")
 
 
 def setup_module(module):
+    logger.info("Setting up module: Storing original user for cleanup")
     ocs_obj = OCP()
     module.original_user = ocs_obj.get_user_name()
+    logger.info(f"Original user stored: {module.original_user}")
 
 
 def teardown_module(module):
+    logger.info("Tearing down module: Restoring original user")
     ocs_obj = OCP()
     ocs_obj.login_as_user(module.original_user)
+    logger.info(f"Restored user: {module.original_user}")

--- a/tests/functional/monitoring/prometheus/alerts/test_prometheus_rules.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_prometheus_rules.py
@@ -6,7 +6,7 @@ from ocs_ci.framework.testlib import tier4c, runs_on_provider
 from ocs_ci.helpers.helpers import run_cmd_verify_cli_output
 
 
-log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 @blue_squad
@@ -18,8 +18,22 @@ def test_prometheus_file():
     Verify ocs-prometheus-rules/prometheus-ocs-rules.yaml file exist.
 
     """
-    assert run_cmd_verify_cli_output(
+    logger.info("Starting test: Verify Prometheus rules file exists")
+
+    logger.test_step("Check for prometheus-ocs-rules.yaml file in OCS operator")
+    rules_file = "/ocs-prometheus-rules/prometheus-ocs-rules.yaml"
+    expected_filename = "prometheus-ocs-rules.yaml"
+    logger.info(f"Verifying file exists: {rules_file}")
+
+    file_found = run_cmd_verify_cli_output(
         ocs_operator_cmd=True,
-        expected_output_lst=["prometheus-ocs-rules.yaml"],
-        cmd="ls /ocs-prometheus-rules/prometheus-ocs-rules.yaml",
-    ), "Prometheus rules file not found"
+        expected_output_lst=[expected_filename],
+        cmd=f"ls {rules_file}",
+    )
+
+    logger.assertion(
+        f"Prometheus rules file exists: expected=True, actual={file_found}"
+    )
+    assert file_found, "Prometheus rules file not found"
+
+    logger.info(f"Test passed: {rules_file} exists successfully")

--- a/tests/functional/monitoring/prometheus/alerts/test_provider_client.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_provider_client.py
@@ -13,7 +13,7 @@ from ocs_ci.utility import prometheus
 from ocs_ci.ocs.ocp import OCP
 
 
-log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 @blue_squad
@@ -33,9 +33,11 @@ def test_change_client_ocs_version_and_stop_heartbeat(
     version should contain previous version.
 
     """
+    logger.info("Starting test: Verify client version change and heartbeat stop alerts")
+
+    logger.test_step("Initialize Prometheus API and retrieve test metadata")
     api = prometheus.PrometheusAPI(threading_lock=threading_lock)
 
-    # get alerts from time when manager deployment was scaled down
     alerts = measure_change_client_ocs_version_and_stop_heartbeat.get(
         "prometheus_alerts"
     )
@@ -44,6 +46,13 @@ def test_change_client_ocs_version_and_stop_heartbeat(
     ).get("client_name")
     cluster_namespace = config.ENV_DATA["cluster_namespace"]
     cluster_name = config.ENV_DATA["storage_cluster_name"]
+
+    logger.info(f"Client name: {client_name}")
+    logger.info(f"Cluster namespace: {cluster_namespace}")
+    logger.info(f"Cluster name: {cluster_name}")
+    logger.info(f"Number of alerts retrieved: {len(alerts) if alerts else 0}")
+
+    logger.test_step("Define expected alerts for client version change and heartbeat")
     target_alerts = [
         {
             "label": constants.ALERT_STORAGECLIENTHEARTBEATMISSED,
@@ -71,29 +80,54 @@ def test_change_client_ocs_version_and_stop_heartbeat(
         },
     ]
     states = ["firing"]
+    logger.info(f"Checking {len(target_alerts)} expected alerts")
+    logger.debug(f"Expected alert states: {states}")
 
-    for target_alert in target_alerts:
+    logger.test_step("Validate and verify clearance for each expected alert")
+    for i, target_alert in enumerate(target_alerts, 1):
+        alert_label = target_alert["label"]
+        alert_severity = target_alert["severity"]
+        logger.info(
+            f"Processing alert {i}/{len(target_alerts)}: {alert_label} "
+            f"(severity: {alert_severity})"
+        )
+
+        logger.debug(f"Validating alert {alert_label} is present in firing state")
         prometheus.check_alert_list(
-            label=target_alert["label"],
+            label=alert_label,
             msg=target_alert["msg"],
             alerts=alerts,
             states=states,
-            severity=target_alert["severity"],
+            severity=alert_severity,
+        )
+        logger.info(f"Alert {alert_label} validated successfully")
+
+        logger.debug(
+            f"Verifying alert {alert_label} is cleared after heartbeat resumes"
         )
         api.check_alert_cleared(
-            label=target_alert["label"],
+            label=alert_label,
             measure_end_time=measure_change_client_ocs_version_and_stop_heartbeat.get(
                 "stop"
             ),
             time_min=300,
         )
+        logger.info(f"Alert {alert_label} cleared successfully")
+
+    logger.info(
+        "Test passed: All client version and heartbeat alerts triggered and cleared as expected"
+    )
 
 
 def setup_module(module):
+    logger.info("Setting up module: Storing original user for cleanup")
     ocs_obj = OCP()
     module.original_user = ocs_obj.get_user_name()
+    logger.info(f"Original user stored: {module.original_user}")
 
 
 def teardown_module(module):
+    logger.info("Tearing down module: Restoring original user")
     ocs_obj = OCP()
     ocs_obj.login_as_user(module.original_user)
+    logger.info(f"Restored user: {module.original_user}")

--- a/tests/functional/monitoring/prometheus/alerts/test_rgw.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_rgw.py
@@ -11,7 +11,7 @@ from ocs_ci.utility import prometheus
 from ocs_ci.ocs.ocp import OCP
 
 
-log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 @blue_squad
@@ -25,27 +25,39 @@ def test_rgw_unavailable(measure_stop_rgw, threading_lock):
     this alert is cleared when the RGW interface is back online.
 
     """
+    logger.info("Starting test: Verify RGW unavailable alert triggers and clears")
 
+    logger.test_step("Initialize Prometheus API and retrieve alerts from RGW downtime")
     api = prometheus.PrometheusAPI(threading_lock=threading_lock)
-
-    # get alerts from time when manager deployment was scaled down
     alerts = measure_stop_rgw.get("prometheus_alerts")
     target_label = constants.ALERT_CLUSTEROBJECTSTORESTATE
-    # The alert message is changed since OCS 4.7
+    logger.info(f"Target alert: {target_label}")
+    logger.info(f"Number of alerts retrieved: {len(alerts) if alerts else 0}")
+
+    logger.test_step("Determine expected alert message based on OCS version")
     ocs_version = config.ENV_DATA["ocs_version"]
+    logger.info(f"OCS version: {ocs_version}")
+
     if Version.coerce(ocs_version) < Version.coerce("4.7"):
         target_msg = (
             "Cluster Object Store is in unhealthy state for more than 15s. "
             "Please check Ceph cluster health or RGW connection."
         )
+        logger.info("Using pre-4.7 alert message format")
     else:
         target_msg = (
             "Cluster Object Store is in unhealthy state or number of ready replicas for "
             "Rook Ceph RGW deployments is less than the desired replicas in "
             f"namespace:cluster {config.ENV_DATA['cluster_namespace']}:."
         )
-    states = ["pending", "firing"]
+        logger.info("Using OCS 4.7+ alert message format")
 
+    states = ["pending", "firing"]
+    logger.debug(f"Expected alert states: {states}")
+
+    logger.test_step(
+        "Validate ClusterObjectStoreState alert is present with correct properties"
+    )
     prometheus.check_alert_list(
         label=target_label,
         msg=target_msg,
@@ -53,16 +65,28 @@ def test_rgw_unavailable(measure_stop_rgw, threading_lock):
         states=states,
         severity="error",
     )
+    logger.info(f"Alert {target_label} validated successfully")
+
+    logger.test_step("Verify alert is cleared after RGW becomes available")
+    stop_time = measure_stop_rgw.get("stop")
+    logger.info(f"Checking alert clearance after time: {stop_time}")
     api.check_alert_cleared(
-        label=target_label, measure_end_time=measure_stop_rgw.get("stop"), time_min=300
+        label=target_label, measure_end_time=stop_time, time_min=300
     )
+    logger.info(f"Alert {target_label} cleared successfully")
+
+    logger.info("Test passed: RGW unavailable alert triggered and cleared as expected")
 
 
 def setup_module(module):
+    logger.info("Setting up module: Storing original user for cleanup")
     ocs_obj = OCP()
     module.original_user = ocs_obj.get_user_name()
+    logger.info(f"Original user stored: {module.original_user}")
 
 
 def teardown_module(module):
+    logger.info("Tearing down module: Restoring original user")
     ocs_obj = OCP()
     ocs_obj.login_as_user(module.original_user)
+    logger.info(f"Restored user: {module.original_user}")

--- a/tests/functional/monitoring/prometheus/metrics/test_block_pvc_kubelet_rbd_usage.py
+++ b/tests/functional/monitoring/prometheus/metrics/test_block_pvc_kubelet_rbd_usage.py
@@ -19,7 +19,13 @@ def teardown(request):
     """
 
     def finalizer():
-        assert ceph_health_check(), "Cluster became unhealthy after metrics test"
+        logger.info("Teardown: Verifying cluster health after metrics test")
+        cluster_healthy = ceph_health_check()
+        logger.assertion(
+            f"Cluster health after test: expected=healthy, actual={'healthy' if cluster_healthy else 'unhealthy'}"
+        )
+        assert cluster_healthy, "Cluster became unhealthy after metrics test"
+        logger.info("Teardown completed: Cluster is healthy")
 
     request.addfinalizer(finalizer)
 
@@ -48,8 +54,15 @@ def test_rbd_metrics_validation_multi_scenario(
     by both Kubelet (via Prometheus) and the Ceph backend (rbd du) across
     multiple write operations and volume modes.
     """
+    logger.info(
+        f"Starting test: Validate RBD metrics across Kubelet and Ceph "
+        f"(volume_mode={volume_mode}, size={pvc_size}Gi, write={write_size_mib}MiB)"
+    )
+
+    logger.test_step("Create project and PVC for metrics validation")
     project_obj = project_factory()
     namespace = project_obj.namespace
+    logger.info(f"Created project with namespace: {namespace}")
 
     pvc_obj = pvc_factory(
         project=project_obj,
@@ -59,7 +72,11 @@ def test_rbd_metrics_validation_multi_scenario(
         interface=constants.CEPHBLOCKPOOL,
         wait_for_resource_status_timeout=300,
     )
+    logger.info(
+        f"Created PVC: {pvc_obj.name}, volume_mode={volume_mode}, size={pvc_size}Gi"
+    )
 
+    logger.test_step("Determine pod configuration based on volume mode")
     pod_dict_path = (
         constants.CSI_RBD_RAW_BLOCK_POD_YAML
         if volume_mode == constants.VOLUME_MODE_BLOCK
@@ -70,36 +87,59 @@ def test_rbd_metrics_validation_multi_scenario(
         if volume_mode == constants.VOLUME_MODE_BLOCK
         else "/var/lib/www/html/test_file"
     )
+    logger.debug(f"Pod template: {pod_dict_path}, device path: {dev_path}")
 
+    logger.test_step("Create pod with PVC attached")
     pod_obj = pod_factory(
         interface=constants.CEPHBLOCKPOOL,
         pvc=pvc_obj,
         pod_dict_path=pod_dict_path,
         status=constants.STATUS_RUNNING,
     )
+    logger.info(f"Created pod: {pod_obj.name}, status=Running")
 
+    logger.test_step("Initialize Prometheus API for metrics queries")
     prom = PrometheusAPI(threading_lock=threading.Lock())
+    logger.debug("Prometheus API initialized")
 
     # Step 1: Initial Write
+    logger.test_step("Perform initial write and validate metrics")
     initial_write_mib = write_size_mib
-    logger.info(f"Step 1: Writing {initial_write_mib}MiB to {dev_path}")
+    logger.info(f"Writing {initial_write_mib}MiB to {dev_path}")
+
+    dd_cmd = get_dd_command(volume_mode, dev_path, initial_write_mib)
+    logger.debug(f"DD command: {dd_cmd}")
     pod_obj.exec_cmd_on_pod(
-        command=f"bash -lc '{get_dd_command(volume_mode, dev_path, initial_write_mib)}'",
+        command=f"bash -lc '{dd_cmd}'",
         out_yaml_format=False,
     )
+    logger.info(f"Initial write completed: {initial_write_mib}MiB written")
 
     validate_all_layers(prom, pvc_obj, namespace, initial_write_mib, volume_mode)
 
     # Step 2: Additional Write
+    logger.test_step("Perform additional write and re-validate metrics")
     extra_write_mib = 128
     total_write_mib = initial_write_mib + extra_write_mib
-    logger.info(f"Step 2: Appending {extra_write_mib}MiB to {dev_path}")
-    pod_obj.exec_cmd_on_pod(
-        command=f"bash -lc '{get_dd_command(volume_mode, dev_path, extra_write_mib, initial_write_mib, True)}'",
-        out_yaml_format=False,
+    logger.info(
+        f"Appending {extra_write_mib}MiB to {dev_path} (total: {total_write_mib}MiB)"
     )
 
+    append_cmd = get_dd_command(
+        volume_mode, dev_path, extra_write_mib, initial_write_mib, True
+    )
+    logger.debug(f"DD append command: {append_cmd}")
+    pod_obj.exec_cmd_on_pod(
+        command=f"bash -lc '{append_cmd}'",
+        out_yaml_format=False,
+    )
+    logger.info(f"Additional write completed: {extra_write_mib}MiB appended")
+
     validate_all_layers(prom, pvc_obj, namespace, total_write_mib, volume_mode)
+
+    logger.info(
+        f"Test passed: RBD metrics validated successfully for {volume_mode} mode"
+    )
 
 
 def validate_all_layers(prom_api, pvc_obj, namespace, expected_mib, volume_mode):
@@ -113,14 +153,20 @@ def validate_all_layers(prom_api, pvc_obj, namespace, expected_mib, volume_mode)
         expected_mib (int): The amount of data written in MiB.
         volume_mode (str): The volume mode (Block or Filesystem).
     """
+    logger.info(
+        f"Validating metrics for PVC {pvc_obj.name}: expected={expected_mib}MiB, mode={volume_mode}"
+    )
     expected_bytes = expected_mib * 1024 * 1024
+    logger.debug(f"Expected bytes: {expected_bytes}")
 
     # 1. Fetch Prometheus Metrics
+    logger.debug("Fetching Kubelet metrics from Prometheus")
     kube_metrics = wait_for_all_metrics(
         prom_api, pvc_obj.name, namespace, expected_bytes
     )
 
     # 2. Fetch Ceph Side Truth
+    logger.debug("Fetching Ceph RBD metrics")
     ceph_metrics = get_ceph_rbd_metrics(pvc_obj)
 
     logger.info(f"Kubelet Metrics: {kube_metrics}")
@@ -128,45 +174,90 @@ def validate_all_layers(prom_api, pvc_obj, namespace, expected_mib, volume_mode)
 
     # CAPACITY CHECK
     if volume_mode == constants.VOLUME_MODE_BLOCK:
+        logger.info("Validating Block mode metrics (exact match expected)")
+
         # Block mode should be exact
+        capacity_match = kube_metrics["capacity"] == ceph_metrics["capacity"]
+        logger.assertion(
+            f"Capacity match: Kube={kube_metrics['capacity']}, Ceph={ceph_metrics['capacity']}, match={capacity_match}"
+        )
         assert (
-            kube_metrics["capacity"] == ceph_metrics["capacity"]
+            capacity_match
         ), f"Capacity mismatch! Kube: {kube_metrics['capacity']}, Ceph: {ceph_metrics['capacity']}"
 
+        used_match = kube_metrics["used"] == ceph_metrics["used"]
+        logger.assertion(
+            f"Used bytes match: Kube={kube_metrics['used']}, Ceph={ceph_metrics['used']}, match={used_match}"
+        )
         assert (
-            kube_metrics["used"] == ceph_metrics["used"]
+            used_match
         ), f"Used bytes out of sync! Kube: {kube_metrics['used']}, Ceph: {ceph_metrics['used']}"
 
+        available_match = kube_metrics["available"] == ceph_metrics["available"]
+        logger.assertion(
+            f"Available bytes match: Kube={kube_metrics['available']}, "
+            f"Ceph={ceph_metrics['available']}, match={available_match}"
+        )
         assert (
-            kube_metrics["available"] == ceph_metrics["available"]
+            available_match
         ), f"Available bytes out of sync! Kube: {kube_metrics['available']}, Ceph: {ceph_metrics['available']}"
 
+        used_sufficient = kube_metrics["used"] >= expected_bytes
+        logger.assertion(
+            f"Used >= expected: Kube={kube_metrics['used']}, expected={expected_bytes}, sufficient={used_sufficient}"
+        )
         assert (
-            kube_metrics["used"] >= expected_bytes
+            used_sufficient
         ), f"Kubelet reports less used than written! Kube: {kube_metrics['used']}, Target: {expected_bytes}"
+
+        logger.info("Block mode validation passed: All metrics match exactly")
+
     else:
+        logger.info("Validating Filesystem mode metrics (tolerance-based)")
+
         # Filesystem mode tolerance check
         tolerance_factor = 0.90
-        assert kube_metrics["capacity"] >= (
-            ceph_metrics["capacity"] * tolerance_factor
-        ), (
+        min_capacity = ceph_metrics["capacity"] * tolerance_factor
+        capacity_ok = kube_metrics["capacity"] >= min_capacity
+        logger.assertion(
+            f"Capacity within tolerance: Kube={kube_metrics['capacity']}, "
+            f"min_required={min_capacity:.0f} (90% of Ceph), ok={capacity_ok}"
+        )
+        assert capacity_ok, (
             f"Capacity mismatch! Kubelet reports too much overhead. "
             f"Kube: {kube_metrics['capacity']}, Ceph: {ceph_metrics['capacity']}"
         )
 
         margin = 50 * 1024 * 1024
-
+        used_diff = abs(kube_metrics["used"] - ceph_metrics["used"])
+        used_in_sync = used_diff < margin
+        logger.assertion(
+            f"Used bytes in sync: Kube={kube_metrics['used']}, Ceph={ceph_metrics['used']}, "
+            f"diff={used_diff}, margin={margin}, in_sync={used_in_sync}"
+        )
         assert (
-            abs(kube_metrics["used"] - ceph_metrics["used"]) < margin
+            used_in_sync
         ), f"Used bytes out of sync! Kube: {kube_metrics['used']}, Ceph: {ceph_metrics['used']}"
 
+        available_diff = abs(kube_metrics["available"] - ceph_metrics["available"])
+        available_in_sync = available_diff < margin
+        logger.assertion(
+            f"Available bytes in sync: Kube={kube_metrics['available']}, Ceph={ceph_metrics['available']}, "
+            f"diff={available_diff}, margin={margin}, in_sync={available_in_sync}"
+        )
         assert (
-            abs(kube_metrics["available"] - ceph_metrics["available"]) < margin
+            available_in_sync
         ), f"Available bytes out of sync! Kube: {kube_metrics['available']}, Ceph: {ceph_metrics['available']}"
 
+        used_sufficient = kube_metrics["used"] >= expected_bytes
+        logger.assertion(
+            f"Used >= expected: Kube={kube_metrics['used']}, expected={expected_bytes}, sufficient={used_sufficient}"
+        )
         assert (
-            kube_metrics["used"] >= expected_bytes
+            used_sufficient
         ), f"Kubelet reports less used than written! Kube: {kube_metrics['used']}, Target: {expected_bytes}"
+
+        logger.info("Filesystem mode validation passed: All metrics within tolerance")
 
 
 def get_ceph_rbd_metrics(pvc_obj):
@@ -179,6 +270,8 @@ def get_ceph_rbd_metrics(pvc_obj):
     Returns:
         dict: A dictionary containing 'used', 'capacity', and 'available' bytes.
     """
+    logger.debug(f"Getting Ceph metrics for PVC: {pvc_obj.name}")
+
     ceph_toolbox = pod_helpers.get_ceph_tools_pod()
     pv_data = pvc_obj.backed_pv_obj.get()
     rbd_pool = default_ceph_block_pool()
@@ -189,12 +282,19 @@ def get_ceph_rbd_metrics(pvc_obj):
         .get("imageName")
     )
 
+    logger.debug(f"RBD image details: pool={rbd_pool}, image={rbd_image}")
+
     rbd_cmd = f"rbd du -p {rbd_pool} {rbd_image}"
+    logger.debug(f"Executing Ceph command: {rbd_cmd}")
     result = ceph_toolbox.exec_ceph_cmd(ceph_cmd=rbd_cmd, format="json")
 
     used = int(result["images"][0]["used_size"])
     capacity = int(result["images"][0]["provisioned_size"])
     available = capacity - used
+
+    logger.debug(
+        f"Ceph metrics retrieved: used={used}, capacity={capacity}, available={available}"
+    )
 
     return {"used": used, "capacity": capacity, "available": available}
 
@@ -260,13 +360,33 @@ def wait_for_all_metrics(prom_api, pvc_name, namespace, expected_used, timeout=6
     Raises:
         AssertionError: If metrics are not updated within the timeout.
     """
+    logger.info(
+        f"Waiting for Kubelet metrics to reflect {expected_used} bytes (timeout: {timeout}s)"
+    )
+
     start_time = time.time()
+    iteration = 0
+
     while time.time() - start_time < timeout:
+        iteration += 1
+        elapsed = round(time.time() - start_time)
+
         space_used = query_kubelet_metric(
             prom_api, "kubelet_volume_stats_used_bytes", pvc_name, namespace
         )
+
+        logger.debug(
+            f"Iteration {iteration}: used={space_used}, expected>={expected_used}, "
+            f"elapsed={elapsed}s, timeout={timeout}s"
+        )
+
         if space_used >= expected_used:
-            return {
+            logger.info(
+                f"Metrics updated successfully after {elapsed}s: "
+                f"used={space_used} >= expected={expected_used}"
+            )
+
+            metrics = {
                 "used": space_used,
                 "capacity": query_kubelet_metric(
                     prom_api, "kubelet_volume_stats_capacity_bytes", pvc_name, namespace
@@ -278,6 +398,17 @@ def wait_for_all_metrics(prom_api, pvc_name, namespace, expected_used, timeout=6
                     namespace,
                 ),
             }
-        logger.info(f"Waiting for Prometheus update... Current Kube Used: {space_used}")
+            logger.debug(f"All metrics retrieved: {metrics}")
+            return metrics
+
+        logger.info(
+            f"Waiting for Prometheus update... "
+            f"Current used: {space_used}, expected: {expected_used}, elapsed: {elapsed}s"
+        )
         time.sleep(60)
+
+    logger.error(
+        f"Metrics timeout after {timeout}s: "
+        f"last_used={space_used}, expected>={expected_used}"
+    )
     raise AssertionError(f"Metrics timeout at {expected_used} bytes")

--- a/tests/functional/monitoring/prometheus/metrics/test_mcg_hpa.py
+++ b/tests/functional/monitoring/prometheus/metrics/test_mcg_hpa.py
@@ -30,32 +30,82 @@ def test_hpa_noobaa_endpoint_metric():
     Test to verify HPA noobaa-hpav2 cpu metrics is available.
     Since 4.10, it uses horizontal-pod-autoscaler-v2 API.
     """
+    logger.info("Starting test: Verify NooBaa HPA CPU metrics are available")
+
+    logger.test_step("Determine OCP version and HPA API version")
     ocp_version = get_semantic_version(get_ocp_version(), only_major_minor=True)
+    logger.info(f"OCP version detected: {ocp_version}")
+
+    logger.test_step("Retrieve HPA status for noobaa-hpav2")
+    namespace = config.ENV_DATA["cluster_namespace"]
+    logger.info(f"Querying HPA resource: noobaa-hpav2 in namespace {namespace}")
+
     ocp_obj = ocp.OCP(
         kind=constants.HPA,
         resource_name="noobaa-hpav2",
-        namespace=config.ENV_DATA["cluster_namespace"],
+        namespace=namespace,
     )
     status = ocp_obj.get()["status"]
-    logger.info("Looking for cpu utilization value for hpa/noobaa-hpav2")
+    logger.debug(f"HPA status retrieved: {status}")
+
+    logger.test_step("Extract CPU utilization metric based on API version")
     cpu_utilization = None
+
     if ocp_version < VERSION_4_10:
-        logger.info("using horizontal-pod-autoscaler-v1 API")
-        assert (
-            "currentCPUUtilizationPercentage" in status
-        ), "Failed: noobaa-hpav2 cpu metrics is unavailable"
+        logger.info(
+            f"Using horizontal-pod-autoscaler-v1 API (OCP {ocp_version} < 4.10)"
+        )
+
+        cpu_field_present = "currentCPUUtilizationPercentage" in status
+        logger.assertion(
+            f"HPA v1 CPU field present: expected=True, actual={cpu_field_present}"
+        )
+        assert cpu_field_present, "Failed: noobaa-hpav2 cpu metrics is unavailable"
+
         cpu_utilization = status["currentCPUUtilizationPercentage"]
+        logger.debug(f"CPU utilization from v1 API: {cpu_utilization}%")
+
     else:
-        logger.info("using horizontal-pod-autoscaler-v2 API")
-        assert (
-            "currentMetrics" in status
-        ), "Failed: metrics not provided in noobaa-hpav2"
-        for metric in status["currentMetrics"]:
+        logger.info(
+            f"Using horizontal-pod-autoscaler-v2 API (OCP {ocp_version} >= 4.10)"
+        )
+
+        metrics_present = "currentMetrics" in status
+        logger.assertion(
+            f"HPA v2 currentMetrics field present: expected=True, actual={metrics_present}"
+        )
+        assert metrics_present, "Failed: metrics not provided in noobaa-hpav2"
+
+        metrics_count = len(status["currentMetrics"])
+        logger.debug(f"Processing {metrics_count} metrics from HPA v2 API")
+
+        for i, metric in enumerate(status["currentMetrics"], 1):
+            logger.debug(
+                f"Checking metric {i}/{metrics_count}: type={metric.get('type')}, "
+                f"resource={metric.get('resource', {}).get('name')}"
+            )
+
             if metric["type"] != "Resource":
                 continue
             if metric["resource"]["name"] != "cpu":
                 continue
+
             cpu_utilization = metric["resource"]["current"]["averageUtilization"]
-    assert cpu_utilization is not None, "Failed: noobaa-hpav2 cpu metrics not available"
-    assert cpu_utilization >= 0
-    logger.info("Current resource cpu utilized: %d%%", cpu_utilization)
+            logger.debug(f"CPU utilization from v2 API: {cpu_utilization}%")
+            break
+
+    logger.test_step("Validate CPU utilization metric")
+    metric_found = cpu_utilization is not None
+    logger.assertion(
+        f"CPU utilization metric found: expected=True, actual={metric_found}"
+    )
+    assert metric_found, "Failed: noobaa-hpav2 cpu metrics not available"
+
+    metric_valid = cpu_utilization >= 0
+    logger.assertion(
+        f"CPU utilization value valid: expected>=0, actual={cpu_utilization}, valid={metric_valid}"
+    )
+    assert metric_valid, f"CPU utilization should be >= 0, got {cpu_utilization}"
+
+    logger.info(f"Current resource cpu utilized: {cpu_utilization}%")
+    logger.info("Test passed: NooBaa HPA CPU metrics validated successfully")

--- a/tests/functional/monitoring/prometheus/metrics/test_monitoring_defaults.py
+++ b/tests/functional/monitoring/prometheus/metrics/test_monitoring_defaults.py
@@ -45,6 +45,7 @@ def test_monitoring_enabled(threading_lock):
     has a post deployment marker) by asking for values of one ceph and one
     noobaa related metrics.
     """
+    logger.info("Starting test: Verify OCS monitoring is enabled and provides metrics")
     prometheus = PrometheusAPI(threading_lock=threading_lock)
 
     if (
@@ -57,31 +58,48 @@ def test_monitoring_enabled(threading_lock):
         )
 
     else:
-        # ask for values of ceph_pool_stored metric
-        logger.info("Checking that ceph data are provided in OCS monitoring")
+        logger.test_step("Query and validate ceph_pool_stored metric")
         result = prometheus.query("ceph_pool_stored")
-        msg = "check that we actually received some values for a ceph query"
-        assert len(result) > 0, msg
+        logger.info(f"Received {len(result)} results for ceph_pool_stored metric")
+        logger.assertion(f"Ceph metric results: expected>0, actual={len(result)}")
+        assert len(result) > 0, "No values received for ceph_pool_stored query"
+
+        logger.info("Validating metric values are non-negative integers")
         for metric in result:
             _, value = metric["value"]
-            assert_msg = "number of bytes in a pool isn't a positive integer or zero"
-            assert int(value) >= 0, assert_msg
-        # additional check that values makes at least some sense
-        logger.info(
-            "Checking that size of ceph_pool_stored result matches number of pools"
+            logger.debug(f"Pool metric value: {value}")
+            logger.assertion(f"Pool bytes value: expected>=0, actual={int(value)}")
+            assert (
+                int(value) >= 0
+            ), "number of bytes in a pool isn't a positive integer or zero"
+
+        logger.test_step(
+            "Verify ceph_pool_stored result count matches actual pool count"
         )
         ct_pod = pod.get_ceph_tools_pod()
         ceph_pools = ct_pod.exec_ceph_cmd("ceph osd pool ls")
-        assert len(result) == len(ceph_pools)
+        logger.info(f"Ceph pools: {len(ceph_pools)}, Metric results: {len(result)}")
+        logger.assertion(
+            f"Pool count validation: expected={len(ceph_pools)}, actual={len(result)}"
+        )
+        assert len(result) == len(
+            ceph_pools
+        ), "Metric result count doesn't match pool count"
 
-    # again for a noobaa metric
-    logger.info("Checking that MCG/NooBaa data are provided in OCS monitoring")
+    logger.test_step("Query and validate NooBaa_bucket_status metric")
     result = prometheus.query("NooBaa_bucket_status")
-    msg = "check that we actually received some values for a MCG/NooBaa query"
-    assert len(result) > 0, msg
+    logger.info(f"Received {len(result)} results for NooBaa_bucket_status metric")
+    logger.assertion(f"NooBaa metric results: expected>0, actual={len(result)}")
+    assert len(result) > 0, "No values received for NooBaa_bucket_status query"
+
+    logger.info("Validating NooBaa metric values are non-negative integers")
     for metric in result:
         _, value = metric["value"]
+        logger.debug(f"Bucket status value: {value}")
+        logger.assertion(f"Bucket status value: expected>=0, actual={int(value)}")
         assert int(value) >= 0, "bucket status isn't a positive integer or zero"
+
+    logger.info("Test passed: OCS monitoring is enabled and providing valid metrics")
 
 
 @provider_mode
@@ -97,28 +115,53 @@ def test_ceph_mgr_dashboard_not_deployed():
 
     .. _`ceph mgr dashboard`: https://rook.io/docs/rook/v1.0/ceph-dashboard.html
     """
-    logger.info("Checking that there is no ceph mgr dashboard pod deployed")
+    logger.info("Starting test: Verify ceph mgr dashboard is not deployed")
+
+    logger.test_step("Verify no ceph mgr dashboard pods are deployed")
     ocp_pod = ocp.OCP(
         kind=constants.POD, namespace=config.ENV_DATA["cluster_namespace"]
     )
-    # if there is no "items" in the reply, OCS is very broken
     ocs_pods = ocp_pod.get()["items"]
+    logger.info(f"Checking {len(ocs_pods)} OCS pods for dashboard references")
+
+    dashboard_pods_found = []
     for pod_item in ocs_pods:
-        # just making the assumptions explicit
         assert pod_item["kind"] == constants.POD
         pod_name = pod_item["metadata"]["name"]
-        msg = "ceph mgr dashboard should not be deployed as part of OCS"
-        assert "dashboard" not in pod_name, msg
-        assert "ceph-mgr-dashboard" not in pod_name, msg
+        if "dashboard" in pod_name or "ceph-mgr-dashboard" in pod_name:
+            dashboard_pods_found.append(pod_name)
 
-    logger.info("Checking that there is no ceph mgr dashboard route")
+    logger.assertion(
+        f"Dashboard pods found: expected=0, actual={len(dashboard_pods_found)}"
+    )
+    assert len(dashboard_pods_found) == 0, (
+        f"ceph mgr dashboard pods should not be deployed as part of OCS. "
+        f"Found: {dashboard_pods_found}"
+    )
+    logger.info("No dashboard pods found in OCS namespace")
+
+    logger.test_step("Verify no ceph mgr dashboard routes are deployed")
     ocp_route = ocp.OCP(kind=constants.ROUTE)
-    for route in ocp_route.get(all_namespaces=True)["items"]:
-        # just making the assumptions explicit
+    all_routes = ocp_route.get(all_namespaces=True)["items"]
+    logger.info(f"Checking {len(all_routes)} routes across all namespaces")
+
+    dashboard_routes_found = []
+    for route in all_routes:
         assert route["kind"] == constants.ROUTE
         route_name = route["metadata"]["name"]
-        msg = "ceph mgr dashboard route should not be deployed as part of OCS"
-        assert "ceph-mgr-dashboard" not in route_name, msg
+        if "ceph-mgr-dashboard" in route_name:
+            dashboard_routes_found.append(route_name)
+
+    logger.assertion(
+        f"Dashboard routes found: expected=0, actual={len(dashboard_routes_found)}"
+    )
+    assert len(dashboard_routes_found) == 0, (
+        f"ceph mgr dashboard routes should not be deployed as part of OCS. "
+        f"Found: {dashboard_routes_found}"
+    )
+    logger.info("No dashboard routes found")
+
+    logger.info("Test passed: Ceph mgr dashboard is not deployed")
 
 
 @skipif_external_mode
@@ -135,15 +178,28 @@ def test_ceph_rbd_metrics_available(threading_lock):
     Ceph RBD metrics should be provided via OCP Prometheus as well.
     See also: https://ceph.com/rbd/new-in-nautilus-rbd-performance-monitoring/
     """
+    logger.info("Starting test: Verify Ceph RBD metrics are available")
+
+    logger.test_step("Check all expected Ceph RBD metrics are available in Prometheus")
     prometheus = PrometheusAPI(threading_lock=threading_lock)
+    logger.info(f"Checking {len(metrics.ceph_rbd_metrics)} RBD metrics")
+
     list_of_metrics_without_results = metrics.get_missing_metrics(
         prometheus, metrics.ceph_rbd_metrics
     )
-    msg = (
-        "OCS Monitoring should provide some value(s) for tested rbd metrics, "
-        "so that the list of metrics without results is empty."
+
+    logger.assertion(
+        f"Missing RBD metrics: expected=0, actual={len(list_of_metrics_without_results)}"
     )
-    assert list_of_metrics_without_results == [], msg
+    if list_of_metrics_without_results:
+        logger.error(f"Missing metrics: {list_of_metrics_without_results}")
+
+    assert list_of_metrics_without_results == [], (
+        "OCS Monitoring should provide some value(s) for tested rbd metrics, "
+        f"but the following metrics are missing: {list_of_metrics_without_results}"
+    )
+
+    logger.info("Test passed: All Ceph RBD metrics are available")
 
 
 @skipif_external_mode
@@ -167,17 +223,32 @@ def test_ceph_metrics_available(threading_lock):
     Since ODF 4.9 only subset of all ceph metrics ``ceph_metrics_healthy`` will
     be always available, as noted in BZ 2028649.
     """
+    logger.info("Starting test: Verify Ceph metrics are available")
+    current_platform = config.ENV_DATA["platform"].lower()
+    logger.info(f"Platform: {current_platform}")
+
+    logger.test_step("Check all expected Ceph metrics are available in Prometheus")
     prometheus = PrometheusAPI(threading_lock=threading_lock)
+    logger.info(f"Checking {len(metrics.ceph_metrics_healthy)} Ceph metrics")
+
     list_of_metrics_without_results = metrics.get_missing_metrics(
         prometheus,
         metrics.ceph_metrics_healthy,
-        current_platform=config.ENV_DATA["platform"].lower(),
+        current_platform=current_platform,
     )
-    msg = (
+
+    logger.assertion(
+        f"Missing Ceph metrics: expected=0, actual={len(list_of_metrics_without_results)}"
+    )
+    if list_of_metrics_without_results:
+        logger.error(f"Missing metrics: {list_of_metrics_without_results}")
+
+    assert list_of_metrics_without_results == [], (
         "OCS Monitoring should provide some value(s) for all tested metrics, "
-        "so that the list of metrics without results is empty."
+        f"but the following metrics are missing: {list_of_metrics_without_results}"
     )
-    assert list_of_metrics_without_results == [], msg
+
+    logger.info("Test passed: All expected Ceph metrics are available")
 
 
 @skipif_external_mode
@@ -196,8 +267,13 @@ def test_monitoring_reporting_ok_when_idle(workload_idle, threading_lock):
     If this test case fails, the status is either reported wrong or the
     cluster is in a broken state. Either way, a failure here is not good.
     """
+    logger.info(
+        "Starting test: Verify monitoring reports OK status when cluster is idle"
+    )
+    logger.info(f"Idle period: {workload_idle['start']} to {workload_idle['stop']}")
     prometheus = PrometheusAPI(threading_lock=threading_lock)
 
+    logger.test_step("Validate ceph_health_status metric reports healthy (value=0)")
     health_result = prometheus.query_range(
         query="ceph_health_status",
         start=workload_idle["start"],
@@ -215,6 +291,7 @@ def test_monitoring_reporting_ok_when_idle(workload_idle, threading_lock):
         health_msg = health_msg.format("should")
         logger.error(health_msg)
 
+    logger.test_step("Validate ceph_mon_quorum_status metric shows healthy quorum")
     mon_result = prometheus.query_range(
         query="ceph_mon_quorum_status",
         start=workload_idle["start"],
@@ -235,8 +312,12 @@ def test_monitoring_reporting_ok_when_idle(workload_idle, threading_lock):
         mon_msg = mon_msg.format("should")
         logger.error(mon_msg)
 
+    logger.test_step(
+        "Validate ceph_osd_up and ceph_osd_in metrics show all OSDs healthy"
+    )
     osd_validations = []
     for metric in ("ceph_osd_up", "ceph_osd_in"):
+        logger.debug(f"Checking {metric} metric")
         osd_result = prometheus.query_range(
             query=metric,
             start=workload_idle["start"],
@@ -258,12 +339,25 @@ def test_monitoring_reporting_ok_when_idle(workload_idle, threading_lock):
             osd_msg = osd_msg.format(metric, "should")
             logger.error(osd_msg)
 
-    # after logging everything properly, make the test fail if necessary
-    # see ERRORs reported in the test log for details
+    # Validate all metrics after logging
+    logger.assertion(
+        f"Ceph health status validation: expected=True, actual={health_validation}"
+    )
     assert health_validation, health_msg
+
+    logger.assertion(
+        f"MON quorum status validation: expected=True, actual={mon_validation}"
+    )
     assert mon_validation, mon_msg
+
+    logger.assertion(
+        f"OSD status validation: expected=all_True, actual={all(osd_validations)}, "
+        f"validations={osd_validations}"
+    )
     osds_msg = "ceph_osd_{up,in} metrics should indicate no OSD issues"
     assert all(osd_validations), osds_msg
+
+    logger.info("Test passed: All monitoring metrics report OK status when idle")
 
 
 @provider_mode
@@ -276,15 +370,28 @@ def test_provider_metrics_available(threading_lock):
     """
     Metrics added in provider-client mode should be provided via OCP Prometheus on provider.
     """
+    logger.info("Starting test: Verify provider-client metrics are available")
+
+    logger.test_step("Check all expected provider metrics are available in Prometheus")
     prometheus = PrometheusAPI(threading_lock=threading_lock)
+    logger.info(f"Checking {len(metrics.provider_metrics)} provider metrics")
+
     list_of_metrics_without_results = metrics.get_missing_metrics(
         prometheus, metrics.provider_metrics
     )
-    msg = (
-        "OCS Monitoring should provide some value(s) for tested provider metrics, "
-        "so that the list of metrics without results is empty."
+
+    logger.assertion(
+        f"Missing provider metrics: expected=0, actual={len(list_of_metrics_without_results)}"
     )
-    assert list_of_metrics_without_results == [], msg
+    if list_of_metrics_without_results:
+        logger.error(f"Missing metrics: {list_of_metrics_without_results}")
+
+    assert list_of_metrics_without_results == [], (
+        "OCS Monitoring should provide some value(s) for tested provider metrics, "
+        f"but the following metrics are missing: {list_of_metrics_without_results}"
+    )
+
+    logger.info("Test passed: All provider metrics are available")
 
 
 @blue_squad
@@ -300,8 +407,14 @@ def test_monitoring_ip_connectivity(threading_lock):
     4. Asserts that the expected Ceph metric is present in the response.
 
     """
+    logger.info("Starting test: Verify monitoring IP connectivity to Ceph exporters")
+
+    logger.test_step("Get rook-ceph-exporter pod IP addresses")
     exporter_pods = pod.get_pods_having_label(constants.EXPORTER_APP_LABEL)
     ip_addresses = [pod_obj["status"]["podIP"] for pod_obj in exporter_pods]
+    logger.info(f"Found {len(ip_addresses)} exporter pods with IPs: {ip_addresses}")
+
+    logger.test_step("Locate prometheus-k8s pod in monitoring namespace")
     pod_obj_list = pod.get_all_pods(
         namespace=defaults.OCS_MONITORING_NAMESPACE, selector_label=["prometheus"]
     )
@@ -310,20 +423,45 @@ def test_monitoring_ip_connectivity(threading_lock):
         if "prometheus-k8s" in pod_obj.name:
             prometheus_pod_obj = pod_obj
             break
+
+    logger.assertion(
+        f"Prometheus pod found: expected=True, actual={prometheus_pod_obj is not None}"
+    )
     assert (
         prometheus_pod_obj is not None
     ), "Prometheus pod not found in the monitoring namespace"
+    logger.info(f"Found Prometheus pod: {prometheus_pod_obj.name}")
+
+    logger.test_step("Verify connectivity and metrics from each exporter pod")
+    failed_ips = []
     for ip_address in ip_addresses:
         formatted_ip = (
             f"[{ip_address}]"
             if ipaddress.ip_address(ip_address).version == 6
             else ip_address
         )
+        logger.debug(f"Testing connectivity to {formatted_ip}:9926")
+
         cmd = (
             f"oc rsh -n {defaults.OCS_MONITORING_NAMESPACE} {prometheus_pod_obj.name} "
             f"curl -vv http://{formatted_ip}:9926/metrics"
         )
         out = run_cmd(cmd=cmd)
-        assert (
-            "ceph_AsyncMessenger_Worker_msgr_connection" in out
-        ), f"Expected Ceph metric not found in output for IP {ip_address}"
+
+        if "ceph_AsyncMessenger_Worker_msgr_connection" not in out:
+            failed_ips.append(ip_address)
+            logger.error(
+                f"Expected Ceph metric not found in output for IP {ip_address}"
+            )
+        else:
+            logger.debug(f"Successfully retrieved metrics from {ip_address}")
+
+    logger.assertion(
+        f"Exporter connectivity validation: expected=0 failed, actual={len(failed_ips)} failed"
+    )
+    assert len(failed_ips) == 0, (
+        f"Expected Ceph metric 'ceph_AsyncMessenger_Worker_msgr_connection' not found "
+        f"in output for {len(failed_ips)} IP(s): {failed_ips}"
+    )
+
+    logger.info("Test passed: All exporter pods are accessible and providing metrics")

--- a/tests/functional/monitoring/prometheus/metrics/test_ocs_utilization.py
+++ b/tests/functional/monitoring/prometheus/metrics/test_ocs_utilization.py
@@ -43,17 +43,46 @@ def test_mcg_cpu_usage(workload_idle, threading_lock):
     Without any IO  workload, cpu utilization of MCG pods should be minimal.
     No pod should utilize more than 0.1 cpu units.
     """
+    logger.info("Starting test: Verify MCG CPU utilization during idle workload")
+
+    logger.test_step("Initialize Prometheus API and query MCG pod CPU usage")
     prometheus = PrometheusAPI(threading_lock=threading_lock)
-    cpu_result = prometheus.query_range(
-        query=CPU_USAGE_POD + '{namespace="openshift-storage",pod=~"^noobaa.*"}',
-        start=workload_idle["start"],
-        end=workload_idle["stop"],
-        step=15,
+
+    # Construct query for NooBaa pods in openshift-storage namespace
+    query = CPU_USAGE_POD + '{namespace="openshift-storage",pod=~"^noobaa.*"}'
+    start_time = workload_idle["start"]
+    end_time = workload_idle["stop"]
+    step = 15
+
+    logger.info(
+        f"Querying CPU usage for NooBaa pods (start={start_time}, end={end_time}, step={step}s)"
     )
+    logger.debug(f"Prometheus query: {query}")
+
+    cpu_result = prometheus.query_range(
+        query=query,
+        start=start_time,
+        end=end_time,
+        step=step,
+    )
+    logger.debug(f"Query returned {len(cpu_result) if cpu_result else 0} time series")
+
+    logger.test_step("Validate CPU usage is within acceptable limits")
+    min_cpu = 0.0
+    max_cpu = 0.25  # Conservative limit (actual requirement is 0.1)
+    logger.info(f"CPU usage limits: min={min_cpu}, max={max_cpu} cpu units")
+
     validation = check_query_range_result_limits(
         result=cpu_result,
-        good_min=0.0,
-        good_max=0.25,
+        good_min=min_cpu,
+        good_max=max_cpu,
     )
+
+    logger.assertion(
+        f"MCG CPU usage within limits: expected=True (all pods < {max_cpu} cpu), actual={validation}"
+    )
+
     msg = "No NooBaa pod should utilize over 0.1 cpu units while idle."
     assert validation, msg
+
+    logger.info("Test passed: MCG CPU utilization validated successfully during idle")

--- a/tests/functional/monitoring/prometheus/metrics/test_rgw.py
+++ b/tests/functional/monitoring/prometheus/metrics/test_rgw.py
@@ -39,33 +39,78 @@ def test_ceph_rgw_metrics_after_metrics_exporter_respin(
     ocs-metrics-exporter pod is respinned.
 
     """
-    logger.info("Respin ocs-metrics-exporter pod")
-    pod_obj = ocp.OCP(
-        kind=constants.POD, namespace=config.ENV_DATA["cluster_namespace"]
+    logger.info(
+        "Starting test: Verify RGW metrics availability after metrics exporter respin"
     )
-    metrics_pods = pod_obj.get(selector="app.kubernetes.io/name=ocs-metrics-exporter")[
-        "items"
-    ]
-    assert len(metrics_pods) == 1
-    metrics_pod_data = metrics_pods[0]
-    metrics_pod = OCS(**metrics_pod_data)
-    metrics_pod.delete(force=True)
 
-    logger.info("Wait for ocs-metrics-exporter pod to come up")
-    assert pod_obj.wait_for_resource(
+    logger.test_step("Locate and delete ocs-metrics-exporter pod")
+    namespace = config.ENV_DATA["cluster_namespace"]
+    selector = "app.kubernetes.io/name=ocs-metrics-exporter"
+    logger.info(
+        f"Looking for metrics exporter pod (namespace: {namespace}, selector: {selector})"
+    )
+
+    pod_obj = ocp.OCP(kind=constants.POD, namespace=namespace)
+    metrics_pods = pod_obj.get(selector=selector)["items"]
+
+    pod_count = len(metrics_pods)
+    logger.assertion(f"Metrics exporter pod count: expected=1, actual={pod_count}")
+    assert pod_count == 1, f"Expected exactly 1 metrics exporter pod, found {pod_count}"
+
+    metrics_pod_data = metrics_pods[0]
+    pod_name = metrics_pod_data.get("metadata", {}).get("name", "unknown")
+    logger.info(f"Found metrics exporter pod: {pod_name}")
+
+    metrics_pod = OCS(**metrics_pod_data)
+    logger.info(f"Deleting pod {pod_name} (force=True)")
+    metrics_pod.delete(force=True)
+    logger.info(f"Pod {pod_name} deleted successfully")
+
+    logger.test_step("Wait for ocs-metrics-exporter pod to be recreated")
+    logger.info(
+        "Waiting for new metrics exporter pod (condition: Running, timeout: 600s)"
+    )
+
+    pod_ready = pod_obj.wait_for_resource(
         condition="Running",
-        selector="app.kubernetes.io/name=ocs-metrics-exporter",
+        selector=selector,
         resource_count=1,
         timeout=600,
     )
+    logger.assertion(
+        f"New metrics exporter pod running: expected=True, actual={pod_ready}"
+    )
+    assert pod_ready, "Metrics exporter pod did not reach Running state within timeout"
+    logger.info("New metrics exporter pod is running")
 
-    logger.info("Collect RGW metrics")
+    logger.test_step("Collect and validate RGW metrics from Prometheus")
     prometheus = PrometheusAPI(threading_lock=threading_lock)
+    expected_metrics_count = len(metrics.ceph_rgw_metrics)
+    logger.info(f"Checking {expected_metrics_count} RGW metrics for availability")
+    logger.debug(f"RGW metrics to check: {metrics.ceph_rgw_metrics}")
+
     list_of_metrics_without_results = metrics.get_missing_metrics(
         prometheus, metrics.ceph_rgw_metrics
     )
+
+    missing_count = len(list_of_metrics_without_results)
+    logger.info(
+        f"Metrics validation: {expected_metrics_count - missing_count}/{expected_metrics_count} metrics have data"
+    )
+
+    if list_of_metrics_without_results:
+        logger.warning(
+            f"Missing metrics ({missing_count}): {list_of_metrics_without_results}"
+        )
+
+    logger.assertion(
+        f"All RGW metrics available: expected=0 missing, actual={missing_count} missing"
+    )
+
     msg = (
         "OCS Monitoring should provide some value(s) for tested rgw metrics, "
         "so that the list of metrics without results is empty."
     )
     assert list_of_metrics_without_results == [], msg
+
+    logger.info("Test passed: All RGW metrics available after metrics exporter respin")

--- a/tests/functional/monitoring/sendgrid/alerts/test_capacity.py
+++ b/tests/functional/monitoring/sendgrid/alerts/test_capacity.py
@@ -9,7 +9,7 @@ from ocs_ci.framework.pytest_customization.marks import (
 )
 from ocs_ci.ocs.ocp import OCP
 
-log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 @blue_squad
@@ -25,18 +25,30 @@ def deprecated_test_capacity_workload_alerts(
     via RBD interface.
 
     """
-    log.warning(
-        "Cluster utilization is completed. "
-        f"There should be proper emails sent to {notification_emails_required}"
+    logger.info("Starting test: Verify capacity alert emails for RBD workload")
+
+    logger.test_step("Verify cluster utilization completed and alert emails sent")
+    logger.info(f"Expected notification recipients: {notification_emails_required}")
+    logger.warning(
+        "Manual verification required: Check that proper capacity alert emails "
+        f"were sent to {notification_emails_required}"
     )
     # TODO(fbalak): automate checking of email content
 
+    logger.info(
+        "Test completed: Cluster utilization reached, manual email verification needed"
+    )
+
 
 def setup_module(module):
+    logger.info("Setting up module: Storing original user for cleanup")
     ocs_obj = OCP()
     module.original_user = ocs_obj.get_user_name()
+    logger.info(f"Original user stored: {module.original_user}")
 
 
 def teardown_module(module):
+    logger.info("Tearing down module: Restoring original user")
     ocs_obj = OCP()
     ocs_obj.login_as_user(module.original_user)
+    logger.info(f"Restored user: {module.original_user}")

--- a/tests/functional/monitoring/test_blackbox_exporter_probe.py
+++ b/tests/functional/monitoring/test_blackbox_exporter_probe.py
@@ -39,51 +39,90 @@ class TestBlackboxExporterProbe(ManageTest):
         """
         logger.info("Starting test: Verify blackbox probe contains OSD and MON IPs")
 
+        logger.test_step("Get odf-blackbox-exporter probe configuration")
         probe = Probe()
         probe_config = probe.get_probe_config("odf-blackbox-exporter")
+        logger.assertion(
+            f"Probe config retrieval: expected=non-empty, actual={'success' if probe_config else 'failed'}"
+        )
         assert probe_config, "Failed to get probe configuration"
 
-        logger.info("Getting OSD pod IPs...")
+        logger.test_step("Get OSD pod IPs from cluster")
         osd_ips = get_pod_ips(
             constants.OSD_APP_LABEL, constants.OPENSHIFT_STORAGE_NAMESPACE
+        )
+        logger.assertion(
+            f"OSD pods found: expected=non-empty, actual={len(osd_ips) if osd_ips else 0} pods"
         )
         assert osd_ips, "No OSD pods found or no IPs available"
         logger.info(f"Found {len(osd_ips)} OSD pods with IPs")
 
-        logger.info("Getting MON pod IPs...")
+        logger.test_step("Get MON pod IPs from cluster")
         mon_ips = get_pod_ips(
             constants.MON_APP_LABEL, constants.OPENSHIFT_STORAGE_NAMESPACE
+        )
+        logger.assertion(
+            f"MON pods found: expected=non-empty, actual={len(mon_ips) if mon_ips else 0} pods"
         )
         assert mon_ips, "No MON pods found or no IPs available"
         logger.info(f"Found {len(mon_ips)} MON pods with IPs")
 
-        logger.info("Extracting IPs from probe configuration...")
+        logger.test_step("Extract static target IPs from probe configuration")
         probe_ips = probe.get_static_targets(probe_config)
+        logger.assertion(
+            f"Probe IPs found: expected=non-empty, actual={len(probe_ips) if probe_ips else 0} IPs"
+        )
         assert probe_ips, "No IPs found in probe configuration"
         logger.info(f"Found {len(probe_ips)} IPs in probe configuration")
 
-        logger.info("Verifying OSD IPs are present in probe configuration...")
+        logger.test_step("Verify all OSD pod IPs are present in probe configuration")
         missing_osd_ips = []
         for pod_name, pod_ip in osd_ips.items():
             if pod_ip not in probe_ips:
                 missing_osd_ips.append(f"{pod_name}: {pod_ip}")
-                logger.error(f"OSD pod IP not found in probe: {pod_name} ({pod_ip})")
+                logger.debug(f"Missing OSD pod IP: {pod_name} ({pod_ip})")
 
-        logger.info("Verifying MON IPs are present in probe configuration...")
+        if missing_osd_ips:
+            logger.error(
+                f"Found {len(missing_osd_ips)} OSD pod IPs missing from probe configuration"
+            )
+        else:
+            logger.info(
+                f"All {len(osd_ips)} OSD pod IPs present in probe configuration"
+            )
+
+        logger.test_step("Verify all MON pod IPs are present in probe configuration")
         missing_mon_ips = []
         for pod_name, pod_ip in mon_ips.items():
             if pod_ip not in probe_ips:
                 missing_mon_ips.append(f"{pod_name}: {pod_ip}")
-                logger.error(f"MON pod IP not found in probe: {pod_name} ({pod_ip})")
+                logger.debug(f"Missing MON pod IP: {pod_name} ({pod_ip})")
 
+        if missing_mon_ips:
+            logger.error(
+                f"Found {len(missing_mon_ips)} MON pod IPs missing from probe configuration"
+            )
+        else:
+            logger.info(
+                f"All {len(mon_ips)} MON pod IPs present in probe configuration"
+            )
+
+        logger.assertion(
+            f"OSD IPs validation: expected=0 missing, actual={len(missing_osd_ips)} missing"
+        )
         assert not missing_osd_ips, (
             f"The following OSD pod IPs are missing from probe configuration: "
             f"{missing_osd_ips}"
+        )
+
+        logger.assertion(
+            f"MON IPs validation: expected=0 missing, actual={len(missing_mon_ips)} missing"
         )
         assert not missing_mon_ips, (
             f"The following MON pod IPs are missing from probe configuration: "
             f"{missing_mon_ips}"
         )
+
         logger.info(
             "Test passed: All OSD and MON pod IPs are present in "
             "odf-blackbox-exporter probe configuration"

--- a/tests/functional/monitoring/test_monitoring_tool.py
+++ b/tests/functional/monitoring/test_monitoring_tool.py
@@ -47,53 +47,86 @@ class TestMonitoringTool(BaseTest):
             6. convert two prometheus rules files with deviation to JSON and verify deviations found
             7. run 'comparealerts' against two identical prometheus rules JSON files, check "No diffs found"
         """
+        logger.info(
+            "Starting test: Verify ODF monitoring comparealert tool functionality"
+        )
+
+        logger.test_step("Verify Go version and build comparealerts tool")
         check_go_version()
-
         os.chdir(clone_odf_monitoring_compare_tool / "comparealerts")
+        logger.info(
+            f"Changed directory to: {clone_odf_monitoring_compare_tool / 'comparealerts'}"
+        )
         exec_cmd("go build")
+        logger.info("comparealerts tool built successfully")
 
+        logger.test_step("Locate and verify Prometheus rules files")
         prometheus_ocs_rules = (
             clone_ocs_operator / "metrics" / "deploy" / "prometheus-ocs-rules.yaml"
         )
         prometheus_alerts_upstream = (
             clone_upstream_ceph / "monitoring" / "ceph-mixin" / "prometheus_alerts.yml"
         )
+        logger.info(f"OCS rules file: {prometheus_ocs_rules}")
+        logger.info(f"Upstream rules file: {prometheus_alerts_upstream}")
 
+        logger.assertion(
+            f"OCS rules file exists: expected=True, actual={os.path.isfile(prometheus_ocs_rules)}"
+        )
         assert os.path.isfile(
             prometheus_ocs_rules
         ), f"cannot find '{prometheus_ocs_rules}' in cloned repo"
+
+        logger.assertion(
+            f"Upstream rules file exists: expected=True, actual={os.path.isfile(prometheus_alerts_upstream)}"
+        )
         assert os.path.isfile(
             prometheus_alerts_upstream
         ), f"cannot find '{prometheus_alerts_upstream}' in cloned repo"
-        logger.debug(f"print '{prometheus_ocs_rules}' file")
+
+        logger.debug(f"Displaying '{prometheus_ocs_rules}' file")
         exec_cmd(f"cat {prometheus_ocs_rules}")
-        logger.debug(f"print '{prometheus_alerts_upstream}' file")
+        logger.debug(f"Displaying '{prometheus_alerts_upstream}' file")
         exec_cmd(f"cat {prometheus_alerts_upstream}")
 
-        logger.info("compare upstream and downstream prometheus rule files")
+        logger.test_step("Compare upstream and downstream Prometheus rules (YAML)")
+        logger.info("Running comparealerts on upstream vs downstream rules")
         complete_proc = exec_cmd(
             f"./comparealerts {prometheus_ocs_rules} {prometheus_alerts_upstream}"
         )
-
         # we cannot control the diff between upstream and downstream versions, hence it's printed for further analysis
+        logger.info("Upstream vs downstream comparison results:")
         logger.info(complete_proc.stdout.decode("utf-8"))
 
-        logger.info(
-            "run 'comparealerts' tool with YAML files in args, without deviations"
+        logger.test_step(
+            "Test comparealerts with identical YAML files (expect no diffs)"
         )
         ocs_prometheus_rules_copy = (
             clone_ocs_operator / "copy-prometheus-ocs-rules.yaml"
         )
+        logger.info(f"Creating copy: {ocs_prometheus_rules_copy}")
         shutil.copy(prometheus_ocs_rules, ocs_prometheus_rules_copy)
+
+        logger.assertion(
+            f"Copy file exists: expected=True, actual={os.path.isfile(ocs_prometheus_rules_copy)}"
+        )
         assert os.path.isfile(
             ocs_prometheus_rules_copy
         ), f"cannot find {ocs_prometheus_rules_copy}"
-        assert filecmp.cmp(prometheus_ocs_rules, ocs_prometheus_rules_copy)
+
+        files_identical = filecmp.cmp(prometheus_ocs_rules, ocs_prometheus_rules_copy)
+        logger.assertion(f"Files identical: expected=True, actual={files_identical}")
+        assert files_identical, "Copied file does not match original"
+
+        logger.info("Verifying no diffs found for identical files")
         comparetool_deviation_check(
             ocs_prometheus_rules_copy, prometheus_ocs_rules, ["No diffs found"]
         )
 
-        logger.info("run 'comparealerts' tool with YAML files in args, with deviations")
+        logger.test_step(
+            "Test comparealerts with modified YAML files (expect deviations)"
+        )
+        logger.info("Extracting alert rules from file")
         alert_rules_list = (
             exec_cmd(
                 f"grep -e '- alert: ' {ocs_prometheus_rules_copy} | sed -e 's|- alert:||g'",
@@ -103,10 +136,13 @@ class TestMonitoringTool(BaseTest):
             .split()
         )
         alert_random = random.choice(alert_rules_list)
+        logger.info(
+            f"Found {len(alert_rules_list)} alert rules, selected: {alert_random}"
+        )
 
         replaced_alert_rule = "ReplacedAlertRule"
         logger.info(
-            f"replace alert-rule: '{alert_random}' with '{replaced_alert_rule}' at (2nd) file"
+            f"Replacing alert rule '{alert_random}' with '{replaced_alert_rule}' in copy file"
         )
         # Works with both GNU and BSD/macOS Sed, due to a *non-empty* option-argument:
         # Create a backup file *temporarily* and remove it on success.
@@ -115,35 +151,62 @@ class TestMonitoringTool(BaseTest):
             f"&& rm {ocs_prometheus_rules_copy}.bak",
             shell=True,
         )
+        logger.info("Alert rule replaced successfully")
 
+        logger.info("Verifying deviations detected between modified files")
         comparetool_deviation_check(
             prometheus_ocs_rules,
             ocs_prometheus_rules_copy,
             [alert_random, replaced_alert_rule],
         )
 
+        logger.test_step("Convert YAML files to JSON format")
+        logger.info("Converting Prometheus rules files to JSON")
         prometheus_ocs_rules_json = convert_yaml_file_to_json_file(prometheus_ocs_rules)
         ocs_prometheus_rules_copy_json = convert_yaml_file_to_json_file(
             ocs_prometheus_rules_copy
         )
+        logger.info(f"Original JSON: {prometheus_ocs_rules_json}")
+        logger.info(f"Modified JSON: {ocs_prometheus_rules_copy_json}")
 
-        logger.info("run 'comparealerts' tool with JSON files in args, with deviations")
+        logger.test_step(
+            "Test comparealerts with modified JSON files (expect deviations)"
+        )
+        logger.info("Verifying deviations detected in JSON format")
         comparetool_deviation_check(
             prometheus_ocs_rules_json,
             ocs_prometheus_rules_copy_json,
             [alert_random, replaced_alert_rule],
         )
 
-        logger.info(
-            "run 'comparealerts' tool with JSON files in args, without deviations"
+        logger.test_step(
+            "Test comparealerts with identical JSON files (expect no diffs)"
         )
+        logger.info("Creating identical JSON copy")
         shutil.copy(prometheus_ocs_rules_json, ocs_prometheus_rules_copy_json)
+
+        logger.assertion(
+            f"JSON copy exists: expected=True, actual={os.path.isfile(ocs_prometheus_rules_copy_json)}"
+        )
         assert os.path.isfile(
             ocs_prometheus_rules_copy_json
         ), f"cannot find copied '{ocs_prometheus_rules_copy_json}'"
-        assert filecmp.cmp(prometheus_ocs_rules_json, ocs_prometheus_rules_copy_json)
+
+        json_files_identical = filecmp.cmp(
+            prometheus_ocs_rules_json, ocs_prometheus_rules_copy_json
+        )
+        logger.assertion(
+            f"JSON files identical: expected=True, actual={json_files_identical}"
+        )
+        assert json_files_identical, "Copied JSON file does not match original"
+
+        logger.info("Verifying no diffs found for identical JSON files")
         comparetool_deviation_check(
             prometheus_ocs_rules_json,
             ocs_prometheus_rules_copy_json,
             ["No diffs found"],
+        )
+
+        logger.info(
+            "Test passed: ODF monitoring comparealert tool verified successfully"
         )

--- a/tests/functional/monitoring/test_operator_probe_resilience.py
+++ b/tests/functional/monitoring/test_operator_probe_resilience.py
@@ -35,11 +35,19 @@ class TestOperatorProbeResilience(ManageTest):
 
     @pytest.fixture(autouse=True)
     def setup(self, csv_prefix):
+        logger.info(f"Setting up test for CSV prefix: {csv_prefix}")
+
         self.namespace = constants.OPENSHIFT_STORAGE_NAMESPACE
+        logger.debug(f"Using namespace: {self.namespace}")
 
         # Using get_csv_name_start_with_prefix logic to resolve the CSV name
+        logger.debug(f"Resolving CSV name with prefix: {csv_prefix}")
         self.csv_name = get_csv_name_start_with_prefix(csv_prefix, self.namespace)
+
         if not self.csv_name:
+            logger.error(
+                f"Could not find CSV with prefix {csv_prefix} in {self.namespace}"
+            )
             pytest.fail(
                 f"Could not find CSV with prefix {csv_prefix} in {self.namespace}"
             )
@@ -51,12 +59,15 @@ class TestOperatorProbeResilience(ManageTest):
             namespace=self.namespace,
             resource_name=self.csv_name,
         )
+        logger.debug(f"Created CSV OCP object for {self.csv_name}")
 
         # Map labels for pod discovery based on the resolved name
         if "ocs-operator" in self.csv_name:
             self.label_key, self.label_value = "name", "ocs-operator"
         else:
             self.label_key, self.label_value = "noobaa-operator", "deployment"
+
+        logger.info(f"Pod discovery labels: {self.label_key}={self.label_value}")
 
     @pytest.fixture(autouse=True)
     def teardown(self, request, probe_type, healthy_path):
@@ -65,16 +76,28 @@ class TestOperatorProbeResilience(ManageTest):
         """
 
         def finalizer():
-            logger.info(f"Finalizer: Restoring {self.csv_name} to {healthy_path}")
+            logger.info(
+                f"Teardown: Restoring {self.csv_name} {probe_type} probe to {healthy_path}"
+            )
+
             # Resetting to healthy state
             self._patch_csv(probe_type, healthy_path)
 
             # Create a POD OCP object to wait for the selector
+            selector = f"{self.label_key}={self.label_value}"
+            logger.info(
+                f"Waiting for pods to reach Running state (selector: {selector}, timeout: 300s)"
+            )
+
             pod_obj = OCP(kind=constants.POD, namespace=self.namespace)
             pod_obj.wait_for_resource(
                 condition=constants.STATUS_RUNNING,
-                selector=f"{self.label_key}={self.label_value}",
+                selector=selector,
                 timeout=300,
+            )
+
+            logger.info(
+                f"Teardown completed: {self.csv_name} restored and pods running"
             )
 
         request.addfinalizer(finalizer)
@@ -94,8 +117,13 @@ class TestOperatorProbeResilience(ManageTest):
             {"op": "replace", "path": f"{base_path}/periodSeconds", "value": 5},
             {"op": "replace", "path": f"{base_path}/failureThreshold", "value": 1},
         ]
-        logger.info(f"Patching {self.csv_name} {probe_type} to: {path_value}")
+        logger.info(
+            f"Patching {self.csv_name} {probe_type}Probe: "
+            f"path={path_value}, initialDelay=5s, period=5s, failureThreshold=1"
+        )
+        logger.debug(f"JSON patch list: {patch_list}")
         self.csv_obj.patch(params=patch_list, format_type="json")
+        logger.debug(f"Patch applied successfully to {self.csv_name}")
 
     def test_probe_resilience(self, probe_type, healthy_path):
         """
@@ -106,12 +134,14 @@ class TestOperatorProbeResilience(ManageTest):
         4. Restores the healthy configuration and ensures stability.
         """
         logger.info(
-            f"Starting {probe_type.upper()} Probe Failure Test for {self.csv_name}"
+            f"Starting test: Verify {probe_type} probe failure resilience for {self.csv_name}"
         )
+        logger.info(f"Healthy probe path: {healthy_path}")
 
         # 1. Trigger and Verify Failure State
         if probe_type == "liveness":
-            logger.info("Verifying Liveness failure: Expecting pod restarts...")
+            logger.test_step("Trigger liveness probe failure and verify pod restarts")
+            logger.info("Patching CSV with invalid liveness probe path: /bad")
             self._patch_csv(probe_type, "/bad")
 
             def check_for_any_restarts():
@@ -120,6 +150,8 @@ class TestOperatorProbeResilience(ManageTest):
                     selector=[self.label_value],
                     selector_label=self.label_key,
                 )
+                logger.debug(f"Checking {len(live_pods)} pods for restarts")
+
                 for p in live_pods:
                     try:
                         status = p.get().get("status", {})
@@ -128,21 +160,34 @@ class TestOperatorProbeResilience(ManageTest):
                             restarts = container_statuses[0].get("restartCount", 0)
                             if restarts > 0:
                                 logger.info(
-                                    f"Confirmed: Pod {p.name} restarted {restarts} times."
+                                    f"Pod restart detected: {p.name} restarted {restarts} times"
                                 )
                                 return True
-                    except (CommandFailed, TypeError, IndexError):
+                            else:
+                                logger.debug(f"Pod {p.name}: no restarts yet (count=0)")
+                    except (CommandFailed, TypeError, IndexError) as e:
+                        logger.debug(f"Error checking pod {p.name}: {e}")
                         continue
                 return False
 
+            logger.info("Waiting for pod restarts (timeout: 450s, interval: 15s)")
             sample = TimeoutSampler(timeout=450, sleep=15, func=check_for_any_restarts)
-            assert sample.wait_for_func_status(
-                result=True
+            restart_detected = sample.wait_for_func_status(result=True)
+
+            logger.assertion(
+                f"Liveness probe failure caused pod restart: expected=True, actual={restart_detected}"
+            )
+            assert (
+                restart_detected
             ), f"Liveness failure: No pod restarts detected for {self.csv_name}."
+            logger.info("Liveness probe failure verified: Pod restarted as expected")
 
         elif probe_type == "readiness":
-            logger.info("Verifying Readiness failure: Expecting NotReady state...")
+            logger.test_step(
+                "Trigger readiness probe failure and verify pod becomes NotReady"
+            )
             bad_path = "/bad-ready" if "ocs-operator" in self.csv_name else "/bad"
+            logger.info(f"Patching CSV with invalid readiness probe path: {bad_path}")
             self._patch_csv(probe_type, bad_path)
 
             def check_for_not_ready():
@@ -151,6 +196,8 @@ class TestOperatorProbeResilience(ManageTest):
                     selector=[self.label_value],
                     selector_label=self.label_key,
                 )
+                logger.debug(f"Checking {len(live_pods)} pods for NotReady state")
+
                 for p in live_pods:
                     try:
                         pod_data = p.get()
@@ -159,20 +206,35 @@ class TestOperatorProbeResilience(ManageTest):
                         statuses = pod_data.get("status", {}).get(
                             "containerStatuses", []
                         )
-                        if statuses and not statuses[0].get("ready"):
-                            logger.info(f"Confirmed: Pod {p.name} status is NotReady.")
-                            return True
-                    except (CommandFailed, TypeError):
+                        if statuses:
+                            is_ready = statuses[0].get("ready", True)
+                            if not is_ready:
+                                logger.info(f"Pod NotReady state detected: {p.name}")
+                                return True
+                            else:
+                                logger.debug(f"Pod {p.name}: still ready")
+                    except (CommandFailed, TypeError) as e:
+                        logger.debug(f"Error checking pod {p.name}: {e}")
                         continue
                 return False
 
+            logger.info("Waiting for pod NotReady state (timeout: 300s, interval: 10s)")
             sample = TimeoutSampler(timeout=300, sleep=10, func=check_for_not_ready)
-            assert sample.wait_for_func_status(
-                result=True
+            not_ready_detected = sample.wait_for_func_status(result=True)
+
+            logger.assertion(
+                f"Readiness probe failure caused NotReady state: expected=True, actual={not_ready_detected}"
+            )
+            assert (
+                not_ready_detected
             ), f"Readiness failure: Pod did not reach NotReady for {self.csv_name}."
+            logger.info(
+                "Readiness probe failure verified: Pod became NotReady as expected"
+            )
 
         # 2. Restore and Verify (Cleanup)
-        logger.info(f"Restoring healthy configuration: {healthy_path}")
+        logger.test_step("Restore healthy probe configuration and verify pod recovery")
+        logger.info(f"Restoring {probe_type} probe to healthy path: {healthy_path}")
         self._patch_csv(probe_type, healthy_path)
 
         def final_sync():
@@ -182,13 +244,33 @@ class TestOperatorProbeResilience(ManageTest):
                 selector_label=self.label_key,
             )
             if not current_pods:
+                logger.debug("No pods found yet during recovery check")
                 return False
+
             names = [p.name for p in current_pods]
-            return pod_helpers.wait_for_pods_to_be_in_statuses(
+            logger.debug(f"Checking {len(names)} pods for Running state: {names}")
+
+            all_running = pod_helpers.wait_for_pods_to_be_in_statuses(
                 [constants.STATUS_RUNNING], pod_names=names, namespace=self.namespace
             )
+            if all_running:
+                logger.info(f"All {len(names)} pods returned to Running state")
+            return all_running
 
+        logger.info(
+            "Waiting for pods to return to Running state (timeout: 300s, interval: 10s)"
+        )
         sample = TimeoutSampler(timeout=300, sleep=10, func=final_sync)
-        assert sample.wait_for_func_status(
-            result=True
+        recovery_successful = sample.wait_for_func_status(result=True)
+
+        logger.assertion(
+            f"Pods recovered to Running state after probe restoration: "
+            f"expected=True, actual={recovery_successful}"
+        )
+        assert (
+            recovery_successful
         ), "Cleanup failed: Pods did not return to healthy Running state."
+
+        logger.info(
+            f"Test passed: {probe_type} probe resilience verified for {self.csv_name}"
+        )

--- a/tests/functional/monitoring/workload/test_workload_with_distruptions.py
+++ b/tests/functional/monitoring/workload/test_workload_with_distruptions.py
@@ -58,12 +58,27 @@ def test_workload_with_checksum(workload_storageutilization_checksum_rbd):
     """
     Purpose of this test is to have checksum workload fixture executed.
     """
-    msg = "fio report should be available"
-    assert workload_storageutilization_checksum_rbd["result"] is not None, msg
+    logger.info("Starting test: Verify checksum workload execution")
+
+    logger.test_step("Validate fio report is available from fixture")
+    result_available = workload_storageutilization_checksum_rbd["result"] is not None
+    logger.assertion(
+        f"Fio report availability: expected=not None, actual={result_available}"
+    )
+    assert result_available, "fio report should be available"
+
+    logger.test_step("Verify fio job execution details")
     fio = workload_storageutilization_checksum_rbd["result"]["fio"]
-    assert len(fio["jobs"]) == 1, "single fio job was executed"
-    msg = "no errors should be reported by fio when writing data"
-    assert fio["jobs"][0]["error"] == 0, msg
+    job_count = len(fio["jobs"])
+    logger.assertion(f"Fio job count: expected=1, actual={job_count}")
+    assert job_count == 1, "single fio job was executed"
+
+    logger.test_step("Verify fio completed without errors")
+    error_count = fio["jobs"][0]["error"]
+    logger.assertion(f"Fio error count: expected=0, actual={error_count}")
+    assert error_count == 0, "no errors should be reported by fio when writing data"
+
+    logger.info("Test passed: Checksum workload executed successfully")
 
 
 @blue_squad
@@ -97,37 +112,54 @@ def test_workload_with_checksum_verify(
     stages of the cluster wide distruptions). We may need to come up with a way
     to track it and delete it when it's no longer needed though.
     """
+    logger.info("Starting test: Verify checksum data persists after disruption")
+
     fixture_name = "workload_storageutilization_checksum_rbd"
     storage_class_name = "ocs-storagecluster-ceph-rbd"
     pv_label = f"fixture={fixture_name}"
+    logger.info(
+        f"Looking for PV with label: {pv_label}, storage class: {storage_class_name}"
+    )
 
-    # find the volume where the data are stored
+    logger.test_step("Locate PV containing previously written fio data")
     ocp_pv = ocp.OCP(kind=constants.PV, namespace=project.namespace)
     logger.info("Searching for PV with label %s, where fio stored data", pv_label)
     pv_data = ocp_pv.get(selector=pv_label)
-    assert pv_data["kind"] == "List"
+
+    logger.assertion(f"PV data kind: expected='List', actual={pv_data.get('kind')}")
+    assert pv_data["kind"] == "List", "PV data should be a List"
+
+    pv_count = len(pv_data["items"])
+    logger.assertion(f"PV count with label {pv_label}: expected=1, actual={pv_count}")
     pv_exists_msg = (
         f"Single PV with label {pv_label} should exists, "
         "so that test can identify where to verify the data."
     )
-    assert len(pv_data["items"]) == 1, pv_exists_msg
+    assert pv_count == 1, pv_exists_msg
+
     pv_dict = pv_data["items"][0]
     pv_name = pv_dict["metadata"]["name"]
     logger.info("PV %s was identified, test can continue.", pv_name)
 
-    # We need to check the PV size so that we can ask for the same via PVC
+    logger.test_step("Extract and validate PV capacity")
     capacity = pv_dict["spec"]["capacity"]["storage"]
     logger.info("Capacity of PV %s is %s.", pv_name, capacity)
 
     # Convert the storage capacity spec into number of GiB
     unit = capacity[-2:]
-    assert unit in ("Gi", "Ti"), "PV size should be within reasonable range"
+    unit_valid = unit in ("Gi", "Ti")
+    logger.assertion(
+        f"PV capacity unit: expected='Gi' or 'Ti', actual={unit}, valid={unit_valid}"
+    )
+    assert unit_valid, "PV size should be within reasonable range"
+
     if capacity.endswith("Gi"):
         pvc_size = int(capacity[0:-2])
     elif capacity.endswith("Ti"):
         pvc_size = int(capacity[0:-2]) * 2**10
+    logger.info(f"Converted PV capacity to PVC size: {pvc_size} GiB")
 
-    # And we need to drop claimRef, so that the PV will become available again
+    logger.test_step("Remove claimRef to make PV available for reuse")
     if "claimRef" in pv_dict["spec"]:
         logger.info("Dropping claimRef from PV %s.", pv_name)
         patch_success = ocp_pv.patch(
@@ -135,6 +167,7 @@ def test_workload_with_checksum_verify(
             params='[{ "op": "remove", "path": "/spec/claimRef" }]',
             format_type="json",
         )
+        logger.assertion(f"ClaimRef removal: expected=True, actual={patch_success}")
         patch_error_msg = (
             "claimRef should be dropped with success, "
             f"otherwise the test can't continue to reuse PV {pv_name}"
@@ -143,12 +176,17 @@ def test_workload_with_checksum_verify(
     else:
         logger.info("PV %s is already without claimRef.", pv_name)
 
+    logger.test_step("Configure and create checksum verification job")
     # The job won't be running fio, it will run sha1sum check only.
     container = fio_job_dict["spec"]["template"]["spec"]["containers"][0]
     container["command"] = ["/usr/bin/sha1sum", "-c", "/mnt/target/fio.sha1sum"]
+    logger.debug("Configured job to run sha1sum verification instead of fio")
+
     # we need to use the same PVC configuration to reuse the PV
     fio_pvc_dict["spec"]["storageClassName"] = storage_class_name
     fio_pvc_dict["spec"]["resources"]["requests"]["storage"] = capacity
+    logger.debug(f"PVC configured: class={storage_class_name}, capacity={capacity}")
+
     # put the dicts together into yaml file of the Job
     fio_objs = [fio_pvc_dict, fio_configmap_dict, fio_job_dict]
     job_file = ObjectConfFile(fixture_name, fio_objs, project, tmp_path)
@@ -161,10 +199,15 @@ def test_workload_with_checksum_verify(
     # that slow down write time
     # TODO(fbalak): calculate this from actual work being executed
     job_timeout = job_timeout * 4
+    logger.info(
+        f"Job timeout calculated: {job_timeout}s (4x base timeout for upgrade workload)"
+    )
 
     # deploy the Job to the cluster and start it
+    logger.info("Creating checksum verification job")
     job_file.create()
 
+    logger.test_step("Wait for checksum verification job to complete")
     # Wait for the job to verify data on the volume. If this fails in any way
     # the job won't finish with success in given time, and the error message
     # below will be reported via exception.
@@ -172,12 +215,16 @@ def test_workload_with_checksum_verify(
         "Checksum verification job failed. We weren't able to verify that "
         "data previously written on the PV are still there."
     )
+    logger.info(f"Waiting for job completion (timeout={job_timeout}s)")
     pod_name = fiojob.wait_for_job_completion(project.namespace, job_timeout, error_msg)
+    logger.info(f"Checksum verification job completed successfully: pod={pod_name}")
 
-    # provide clear evidence of the verification in the logs
+    logger.test_step("Retrieve and log verification results")
     ocp_pod = ocp.OCP(kind="Pod", namespace=project.namespace)
     sha1sum_output = ocp_pod.exec_oc_cmd(f"logs {pod_name}", out_yaml_format=False)
     logger.info("sha1sum output: %s", sha1sum_output)
+
+    logger.info("Test passed: Data persisted successfully after disruption")
 
 
 @blue_squad
@@ -197,24 +244,52 @@ def test_workload_rbd_cephfs_10g(
     direct failure (fio job could fail to be scheduled, fail during writing or
     timeout when write progress is too slow ...).
     """
-    logger.info("checking fio report results as provided by workload fixtures")
-    msg = "workload results should be recorded and provided to the test"
-    assert workload_storageutilization_10g_rbd["result"] is not None, msg
-    assert workload_storageutilization_10g_cephfs["result"] is not None, msg
+    logger.info("Starting test: Verify 10 GiB workload on RBD and CephFS")
 
+    logger.test_step("Validate workload fixture results are available")
+    rbd_result_available = workload_storageutilization_10g_rbd["result"] is not None
+    cephfs_result_available = (
+        workload_storageutilization_10g_cephfs["result"] is not None
+    )
+    logger.assertion(
+        f"RBD workload result: expected=not None, actual={rbd_result_available}"
+    )
+    logger.assertion(
+        f"CephFS workload result: expected=not None, actual={cephfs_result_available}"
+    )
+    assert (
+        rbd_result_available
+    ), "RBD workload results should be recorded and provided to the test"
+    assert (
+        cephfs_result_available
+    ), "CephFS workload results should be recorded and provided to the test"
+
+    logger.test_step("Validate fio execution details for both volume types")
     fio_reports = (
         ("rbd", workload_storageutilization_10g_rbd["result"]["fio"]),
         ("cephfs", workload_storageutilization_10g_cephfs["result"]["fio"]),
     )
+
     for vol_type, fio in fio_reports:
-        logger.info("starting to check fio run on %s volume", vol_type)
-        msg = "single fio job should be executed in each workload run"
-        assert len(fio["jobs"]) == 1, msg
+        logger.info(f"Checking fio run on {vol_type} volume")
+
+        job_count = len(fio["jobs"])
+        logger.assertion(f"{vol_type} fio job count: expected=1, actual={job_count}")
+        assert job_count == 1, "single fio job should be executed in each workload run"
+
         logger.info(
             "fio (version %s) executed %s job on %s volume",
             fio["fio version"],
             fio["jobs"][0]["jobname"],
             vol_type,
         )
-        msg = f"no errors should be reported by fio writing on {vol_type} volume"
-        assert fio["jobs"][0]["error"] == 0, msg
+
+        error_count = fio["jobs"][0]["error"]
+        logger.assertion(
+            f"{vol_type} fio error count: expected=0, actual={error_count}"
+        )
+        assert (
+            error_count == 0
+        ), f"no errors should be reported by fio writing on {vol_type} volume"
+
+    logger.info("Test passed: 10 GiB workload succeeded on both RBD and CephFS volumes")


### PR DESCRIPTION
Standardize logging across Blue squad tests to comply with docs/logging_guide.md. Key changes applied consistently:

Rename logger variable from 'log' to 'logger' for consistency
Add logger.test_step() calls for major test workflow phases
Add logger.assertion() before assert statements with expected/actual values
Use logger.exception() in except blocks that re-raise (instead of logger.error)
Remove decorative framing lines ("=" * N, "-" * N) and leading newlines
Fix log levels: variable dumps INFO->DEBUG, loop iterations INFO->DEBUG
Add context to generic messages with resource names and counts
Consolidate excessive loop logging with DEBUG per-iteration + INFO summaries

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

**Tests**
  * Enhanced monitoring, alert, Prometheus, PagerDuty, metrics, and workload test suites with structured step-by-step logging for clearer execution tracing.
  * Improved validations by adding explicit assertion helpers (`logger.assertion`) and more descriptive success/failure messages across alert presence, clearance, and metric checks.
  * Added more granular logging and reporting for Prometheus query results, alert instance/state handling, utilization/capacity validations, and Ceph/PVC workload verification to simplify troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->