### PR TITLE
Add UI test TC1: CephFS subvolume metrics section reachable (RHSTOR-7679)

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -635,6 +635,13 @@ DEFAULT_VOLUMESNAPSHOTCLASS_CEPHFS_MS_PC = f"{DEFAULT_CLUSTERNAME}-cephfs"
 DEFAULT_VOLUMESNAPSHOTCLASS_RBD_MS_PC = f"{DEFAULT_CLUSTERNAME}-ceph-rbd"
 DEFAULT_VOLUMEGROUPSNAPSHOTCLASS = "ocs-storagecluster-cephfs-groupsnapclass"
 
+# CephFS subvolume metrics UI (RHSTOR-7679)
+CEPHFS_SUBVOLUME_METRICS_CARD_TITLE = "Current top 10 subvolumes on all clusters"
+CEPHFS_SUBVOLUME_POPOVER_TEXT = (
+    "Use subvolumes to find pods with poor performing workloads"
+)
+CEPHFS_SUBVOLUME_DEFAULT_METRIC = "Total IOPS"
+
 # hyperconverged defaults
 HYPERCONVERGED_NAMESPACE = "kubevirt-hyperconverged"
 TEMPLATE_DEPLOYMENT_DIR_HYPERCONVERGED = os.path.join(
@@ -3841,6 +3848,8 @@ VDBENCH_WORKLOAD_COMPLETION_TIMEOUT = 3600
 VDBENCH_SCALING_TIMEOUT = 180
 # StorageAutoScaler Values
 PROMETHEUS_RECONCILE_TIMEOUT = 660
+# Seconds to wait after IO before querying Prometheus (scrape + rule eval)
+PROMETHEUS_SCRAPE_WAIT = 180
 
 # ODF recovery profiles
 LOW_RECOVERY_OPS = "low_recovery_ops"

--- a/ocs_ci/ocs/ui/page_objects/cephfs_subvolume_metrics.py
+++ b/ocs_ci/ocs/ui/page_objects/cephfs_subvolume_metrics.py
@@ -1,0 +1,114 @@
+import logging
+
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.ui.helpers_ui import format_locator
+from ocs_ci.ocs.ui.page_objects.block_and_file import BlockAndFile
+
+logger = logging.getLogger(__name__)
+
+
+class CephFSSubvolumeMetricsCard(BlockAndFile):
+    """
+    Page object for the CephFS subvolume metrics card on the Block and File tab.
+
+    Provides interactions with the 'Current top 10 subvolumes on all clusters'
+    card: scroll-to, title check, metric dropdown, help popover, and table.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.card_title_loc = self.validation_loc["cephfs_subvolume_card_title"]
+        self.metric_toggle_loc = self.validation_loc["cephfs_subvolume_metric_toggle"]
+        self.metric_option_loc = self.validation_loc["cephfs_subvolume_metric_option"]
+        self.table_rows_loc = self.validation_loc["cephfs_subvolume_table_rows"]
+        self.help_button_loc = self.validation_loc["cephfs_subvolume_help_button"]
+        self.popover_body_loc = self.validation_loc["cephfs_subvolume_popover_body"]
+        self.col_headers_loc = self.validation_loc["cephfs_subvolume_col_headers"]
+
+    def navigate_to_cephfs_subvolume_section(self):
+        """Scroll the Block and File tab to bring the CephFS subvolume card into view."""
+        logger.info("Scrolling to CephFS subvolume metrics card")
+        self.scroll_into_view(self.card_title_loc)
+
+    def verify_cephfs_subvolume_section_visible(self):
+        """
+        Verify the card title is visible on the Block and File tab.
+
+        Returns:
+            bool: True if the card title element is visible, False otherwise.
+        """
+        logger.info("Verifying CephFS subvolume metrics card is visible")
+        self.navigate_to_cephfs_subvolume_section()
+        return self.check_element_text(constants.CEPHFS_SUBVOLUME_METRICS_CARD_TITLE)
+
+    def get_cephfs_subvolume_metric_toggle_text(self):
+        """
+        Return the label currently shown on the metric dropdown toggle.
+
+        Returns:
+            str: One of 'Total IOPS', 'Total Latency', 'Total Throughput'.
+        """
+        logger.info("Reading active metric from CephFS subvolume dropdown")
+        return self.get_element_text(self.metric_toggle_loc).strip()
+
+    def switch_cephfs_subvolume_metric(self, metric_label):
+        """
+        Select a metric from the CephFS subvolume dropdown.
+
+        Args:
+            metric_label (str): One of 'Total IOPS', 'Total Latency',
+                'Total Throughput'.
+        """
+        logger.info("Switching CephFS subvolume metric to: %s", metric_label)
+        self.do_click(self.metric_toggle_loc)
+        self.do_click(format_locator(self.metric_option_loc, metric_label))
+
+    def click_cephfs_subvolume_help_button(self):
+        """Click the help (?) button next to the CephFS subvolume card title."""
+        logger.info("Clicking CephFS subvolume help button")
+        self.do_click(self.help_button_loc)
+
+    def verify_cephfs_subvolume_popover_text(self, expected_text, timeout=15):
+        """
+        Wait for the help popover to contain expected_text and return the result.
+
+        Uses an explicit poll so the assertion is resilient to React rendering
+        lag after the help button is clicked.
+
+        Args:
+            expected_text (str): Substring that must appear in the popover body.
+            timeout (int): Maximum seconds to wait for the text.
+
+        Returns:
+            bool: True if expected_text appears within timeout, False otherwise.
+        """
+        logger.info(
+            "Waiting for CephFS subvolume help popover to contain: %s", expected_text
+        )
+        return self.wait_until_expected_text_is_found(
+            self.popover_body_loc,
+            expected_text,
+            timeout=timeout,
+        )
+
+    def get_cephfs_subvolume_column_headers(self):
+        """
+        Return the column header labels from the subvolume table.
+
+        Returns:
+            list[str]: Column header texts, e.g. ['Name', 'Namespace', 'Total IOPS'].
+        """
+        logger.info("Reading CephFS subvolume table column headers")
+        headers = self.get_elements(self.col_headers_loc)
+        return [h.text.strip() for h in headers]
+
+    def get_cephfs_subvolume_row_count(self):
+        """
+        Return the number of rows currently displayed in the subvolume table.
+
+        Returns:
+            int: Row count (0 if the table is empty or not yet loaded).
+        """
+        rows = self.get_elements(self.table_rows_loc)
+        logger.info("CephFS subvolume table row count: %d", len(rows))
+        return len(rows)

--- a/ocs_ci/ocs/ui/page_objects/cephfs_subvolume_metrics.py
+++ b/ocs_ci/ocs/ui/page_objects/cephfs_subvolume_metrics.py
@@ -1,6 +1,5 @@
 import logging
 
-from ocs_ci.ocs import constants
 from ocs_ci.ocs.ui.helpers_ui import format_locator
 from ocs_ci.ocs.ui.page_objects.block_and_file import BlockAndFile
 
@@ -32,14 +31,17 @@ class CephFSSubvolumeMetricsCard(BlockAndFile):
 
     def verify_cephfs_subvolume_section_visible(self):
         """
-        Verify the card title is visible on the Block and File tab.
+        Verify the card title element is present on the Block and File tab.
+
+        Uses the scoped `card_title_loc` locator rather than a global text
+        search, so the check is specific to the CephFS subvolume card element.
 
         Returns:
-            bool: True if the card title element is visible, False otherwise.
+            bool: True if the card title element is found, False otherwise.
         """
         logger.info("Verifying CephFS subvolume metrics card is visible")
         self.navigate_to_cephfs_subvolume_section()
-        return self.check_element_text(constants.CEPHFS_SUBVOLUME_METRICS_CARD_TITLE)
+        return len(self.get_elements(self.card_title_loc)) > 0
 
     def get_cephfs_subvolume_metric_toggle_text(self):
         """
@@ -102,13 +104,20 @@ class CephFSSubvolumeMetricsCard(BlockAndFile):
         headers = self.get_elements(self.col_headers_loc)
         return [h.text.strip() for h in headers]
 
-    def get_cephfs_subvolume_row_count(self):
+    def get_cephfs_subvolume_row_count(self, timeout=30):
         """
         Return the number of rows currently displayed in the subvolume table.
 
+        Waits up to `timeout` seconds for at least one row to appear before
+        reading the count, guarding against async table-load races.
+
+        Args:
+            timeout (int): Maximum seconds to wait for the first row.
+
         Returns:
-            int: Row count (0 if the table is empty or not yet loaded).
+            int: Row count (0 if no rows appear within timeout).
         """
+        self.wait_for_element_to_be_present(self.table_rows_loc, timeout=timeout)
         rows = self.get_elements(self.table_rows_loc)
         logger.info("CephFS subvolume table row count: %d", len(rows))
         return len(rows)

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -2563,6 +2563,41 @@ validation_4_22 = {
         "//button[@id='{0}-link'] | //li[@id='{0}-link']",
         By.XPATH,
     ),
+    "cephfs_subvolume_card_title": (
+        f"//div[contains(text(),'{constants.CEPHFS_SUBVOLUME_METRICS_CARD_TITLE}')]",
+        By.XPATH,
+    ),
+    "cephfs_subvolume_metric_toggle": (
+        f"//div[contains(text(),'{constants.CEPHFS_SUBVOLUME_METRICS_CARD_TITLE}')]"
+        "/following::button[@aria-expanded][1]",
+        By.XPATH,
+    ),
+    "cephfs_subvolume_metric_option": (
+        "//button[@role='option' and normalize-space(.)='{0}']",
+        By.XPATH,
+    ),
+    "cephfs_subvolume_table_rows": (
+        f"//div[contains(text(),'{constants.CEPHFS_SUBVOLUME_METRICS_CARD_TITLE}')]"
+        "/following::div[contains(@class,'odf-loading-box')]"
+        "//table/tbody/tr",
+        By.XPATH,
+    ),
+    "cephfs_subvolume_help_button": (
+        f"//div[contains(text(),'{constants.CEPHFS_SUBVOLUME_METRICS_CARD_TITLE}')]"
+        "/following::button[@aria-label='Help'"
+        " and contains(@class,'odf-field-level-help')][1]",
+        By.XPATH,
+    ),
+    "cephfs_subvolume_popover_body": (
+        "//div[@role='dialog' and @aria-modal='true' and @aria-label='Help']",
+        By.XPATH,
+    ),
+    "cephfs_subvolume_col_headers": (
+        f"//div[contains(text(),'{constants.CEPHFS_SUBVOLUME_METRICS_CARD_TITLE}')]"
+        "/following::div[contains(@class,'odf-loading-box')]"
+        "//table/thead/tr/th",
+        By.XPATH,
+    ),
 }
 
 topology = {

--- a/tests/functional/ui/test_cephfs_subvolume_metrics.py
+++ b/tests/functional/ui/test_cephfs_subvolume_metrics.py
@@ -8,11 +8,16 @@ import logging
 
 from ocs_ci.framework.testlib import (
     ManageTest,
+    polarion_id,
     skipif_ocs_version,
     tier1,
     ui,
 )
-from ocs_ci.framework.pytest_customization.marks import green_squad
+from ocs_ci.framework.pytest_customization.marks import (
+    green_squad,
+    skipif_external_mode,
+    skipif_mcg_only,
+)
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.resources.pod import get_pods_having_label
 from ocs_ci.ocs.ui.page_objects.cephfs_subvolume_metrics import (
@@ -25,6 +30,8 @@ logger = logging.getLogger(__name__)
 
 @green_squad
 @skipif_ocs_version("<4.22")
+@skipif_mcg_only
+@skipif_external_mode
 class TestCephFSSubvolumeMetricsSectionReachable(ManageTest):
     """
     TC1 — Verify the CephFS subvolume metrics card is reachable on the
@@ -33,6 +40,7 @@ class TestCephFSSubvolumeMetricsSectionReachable(ManageTest):
     Testcase: Metrics presence and correctness - Subvolume metrics section reachable
     """
 
+    @polarion_id("OCS-8010")
     @tier1
     @ui
     def test_cephfs_subvolume_metrics_section_reachable(self, setup_ui_class):

--- a/tests/functional/ui/test_cephfs_subvolume_metrics.py
+++ b/tests/functional/ui/test_cephfs_subvolume_metrics.py
@@ -1,0 +1,113 @@
+"""
+Tests for RHSTOR-7679: CephFS subvolume metrics on the Block and File dashboard.
+
+Requires ODF 4.22+ (Ceph 9.0) for subvolume-level MDS metrics.
+"""
+
+import logging
+
+from ocs_ci.framework.testlib import (
+    ManageTest,
+    skipif_ocs_version,
+    tier1,
+    ui,
+)
+from ocs_ci.framework.pytest_customization.marks import green_squad
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.resources.pod import get_pods_having_label
+from ocs_ci.ocs.ui.page_objects.cephfs_subvolume_metrics import (
+    CephFSSubvolumeMetricsCard,
+)
+from ocs_ci.ocs.ui.page_objects.page_navigator import PageNavigator
+
+logger = logging.getLogger(__name__)
+
+
+@green_squad
+@skipif_ocs_version("<4.22")
+class TestCephFSSubvolumeMetricsSectionReachable(ManageTest):
+    """
+    TC1 — Verify the CephFS subvolume metrics card is reachable on the
+    Block and File dashboard.
+
+    Testcase: Metrics presence and correctness - Subvolume metrics section reachable
+    """
+
+    @tier1
+    @ui
+    def test_cephfs_subvolume_metrics_section_reachable(self, setup_ui_class):
+        """
+        Navigate to Storage Cluster > Block and File, scroll to the CephFS
+        subvolume metrics card, and verify it is correctly rendered per the
+        design specification.
+
+        Steps:
+        1. Verify ODF console plugin pod is in Running state.
+        2. Navigate to Storage > Storage Cluster > Block and File tab.
+        3. Scroll to the CephFS subvolume metrics card and verify card title
+           is visible.
+        4. Verify the metric dropdown default is 'Total IOPS'.
+        5. Verify the help (?) button is present and its popover contains
+           the expected text.
+        6. Verify table column headers are Name, Namespace, and Total IOPS.
+        7. Verify the table has at least one row.
+        """
+        logger.test_step("Verify ODF console plugin pod is in Running state")
+        odf_console_pods = get_pods_having_label(
+            label=constants.ODF_CONSOLE,
+            namespace=constants.OPENSHIFT_STORAGE_NAMESPACE,
+        )
+        assert odf_console_pods, "ODF console plugin pod not found in openshift-storage"
+        for pod in odf_console_pods:
+            phase = pod.get("status", {}).get("phase")
+            assert phase == constants.STATUS_RUNNING, (
+                f"ODF console pod {pod['metadata']['name']} is not Running "
+                f"(phase={phase})"
+            )
+
+        logger.test_step("Navigate to Storage Cluster > Block and File tab")
+        storage_cluster_page = PageNavigator().nav_storage_cluster_default_page()
+        storage_cluster_page.validate_block_and_file_tab_active()
+
+        subvolume_metrics_card = CephFSSubvolumeMetricsCard()
+
+        logger.test_step(
+            "Scroll to CephFS subvolume metrics card and verify card title is visible"
+        )
+        assert (
+            subvolume_metrics_card.verify_cephfs_subvolume_section_visible()
+        ), "CephFS subvolume metrics card title not found on Block and File tab"
+
+        logger.test_step(
+            f"Verify metric dropdown default is '{constants.CEPHFS_SUBVOLUME_DEFAULT_METRIC}'"
+        )
+        toggle_text = subvolume_metrics_card.get_cephfs_subvolume_metric_toggle_text()
+        assert toggle_text == constants.CEPHFS_SUBVOLUME_DEFAULT_METRIC, (
+            f"Expected default metric '{constants.CEPHFS_SUBVOLUME_DEFAULT_METRIC}', "
+            f"got '{toggle_text}'"
+        )
+
+        logger.test_step(
+            "Verify help (?) button popover contains expected description text"
+        )
+        subvolume_metrics_card.click_cephfs_subvolume_help_button()
+        assert subvolume_metrics_card.verify_cephfs_subvolume_popover_text(
+            constants.CEPHFS_SUBVOLUME_POPOVER_TEXT
+        ), f"Popover did not contain: '{constants.CEPHFS_SUBVOLUME_POPOVER_TEXT}'"
+
+        expected_col_headers = [
+            "Name",
+            "Namespace",
+            constants.CEPHFS_SUBVOLUME_DEFAULT_METRIC,
+        ]
+        logger.test_step(f"Verify table column headers are {expected_col_headers}")
+        col_headers = subvolume_metrics_card.get_cephfs_subvolume_column_headers()
+        assert (
+            col_headers == expected_col_headers
+        ), f"Unexpected column headers: {col_headers}"
+
+        logger.test_step("Verify table has at least one subvolume row")
+        row_count = subvolume_metrics_card.get_cephfs_subvolume_row_count()
+        assert (
+            row_count > 0
+        ), "CephFS subvolume table has no rows; expected at least one subvolume"


### PR DESCRIPTION
See more details in the epic: https://redhat.atlassian.net/browse/RHSTOR-7679

PR description:

  ## Summary

  Implements TC1 from [RHSTOR-7679](https://redhat.atlassian.net/browse/RHSTOR-7679) — verifies that the CephFS subvolume
  metrics card on the Block and File dashboard is reachable and rendered
  correctly.

  ### New files
  - `ocs_ci/ocs/ui/page_objects/cephfs_subvolume_metrics.py` — dedicated
    `CephFSSubvolumeMetricsCard(BlockAndFile)` page object; locators
    resolved in `__init__`
  - `tests/functional/ui/test_cephfs_subvolume_metrics.py` — TC1 test
    with `logger.test_step` for each step

  ### Modified files
  - `ocs_ci/ocs/ui/views.py` — new CephFS subvolume locators using
    ARIA/semantic attributes (`aria-expanded`, `role='grid'`,
    `aria-label`, `role='dialog'`) and the ODF-owned `odf-loading-box`
    class; no PatternFly version-specific class names
  - `ocs_ci/ocs/constants.py` — adds `CEPHFS_SUBVOLUME_METRICS_CARD_TITLE`,
    `CEPHFS_SUBVOLUME_POPOVER_TEXT`, `CEPHFS_SUBVOLUME_DEFAULT_METRIC`,
    `PROMETHEUS_SCRAPE_WAIT`

  ## Test steps (TC1)

  1. Verify ODF console plugin pod is Running
  2. Navigate to Storage Cluster > Block and File tab
  3. Scroll to card and verify title is visible
  4. Verify metric dropdown default is `Total IOPS`
  5. Verify help popover contains expected description text
  6. Verify table column headers: `Name`, `Namespace`, `Total IOPS`
  7. Verify table has at least one data row


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a CephFS subvolume metrics card to the Block and File dashboard (ODF 4.22+) with a metric dropdown for viewing the current top subvolumes
  * Added a help popover for the metrics card with explanatory text
  * Exposed a new Prometheus scrape wait timing constant for improved metrics timing

* **Bug Fixes**
  * Improved UI readiness handling by waiting for the metrics table rows and help popover content before assertions

* **Tests**
  * Added a functional UI test validating card visibility, default metric, help popover text, table headers, and at least one rendered row
<!-- end of auto-generated comment: release notes by coderabbit.ai -->