### PR TITLE
bug fix on ec_allowed marker

### DIFF
--- a/ocs_ci/ocs/cluster.py
+++ b/ocs_ci/ocs/cluster.py
@@ -2396,7 +2396,7 @@ def is_ec_pool_supported():
     Check if erasure coded RBD pools are supported on this cluster.
 
     All conditions must be met:
-    - Platform is vSphere or baremetal
+    - Platform is on-prem or HCI (vSphere, baremetal, ibm_hci, etc.)
     - Cluster uses local storage (LSO / no-provisioner / localblock)
     - Failure domain is 'host'
     - At least 3 OSDs are running
@@ -2408,11 +2408,14 @@ def is_ec_pool_supported():
     from ocs_ci.ocs.resources import pod
 
     cluster_type = config.ENV_DATA.get("cluster_type", "").lower()
-    if cluster_type == "provider":
+    if cluster_type in ["hci_client", "consumer"]:
         return False
 
     platform = config.ENV_DATA["platform"].lower()
-    if platform not in constants.ON_PREM_PLATFORMS:
+    if (
+        platform not in constants.ON_PREM_PLATFORMS
+        and platform not in constants.HCI_PROVIDER_CLIENT_PLATFORMS
+    ):
         return False
     if not is_lso_cluster():
         return False


### PR DESCRIPTION
make the EC pool related tests run on all clusters but not consumer clusters. 
consumer clusters can not create/initiate creation of pools or storage classes 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved reliability of Erasure Coded (EC) pool support detection on on-premises clusters by tightening eligibility checks (cluster type exclusions and expanded platform validation), while preserving existing requirements for local storage, host-level failure domains, and sufficient OSD pod count.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->