### PR TITLE
Update cephblockpool template to move annotation from spec

### DIFF
--- a/ocs_ci/templates/ocs-deployment/cephblockpool.yaml
+++ b/ocs_ci/templates/ocs-deployment/cephblockpool.yaml
@@ -4,6 +4,8 @@ kind: CephBlockPool
 metadata:
   name: replicapool
   namespace: default
+  annotations:
+  #  key: valueplica_size | default('3') }}
 spec:
   # The failure domain will spread the replicas of the data across different failure zones
   failureDomain: host
@@ -16,5 +18,3 @@ spec:
     # Further reference: https://docs.ceph.com/docs/nautilus/rados/configuration/bluestore-config-ref/#inline-compression
     compression_mode: none
   # A key/value list of annotations
-  annotations:
-  #  key: valueplica_size | default('3') }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CephBlockPool deployment template annotations configuration to improve replica size setting defaults during cluster deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->