### PR TITLE
Update Submariner to 0.24.0 and mark ACM released for OCP 4.22

### DIFF
--- a/conf/examples/submariner_unreleased_image.yaml
+++ b/conf/examples/submariner_unreleased_image.yaml
@@ -1,3 +1,3 @@
 ---
 ENV_DATA:
-  submariner_image: "quay.io/redhat-user-workloads/submariner-tenant/submariner-fbc-4-21@sha256:1585a2a6c372f8a66b7644e742d95356b577072dfc83492c14759f6b2372b609"
+  submariner_image: "quay.io/redhat-user-workloads/submariner-tenant/submariner-fbc-4-22@sha256:1a666c3c2c99b1148f184f54efcee293f45cfff32cf9ca7a239097fe574ff700"

--- a/conf/ocsci/submariner_downstream.yaml
+++ b/conf/ocsci/submariner_downstream.yaml
@@ -1,3 +1,3 @@
 ENV_DATA:
   submariner_source: "downstream"
-  subctl_version: "subctl-rhel9:v0.23"
+  subctl_version: "subctl-rhel9:v0.24"

--- a/conf/ocsci/submariner_downstream_released.yaml
+++ b/conf/ocsci/submariner_downstream_released.yaml
@@ -2,4 +2,4 @@ ENV_DATA:
   submariner_source: "downstream"
   submariner_release_type: "released"
   submariner_channel: ""
-  subctl_version: "subctl-rhel9:v0.23"
+  subctl_version: "subctl-rhel9:v0.24"

--- a/conf/ocsci/submariner_downstream_unreleased.yaml
+++ b/conf/ocsci/submariner_downstream_unreleased.yaml
@@ -2,4 +2,4 @@ ENV_DATA:
   submariner_source: "downstream"
   submariner_release_type: "unreleased"
   submariner_channel: ""
-  subctl_version: "subctl-rhel9:v0.23"
+  subctl_version: "subctl-rhel9:v0.24"

--- a/ocs_ci/framework/conf/ocp_version/ocp-4.21-config.yaml
+++ b/ocs_ci/framework/conf/ocp_version/ocp-4.21-config.yaml
@@ -14,5 +14,4 @@ ENV_DATA:
   acm_version: "2.16"
   mce_version: "2.11"
   submariner_version: "0.23.1"
-  # Below values needs to be changed when acm and submariner are GAed
   oadp_version: "1.5"

--- a/ocs_ci/framework/conf/ocp_version/ocp-4.21-ga-config.yaml
+++ b/ocs_ci/framework/conf/ocp_version/ocp-4.21-ga-config.yaml
@@ -12,5 +12,5 @@ ENV_DATA:
   acm_hub_channel: "release-2.16"
   acm_version: "2.16"
   mce_version: "2.11"
-  submariner_version: "0.22.0"
+  submariner_version: "0.23.1"
   oadp_version: "1.5"

--- a/ocs_ci/framework/conf/ocp_version/ocp-4.22-config.yaml
+++ b/ocs_ci/framework/conf/ocp_version/ocp-4.22-config.yaml
@@ -19,7 +19,5 @@ ENV_DATA:
   acm_hub_channel: "release-2.17"
   acm_version: "2.17"
   mce_version: "2.17"
-  submariner_version: "0.23.1"
-  submariner_image: "quay.io/redhat-user-workloads/submariner-tenant/submariner-fbc-4-21@sha256:1585a2a6c372f8a66b7644e742d95356b577072dfc83492c14759f6b2372b609"
-  # Below values needs to be changed when acm and submariner are GAed
+  submariner_version: "0.24.0"
   oadp_version: "1.6"

--- a/ocs_ci/framework/conf/ocp_version/ocp-4.22-ga-config.yaml
+++ b/ocs_ci/framework/conf/ocp_version/ocp-4.22-ga-config.yaml
@@ -14,7 +14,5 @@ ENV_DATA:
   # TODO: Versions bellow will be updated by RDR
   acm_version: "2.17"
   mce_version: "2.17"
-  submariner_version: "0.23.1"
-  submariner_image: "quay.io/redhat-user-workloads/submariner-tenant/submariner-fbc-4-21@sha256:1585a2a6c372f8a66b7644e742d95356b577072dfc83492c14759f6b2372b609"
-  # Below values needs to be changed when acm and submariner are GAed
+  submariner_version: "0.24.0"
   oadp_version: "1.6"

--- a/ocs_ci/ocs/defaults.py
+++ b/ocs_ci/ocs/defaults.py
@@ -204,7 +204,7 @@ ocp_to_acm_unreleased_mapping = {
     "4.19": False,
     "4.20": False,
     "4.21": False,
-    "4.22": True,
+    "4.22": False,
     "4.23": True,
 }
 


### PR DESCRIPTION
Bump submariner_version to 0.24.0 in OCP 4.22 configs, align OCP 4.21 GA to submariner 0.23.1, update downstream subctl to v0.24, and refresh the unreleased Submariner image in the example config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Submariner to **0.24.0** for **OCP 4.22** CI and GA configurations.
  * Updated Submariner to **0.23.1** for **OCP 4.21 GA** configuration.
  * Updated **subctl** to **v0.24** across downstream configurations.
  * Updated the **Submariner image digest** used in the unreleased example.
  * Adjusted **how OCP 4.22 is classified** for ACM releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->