### PR TITLE
Fall back to latest known version in must-gather test

### DIFF
--- a/ocs_ci/ocs/must_gather/must_gather.py
+++ b/ocs_ci/ocs/must_gather/must_gather.py
@@ -80,6 +80,12 @@ class MustGather(object):
                 f"{version.get_ocs_version_from_csv(only_major_minor=True)}"
             )
             logger.debug(f"Using CSV version for must-gather validation: {ocs_version}")
+        if ocs_version not in GATHER_COMMANDS_VERSION:
+            fallback = max(v for v in GATHER_COMMANDS_VERSION if v <= ocs_version)
+            logger.warning(
+                f"No must-gather data for {ocs_version}, falling back to {fallback}"
+            )
+            ocs_version = fallback
         if (
             self.type_log == "OTHERS"
             and config.ENV_DATA["platform"] in MANAGED_SERVICE_PLATFORMS

--- a/ocs_ci/ocs/must_gather/must_gather.py
+++ b/ocs_ci/ocs/must_gather/must_gather.py
@@ -81,7 +81,13 @@ class MustGather(object):
             )
             logger.debug(f"Using CSV version for must-gather validation: {ocs_version}")
         if ocs_version not in GATHER_COMMANDS_VERSION:
-            fallback = max(v for v in GATHER_COMMANDS_VERSION if v <= ocs_version)
+            candidates = [v for v in GATHER_COMMANDS_VERSION if v <= ocs_version]
+            if not candidates:
+                raise ValueError(
+                    f"No must-gather data for OCS {ocs_version}; "
+                    f"available versions: {sorted(GATHER_COMMANDS_VERSION)}"
+                )
+            fallback = max(candidates)
             logger.warning(
                 f"No must-gather data for {ocs_version}, falling back to {fallback}"
             )

--- a/tests/functional/z_cluster/test_must_gather.py
+++ b/tests/functional/z_cluster/test_must_gather.py
@@ -1,7 +1,6 @@
 import logging
 import pytest
 
-from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import brown_squad
 from ocs_ci.framework.testlib import (
     ManageTest,
@@ -12,7 +11,6 @@ from ocs_ci.framework.testlib import (
     skipif_hci_client,
 )
 from ocs_ci.ocs.must_gather.must_gather import MustGather
-from ocs_ci.ocs.must_gather.const_must_gather import GATHER_COMMANDS_VERSION
 
 logger = logging.getLogger(__name__)
 
@@ -60,12 +58,6 @@ class TestMustGather(ManageTest):
                 *["OTHERS"], marks=[tier2, pytest.mark.polarion_id("OCS-1583")]
             ),
         ],
-    )
-    @pytest.mark.skipif(
-        float(config.ENV_DATA["ocs_version"]) not in GATHER_COMMANDS_VERSION,
-        reason=(
-            "Skipping must_gather test, because there is not data for this version"
-        ),
     )
     def test_must_gather(self, mustgather, log_type):
         """


### PR DESCRIPTION
## Summary
- Remove the `skipif` marker that skips `test_must_gather` for versions not listed in `GATHER_COMMANDS_VERSION`
- Instead, fall back to the latest known version's expected files when the exact version is missing
- New releases (4.21, 4.22, etc.) now get validated automatically instead of silently skipped

## Test plan
- [x] Verify test runs on a version listed in `GATHER_COMMANDS_VERSION` (e.g., 4.20) — no change in behavior
- [x] Verify test runs on a version NOT listed (e.g., 4.21) — falls back to 4.20 expectations instead of skipping
- [ ] Check log output contains the fallback warning message

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `must-gather` version handling by falling back to the nearest compatible lower version when the current version isn’t supported, including a warning to indicate the fallback.

* **Tests**
  * Updated must-gather functional tests to run without version-based skipping, increasing coverage across supported scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->