### PR TITLE
Fix test_nodes_restart NotImplementedError on baremetal

### DIFF
--- a/ocs_ci/ocs/platform_nodes.py
+++ b/ocs_ci/ocs/platform_nodes.py
@@ -2181,6 +2181,17 @@ class BaremetalNodes(NodesBase):
         """
         self.baremetal.restart_baremetal_machines(nodes, force=force)
 
+    def restart_nodes_by_stop_and_start(self, nodes, force=True):
+        """
+        Restart baremetal machines by stop and start (IPMI power cycle).
+
+        Args:
+            nodes (list): The OCS objects of the nodes
+            force (bool): True for force BM stop, False otherwise
+
+        """
+        self.restart_nodes(nodes, force=force)
+
     def restart_nodes_by_stop_and_start_teardown(self):
         """
         Make sure all BMs are up by the end of the test


### PR DESCRIPTION
- Add baremetal platform branch to test_nodes_restart using restart_nodes (IPMI) instead of restart_nodes_by_stop_and_start which BaremetalNodes does not implement
- Follows the existing vSphere IPI pattern already in the test
- BaremetalNodes.restart_nodes internally calls stop+start via IPMI, so the test behavior is functionally equivalent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new restart option for bare metal nodes that performs a stop/start power cycle through the existing restart flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->