### PR TITLE
Ignore cnpg-controller-manager pod leftovers in MCG tests

### DIFF
--- a/ocs_ci/framework/testlib.py
+++ b/ocs_ci/framework/testlib.py
@@ -4,6 +4,7 @@ from ocs_ci.framework.pytest_customization.marks import *  # noqa: F403
 from ocs_ci.ocs.constants import (
     MCG_TESTS_MIN_NB_ENDPOINT_COUNT,
     MAX_NB_ENDPOINT_COUNT,
+    NOOBAA_CNPG_POD_LABEL,
     NOOBAA_ENDPOINT_POD_LABEL,
 )
 
@@ -47,8 +48,8 @@ class EcosystemTest(BaseTest):
     pass
 
 
-# nb endpoint pods might change during MCG tests due to scaling or mounts
-@ignore_leftover_label(NOOBAA_ENDPOINT_POD_LABEL)  # noqa: F405
+# nb endpoint and cnpg-controller-manager pods might change during MCG tests
+@ignore_leftover_label(NOOBAA_ENDPOINT_POD_LABEL, NOOBAA_CNPG_POD_LABEL)  # noqa: F405
 @pytest.mark.usefixtures("nb_ensure_endpoint_count")
 class MCGTest(ManageTest):
     MIN_ENDPOINT_COUNT = MCG_TESTS_MIN_NB_ENDPOINT_COUNT


### PR DESCRIPTION
Fixes #15469

## Summary
- The `cnpg-controller-manager` pod may restart during MCG tests, causing a false `ResourceLeftoversException` in the environment checker
- Add `NOOBAA_CNPG_POD_LABEL` to the `ignore_leftover_label` on `MCGTest`, alongside the existing `NOOBAA_ENDPOINT_POD_LABEL`

## Changes
- `ocs_ci/framework/testlib.py`: Import `NOOBAA_CNPG_POD_LABEL` and add it to the `@ignore_leftover_label` decorator on `MCGTest`