### PR TITLE
Skip unrelated tests for disabled components (block only deployment)

### DIFF
--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -924,6 +924,27 @@ skipif_lean_deployment = pytest.mark.skipif(
     reason="Test cannot run on lean profile or requires higher cluster resources (insufficient CPU/memory)",
 )
 
+# Markers for disabled components
+skipif_noobaa_disabled = pytest.mark.skipif(
+    config.COMPONENTS.get("disable_noobaa", False),
+    reason="Test requires NooBaa but it is disabled",
+)
+
+skipif_rgw_disabled = pytest.mark.skipif(
+    config.COMPONENTS.get("disable_rgw", False),
+    reason="Test requires RGW but it is disabled",
+)
+
+skipif_cephfs_disabled = pytest.mark.skipif(
+    config.COMPONENTS.get("disable_cephfs", False),
+    reason="Test requires CephFS but it is disabled",
+)
+
+skipif_blockpools_disabled = pytest.mark.skipif(
+    config.COMPONENTS.get("disable_blockpools", False),
+    reason="Test requires block pools but they are disabled",
+)
+
 
 def skipif_insufficient_resources(ram_gb=65, cpu_cores=6):
     """

--- a/ocs_ci/framework/pytest_customization/ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/ocscilib.py
@@ -1132,12 +1132,66 @@ def set_stop_flags_for_all_clusters(stop_requested, graceful_stop):
         ocsci_config.RUN["graceful_stop"] = graceful_stop
 
 
+def _check_disabled_components(item):
+    """
+    Check if test should be skipped based on disabled components.
+
+    This function automatically detects component requirements based on:
+    - Test file path (e.g., tests/functional/object/mcg/ -> requires NooBaa)
+    - Test markers (e.g., @pytest.mark.mcg -> requires NooBaa)
+
+    Args:
+        item: pytest test item
+
+    Raises:
+        pytest.skip: If test requires a disabled component
+    """
+    # Component path patterns - map directory patterns to component requirements
+    component_paths = {
+        "/object/mcg/": ("disable_noobaa", "NooBaa"),
+        "/object/rgw/": ("disable_rgw", "RGW"),
+        "/monitoring/prometheus/alerts/test_rgw": ("disable_rgw", "RGW"),
+        "/monitoring/prometheus/metrics/test_rgw": ("disable_rgw", "RGW"),
+        "/workloads/app/amq/test_rgw": ("disable_rgw", "RGW"),
+        "test_bucket": ("disable_noobaa", "NooBaa"),
+        "test_mcg": ("disable_noobaa", "NooBaa"),
+        "test_noobaa": ("disable_noobaa", "NooBaa"),
+        "cephfs": ("disable_cephfs", "CephFS"),
+    }
+
+    # Component markers - map pytest markers to component requirements
+    component_markers = {
+        "mcg": ("disable_noobaa", "NooBaa"),
+        "rgw": ("disable_rgw", "RGW"),
+    }
+
+    # Get test file path
+    test_path = str(item.fspath)
+
+    # Check if test path indicates a specific component
+    for path_pattern, (disable_key, component_name) in component_paths.items():
+        if path_pattern in test_path:
+            if ocsci_config.COMPONENTS.get(disable_key, False):
+                pytest.skip(f"Test requires {component_name} but it is disabled")
+
+    # Check test markers
+    for marker_name, (disable_key, component_name) in component_markers.items():
+        if item.get_closest_marker(marker_name):
+            if ocsci_config.COMPONENTS.get(disable_key, False):
+                pytest.skip(
+                    f"Test requires {component_name} but it is disabled (marker: {marker_name})"
+                )
+
+
 global consumed_ram_start_test
 
 
 @pytest.hookimpl(tryfirst=True)
 def pytest_runtest_setup(item):
     try:
+        # Check if test should be skipped due to disabled components
+        _check_disabled_components(item)
+
         # Check for stop files before starting the test
         stop_requested, graceful_stop, skip_message = check_stop_file()
 

--- a/tests/functional/pod_and_daemons/test_csiaddon_daemons_pods.py
+++ b/tests/functional/pod_and_daemons/test_csiaddon_daemons_pods.py
@@ -11,6 +11,7 @@ from ocs_ci.framework.testlib import (
     green_squad,
     skipif_ocs_version,
 )
+from ocs_ci.framework.pytest_customization.marks import skipif_cephfs_disabled
 from ocs_ci.ocs import (
     ocp,
     constants,
@@ -40,7 +41,12 @@ class TestCSIADDonDaemonset(ManageTest):
             ),
             pytest.param(
                 "cephfs",
-                marks=[tier1, green_squad, pytest.mark.polarion_id("OCS-7501")],
+                marks=[
+                    tier1,
+                    green_squad,
+                    pytest.mark.polarion_id("OCS-7501"),
+                    skipif_cephfs_disabled,
+                ],
             ),
         ],
     )
@@ -121,6 +127,7 @@ class TestCSIADDonDaemonset(ManageTest):
                     tier1,
                     green_squad,
                     pytest.mark.polarion_id("OCS-7503"),
+                    skipif_cephfs_disabled,
                 ],
             ),
         ],
@@ -155,7 +162,12 @@ class TestCSIADDonDaemonset(ManageTest):
             ),
             pytest.param(
                 constants.CSI_CEPHFS_ADDON_NODEPLUGIN_LABEL_420,
-                marks=[tier1, green_squad, pytest.mark.polarion_id("OCS-7502")],
+                marks=[
+                    tier1,
+                    green_squad,
+                    pytest.mark.polarion_id("OCS-7502"),
+                    skipif_cephfs_disabled,
+                ],
             ),
         ],
     )
@@ -189,7 +201,12 @@ class TestCSIADDonDaemonset(ManageTest):
             ),
             pytest.param(
                 constants.DAEMONSET_CSI_CEPHFS_CSI_ADDONS,
-                marks=[tier1, green_squad, pytest.mark.polarion_id("OCS-7504")],
+                marks=[
+                    tier1,
+                    green_squad,
+                    pytest.mark.polarion_id("OCS-7504"),
+                    skipif_cephfs_disabled,
+                ],
             ),
         ],
     )
@@ -239,7 +256,12 @@ class TestCSIADDonDaemonset(ManageTest):
             ),
             pytest.param(
                 constants.CSI_CEPHFS_ADDON_NODEPLUGIN_LABEL_420,
-                marks=[tier1, green_squad, pytest.mark.polarion_id("OCS-7505")],
+                marks=[
+                    tier1,
+                    green_squad,
+                    pytest.mark.polarion_id("OCS-7505"),
+                    skipif_cephfs_disabled,
+                ],
             ),
         ],
     )
@@ -299,7 +321,12 @@ class TestCSIADDonDaemonset(ManageTest):
             ),
             pytest.param(
                 constants.CSI_CEPHFS_ADDON_NODEPLUGIN_LABEL_420,
-                marks=[tier1, green_squad, pytest.mark.polarion_id("OCS-7506")],
+                marks=[
+                    tier1,
+                    green_squad,
+                    pytest.mark.polarion_id("OCS-7506"),
+                    skipif_cephfs_disabled,
+                ],
             ),
         ],
     )
@@ -335,7 +362,12 @@ class TestCSIADDonDaemonset(ManageTest):
             ),
             pytest.param(
                 "cephfs",
-                marks=[tier1, green_squad, pytest.mark.polarion_id("OCS-7507")],
+                marks=[
+                    tier1,
+                    green_squad,
+                    pytest.mark.polarion_id("OCS-7507"),
+                    skipif_cephfs_disabled,
+                ],
             ),
         ],
     )

--- a/tests/functional/pv/add_metadata_feature/test_metadata.py
+++ b/tests/functional/pv/add_metadata_feature/test_metadata.py
@@ -5,7 +5,10 @@ from ocs_ci.utility import metadata_utils
 from ocs_ci.ocs import constants, ocp
 from ocs_ci.helpers import helpers
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import green_squad
+from ocs_ci.framework.pytest_customization.marks import (
+    green_squad,
+    skipif_cephfs_disabled,
+)
 from ocs_ci.ocs.resources import pod
 from ocs_ci.framework.testlib import (
     skipif_ocs_version,
@@ -194,7 +197,11 @@ class TestMetadata(ManageTest):
             pytest.param(
                 "ocs-storagecluster-cephfilesystem",
                 constants.DEFAULT_STORAGECLASS_CEPHFS,
-                marks=[tier1, pytest.mark.polarion_id("OCS-4676")],
+                marks=[
+                    tier1,
+                    pytest.mark.polarion_id("OCS-4676"),
+                    skipif_cephfs_disabled,
+                ],
             ),
             pytest.param(
                 "ocs-storagecluster-cephblockpool",

--- a/tests/functional/pv/pv_services/test_dynamic_pvc_accessmodes_with_reclaim_policies.py
+++ b/tests/functional/pv/pv_services/test_dynamic_pvc_accessmodes_with_reclaim_policies.py
@@ -105,6 +105,7 @@ class TestDynamicPvc(ManageTest):
                     pytest.mark.polarion_id("OCS-525"),
                     skipif_managed_service,
                     skipif_hci_provider_and_client,
+                    skipif_cephfs_disabled,
                 ],
             ),
             pytest.param(
@@ -240,6 +241,7 @@ class TestDynamicPvc(ManageTest):
                     pytest.mark.polarion_id("OCS-542"),
                     skipif_managed_service,
                     skipif_hci_provider_and_client,
+                    skipif_cephfs_disabled,
                 ],
             ),
             pytest.param(

--- a/tests/functional/pv/pv_services/test_dynamic_pvc_accessmodes_with_reclaim_policies.py
+++ b/tests/functional/pv/pv_services/test_dynamic_pvc_accessmodes_with_reclaim_policies.py
@@ -10,6 +10,7 @@ from ocs_ci.framework.testlib import (
     skipif_managed_service,
     skipif_hci_provider_and_client,
 )
+from ocs_ci.framework.pytest_customization.marks import skipif_cephfs_disabled
 from ocs_ci.helpers.helpers import default_storage_class
 from ocs_ci.ocs import constants, node
 from ocs_ci.ocs.exceptions import UnexpectedBehaviour
@@ -108,7 +109,11 @@ class TestDynamicPvc(ManageTest):
             ),
             pytest.param(
                 *[constants.CEPHFILESYSTEM, constants.RECLAIM_POLICY_DELETE],
-                marks=[pytest.mark.polarion_id("OCS-526"), acceptance],
+                marks=[
+                    pytest.mark.polarion_id("OCS-526"),
+                    acceptance,
+                    skipif_cephfs_disabled,
+                ],
             ),
         ],
     )
@@ -239,7 +244,11 @@ class TestDynamicPvc(ManageTest):
             ),
             pytest.param(
                 *[constants.CEPHFILESYSTEM, constants.RECLAIM_POLICY_DELETE],
-                marks=[pytest.mark.polarion_id("OCS-529"), acceptance],
+                marks=[
+                    pytest.mark.polarion_id("OCS-529"),
+                    acceptance,
+                    skipif_cephfs_disabled,
+                ],
             ),
         ],
     )

--- a/tests/functional/pv/pv_services/test_overprovision_level_policy_control.py
+++ b/tests/functional/pv/pv_services/test_overprovision_level_policy_control.py
@@ -13,7 +13,10 @@ from ocs_ci.helpers.helpers import (
     verify_substrings_in_string,
 )
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import green_squad
+from ocs_ci.framework.pytest_customization.marks import (
+    green_squad,
+    skipif_cephfs_disabled,
+)
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier1,
@@ -89,7 +92,8 @@ class TestOverProvisionLevelPolicyControl(ManageTest):
                 *[constants.CEPHBLOCKPOOL_SC, constants.CEPHBLOCKPOOL], marks=[tier1]
             ),
             pytest.param(
-                *[constants.CEPHFILESYSTEM_SC, constants.CEPHFILESYSTEM], marks=[tier2]
+                *[constants.CEPHFILESYSTEM_SC, constants.CEPHFILESYSTEM],
+                marks=[tier2, skipif_cephfs_disabled],
             ),
             pytest.param(
                 *["sc-test-blk", constants.CEPHBLOCKPOOL],
@@ -97,7 +101,7 @@ class TestOverProvisionLevelPolicyControl(ManageTest):
             ),
             pytest.param(
                 *["sc-test-fs", constants.CEPHFILESYSTEM],
-                marks=[tier2, skipif_ocs_version("<4.10")],
+                marks=[tier2, skipif_ocs_version("<4.10"), skipif_cephfs_disabled],
             ),
         ],
     )

--- a/tests/functional/pv/pvc_clone/test_pvc_to_pvc_clone.py
+++ b/tests/functional/pv/pvc_clone/test_pvc_to_pvc_clone.py
@@ -7,6 +7,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     jira,
     provider_mode,
     run_on_all_clients_push_missing_configs,
+    skipif_cephfs_disabled,
 )
 from ocs_ci.framework.pytest_customization.marks import skipif_hci_provider_and_client
 from ocs_ci.framework.testlib import (
@@ -74,7 +75,7 @@ class TestClone(ManageTest):
                 constants.CEPHFILESYSTEM,
                 None,
                 constants.ACCESS_MODE_RWO,
-                marks=pytest.mark.polarion_id("OCS-256"),
+                marks=[pytest.mark.polarion_id("OCS-256"), skipif_cephfs_disabled],
             ),
         ],
     )

--- a/tests/functional/pv/pvc_snapshot/test_pvc_snapshot.py
+++ b/tests/functional/pv/pvc_snapshot/test_pvc_snapshot.py
@@ -7,6 +7,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     green_squad,
     provider_mode,
     run_on_all_clients_push_missing_configs,
+    skipif_cephfs_disabled,
 )
 from ocs_ci.framework.testlib import (
     skipif_ocs_version,
@@ -32,7 +33,8 @@ log = logging.getLogger(__name__)
     argvalues=[
         pytest.param(constants.CEPHBLOCKPOOL, marks=pytest.mark.polarion_id("OCS-251")),
         pytest.param(
-            constants.CEPHFILESYSTEM, marks=pytest.mark.polarion_id("OCS-251")
+            constants.CEPHFILESYSTEM,
+            marks=[pytest.mark.polarion_id("OCS-251"), skipif_cephfs_disabled],
         ),
     ],
 )

--- a/tests/functional/ui/test_pvc_ui.py
+++ b/tests/functional/ui/test_pvc_ui.py
@@ -7,6 +7,7 @@ from ocs_ci.framework.testlib import skipif_ocs_version
 from ocs_ci.framework.pytest_customization.marks import (
     green_squad,
     runs_on_provider,
+    skipif_cephfs_disabled,
 )
 from ocs_ci.ocs.resources.pvc import get_all_pvc_objs, get_pvc_objs
 from ocs_ci.ocs.ocp import OCP
@@ -40,7 +41,7 @@ class TestPvcUserInterface(object):
                 "ReadWriteMany",
                 "2",
                 "Filesystem",
-                marks=pytest.mark.polarion_id("OCS-5210"),
+                marks=[pytest.mark.polarion_id("OCS-5210"), skipif_cephfs_disabled],
             ),
             pytest.param(
                 "ocs-storagecluster-ceph-rbd",
@@ -54,7 +55,7 @@ class TestPvcUserInterface(object):
                 "ReadWriteOnce",
                 "10",
                 "Filesystem",
-                marks=pytest.mark.polarion_id("OCS-5212"),
+                marks=[pytest.mark.polarion_id("OCS-5212"), skipif_cephfs_disabled],
             ),
             pytest.param(
                 *["ocs-storagecluster-ceph-rbd", "ReadWriteOnce", "11", "Block"],
@@ -242,7 +243,7 @@ class TestPvcUserInterface(object):
                 "ocs-storagecluster-cephfs",
                 constants.ACCESS_MODE_RWX,
                 constants.ACCESS_MODE_RWO,
-                marks=pytest.mark.polarion_id("OCS-5209"),
+                marks=[pytest.mark.polarion_id("OCS-5209"), skipif_cephfs_disabled],
             ),
         ],
     )


### PR DESCRIPTION
Related to: https://github.com/red-hat-storage/ocs-ci/pull/15325 and [OCSQE-3874](https://url.corp.redhat.com/a2d5da0).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Tests now automatically skip when required components—NooBaa, RGW, CephFS, or BlockPools—are disabled in configuration, improving test suite efficiency.
  * CephFS-dependent coverage for storage volumes, metadata, cloning, snapshots, access modes, reclaim policies, and related UI workflows now avoids running in unsupported environments.
  * Tests for enabled components continue to run normally, reducing misleading failures caused by unavailable platform features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->