### PR TITLE
support OCP 5.0 deployment

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -533,7 +533,7 @@
         "hashed_secret": "bea1af2a15561a266eda3472673d24cb4f2020d4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 241,
+        "line_number": 242,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -543,7 +543,7 @@
         "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 6956,
+        "line_number": 7165,
         "type": "Private Key",
         "verified_result": null
       }

--- a/ocs_ci/deployment/flexy.py
+++ b/ocs_ci/deployment/flexy.py
@@ -27,6 +27,7 @@ from ocs_ci.utility.utils import (
     exec_cmd,
     expose_ocp_version,
     get_ocp_version,
+    get_registry_svc,
     get_terraform,
     get_terraform_ignition_provider,
     login_to_mirror_registry,
@@ -267,7 +268,7 @@ class FlexyBase(object):
         vers = version or config.DEPLOYMENT["installer_version"]
         installer_version = expose_ocp_version(vers)
         payload_img["installer_payload_image"] = ":".join(
-            [constants.REGISTRY_SVC, installer_version]
+            [get_registry_svc(installer_version), installer_version]
         )
         return payload_img
 

--- a/ocs_ci/deployment/helpers/hypershift_base.py
+++ b/ocs_ci/deployment/helpers/hypershift_base.py
@@ -29,6 +29,7 @@ from ocs_ci.utility.utils import (
     TimeoutSampler,
     get_latest_release_version,
     get_random_letters,
+    get_registry_svc,
 )
 from ocs_ci.utility.decorators import switch_to_orig_index_at_last
 from ocs_ci.ocs.utils import get_namespce_name_by_pattern
@@ -453,12 +454,12 @@ def resolve_ocp_image(ocp_version: str) -> str:
         with config.RunWithProviderConfigContextIfAvailable():
             provider_version = get_ocp_version()
         if "nightly" in provider_version:
-            index_image = f"{constants.REGISTRY_SVC}:{provider_version}"
+            index_image = f"{get_registry_svc(provider_version)}:{provider_version}"
         else:
             index_image = f"{constants.QUAY_REGISTRY_SVC}:{provider_version}-x86_64"
     else:
         if "nightly" in ocp_version:
-            index_image = f"{constants.REGISTRY_SVC}:{ocp_version}"
+            index_image = f"{get_registry_svc(ocp_version)}:{ocp_version}"
         else:
             index_image = f"{constants.QUAY_REGISTRY_SVC}:{ocp_version}-x86_64"
     return index_image
@@ -752,7 +753,9 @@ class HyperShiftBase:
             if not ocp_version:
                 provider_version = get_ocp_version()
                 if "nightly" in provider_version:
-                    index_image = f"{constants.REGISTRY_SVC}:{provider_version}"
+                    index_image = (
+                        f"{get_registry_svc(provider_version)}:{provider_version}"
+                    )
                 else:
                     index_image = (
                         f"{constants.QUAY_REGISTRY_SVC}:{provider_version}-x86_64"

--- a/ocs_ci/deployment/hub_spoke.py
+++ b/ocs_ci/deployment/hub_spoke.py
@@ -86,6 +86,7 @@ from ocs_ci.utility.utils import (
     wait_for_machineconfigpool_status,
     get_server_version,
     get_client_type_by_name,
+    get_registry_svc,
 )
 from ocs_ci.utility.aws import AWS, get_unused_vpc_cidr, get_cluster_region
 from botocore.exceptions import ClientError
@@ -1921,7 +1922,7 @@ class SpokeOCP(ABC):
 
         target_version = ocp_version or provider_version
         if "nightly" in target_version:
-            return f"{constants.REGISTRY_SVC}:{target_version}"
+            return f"{get_registry_svc(target_version)}:{target_version}"
         return f"{constants.QUAY_REGISTRY_SVC}:{target_version}-x86_64"
 
     @abstractmethod

--- a/ocs_ci/framework/conf/ocp_version/ocp-5.0-config.yaml
+++ b/ocs_ci/framework/conf/ocp_version/ocp-5.0-config.yaml
@@ -1,0 +1,22 @@
+---
+# Config file for nightly OCP 5.0
+RUN:
+  client_version: "5.0.0-0.nightly"
+DEPLOYMENT:
+  installer_version: "5.0.0-0.nightly"
+  terraform_version: "1.0.11"
+  # ignition_version can be found here
+  # https://docs.openshift.com/container-platform/4.7/post_installation_configuration/machine-configuration-tasks.html#machine-config-overview-post-install-machine-configuration-tasks
+  ignition_version: "3.2.0" # TODO: We might want to update to 3.5 or later: https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/release_notes/ocp-4-19-release-notes
+ENV_DATA:
+  vm_template: "scos-10.0.20251103-0-vmware.x86_64"
+  acm_hub_channel: "release-2.17"
+  acm_version: "2.17"
+  mce_version: "2.17"
+  submariner_version: "0.23.1"
+  submariner_image: "quay.io/redhat-user-workloads/submariner-tenant/submariner-fbc-4-21@sha256:1585a2a6c372f8a66b7644e742d95356b577072dfc83492c14759f6b2372b609"
+  # Below values needs to be changed when acm and submariner are GAed
+  submariner_source: "downstream"
+  submariner_release_type: "released"
+  acm_hub_unreleased: true
+  oadp_version: "1.6"

--- a/ocs_ci/framework/conf/ocp_version/ocp-5.0-config.yaml
+++ b/ocs_ci/framework/conf/ocp_version/ocp-5.0-config.yaml
@@ -15,8 +15,4 @@ ENV_DATA:
   mce_version: "2.17"
   submariner_version: "0.23.1"
   submariner_image: "quay.io/redhat-user-workloads/submariner-tenant/submariner-fbc-4-21@sha256:1585a2a6c372f8a66b7644e742d95356b577072dfc83492c14759f6b2372b609"
-  # Below values needs to be changed when acm and submariner are GAed
-  submariner_source: "downstream"
-  submariner_release_type: "released"
-  acm_hub_unreleased: true
   oadp_version: "1.6"

--- a/ocs_ci/ocs/ui/acm_ui.py
+++ b/ocs_ci/ocs/ui/acm_ui.py
@@ -23,6 +23,7 @@ from ocs_ci.ocs.ui.helpers_ui import format_locator
 from ocs_ci.ocs.ui.views import acm_ui_specific
 from ocs_ci.utility.utils import (
     expose_ocp_version,
+    get_registry_svc,
     run_cmd,
     get_running_acm_version,
 )
@@ -32,7 +33,6 @@ from ocs_ci.ocs.constants import (
     ACM_PLATOFRM_VSPHERE_CRED_PREFIX,
     VSPHERE_CA_FILE_PATH,
     DATA_DIR,
-    ACM_OCP_RELEASE_IMG_URL_PREFIX,
     ACM_VSPHERE_NETWORK,
     ACM_CLUSTER_DEPLOY_TIMEOUT,
     ACM_CLUSTER_DEPLOYMENT_LABEL_KEY,
@@ -898,7 +898,7 @@ class ACMOCPPlatformVsphereIPI(ACMOCPClusterDeployment):
 
     def get_ocp_release_img(self):
         vers = expose_ocp_version(self.cluster_conf.DEPLOYMENT["installer_version"])
-        return f"{ACM_OCP_RELEASE_IMG_URL_PREFIX}:{vers}"
+        return f"{get_registry_svc(vers)}:{vers}"
 
     def post_destroy_ops(self):
         """

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -1313,6 +1313,26 @@ def download_ga_oc_client_as_bootstrap(bin_dir, target_version):
         os.chdir(previous_dir)
 
 
+def get_registry_svc(version):
+    """
+    Get the CI registry image path for the given OCP version.
+
+    OCP 5.x uses a different image stream name (release-5) than
+    OCP 4.x (release).
+
+    Args:
+        version (str): OCP version string (e.g. "5.0.0-0.nightly-2026-06-18-000016")
+
+    Returns:
+        str: Registry image path (e.g. "registry.ci.openshift.org/ocp/release-5")
+
+    """
+    major = version.split(".")[0]
+    if int(major) >= 5:
+        return "registry.ci.openshift.org/ocp/release-5"
+    return constants.REGISTRY_SVC
+
+
 @retry(CommandFailed, tries=2, delay=5, backoff=2)
 def get_openshift_installer(
     version=None,
@@ -1371,7 +1391,7 @@ def get_openshift_installer(
         pull_secret_path = os.path.join(constants.DATA_DIR, "pull-secret")
         cmd = (
             f"oc adm release extract --registry-config {pull_secret_path} --command={installer_filename} "
-            f"--to ./ registry.ci.openshift.org/ocp/release:{version}"
+            f"--to ./ {get_registry_svc(version)}:{version}"
         )
         exec_cmd(cmd)
         # return to the previous working directory
@@ -1542,12 +1562,13 @@ def _try_extract_from_fallback_ga_image(binary, original_image, bin_dir):
     """
     # Check if this looks like a nightly build that we can fallback
     if (
-        "registry.ci.openshift.org/ocp/release:" in original_image
+        "registry.ci.openshift.org/ocp/release" in original_image
         and "nightly" in original_image
     ):
         try:
             # Extract version from nightly image name
             # e.g., "registry.ci.openshift.org/ocp/release:4.22.0-0.nightly-2026-06-10-104337"
+            # or "registry.ci.openshift.org/ocp/release-5:5.0.0-0.nightly-2026-06-18-000016"
             image_tag = original_image.split(":")[
                 -1
             ]  # "4.22.0-0.nightly-2026-06-10-104337"
@@ -2007,7 +2028,7 @@ def get_nightly_oc_via_ga(version, tarball="openshift-client.tar.gz"):
             # extract oc
             cmd = (
                 f"{tmp_oc_path}/oc adm release extract -a {pull_secret_path} --command={oc_type} "
-                f"registry.ci.openshift.org/ocp/release:{version} --to ."
+                f"{get_registry_svc(version)}:{version} --to ."
             )
             exec_cmd(cmd)
             delete_file(tarball)

--- a/ocs_ci/utility/version.py
+++ b/ocs_ci/utility/version.py
@@ -73,6 +73,7 @@ VERSION_4_19 = get_semantic_version("4.19", True)
 VERSION_4_20 = get_semantic_version("4.20", True)
 VERSION_4_21 = get_semantic_version("4.21", True)
 VERSION_4_22 = get_semantic_version("4.22", True)
+VERSION_5_0 = get_semantic_version("5.0", True)
 
 # Fusion version constants
 VERSION_2_11 = get_semantic_version("2.11", True)


### PR DESCRIPTION
Signed-off-by: vavuthu [vavuthu@redhat.com](mailto:vavuthu@redhat.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added OpenShift Container Platform 5.0 nightly configuration, including pinned component versions for VM templates, ACM, MCE, Submariner, and OADP.
  * Updated nightly and release image URL construction to dynamically select the correct registry service for OCP 5+ (and keep prior behavior for older versions) across installer/client payload and cluster creation flows.
* **Bug Fixes**
  * Improved nightly-to-GA fallback detection to support multiple release image reference formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->