### PR TITLE
Add post-upgrade test to verify NFS driver pods are absent by default after ODF 4.22 upgrade

### DIFF
--- a/tests/functional/upgrade/test_resources.py
+++ b/tests/functional/upgrade/test_resources.py
@@ -241,7 +241,15 @@ def test_nfs_driver_pods_not_deployed_by_default_after_upgrade():
     namespace = config.ENV_DATA["cluster_namespace"]
 
     for selector in nfs_selectors:
-        pods = get_all_pods(namespace=namespace, selector=[selector.split("=")[1]])
+        label_key, sep, label_value = selector.partition("=")
+        assert (
+            sep
+        ), f"Malformed NFS pod selector '{selector}' — expected 'key=value' format"
+        pods = get_all_pods(
+            namespace=namespace,
+            selector=[label_value],
+            selector_label=label_key,
+        )
         assert not pods, (
             f"NFS driver pods found with selector '{selector}' after upgrade "
             "to ODF 4.22. NFS driver pods should not be deployed by default "

--- a/tests/functional/upgrade/test_resources.py
+++ b/tests/functional/upgrade/test_resources.py
@@ -216,7 +216,7 @@ def test_blackbox_pod_after_upgrade():
 @skipif_external_mode
 @skipif_hci_client
 @skipif_mcg_only
-@purple_squad
+@brown_squad
 def test_nfs_driver_pods_not_deployed_by_default_after_upgrade():
     """
     Verify NFS driver pods (csi-nfsplugin / ctrlplugin / nodeplugin) are not

--- a/tests/functional/upgrade/test_resources.py
+++ b/tests/functional/upgrade/test_resources.py
@@ -29,6 +29,7 @@ from ocs_ci.ocs.resources.pod import (
 )
 from ocs_ci.helpers import helpers
 from ocs_ci.utility import nfs_utils
+from ocs_ci.framework.testlib import skipif_ocs_version
 
 log = logging.getLogger(__name__)
 
@@ -216,6 +217,7 @@ def test_blackbox_pod_after_upgrade():
 @skipif_external_mode
 @skipif_hci_client
 @skipif_mcg_only
+@skipif_ocs_version("<4.22")
 @brown_squad
 def test_nfs_driver_pods_not_deployed_by_default_after_upgrade():
     """
@@ -227,32 +229,27 @@ def test_nfs_driver_pods_not_deployed_by_default_after_upgrade():
     a vanilla upgrade from 4.21 does not leave stale NFS driver pods running.
 
     Steps:
-    1. Skip if the post-upgrade ODF version is less than 4.22
-    2. Fetch the NFS driver pod selectors for the current version
-    3. Assert that no pods matching any NFS selector exist in the
+    1. Fetch the NFS driver pod selectors for the current version
+    2. Assert that no pods matching any NFS selector exist in the
        openshift-storage namespace
 
     """
-    ocs_version = version.get_ocs_version_from_csv(only_major_minor=True)
-    if ocs_version < version.VERSION_4_22:
-        pytest.skip("Test only applies to ODF 4.22 and above (upgrade from 4.21)")
-
     nfs_selectors = nfs_utils.provisioner_selectors(nfs_plugins=True)
     namespace = config.ENV_DATA["cluster_namespace"]
 
     for selector in nfs_selectors:
         label_key, sep, label_value = selector.partition("=")
-        assert (
-            sep
-        ), f"Malformed NFS pod selector '{selector}' — expected 'key=value' format"
+        assert sep, (
+            "Malformed NFS pod selector '%s' — expected 'key=value' format" % selector
+        )
         pods = get_all_pods(
             namespace=namespace,
             selector=[label_value],
             selector_label=label_key,
         )
         assert not pods, (
-            f"NFS driver pods found with selector '{selector}' after upgrade "
-            "to ODF 4.22. NFS driver pods should not be deployed by default "
-            "unless NFS is explicitly enabled on the StorageCluster."
+            "NFS driver pods found with selector '%s' after upgrade to ODF 4.22. "
+            "NFS driver pods should not be deployed by default unless NFS is "
+            "explicitly enabled on the StorageCluster." % selector
         )
         log.info("No NFS driver pods found for selector '%s' — as expected", selector)

--- a/tests/functional/upgrade/test_resources.py
+++ b/tests/functional/upgrade/test_resources.py
@@ -25,8 +25,10 @@ from ocs_ci.ocs.resources.pod import (
     get_osd_pods,
     get_mon_pods,
     get_mgr_pods,
+    get_all_pods,
 )
 from ocs_ci.helpers import helpers
+from ocs_ci.utility import nfs_utils
 
 log = logging.getLogger(__name__)
 
@@ -208,3 +210,41 @@ def test_blackbox_pod_after_upgrade():
             ), f"Unexpected pod label on {pod_name}"
 
         log.info("Blackbox exporter pod exists after upgrade")
+
+
+@post_upgrade
+@skipif_external_mode
+@skipif_hci_client
+@skipif_mcg_only
+@purple_squad
+def test_nfs_driver_pods_not_deployed_by_default_after_upgrade():
+    """
+    Verify NFS driver pods (csi-nfsplugin / ctrlplugin / nodeplugin) are not
+    deployed by default after upgrading ODF from 4.21 to 4.22.
+
+    Starting with ODF 4.22, NFS CSI driver pods should only be present when
+    NFS is explicitly enabled on the StorageCluster. This test confirms that
+    a vanilla upgrade from 4.21 does not leave stale NFS driver pods running.
+
+    Steps:
+    1. Skip if the post-upgrade ODF version is less than 4.22
+    2. Fetch the NFS driver pod selectors for the current version
+    3. Assert that no pods matching any NFS selector exist in the
+       openshift-storage namespace
+
+    """
+    ocs_version = version.get_ocs_version_from_csv(only_major_minor=True)
+    if ocs_version < version.VERSION_4_22:
+        pytest.skip("Test only applies to ODF 4.22 and above (upgrade from 4.21)")
+
+    nfs_selectors = nfs_utils.provisioner_selectors(nfs_plugins=True)
+    namespace = config.ENV_DATA["cluster_namespace"]
+
+    for selector in nfs_selectors:
+        pods = get_all_pods(namespace=namespace, selector=[selector.split("=")[1]])
+        assert not pods, (
+            f"NFS driver pods found with selector '{selector}' after upgrade "
+            "to ODF 4.22. NFS driver pods should not be deployed by default "
+            "unless NFS is explicitly enabled on the StorageCluster."
+        )
+        log.info("No NFS driver pods found for selector '%s' — as expected", selector)


### PR DESCRIPTION
Test to verify bug, https://redhat.atlassian.net/browse/DFBUGS-4704

##Problem
Clusters with Convergence changes always have nfs driver deployed. 

What changed
This issue is fixed for 4.22 now. Added test_nfs_driver_pods_not_deployed_by_default_after_upgrade to [tests/functional/upgrade/test_resources.py](vscode-webview://0tc78444a0naj3vm84j1sedbcen03v4t9f68bsmhakin6n2qei0l/tests/functional/upgrade/test_resources.py):

Decorated with @post_upgrade so it runs after the ODF upgrade completes
Automatically skips if the post-upgrade version is below 4.22 (not applicable to older upgrade paths for now. the same fix will be back ported to later builds 4.20 and 4.21)
Reuses nfs_utils.provisioner_selectors(nfs_plugins=True) to get the correct NFS pod label selectors for the running version
Asserts that no pods matching any NFS CSI driver selector exist in the openshift-storage namespace

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Tests**
  * Added a post-upgrade functional test to verify NFS CSI driver pods are not deployed by default after upgrading from 4.21 to 4.22.
  * The test queries for NFS driver pods using generated pod selector labels and fails if any matching pods are found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->