### PR TITLE
Adjust expected mon_target_pg_per_osd for lower-req clusters

### DIFF
--- a/tests/functional/z_cluster/test_ceph_default_values_check.py
+++ b/tests/functional/z_cluster/test_ceph_default_values_check.py
@@ -177,6 +177,15 @@ class TestCephDefaultValuesCheck(ManageTest):
         # Get expected values - currently only 4.20+ supported
         expected_config = constants.ROOK_CEPH_CONFIG_VALUES_420
 
+        if is_lower_requirements():
+            expected_config = {
+                **expected_config,
+                "global": {
+                    **expected_config["global"],
+                    "mon_target_pg_per_osd": "100",
+                },
+            }
+
         log.info(f"OCS version is {ocs_version}")
         log.info(f"Expected config values: {expected_config}")
 


### PR DESCRIPTION
- On lower-requirements clusters (IBM Cloud bx2-8x32, AWS m4.4xlarge), the product sets `mon_target_pg_per_osd` to `100` instead of the standard `200`
- Adjust expected config in `_validate_config_post_420()` to account for this, rather than skipping the entire test
- Preserves validation coverage for all other config keys on lower-req clusters

Fixes 100% failure rate of `test_validate_ceph_config_values_in_rook_config_override` on IBM Cloud LOWERREQ (4/4 runs on 4.22)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced validation for Ceph configuration defaults in lower requirement scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->