### PR TITLE
Add DR Topology view UI automation

### DIFF
--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -1948,9 +1948,7 @@ def get_dr_topology_clusters():
         list: Sorted DRCluster names for topology UI checks
     """
     return sorted(
-        name
-        for name in get_all_drclusters()
-        if name != constants.ACM_LOCAL_CLUSTER
+        name for name in get_all_drclusters() if name != constants.ACM_LOCAL_CLUSTER
     )
 
 
@@ -1974,6 +1972,39 @@ def get_dr_topology_policy_details():
     }
     logger.info(f"DRPolicy details for topology validation: {policy_details}")
     return policy_details
+
+
+def get_dr_topology_protected_apps(workloads):
+    """
+    Return protected application details for DR Topology Applications sidebar checks.
+
+    Args:
+        workloads (list): Deployed DR workload objects (ApplicationSet and/or discovered)
+
+    Returns:
+        list: dicts with application name, UI DR status, and DRPolicy name
+    """
+    protected_apps = []
+    for workload in workloads:
+        if workload.workload_type == constants.APPLICATION_SET:
+            app_name = workload._get_applicationset_name()
+        elif getattr(workload, "discovered_apps_placement_name", None):
+            app_name = workload.discovered_apps_placement_name
+        else:
+            workload_type = getattr(workload, "workload_type", type(workload).__name__)
+            raise ValueError(
+                f"Unsupported workload type for DR Topology validation: "
+                f"{workload_type}"
+            )
+        protected_apps.append(
+            {
+                "name": app_name,
+                "status": constants.DR_TOPOLOGY_DRPC_HEALTHY_STATUS,
+                "policy": workload.dr_policy_name,
+            }
+        )
+    logger.info(f"Protected applications for topology validation: {protected_apps}")
+    return protected_apps
 
 
 def ordered_unique_cidrs(cidrs):

--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -1938,6 +1938,103 @@ def get_all_drclusters():
     return drclusters
 
 
+def get_dr_topology_clusters():
+    """
+    Return DRCluster names eligible for DR Topology validation.
+
+    The ACM hub (local-cluster) is excluded because it does not have ODF installed.
+
+    Returns:
+        list: Sorted DRCluster names for topology UI checks
+    """
+    return sorted(
+        name
+        for name in get_all_drclusters()
+        if name != constants.ACM_LOCAL_CLUSTER
+    )
+
+
+def get_dr_topology_policy_details():
+    """
+    Return DRPolicy details from the hub for DR Topology validation.
+
+    Returns:
+        dict: policy name, connected cluster names, and scheduling interval
+    """
+    policies = get_all_drpolicy()
+    if not policies:
+        raise AssertionError(
+            "No DRPolicy found on hub; cannot validate DR Topology policy"
+        )
+    policy = policies[0]
+    policy_details = {
+        "name": policy["metadata"]["name"],
+        "connected_clusters": sorted(policy["spec"]["drClusters"]),
+        "scheduling_interval": policy["spec"]["schedulingInterval"],
+    }
+    logger.info(f"DRPolicy details for topology validation: {policy_details}")
+    return policy_details
+
+
+def ordered_unique_cidrs(cidrs):
+    """
+    Preserve order while removing duplicates
+    """
+    seen = set()
+    ordered = []
+    for cidr in cidrs:
+        if not cidr or cidr in seen:
+            continue
+        seen.add(cidr)
+        ordered.append(cidr)
+    return ordered
+
+
+@retry(UnexpectedBehaviour, tries=25, delay=10, backoff=2)
+def get_fencing_cidrs_from_drclusterconfig(cluster_name):
+    """
+    Read fencing CIDRs from DRClusterConfig.status.storageAccessDetails on the
+    current (managed) cluster context (ODF 4.21+ / Ramen).
+
+    Prefers the DRClusterConfig named like the managed cluster, then RBD CSI
+    provisioner entries, with sensible fallbacks.
+
+    Args:
+        cluster_name (str): Managed cluster name (matches DRCluster / DRClusterConfig name on hub)
+
+    Returns:
+        list: CIDR strings for hub DRCluster.spec.cidrs
+
+    Raises:
+        UnexpectedBehaviour: If CIDRs are not yet published or cannot be determined
+    """
+    drc_ocp = ocp.OCP(kind=constants.DRCLUSTERCONFIG)
+    items = (drc_ocp.get(silent=True) or {}).get("items") or []
+    if not items:
+        raise UnexpectedBehaviour(
+            "No DRClusterConfig resources found on managed cluster"
+        )
+    configs = [i for i in items if i.get("metadata", {}).get("name") == cluster_name]
+
+    cidrs = []
+    for item in configs:
+        details = (item.get("status") or {}).get("storageAccessDetails") or []
+        for detail in details:
+            detail_cidrs = detail.get("cidrs") or []
+            cidrs.extend(detail_cidrs)
+
+    cidrs = ordered_unique_cidrs(cidrs)
+    if not cidrs:
+        raise UnexpectedBehaviour(
+            f"DRClusterConfig on cluster {cluster_name} has no status.storageAccessDetails.cidrs yet"
+        )
+    logger.info(
+        f"Collected {len(cidrs)} fencing CIDR(s) from DRClusterConfig for {cluster_name}"
+    )
+
+    return cidrs
+
+
 def get_managed_cluster_node_ips():
     """
     Gets worker node IPs of individual managed clusters for enabling fencing on MDR DRCluster configuration

--- a/ocs_ci/helpers/dr_helpers_ui.py
+++ b/ocs_ci/helpers/dr_helpers_ui.py
@@ -9,12 +9,16 @@ from typing import List
 
 from ocs_ci.utility.version import compare_versions
 from selenium.common.exceptions import (
+    ElementClickInterceptedException,
     NoSuchElementException,
     StaleElementReferenceException,
+    TimeoutException as SeleniumTimeoutException,
 )
 
 from ocs_ci.framework import config
+from ocs_ci.helpers import dr_helpers
 from ocs_ci.ocs import constants
+from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.exceptions import ResourceWrongStatusException, TimeoutException
 from ocs_ci.ocs.ui.base_ui import (
     wait_for_element_to_be_clickable,
@@ -26,6 +30,530 @@ from ocs_ci.ocs.utils import get_non_acm_cluster_config
 from ocs_ci.utility.utils import get_running_acm_version
 
 log = logging.getLogger(__name__)
+
+
+def get_managed_clusters_not_eligible_for_dr_topology():
+    """
+    Return ACM managed cluster names that are not registered as DRClusters on the hub.
+
+    Returns:
+        list: Managed cluster names without a corresponding DRCluster
+    """
+    restore_index = config.cur_index
+    config.switch_acm_ctx()
+    managed_clusters = OCP(kind=constants.ACM_MANAGEDCLUSTER).get().get("items", [])
+    managed_cluster_names = [
+        cluster["metadata"]["name"] for cluster in managed_clusters
+    ]
+    drcluster_names = set(dr_helpers.get_all_drclusters())
+    config.switch_ctx(restore_index)
+    return sorted(
+        name for name in managed_cluster_names if name not in drcluster_names
+    )
+
+
+def navigate_to_dr_topology_tab(acm_obj, timeout=120):
+    """
+    Navigate to Disaster recovery and open the Topology tab.
+
+    Args:
+        acm_obj (AcmAddClusters): ACM Page Navigator Class
+        timeout (int): Timeout for UI elements on the DR Topology page
+    """
+    acm_loc = locators_for_current_ocp_version()["acm_page"]
+    acm_obj.navigate_data_services()
+    acm_obj.do_click(
+        acm_loc["dr-topology-tab"],
+        avoid_stale=True,
+        enable_screenshot=True,
+        timeout=timeout,
+    )
+    acm_obj.page_has_loaded(retries=5, sleep_time=3)
+    log.info("Opened Disaster recovery Topology tab")
+
+
+def is_dr_cluster_displayed_on_topology(acm_obj, cluster_name, timeout=60):
+    """
+    Check whether a cluster name is rendered on the DR Topology view.
+
+    Args:
+        acm_obj (AcmAddClusters): ACM Page Navigator Class
+        cluster_name (str): DRCluster name to look for on the topology canvas
+        timeout (int): Timeout for the cluster label to become visible
+
+    Returns:
+        bool: True if the cluster name is found on the DR Topology view
+    """
+    acm_loc = locators_for_current_ocp_version()["acm_page"]
+    return acm_obj.wait_until_expected_text_is_found(
+        format_locator(acm_loc["dr-topology-cluster-name"], cluster_name),
+        expected_text=cluster_name,
+        timeout=timeout,
+    )
+
+
+def verify_df_cluster_listing_on_topology_view(
+    acm_obj, expected_clusters=None, timeout=60
+):
+    """
+    Verify cluster labels on the open DR Topology tab match expected DRClusters.
+
+    Managed clusters without a DRCluster (including local-cluster) must not appear
+    on the topology canvas.
+
+    Args:
+        acm_obj (AcmAddClusters): ACM Page Navigator Class
+        expected_clusters (list): Optional DRCluster names; fetched via CLI when omitted
+        timeout (int): Timeout for DR Topology UI elements
+
+    Returns:
+        list: Data Foundation cluster names verified on the DR Topology tab
+    """
+    if expected_clusters is None:
+        expected_clusters = dr_helpers.get_dr_topology_clusters()
+    expected_clusters = sorted(
+        name for name in expected_clusters if name != constants.ACM_LOCAL_CLUSTER
+    )
+    assert expected_clusters, (
+        "No DRClusters found via CLI; cannot verify Data Foundation cluster listing"
+    )
+
+    missing_clusters = [
+        cluster_name
+        for cluster_name in expected_clusters
+        if not is_dr_cluster_displayed_on_topology(
+            acm_obj, cluster_name, timeout=timeout
+        )
+    ]
+    assert not missing_clusters, (
+        f"Data Foundation clusters missing on Topology UI: {missing_clusters}"
+    )
+    for cluster_name in expected_clusters:
+        log.info(
+            f"Data Foundation cluster '{cluster_name}' is displayed on DR Topology tab"
+        )
+
+    non_dr_managed_clusters = get_managed_clusters_not_eligible_for_dr_topology()
+    if non_dr_managed_clusters:
+        cluster_name_locator = locators_for_current_ocp_version()["acm_page"][
+            "dr-topology-cluster-name"
+        ]
+        unexpected_clusters = [
+            cluster_name
+            for cluster_name in non_dr_managed_clusters
+            if acm_obj.check_element_presence(
+                format_locator(cluster_name_locator, cluster_name)[::-1],
+                timeout=5,
+            )
+        ]
+        assert not unexpected_clusters, (
+            "Managed clusters without DRCluster shown on Topology UI: "
+            f"{unexpected_clusters}"
+        )
+    else:
+        log.info(
+            "No managed clusters without DRCluster in this environment; "
+            "skipping negative topology listing check"
+        )
+
+    acm_obj.take_screenshot()
+    return expected_clusters
+
+
+def open_dr_topology_cluster_sidebar(acm_obj, cluster_name, timeout=60):
+    """
+    Click a cluster node on the DR Topology view to open its sidebar.
+
+    Click the label parent element, with zoom-out retries and a JS click 
+    fallback when the canvas intercepts the click.
+
+    Args:
+        acm_obj (AcmAddClusters): ACM Page Navigator Class
+        cluster_name (str): DRCluster name shown on the topology canvas
+        timeout (int): Timeout for the cluster label to become visible
+    """
+    acm_loc = locators_for_current_ocp_version()["acm_page"]
+    topology_loc = locators_for_current_ocp_version()["topology"]
+    cluster_click_locator = format_locator(
+        acm_loc["dr-topology-cluster-click"], cluster_name
+    )
+
+    for attempt in range(1, 4):
+        try:
+            acm_obj.do_click(
+                cluster_click_locator, use_fallback=False, timeout=timeout
+            )
+            break
+        except (NoSuchElementException, SeleniumTimeoutException):
+            log.info("Zooming out DR Topology view")
+            acm_obj.do_click(topology_loc["zoom_out"])
+            acm_obj.page_has_loaded(retries=3, sleep_time=2)
+            log.info(f"Retry cluster click on DR Topology. attempt {attempt}")
+        except ElementClickInterceptedException:
+            log.info(
+                "Click intercepted on DR Topology node. "
+                "Falling back to JS dispatchEvent click."
+            )
+            acm_obj.click_with_script(cluster_click_locator)
+            break
+
+    acm_obj.take_screenshot()
+    acm_obj.page_has_loaded(retries=3, sleep_time=2)
+    log.info(f"Clicked cluster '{cluster_name}' on DR Topology tab")
+
+
+def verify_dr_topology_cluster_sidebar_open(acm_obj, cluster_name, timeout=60):
+    """
+    Verify the cluster sidebar opens with Details and Application Details tabs.
+
+    Args:
+        acm_obj (AcmAddClusters): ACM Page Navigator Class
+        cluster_name (str): DRCluster name expected in the sidebar
+        timeout (int): Timeout for sidebar elements
+    """
+    acm_loc = locators_for_current_ocp_version()["acm_page"]
+    sidebar_open = acm_obj.check_element_presence(
+        acm_loc["dr-topology-sidebar-close"][::-1], timeout=timeout
+    )
+    assert sidebar_open, (
+        f"Cluster sidebar did not open for '{cluster_name}' "
+        "(close button not found)"
+    )
+
+    details_tab = acm_obj.wait_until_expected_text_is_found(
+        acm_loc["dr-topology-sidebar-details-tab"],
+        expected_text=constants.DR_TOPOLOGY_SIDEBAR_DETAILS_TAB,
+        timeout=timeout,
+    )
+    application_details_tab = acm_obj.wait_until_expected_text_is_found(
+        acm_loc["dr-topology-sidebar-application-details-tab"],
+        expected_text=constants.DR_TOPOLOGY_SIDEBAR_APPLICATION_DETAILS_TAB,
+        timeout=timeout,
+    )
+    cluster_visible = acm_obj.wait_until_expected_text_is_found(
+        format_locator(acm_loc["dr-topology-sidebar-cluster-name"], cluster_name),
+        expected_text=cluster_name,
+        timeout=timeout,
+    )
+    assert details_tab and application_details_tab and cluster_visible, (
+        f"Cluster sidebar did not open as expected for '{cluster_name}'"
+    )
+    acm_obj.take_screenshot()
+    log.info(f"Cluster sidebar opened for '{cluster_name}'")
+
+
+def close_dr_topology_sidebar(acm_obj, timeout=30):
+    """
+    Close the DR Topology sidebar.
+
+    Args:
+        acm_obj (AcmAddClusters): ACM Page Navigator Class
+        timeout (int): Timeout for the close button
+    """
+    acm_loc = locators_for_current_ocp_version()["acm_page"]
+    if acm_obj.check_element_presence(
+        acm_loc["dr-topology-sidebar-close"][::-1], timeout=5
+    ):
+        acm_obj.do_click(
+            acm_loc["dr-topology-sidebar-close"],
+            enable_screenshot=True,
+            timeout=timeout,
+        )
+        acm_obj.page_has_loaded(retries=2, sleep_time=1)
+        log.info("Closed DR Topology sidebar")
+
+
+def open_dr_topology_policy_sidebar(acm_obj, policy_name, timeout=60):
+    """
+    Click a DRPolicy label on the DR Topology view to open its sidebar.
+
+    Args:
+        acm_obj (AcmAddClusters): ACM Page Navigator Class
+        policy_name (str): DRPolicy name shown on the topology canvas
+        timeout (int): Timeout for the policy label to become clickable
+    """
+    acm_loc = locators_for_current_ocp_version()["acm_page"]
+    topology_loc = locators_for_current_ocp_version()["topology"]
+    policy_click_locator = format_locator(
+        acm_loc["dr-topology-policy-click"], policy_name
+    )
+
+    for attempt in range(1, 4):
+        try:
+            acm_obj.do_click(
+                policy_click_locator, use_fallback=False, timeout=timeout
+            )
+            break
+        except (NoSuchElementException, SeleniumTimeoutException):
+            log.info("Zooming out DR Topology view")
+            acm_obj.do_click(topology_loc["zoom_out"])
+            acm_obj.page_has_loaded(retries=3, sleep_time=2)
+            log.info(f"Retry policy click on DR Topology. attempt {attempt}")
+        except ElementClickInterceptedException:
+            log.info(
+                "Click intercepted on DR Topology policy. "
+                "Falling back to JS dispatchEvent click."
+            )
+            acm_obj.click_with_script(policy_click_locator)
+            break
+
+    acm_obj.take_screenshot()
+    acm_obj.page_has_loaded(retries=3, sleep_time=2)
+    log.info(f"Clicked policy '{policy_name}' on DR Topology tab")
+
+
+def verify_dr_topology_policy_sidebar_open(
+    acm_obj,
+    policy_name,
+    connected_clusters,
+    scheduling_interval,
+    timeout=60,
+):
+    """
+    Verify the DRPolicy sidebar opens with expected policy details.
+
+    Args:
+        acm_obj (AcmAddClusters): ACM Page Navigator Class
+        policy_name (str): DRPolicy name expected in the sidebar
+        connected_clusters (list): Cluster names paired by the DRPolicy
+        scheduling_interval (str): DRPolicy scheduling interval (e.g. 5m)
+        timeout (int): Timeout for sidebar elements
+    """
+    acm_loc = locators_for_current_ocp_version()["acm_page"]
+    sidebar_open = acm_obj.check_element_presence(
+        acm_loc["dr-topology-sidebar-close"][::-1], timeout=timeout
+    )
+    assert sidebar_open, (
+        f"Policy sidebar did not open for '{policy_name}' (close button not found)"
+    )
+
+    policy_visible = acm_obj.wait_until_expected_text_is_found(
+        format_locator(acm_loc["dr-topology-sidebar-policy-name"], policy_name),
+        expected_text=policy_name,
+        timeout=timeout,
+    )
+    validated_status = acm_obj.wait_until_expected_text_is_found(
+        acm_loc["drpolicy-status"],
+        expected_text=constants.DRPOLICY_STATUS,
+        timeout=timeout,
+    )
+    scheduling_visible = acm_obj.wait_until_expected_text_is_found(
+        format_locator(
+            acm_loc["dr-topology-sidebar-scheduling-interval"],
+            scheduling_interval,
+        ),
+        expected_text=scheduling_interval,
+        timeout=timeout,
+    )
+    connected_cluster_checks = [
+        acm_obj.wait_until_expected_text_is_found(
+            format_locator(
+                acm_loc["dr-topology-sidebar-connected-cluster"], cluster_name
+            ),
+            expected_text=cluster_name,
+            timeout=timeout,
+        )
+        for cluster_name in connected_clusters
+    ]
+
+    assert (
+        policy_visible
+        and validated_status
+        and scheduling_visible
+        and all(connected_cluster_checks)
+    ), f"Policy sidebar did not open as expected for '{policy_name}'"
+    acm_obj.take_screenshot()
+    log.info(f"Policy sidebar opened for '{policy_name}'")
+
+
+def select_dr_topology_filter(acm_obj, filter_option, timeout=30):
+    """
+    Select a filter option on the DR Topology search bar.
+
+    Args:
+        acm_obj (AcmAddClusters): ACM Page Navigator Class
+        filter_option (str): Filter label, e.g. Cluster name or Policy
+        timeout (int): Timeout for filter UI elements
+    """
+    acm_loc = locators_for_current_ocp_version()["acm_page"]
+    selected_filter_locator = (
+        f"//button[contains(.,'{filter_option}')]",
+        acm_loc["dr-topology-filter-toggle"][1],
+    )
+    if acm_obj.check_element_presence(selected_filter_locator[::-1], timeout=3):
+        log.info(f"DR Topology filter '{filter_option}' is already selected")
+        return
+
+    acm_obj.do_click(acm_loc["dr-topology-filter-toggle"], timeout=timeout)
+    acm_obj.do_click(
+        format_locator(acm_loc["dr-topology-filter-option"], filter_option),
+        timeout=timeout,
+    )
+    acm_obj.page_has_loaded(retries=2, sleep_time=1)
+    log.info(f"Selected DR Topology filter '{filter_option}'")
+
+
+def search_dr_topology(acm_obj, search_text, timeout=30):
+    """
+    Enter text in the DR Topology search bar.
+
+    Args:
+        acm_obj (AcmAddClusters): ACM Page Navigator Class
+        search_text (str): Text to search on the topology view
+        timeout (int): Timeout for the search input
+    """
+    acm_loc = locators_for_current_ocp_version()["acm_page"]
+    acm_obj.do_send_keys(
+        acm_loc["dr-topology-search"], search_text, timeout=timeout
+    )
+    acm_obj.page_has_loaded(retries=3, sleep_time=2)
+    log.info(f"Searched DR Topology for '{search_text}'")
+
+
+def reset_dr_topology_search(acm_obj, timeout=30):
+    """
+    Reset the DR Topology search bar.
+
+    Args:
+        acm_obj (AcmAddClusters): ACM Page Navigator Class
+        timeout (int): Timeout for the reset button
+    """
+    acm_loc = locators_for_current_ocp_version()["acm_page"]
+    acm_obj.do_click(acm_loc["dr-topology-search-reset"], timeout=timeout)
+    acm_obj.page_has_loaded(retries=3, sleep_time=2)
+    log.info("Reset DR Topology search")
+
+
+def is_dr_topology_entity_displayed(acm_obj, entity_name, timeout=30):
+    """
+    Check whether an entity name is rendered on the DR Topology canvas.
+
+    Args:
+        acm_obj (AcmAddClusters): ACM Page Navigator Class
+        entity_name (str): Cluster or policy name to look for
+        timeout (int): Timeout for the entity label to become visible
+
+    Returns:
+        bool: True if the entity name is found on the DR Topology view
+    """
+    return is_dr_cluster_displayed_on_topology(
+        acm_obj, entity_name, timeout=timeout
+    )
+
+
+def verify_dr_topology_cluster_name_search_filter(
+    acm_obj, cluster_name, hidden_cluster_names, timeout=60
+):
+    """
+    Verify Cluster name filter and search narrows the topology to one cluster.
+
+    Args:
+        acm_obj (AcmAddClusters): ACM Page Navigator Class
+        cluster_name (str): Cluster name to search for
+        hidden_cluster_names (list): Cluster names expected to be hidden by search
+        timeout (int): Timeout for topology UI elements
+    """
+    select_dr_topology_filter(
+        acm_obj, constants.DR_TOPOLOGY_SEARCH_FILTER_CLUSTER_NAME, timeout=timeout
+    )
+    search_dr_topology(acm_obj, cluster_name, timeout=timeout)
+    assert is_dr_topology_entity_displayed(
+        acm_obj, cluster_name, timeout=timeout
+    ), f"Cluster '{cluster_name}' not found after Cluster name search"
+
+    hidden_clusters = [
+        name
+        for name in hidden_cluster_names
+        if acm_obj.check_element_presence(
+            format_locator(
+                locators_for_current_ocp_version()["acm_page"][
+                    "dr-topology-cluster-name"
+                ],
+                name,
+            )[::-1],
+            timeout=5,
+        )
+    ]
+    assert not hidden_clusters, (
+        "Clusters should be hidden by Cluster name search filter: "
+        f"{hidden_clusters}"
+    )
+    acm_obj.take_screenshot()
+    reset_dr_topology_search(acm_obj, timeout=timeout)
+    log.info(f"Cluster name search filter validated for '{cluster_name}'")
+
+
+def verify_dr_topology_policy_search_filter(
+    acm_obj, policy_name, connected_clusters, timeout=60
+):
+    """
+    Verify Policy filter and search shows the policy and connected clusters.
+
+    Args:
+        acm_obj (AcmAddClusters): ACM Page Navigator Class
+        policy_name (str): DRPolicy name to search for
+        connected_clusters (list): Cluster names paired by the DRPolicy
+        timeout (int): Timeout for topology UI elements
+    """
+    select_dr_topology_filter(
+        acm_obj, constants.DR_TOPOLOGY_SEARCH_FILTER_POLICY, timeout=timeout
+    )
+    search_dr_topology(acm_obj, policy_name, timeout=timeout)
+    assert is_dr_topology_entity_displayed(
+        acm_obj, policy_name, timeout=timeout
+    ), f"Policy '{policy_name}' not found after Policy search"
+
+    missing_clusters = [
+        cluster_name
+        for cluster_name in connected_clusters
+        if not is_dr_topology_entity_displayed(
+            acm_obj, cluster_name, timeout=timeout
+        )
+    ]
+    assert not missing_clusters, (
+        "Connected clusters missing after Policy search filter: "
+        f"{missing_clusters}"
+    )
+    acm_obj.take_screenshot()
+    reset_dr_topology_search(acm_obj, timeout=timeout)
+    log.info(f"Policy search filter validated for '{policy_name}'")
+
+
+def wait_for_dr_topology_workloads_healthy(
+    workloads, scheduling_interval, pvc_interface=constants.CEPHBLOCKPOOL
+):
+    """
+    Wait until DR protected workloads are healthy before Topology UI validation.
+
+    Args:
+        workloads (list): Deployed DR workload objects
+        scheduling_interval (int): DRPolicy scheduling interval in minutes
+        pvc_interface (str): PVC interface used by the deployed workloads
+    """
+    from ocs_ci.ocs.resources.drpc import DRPC
+
+    config.switch_acm_ctx()
+    for workload in workloads:
+        if getattr(workload, "discovered_apps_placement_name", None):
+            drpc_obj = DRPC(
+                namespace=constants.DR_OPS_NAMESPACE,
+                resource_name=workload.discovered_apps_placement_name,
+            )
+        elif workload.workload_type == constants.APPLICATION_SET:
+            drpc_obj = DRPC(
+                namespace=constants.GITOPS_CLUSTER_NAMESPACE,
+                resource_name=f"{workload.appset_placement_name}-drpc",
+            )
+        else:
+            drpc_obj = DRPC(namespace=workload.workload_namespace)
+        drpc_obj.wait_for_peer_ready_status()
+
+    total_pvc_count = sum(
+        getattr(workload, "workload_pvc_count", 1) for workload in workloads
+    )
+    dr_helpers.wait_for_mirroring_status_ok(replaying_images=total_pvc_count)
+    time.sleep(2 * scheduling_interval * 60)
+    log.info("DR protected workloads are healthy for Topology UI validation")
 
 
 def dr_submariner_validation_from_ui(acm_obj):

--- a/ocs_ci/helpers/dr_helpers_ui.py
+++ b/ocs_ci/helpers/dr_helpers_ui.py
@@ -164,6 +164,7 @@ def verify_df_cluster_listing_on_topology_view(
             if acm_obj.check_element_presence(
                 format_locator(cluster_name_locator, cluster_name)[::-1],
                 timeout=5,
+                use_fallback=False,
             )
         ]
         assert not unexpected_clusters, (
@@ -402,7 +403,9 @@ def select_dr_topology_filter(acm_obj, filter_option, timeout=30):
     selected_filter_locator = format_locator(
         acm_loc["dr-topology-filter-selected"], filter_option
     )
-    if acm_obj.check_element_presence(selected_filter_locator[::-1], timeout=3):
+    if acm_obj.check_element_presence(
+        selected_filter_locator[::-1], timeout=3, use_fallback=False
+    ):
         log.info(f"DR Topology filter '{filter_option}' is already selected")
         return
 
@@ -475,6 +478,7 @@ def verify_dr_topology_cluster_name_search_filter(
                 name,
             )[::-1],
             timeout=5,
+            use_fallback=False,
         )
     ]
     assert not hidden_clusters, (

--- a/ocs_ci/helpers/dr_helpers_ui.py
+++ b/ocs_ci/helpers/dr_helpers_ui.py
@@ -40,16 +40,16 @@ def get_managed_clusters_not_eligible_for_dr_topology():
         list: Managed cluster names without a corresponding DRCluster
     """
     restore_index = config.cur_index
-    config.switch_acm_ctx()
-    managed_clusters = OCP(kind=constants.ACM_MANAGEDCLUSTER).get().get("items", [])
-    managed_cluster_names = [
-        cluster["metadata"]["name"] for cluster in managed_clusters
-    ]
-    drcluster_names = set(dr_helpers.get_all_drclusters())
-    config.switch_ctx(restore_index)
-    return sorted(
-        name for name in managed_cluster_names if name not in drcluster_names
-    )
+    try:
+        config.switch_acm_ctx()
+        managed_clusters = OCP(kind=constants.ACM_MANAGEDCLUSTER).get().get("items", [])
+        managed_cluster_names = [
+            cluster["metadata"]["name"] for cluster in managed_clusters
+        ]
+        drcluster_names = set(dr_helpers.get_all_drclusters())
+    finally:
+        config.switch_ctx(restore_index)
+    return sorted(name for name in managed_cluster_names if name not in drcluster_names)
 
 
 def navigate_to_dr_topology_tab(acm_obj, timeout=120):
@@ -92,6 +92,26 @@ def is_dr_cluster_displayed_on_topology(acm_obj, cluster_name, timeout=60):
     )
 
 
+def is_dr_policy_displayed_on_topology(acm_obj, policy_name, timeout=60):
+    """
+    Check whether a DRPolicy name is rendered on the DR Topology view.
+
+    Args:
+        acm_obj (AcmAddClusters): ACM Page Navigator Class
+        policy_name (str): DRPolicy name to look for on the topology canvas
+        timeout (int): Timeout for the policy label to become visible
+
+    Returns:
+        bool: True if the policy name is found on the DR Topology view
+    """
+    acm_loc = locators_for_current_ocp_version()["acm_page"]
+    return acm_obj.wait_until_expected_text_is_found(
+        format_locator(acm_loc["dr-topology-policy-name"], policy_name),
+        expected_text=policy_name,
+        timeout=timeout,
+    )
+
+
 def verify_df_cluster_listing_on_topology_view(
     acm_obj, expected_clusters=None, timeout=60
 ):
@@ -114,9 +134,9 @@ def verify_df_cluster_listing_on_topology_view(
     expected_clusters = sorted(
         name for name in expected_clusters if name != constants.ACM_LOCAL_CLUSTER
     )
-    assert expected_clusters, (
-        "No DRClusters found via CLI; cannot verify Data Foundation cluster listing"
-    )
+    assert (
+        expected_clusters
+    ), "No DRClusters found via CLI; cannot verify Data Foundation cluster listing"
 
     missing_clusters = [
         cluster_name
@@ -125,9 +145,9 @@ def verify_df_cluster_listing_on_topology_view(
             acm_obj, cluster_name, timeout=timeout
         )
     ]
-    assert not missing_clusters, (
-        f"Data Foundation clusters missing on Topology UI: {missing_clusters}"
-    )
+    assert (
+        not missing_clusters
+    ), f"Data Foundation clusters missing on Topology UI: {missing_clusters}"
     for cluster_name in expected_clusters:
         log.info(
             f"Data Foundation cluster '{cluster_name}' is displayed on DR Topology tab"
@@ -164,7 +184,7 @@ def open_dr_topology_cluster_sidebar(acm_obj, cluster_name, timeout=60):
     """
     Click a cluster node on the DR Topology view to open its sidebar.
 
-    Click the label parent element, with zoom-out retries and a JS click 
+    Click the label parent element, with zoom-out retries and a JS click
     fallback when the canvas intercepts the click.
 
     Args:
@@ -180,11 +200,13 @@ def open_dr_topology_cluster_sidebar(acm_obj, cluster_name, timeout=60):
 
     for attempt in range(1, 4):
         try:
-            acm_obj.do_click(
-                cluster_click_locator, use_fallback=False, timeout=timeout
-            )
+            acm_obj.do_click(cluster_click_locator, use_fallback=False, timeout=timeout)
             break
-        except (NoSuchElementException, SeleniumTimeoutException):
+        except (NoSuchElementException, SeleniumTimeoutException) as ex:
+            if attempt == 3:
+                raise AssertionError(
+                    f"Cluster '{cluster_name}' was not clickable after 3 attempts"
+                ) from ex
             log.info("Zooming out DR Topology view")
             acm_obj.do_click(topology_loc["zoom_out"])
             acm_obj.page_has_loaded(retries=3, sleep_time=2)
@@ -216,8 +238,7 @@ def verify_dr_topology_cluster_sidebar_open(acm_obj, cluster_name, timeout=60):
         acm_loc["dr-topology-sidebar-close"][::-1], timeout=timeout
     )
     assert sidebar_open, (
-        f"Cluster sidebar did not open for '{cluster_name}' "
-        "(close button not found)"
+        f"Cluster sidebar did not open for '{cluster_name}' " "(close button not found)"
     )
 
     details_tab = acm_obj.wait_until_expected_text_is_found(
@@ -235,9 +256,9 @@ def verify_dr_topology_cluster_sidebar_open(acm_obj, cluster_name, timeout=60):
         expected_text=cluster_name,
         timeout=timeout,
     )
-    assert details_tab and application_details_tab and cluster_visible, (
-        f"Cluster sidebar did not open as expected for '{cluster_name}'"
-    )
+    assert (
+        details_tab and application_details_tab and cluster_visible
+    ), f"Cluster sidebar did not open as expected for '{cluster_name}'"
     acm_obj.take_screenshot()
     log.info(f"Cluster sidebar opened for '{cluster_name}'")
 
@@ -280,11 +301,13 @@ def open_dr_topology_policy_sidebar(acm_obj, policy_name, timeout=60):
 
     for attempt in range(1, 4):
         try:
-            acm_obj.do_click(
-                policy_click_locator, use_fallback=False, timeout=timeout
-            )
+            acm_obj.do_click(policy_click_locator, use_fallback=False, timeout=timeout)
             break
-        except (NoSuchElementException, SeleniumTimeoutException):
+        except (NoSuchElementException, SeleniumTimeoutException) as ex:
+            if attempt == 3:
+                raise AssertionError(
+                    f"Policy '{policy_name}' was not clickable after 3 attempts"
+                ) from ex
             log.info("Zooming out DR Topology view")
             acm_obj.do_click(topology_loc["zoom_out"])
             acm_obj.page_has_loaded(retries=3, sleep_time=2)
@@ -323,9 +346,9 @@ def verify_dr_topology_policy_sidebar_open(
     sidebar_open = acm_obj.check_element_presence(
         acm_loc["dr-topology-sidebar-close"][::-1], timeout=timeout
     )
-    assert sidebar_open, (
-        f"Policy sidebar did not open for '{policy_name}' (close button not found)"
-    )
+    assert (
+        sidebar_open
+    ), f"Policy sidebar did not open for '{policy_name}' (close button not found)"
 
     policy_visible = acm_obj.wait_until_expected_text_is_found(
         format_locator(acm_loc["dr-topology-sidebar-policy-name"], policy_name),
@@ -376,9 +399,8 @@ def select_dr_topology_filter(acm_obj, filter_option, timeout=30):
         timeout (int): Timeout for filter UI elements
     """
     acm_loc = locators_for_current_ocp_version()["acm_page"]
-    selected_filter_locator = (
-        f"//button[contains(.,'{filter_option}')]",
-        acm_loc["dr-topology-filter-toggle"][1],
+    selected_filter_locator = format_locator(
+        acm_loc["dr-topology-filter-selected"], filter_option
     )
     if acm_obj.check_element_presence(selected_filter_locator[::-1], timeout=3):
         log.info(f"DR Topology filter '{filter_option}' is already selected")
@@ -403,9 +425,7 @@ def search_dr_topology(acm_obj, search_text, timeout=30):
         timeout (int): Timeout for the search input
     """
     acm_loc = locators_for_current_ocp_version()["acm_page"]
-    acm_obj.do_send_keys(
-        acm_loc["dr-topology-search"], search_text, timeout=timeout
-    )
+    acm_obj.do_send_keys(acm_loc["dr-topology-search"], search_text, timeout=timeout)
     acm_obj.page_has_loaded(retries=3, sleep_time=2)
     log.info(f"Searched DR Topology for '{search_text}'")
 
@@ -424,23 +444,6 @@ def reset_dr_topology_search(acm_obj, timeout=30):
     log.info("Reset DR Topology search")
 
 
-def is_dr_topology_entity_displayed(acm_obj, entity_name, timeout=30):
-    """
-    Check whether an entity name is rendered on the DR Topology canvas.
-
-    Args:
-        acm_obj (AcmAddClusters): ACM Page Navigator Class
-        entity_name (str): Cluster or policy name to look for
-        timeout (int): Timeout for the entity label to become visible
-
-    Returns:
-        bool: True if the entity name is found on the DR Topology view
-    """
-    return is_dr_cluster_displayed_on_topology(
-        acm_obj, entity_name, timeout=timeout
-    )
-
-
 def verify_dr_topology_cluster_name_search_filter(
     acm_obj, cluster_name, hidden_cluster_names, timeout=60
 ):
@@ -457,7 +460,7 @@ def verify_dr_topology_cluster_name_search_filter(
         acm_obj, constants.DR_TOPOLOGY_SEARCH_FILTER_CLUSTER_NAME, timeout=timeout
     )
     search_dr_topology(acm_obj, cluster_name, timeout=timeout)
-    assert is_dr_topology_entity_displayed(
+    assert is_dr_cluster_displayed_on_topology(
         acm_obj, cluster_name, timeout=timeout
     ), f"Cluster '{cluster_name}' not found after Cluster name search"
 
@@ -475,8 +478,7 @@ def verify_dr_topology_cluster_name_search_filter(
         )
     ]
     assert not hidden_clusters, (
-        "Clusters should be hidden by Cluster name search filter: "
-        f"{hidden_clusters}"
+        "Clusters should be hidden by Cluster name search filter: " f"{hidden_clusters}"
     )
     acm_obj.take_screenshot()
     reset_dr_topology_search(acm_obj, timeout=timeout)
@@ -484,7 +486,7 @@ def verify_dr_topology_cluster_name_search_filter(
 
 
 def verify_dr_topology_policy_search_filter(
-    acm_obj, policy_name, connected_clusters, timeout=60
+    acm_obj, policy_name, connected_clusters, timeout=120
 ):
     """
     Verify Policy filter and search shows the policy and connected clusters.
@@ -499,61 +501,191 @@ def verify_dr_topology_policy_search_filter(
         acm_obj, constants.DR_TOPOLOGY_SEARCH_FILTER_POLICY, timeout=timeout
     )
     search_dr_topology(acm_obj, policy_name, timeout=timeout)
-    assert is_dr_topology_entity_displayed(
+    assert is_dr_policy_displayed_on_topology(
         acm_obj, policy_name, timeout=timeout
     ), f"Policy '{policy_name}' not found after Policy search"
 
     missing_clusters = [
         cluster_name
         for cluster_name in connected_clusters
-        if not is_dr_topology_entity_displayed(
+        if not is_dr_cluster_displayed_on_topology(
             acm_obj, cluster_name, timeout=timeout
         )
     ]
     assert not missing_clusters, (
-        "Connected clusters missing after Policy search filter: "
-        f"{missing_clusters}"
+        "Connected clusters missing after Policy search filter: " f"{missing_clusters}"
     )
     acm_obj.take_screenshot()
     reset_dr_topology_search(acm_obj, timeout=timeout)
     log.info(f"Policy search filter validated for '{policy_name}'")
 
 
-def wait_for_dr_topology_workloads_healthy(
-    workloads, scheduling_interval, pvc_interface=constants.CEPHBLOCKPOOL
+def open_dr_topology_drpc_sidebar(
+    acm_obj,
+    cluster_name,
+    dr_status=constants.DR_TOPOLOGY_DRPC_HEALTHY_STATUS,
+    timeout=60,
 ):
+    """
+    Click the DRPC status label on a cluster node to open the Applications sidebar.
+
+    Args:
+        acm_obj (AcmAddClusters): ACM Page Navigator Class
+        cluster_name (str): DRCluster name that shows the DRPC status badge
+        dr_status (str): DRPC status text on the topology node (default: healthy)
+        timeout (int): Timeout for the DRPC label to become clickable
+    """
+    acm_loc = locators_for_current_ocp_version()["acm_page"]
+    topology_loc = locators_for_current_ocp_version()["topology"]
+    drpc_click_locator = format_locator(
+        acm_loc["dr-topology-drpc-click"], dr_status, cluster_name
+    )
+
+    for attempt in range(1, 4):
+        try:
+            acm_obj.do_click(drpc_click_locator, use_fallback=False, timeout=timeout)
+            break
+        except (NoSuchElementException, SeleniumTimeoutException) as ex:
+            if attempt == 3:
+                raise AssertionError(
+                    f"DRPC status '{dr_status}' on cluster '{cluster_name}' "
+                    f"was not clickable after 3 attempts"
+                ) from ex
+            log.info("Zooming out DR Topology view")
+            acm_obj.do_click(topology_loc["zoom_out"])
+            acm_obj.page_has_loaded(retries=3, sleep_time=2)
+            log.info(f"Retry DRPC click on DR Topology. attempt {attempt}")
+        except ElementClickInterceptedException:
+            log.info(
+                "Click intercepted on DR Topology DRPC label. "
+                "Falling back to JS dispatchEvent click."
+            )
+            acm_obj.click_with_script(drpc_click_locator)
+            break
+
+    acm_obj.take_screenshot()
+    acm_obj.page_has_loaded(retries=3, sleep_time=2)
+    log.info(
+        f"Clicked DRPC status '{dr_status}' on cluster '{cluster_name}' "
+        "on DR Topology tab"
+    )
+
+
+def verify_dr_topology_applications_sidebar(acm_obj, protected_apps, timeout=60):
+    """
+    Verify the Applications sidebar shows expected table headers and app rows.
+
+    Args:
+        acm_obj (AcmAddClusters): ACM Page Navigator Class
+        protected_apps (list): Application dicts with name, status, and policy
+        timeout (int): Timeout for sidebar elements
+    """
+    acm_loc = locators_for_current_ocp_version()["acm_page"]
+    sidebar_open = acm_obj.check_element_presence(
+        acm_loc["dr-topology-sidebar-close"][::-1], timeout=timeout
+    )
+    assert sidebar_open, "Applications sidebar did not open (close button not found)"
+
+    header_checks = [
+        acm_obj.wait_until_expected_text_is_found(
+            acm_loc["dr-topology-sidebar-app-table-header-name"],
+            expected_text="Name",
+            timeout=timeout,
+        ),
+        acm_obj.wait_until_expected_text_is_found(
+            acm_loc["dr-topology-sidebar-app-table-header-dr-status"],
+            expected_text="DR Status",
+            timeout=timeout,
+        ),
+        acm_obj.wait_until_expected_text_is_found(
+            acm_loc["dr-topology-sidebar-app-table-header-policy"],
+            expected_text="Policy",
+            timeout=timeout,
+        ),
+    ]
+    assert all(
+        header_checks
+    ), "Applications sidebar table headers are not displayed as expected"
+
+    for app in protected_apps:
+        app_name = app["name"]
+        assert acm_obj.wait_until_expected_text_is_found(
+            format_locator(
+                acm_loc["dr-topology-sidebar-app-row-name"],
+                app_name,
+                app_name,
+            ),
+            expected_text=app_name,
+            timeout=timeout,
+        ), f"Application name '{app_name}' not found in Applications sidebar"
+        assert acm_obj.wait_until_expected_text_is_found(
+            format_locator(
+                acm_loc["dr-topology-sidebar-app-row-status"],
+                app_name,
+                app["status"],
+            ),
+            expected_text=app["status"],
+            timeout=timeout,
+        ), (
+            f"DR Status '{app['status']}' not found for application "
+            f"'{app_name}' in Applications sidebar"
+        )
+        assert acm_obj.wait_until_expected_text_is_found(
+            format_locator(
+                acm_loc["dr-topology-sidebar-app-row-policy"],
+                app_name,
+                app["policy"],
+            ),
+            expected_text=app["policy"],
+            timeout=timeout,
+        ), (
+            f"Policy '{app['policy']}' not found for application "
+            f"'{app_name}' in Applications sidebar"
+        )
+
+    acm_obj.take_screenshot()
+    log.info(
+        "Applications sidebar validated for apps: "
+        f"{[app['name'] for app in protected_apps]}"
+    )
+
+
+def wait_for_dr_topology_workloads_healthy(workloads, scheduling_interval):
     """
     Wait until DR protected workloads are healthy before Topology UI validation.
 
     Args:
         workloads (list): Deployed DR workload objects
-        scheduling_interval (int): DRPolicy scheduling interval in minutes
-        pvc_interface (str): PVC interface used by the deployed workloads
+        scheduling_interval (int): Wait time in minutes before Topology UI validation
     """
     from ocs_ci.ocs.resources.drpc import DRPC
 
-    config.switch_acm_ctx()
-    for workload in workloads:
-        if getattr(workload, "discovered_apps_placement_name", None):
-            drpc_obj = DRPC(
-                namespace=constants.DR_OPS_NAMESPACE,
-                resource_name=workload.discovered_apps_placement_name,
-            )
-        elif workload.workload_type == constants.APPLICATION_SET:
-            drpc_obj = DRPC(
-                namespace=constants.GITOPS_CLUSTER_NAMESPACE,
-                resource_name=f"{workload.appset_placement_name}-drpc",
-            )
-        else:
-            drpc_obj = DRPC(namespace=workload.workload_namespace)
-        drpc_obj.wait_for_peer_ready_status()
+    restore_index = config.cur_index
+    try:
+        config.switch_acm_ctx()
+        for workload in workloads:
+            if getattr(workload, "discovered_apps_placement_name", None):
+                drpc_obj = DRPC(
+                    namespace=constants.DR_OPS_NAMESPACE,
+                    resource_name=workload.discovered_apps_placement_name,
+                )
+            elif workload.workload_type == constants.APPLICATION_SET:
+                drpc_obj = DRPC(
+                    namespace=constants.GITOPS_CLUSTER_NAMESPACE,
+                    resource_name=f"{workload.appset_placement_name}-drpc",
+                )
+            else:
+                drpc_obj = DRPC(namespace=workload.workload_namespace)
+            drpc_obj.wait_for_peer_ready_status()
 
-    total_pvc_count = sum(
-        getattr(workload, "workload_pvc_count", 1) for workload in workloads
-    )
-    dr_helpers.wait_for_mirroring_status_ok(replaying_images=total_pvc_count)
-    time.sleep(2 * scheduling_interval * 60)
-    log.info("DR protected workloads are healthy for Topology UI validation")
+        total_pvc_count = sum(
+            getattr(workload, "workload_pvc_count", 1) for workload in workloads
+        )
+        dr_helpers.wait_for_mirroring_status_ok(replaying_images=total_pvc_count)
+        time.sleep(scheduling_interval * 60)
+        log.info("DR protected workloads are healthy for Topology UI validation")
+    finally:
+        config.switch_ctx(restore_index)
 
 
 def dr_submariner_validation_from_ui(acm_obj):

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -60,6 +60,9 @@ TEMPLATE_COUCHBASE_SERVER_DIR = os.path.join(TEMPLATE_COUCHBASE_DIR, "server")
 TEMPLATE_COUCHBASE_PILLOWFIGHT_DIR = os.path.join(TEMPLATE_COUCHBASE_DIR, "pillowfight")
 TEMPLATE_CEPHFS_STRESS_DIR = os.path.join(TEMPLATE_WORKLOAD_DIR, "cephfs_stress")
 TEMPLATE_MCG_DIR = os.path.join(TEMPLATE_DIR, "mcg")
+TEMPLATE_BLOCK_NB_EGRESS_NETWORK_POLICY = os.path.join(
+    TEMPLATE_MCG_DIR, "block_egress_network_policy.yaml"
+)
 TEMPLATE_RGW_DIR = os.path.join(TEMPLATE_DIR, "rgw")
 TEMPLATE_AMQ_DIR = os.path.join(TEMPLATE_WORKLOAD_DIR, "amq")
 TEMPLATE_OPENSHIFT_INFRA_DIR = os.path.join(TEMPLATE_DIR, "openshift-infra/")
@@ -259,6 +262,7 @@ DR_TOPOLOGY_SEARCH_FILTER_CLUSTER_NAME = "Cluster name"
 DR_TOPOLOGY_SEARCH_FILTER_POLICY = "Policy"
 DR_TOPOLOGY_SEARCH_FILTER_APPLICATION = "Application name"
 DR_TOPOLOGY_DRPC_READY_STATUS = "Ready"
+DR_TOPOLOGY_DRPC_HEALTHY_STATUS = "healthy"
 ACTION_FENCE = "Fenced"
 ACTION_UNFENCE = "Unfenced"
 CEPHFILESYSTEMSUBVOLUMEGROUP = "cephfilesystemsubvolumegroup"
@@ -632,6 +636,10 @@ DEFAULT_EXTERNAL_MODE_STORAGECLASS_RBD_NAMESPACE_PREFIX = (
     f"{DEFAULT_EXTERNAL_MODE_STORAGECLASS_RBD}-rados-namespace"
 )
 
+# Label on RBD/CephFS StorageClasses (all deployment types; provider/consumer model).
+OCS_EXTERNAL_STORAGECLASS_LABEL = "storageclass.ocs.openshift.io/is-external"
+OCS_EXTERNAL_STORAGECLASS_LABEL_VALUE = "true"
+
 # Default StorageClass for Provider-mode
 DEFAULT_STORAGECLASS_CLIENT_CEPHFS = f"{STORAGE_CLIENT_NAME}-cephfs"
 DEFAULT_STORAGECLASS_CLIENT_RBD = f"{STORAGE_CLIENT_NAME}-ceph-rbd"
@@ -928,6 +936,8 @@ CSI_PVC_YAML = os.path.join(TEMPLATE_PV_PVC_DIR, "PersistentVolumeClaim.yaml")
 
 MCG_OBC_YAML = os.path.join(TEMPLATE_MCG_DIR, "ObjectBucketClaim.yaml")
 
+VECTOR_OBC_YAML = os.path.join(TEMPLATE_MCG_DIR, "VectorObjectBucketClaim.yaml")
+
 RGW_OBC_YAML = os.path.join(TEMPLATE_MCG_DIR, "ObjectBucketClaim-RGW.yaml")
 
 CEPHOBJECTSTORE_USER_YAML = os.path.join(TEMPLATE_RGW_DIR, "cephobjectstoreuser.yaml")
@@ -1161,6 +1171,7 @@ OC_MIRROR_IMAGESET_CONFIG = os.path.join(
 OC_MIRROR_IMAGESET_CONFIG_V2 = os.path.join(
     TEMPLATE_DIR, "ocp-deployment", "oc-mirror-imageset-config-v2.yaml"
 )
+OC_INGRESS_CERT_YAML = os.path.join(TEMPLATE_DIR, "ocp-deployment", "ingress_cert.yaml")
 
 CSI_CEPHFS_ROX_POD_YAML = os.path.join(TEMPLATE_APP_POD_DIR, "csi-cephfs-rox.yaml")
 
@@ -1619,6 +1630,7 @@ ALERT_BUCKETEXCEEDINGQUOTASTATE = "NooBaaBucketExceedingQuotaState"
 ALERT_BUCKETEXCEEDINGSIZEQUOTASTATE = "NooBaaBucketExceedingSizeQuotaState"
 ALERT_NAMESPACERESOURCEERRORSTATE = "NooBaaNamespaceResourceErrorState"
 ALERT_NAMESPACEBUCKETERRORSTATE = "NooBaaNamespaceBucketErrorState"
+ALERT_NOOBAA_REPLICATION_TARGET_UNREACHABLE = "NooBaaReplicationTargetUnreachable"
 ALERT_NODEDOWN = "CephNodeDown"
 ALERT_CLUSTERNEARFULL = "CephClusterNearFull"
 ALERT_CLUSTERCRITICALLYFULL = "CephClusterCriticallyFull"
@@ -1828,6 +1840,7 @@ PSA_RESTRICTED = "restricted"
 AWS_PLATFORM = "aws"
 AZURE_PLATFORM = "azure"
 AZURE_WITH_LOGS_PLATFORM = "azure-with-logs"
+AZURE_STS_PLATFORM = "azure-sts"
 GCP_PLATFORM = "gcp"
 VSPHERE_PLATFORM = "vsphere"
 BAREMETAL_PLATFORM = "baremetal"
@@ -2474,6 +2487,7 @@ CLI_TOOL_LOCAL_PATH = os.path.join(DATA_DIR, "odf-cli")
 ODF_CLI_LOCAL_PATH = os.path.join(DATA_DIR, "odf-cli")
 DEFAULT_INGRESS_CRT = "router-ca.crt"
 DEFAULT_INGRESS_CRT_LOCAL_PATH = f"{DATA_DIR}/mcg-{DEFAULT_INGRESS_CRT}"
+DEFAULT_INGRESS_CRT_OPENSHIFT = "default-ingress-cert"
 SERVICE_CA_CRT = "service-ca.crt"
 SERVICE_MONITORS = "servicemonitors"
 SERVICE_CA_CRT_AWSCLI_PATH = f"/cert/{SERVICE_CA_CRT}"
@@ -2528,6 +2542,7 @@ FLEXY_DEFAULT_PRIVATE_CONF_REPO = (
 FLEXY_JENKINS_USER = "jenkins"
 FLEXY_DEFAULT_PRIVATE_CONF_BRANCH = "master"
 OPENSHIFT_CONFIG_NAMESPACE = "openshift-config"
+OPENSHIFT_CONFIG_MANAGED_NAMESPACE = "openshift-config-managed"
 FLEXY_RELATIVE_CLUSTER_DIR = "flexy/workdir/install-dir"
 FLEXY_IMAGE_URL = "images.paas.redhat.com/dno-ood/ocp4:latest"
 FLEXY_ENV_FILE_UPDATED_NAME = "ocs-flexy-env-file-updated.env"
@@ -2739,6 +2754,8 @@ RHEL_OS = "RHEL"
 RHCOS = "RHCOS"
 
 # Scale constants
+IBM_STORAGE_SCALE_NAMESPACE = "ibm-spectrum-scale"
+REMOTE_CLUSTER = "RemoteCluster"
 SCALE_NODE_SELECTOR = {"scale-label": "app-scale"}
 SCALE_LABEL = "scale-label=app-scale"
 # TODO: Revisit the dict value once there is change in instance/vm/server type
@@ -3798,7 +3815,8 @@ SPECTRUM_FUSION_CR = os.path.join(
     TEMPLATE_DEPLOYMENT_DIR_FUSION, "spectrum-fusion.yaml"
 )
 FDF_ODFCLUSTER_CR = os.path.join(FDF_TEMPLATE_DIR, "odfcluster.yaml")
-
+FDF_CATSRC_CR = os.path.join(FDF_TEMPLATE_DIR, "isf_datafoundation_catsrc.yaml")
+FDF_CATSRC_IMAGE_PATH = "icr.io/cpopen/isf-data-foundation-catalog"
 FDF_NAMESPACE = "ibm-spectrum-fusion-ns"
 FUSION_NAMESPACE = "ibm-spectrum-fusion-ns"
 ISF_CATALOG_SOURCE_NAME = "isf-catalog"
@@ -3996,6 +4014,8 @@ BLACKBOX_POD_LABEL_422_AND_ABOVE = "app=odf-blackbox-exporter"
 
 # ODF 4.21 health overview mock alerts dir
 HEALTHALERTS_DIR = os.path.join(TEMPLATE_DIR, "health_overview_alerts")
+FDF_CATALOG_NAME = "isf-data-foundation-catalog"
+FDF_OPERATOR_SELECTOR = "fdf-operator-internal=true"
 
 # CSI PORTS
 CEPH_NODE_PORT = 31659

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -60,9 +60,6 @@ TEMPLATE_COUCHBASE_SERVER_DIR = os.path.join(TEMPLATE_COUCHBASE_DIR, "server")
 TEMPLATE_COUCHBASE_PILLOWFIGHT_DIR = os.path.join(TEMPLATE_COUCHBASE_DIR, "pillowfight")
 TEMPLATE_CEPHFS_STRESS_DIR = os.path.join(TEMPLATE_WORKLOAD_DIR, "cephfs_stress")
 TEMPLATE_MCG_DIR = os.path.join(TEMPLATE_DIR, "mcg")
-TEMPLATE_BLOCK_NB_EGRESS_NETWORK_POLICY = os.path.join(
-    TEMPLATE_MCG_DIR, "block_egress_network_policy.yaml"
-)
 TEMPLATE_RGW_DIR = os.path.join(TEMPLATE_DIR, "rgw")
 TEMPLATE_AMQ_DIR = os.path.join(TEMPLATE_WORKLOAD_DIR, "amq")
 TEMPLATE_OPENSHIFT_INFRA_DIR = os.path.join(TEMPLATE_DIR, "openshift-infra/")
@@ -249,6 +246,19 @@ DRPC = "DRPlacementControl"
 DRCLUSTER = "DRCluster"
 DRCLUSTERCONFIG = "DRClusterConfig"
 DRPOLICY = "DRPolicy"
+DR_TOPOLOGY_PAGE_TABS = (
+    "Overview",
+    "Topology",
+    "Policies",
+    "Protected applications",
+)
+DR_TOPOLOGY_SIDEBAR_APPLICATIONS_TAB = "Applications"
+DR_TOPOLOGY_SIDEBAR_DETAILS_TAB = "Details"
+DR_TOPOLOGY_SIDEBAR_APPLICATION_DETAILS_TAB = "Application Details"
+DR_TOPOLOGY_SEARCH_FILTER_CLUSTER_NAME = "Cluster name"
+DR_TOPOLOGY_SEARCH_FILTER_POLICY = "Policy"
+DR_TOPOLOGY_SEARCH_FILTER_APPLICATION = "Application name"
+DR_TOPOLOGY_DRPC_READY_STATUS = "Ready"
 ACTION_FENCE = "Fenced"
 ACTION_UNFENCE = "Unfenced"
 CEPHFILESYSTEMSUBVOLUMEGROUP = "cephfilesystemsubvolumegroup"
@@ -622,10 +632,6 @@ DEFAULT_EXTERNAL_MODE_STORAGECLASS_RBD_NAMESPACE_PREFIX = (
     f"{DEFAULT_EXTERNAL_MODE_STORAGECLASS_RBD}-rados-namespace"
 )
 
-# Label on RBD/CephFS StorageClasses (all deployment types; provider/consumer model).
-OCS_EXTERNAL_STORAGECLASS_LABEL = "storageclass.ocs.openshift.io/is-external"
-OCS_EXTERNAL_STORAGECLASS_LABEL_VALUE = "true"
-
 # Default StorageClass for Provider-mode
 DEFAULT_STORAGECLASS_CLIENT_CEPHFS = f"{STORAGE_CLIENT_NAME}-cephfs"
 DEFAULT_STORAGECLASS_CLIENT_RBD = f"{STORAGE_CLIENT_NAME}-ceph-rbd"
@@ -922,8 +928,6 @@ CSI_PVC_YAML = os.path.join(TEMPLATE_PV_PVC_DIR, "PersistentVolumeClaim.yaml")
 
 MCG_OBC_YAML = os.path.join(TEMPLATE_MCG_DIR, "ObjectBucketClaim.yaml")
 
-VECTOR_OBC_YAML = os.path.join(TEMPLATE_MCG_DIR, "VectorObjectBucketClaim.yaml")
-
 RGW_OBC_YAML = os.path.join(TEMPLATE_MCG_DIR, "ObjectBucketClaim-RGW.yaml")
 
 CEPHOBJECTSTORE_USER_YAML = os.path.join(TEMPLATE_RGW_DIR, "cephobjectstoreuser.yaml")
@@ -1157,7 +1161,6 @@ OC_MIRROR_IMAGESET_CONFIG = os.path.join(
 OC_MIRROR_IMAGESET_CONFIG_V2 = os.path.join(
     TEMPLATE_DIR, "ocp-deployment", "oc-mirror-imageset-config-v2.yaml"
 )
-OC_INGRESS_CERT_YAML = os.path.join(TEMPLATE_DIR, "ocp-deployment", "ingress_cert.yaml")
 
 CSI_CEPHFS_ROX_POD_YAML = os.path.join(TEMPLATE_APP_POD_DIR, "csi-cephfs-rox.yaml")
 
@@ -1616,7 +1619,6 @@ ALERT_BUCKETEXCEEDINGQUOTASTATE = "NooBaaBucketExceedingQuotaState"
 ALERT_BUCKETEXCEEDINGSIZEQUOTASTATE = "NooBaaBucketExceedingSizeQuotaState"
 ALERT_NAMESPACERESOURCEERRORSTATE = "NooBaaNamespaceResourceErrorState"
 ALERT_NAMESPACEBUCKETERRORSTATE = "NooBaaNamespaceBucketErrorState"
-ALERT_NOOBAA_REPLICATION_TARGET_UNREACHABLE = "NooBaaReplicationTargetUnreachable"
 ALERT_NODEDOWN = "CephNodeDown"
 ALERT_CLUSTERNEARFULL = "CephClusterNearFull"
 ALERT_CLUSTERCRITICALLYFULL = "CephClusterCriticallyFull"
@@ -1826,7 +1828,6 @@ PSA_RESTRICTED = "restricted"
 AWS_PLATFORM = "aws"
 AZURE_PLATFORM = "azure"
 AZURE_WITH_LOGS_PLATFORM = "azure-with-logs"
-AZURE_STS_PLATFORM = "azure-sts"
 GCP_PLATFORM = "gcp"
 VSPHERE_PLATFORM = "vsphere"
 BAREMETAL_PLATFORM = "baremetal"
@@ -2473,7 +2474,6 @@ CLI_TOOL_LOCAL_PATH = os.path.join(DATA_DIR, "odf-cli")
 ODF_CLI_LOCAL_PATH = os.path.join(DATA_DIR, "odf-cli")
 DEFAULT_INGRESS_CRT = "router-ca.crt"
 DEFAULT_INGRESS_CRT_LOCAL_PATH = f"{DATA_DIR}/mcg-{DEFAULT_INGRESS_CRT}"
-DEFAULT_INGRESS_CRT_OPENSHIFT = "default-ingress-cert"
 SERVICE_CA_CRT = "service-ca.crt"
 SERVICE_MONITORS = "servicemonitors"
 SERVICE_CA_CRT_AWSCLI_PATH = f"/cert/{SERVICE_CA_CRT}"
@@ -2528,7 +2528,6 @@ FLEXY_DEFAULT_PRIVATE_CONF_REPO = (
 FLEXY_JENKINS_USER = "jenkins"
 FLEXY_DEFAULT_PRIVATE_CONF_BRANCH = "master"
 OPENSHIFT_CONFIG_NAMESPACE = "openshift-config"
-OPENSHIFT_CONFIG_MANAGED_NAMESPACE = "openshift-config-managed"
 FLEXY_RELATIVE_CLUSTER_DIR = "flexy/workdir/install-dir"
 FLEXY_IMAGE_URL = "images.paas.redhat.com/dno-ood/ocp4:latest"
 FLEXY_ENV_FILE_UPDATED_NAME = "ocs-flexy-env-file-updated.env"
@@ -2740,8 +2739,6 @@ RHEL_OS = "RHEL"
 RHCOS = "RHCOS"
 
 # Scale constants
-IBM_STORAGE_SCALE_NAMESPACE = "ibm-spectrum-scale"
-REMOTE_CLUSTER = "RemoteCluster"
 SCALE_NODE_SELECTOR = {"scale-label": "app-scale"}
 SCALE_LABEL = "scale-label=app-scale"
 # TODO: Revisit the dict value once there is change in instance/vm/server type
@@ -3801,8 +3798,7 @@ SPECTRUM_FUSION_CR = os.path.join(
     TEMPLATE_DEPLOYMENT_DIR_FUSION, "spectrum-fusion.yaml"
 )
 FDF_ODFCLUSTER_CR = os.path.join(FDF_TEMPLATE_DIR, "odfcluster.yaml")
-FDF_CATSRC_CR = os.path.join(FDF_TEMPLATE_DIR, "isf_datafoundation_catsrc.yaml")
-FDF_CATSRC_IMAGE_PATH = "icr.io/cpopen/isf-data-foundation-catalog"
+
 FDF_NAMESPACE = "ibm-spectrum-fusion-ns"
 FUSION_NAMESPACE = "ibm-spectrum-fusion-ns"
 ISF_CATALOG_SOURCE_NAME = "isf-catalog"
@@ -4000,8 +3996,6 @@ BLACKBOX_POD_LABEL_422_AND_ABOVE = "app=odf-blackbox-exporter"
 
 # ODF 4.21 health overview mock alerts dir
 HEALTHALERTS_DIR = os.path.join(TEMPLATE_DIR, "health_overview_alerts")
-FDF_CATALOG_NAME = "isf-data-foundation-catalog"
-FDF_OPERATOR_SELECTOR = "fdf-operator-internal=true"
 
 # CSI PORTS
 CEPH_NODE_PORT = 31659

--- a/ocs_ci/ocs/ui/base_ui.py
+++ b/ocs_ci/ocs/ui/base_ui.py
@@ -841,7 +841,7 @@ class BaseUI:
                     pass
             return False
 
-    def check_element_presence(self, locator, timeout=5):
+    def check_element_presence(self, locator, timeout=5, use_fallback=True):
         """
         Check if an web element is present on the web console or not.
 
@@ -849,6 +849,7 @@ class BaseUI:
         Args:
              locator (tuple): (GUI element needs to operate on (str), type (By))
              timeout (int): Looks for a web element repeatedly until timeout (sec) occurs
+             use_fallback (bool): if True, attempt AI locator fallback when element is not found
         Returns:
             bool: True if the element is found, returns False otherwise and raises NoSuchElementException
 
@@ -869,38 +870,44 @@ class BaseUI:
         except (NoSuchElementException, StaleElementReferenceException):
             logger.error("Expected element not found on UI")
             self.take_screenshot()
-            # locator here is (By, value) — reverse for fallback which expects (value, By)
-            new_locator = self.locator_fallback.attempt_fallback(
-                (locator[1], locator[0]),
-                "check_presence",
-                stack_trace=traceback.format_exc(),
-            )
-            if new_locator:
-                try:
-                    WebDriverWait(self.driver, min(timeout, 10)).until(
-                        ec.presence_of_element_located((new_locator[1], new_locator[0]))
-                    )
-                    return True
-                except (TimeoutException, NoSuchElementException):
-                    pass
+            if use_fallback:
+                # locator here is (By, value) — reverse for fallback which expects (value, By)
+                new_locator = self.locator_fallback.attempt_fallback(
+                    (locator[1], locator[0]),
+                    "check_presence",
+                    stack_trace=traceback.format_exc(),
+                )
+                if new_locator:
+                    try:
+                        WebDriverWait(self.driver, min(timeout, 10)).until(
+                            ec.presence_of_element_located(
+                                (new_locator[1], new_locator[0])
+                            )
+                        )
+                        return True
+                    except (TimeoutException, NoSuchElementException):
+                        pass
             return False
         except TimeoutException:
             logger.error(f"Timedout while waiting for element with {locator}")
             self.take_screenshot()
-            # locator here is (By, value) — reverse for fallback which expects (value, By)
-            new_locator = self.locator_fallback.attempt_fallback(
-                (locator[1], locator[0]),
-                "check_presence",
-                stack_trace=traceback.format_exc(),
-            )
-            if new_locator:
-                try:
-                    WebDriverWait(self.driver, min(timeout, 10)).until(
-                        ec.presence_of_element_located((new_locator[1], new_locator[0]))
-                    )
-                    return True
-                except (TimeoutException, NoSuchElementException):
-                    pass
+            if use_fallback:
+                # locator here is (By, value) — reverse for fallback which expects (value, By)
+                new_locator = self.locator_fallback.attempt_fallback(
+                    (locator[1], locator[0]),
+                    "check_presence",
+                    stack_trace=traceback.format_exc(),
+                )
+                if new_locator:
+                    try:
+                        WebDriverWait(self.driver, min(timeout, 10)).until(
+                            ec.presence_of_element_located(
+                                (new_locator[1], new_locator[0])
+                            )
+                        )
+                        return True
+                    except (TimeoutException, NoSuchElementException):
+                        pass
             return False
 
     def wait_for_endswith_url(self, endswith, timeout=60):

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -1442,6 +1442,79 @@ acm_configuration_4_12 = {
         "a[data-test-id='horizontal-link-Overview']",
         By.CSS_SELECTOR,
     ),
+    "dr-topology-tab": (
+        "//a[@data-test-id='horizontal-link-Topology'] | "
+        "//button[@data-test='horizontal-link-Topology'] | "
+        "//a[normalize-space()='Topology'] | "
+        "//button[normalize-space()='Topology']",
+        By.XPATH,
+    ),
+    "dr-topology-cluster-name": (
+        "//*[contains(text(), '{}')]",
+        By.XPATH,
+    ),
+    "dr-topology-cluster-click": (
+        "//*[contains(@class,'topology__node__label')]"
+        "//*[contains(text(), '{}')]/..",
+        By.XPATH,
+    ),
+    "dr-topology-sidebar-details-tab": (
+        "//span[normalize-space()='Details']",
+        By.XPATH,
+    ),
+    "dr-topology-sidebar-application-details-tab": (
+        "//*[contains(text(), 'Application Details')]",
+        By.XPATH,
+    ),
+    "dr-topology-sidebar-cluster-name": (
+        "//dt[normalize-space()='Name']/following-sibling::dd"
+        "//*[normalize-space()='{}']",
+        By.XPATH,
+    ),
+    "dr-topology-sidebar-close": (
+        "//button[@aria-label='Close']",
+        By.XPATH,
+    ),
+    "dr-topology-policy-name": (
+        "//*[contains(text(), '{}')]",
+        By.XPATH,
+    ),
+    "dr-topology-policy-click": (
+        "//*[contains(@class,'topology__group__label')]"
+        "//*[contains(text(), '{}')]/..",
+        By.XPATH,
+    ),
+    "dr-topology-sidebar-policy-name": (
+        "//dt[normalize-space()='Name']/following-sibling::dd"
+        "//*[normalize-space()='{}']",
+        By.XPATH,
+    ),
+    "dr-topology-sidebar-connected-cluster": (
+        "//dt[normalize-space()='Connected clusters']/following-sibling::dd"
+        "//*[contains(text(), '{}')]",
+        By.XPATH,
+    ),
+    "dr-topology-sidebar-scheduling-interval": (
+        "//dt[normalize-space()='Scheduling interval']/following-sibling::dd"
+        "//*[normalize-space()='{}']",
+        By.XPATH,
+    ),
+    "dr-topology-search": (
+        "//input[@placeholder='Search']",
+        By.XPATH,
+    ),
+    "dr-topology-search-reset": (
+        "//button[@aria-label='Reset']",
+        By.XPATH,
+    ),
+    "dr-topology-filter-toggle": (
+        "//button[contains(.,'Cluster name') or contains(.,'Policy')]",
+        By.XPATH,
+    ),
+    "dr-topology-filter-option": (
+        "//li//*[normalize-space()='{}']",
+        By.XPATH,
+    ),
     "drpolicy-status": ("//*[text()='Validated']", By.XPATH),
     "workload-name": ('//*[text()="{}"]', By.XPATH),
     "search-bar": (

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -1443,19 +1443,17 @@ acm_configuration_4_12 = {
         By.CSS_SELECTOR,
     ),
     "dr-topology-tab": (
-        "//a[@data-test-id='horizontal-link-Topology'] | "
-        "//button[@data-test='horizontal-link-Topology'] | "
-        "//a[normalize-space()='Topology'] | "
-        "//button[normalize-space()='Topology']",
+        "//a[@data-test-id='horizontal-link-Topology']",
         By.XPATH,
     ),
     "dr-topology-cluster-name": (
-        "//*[contains(text(), '{}')]",
+        "//*[@data-type='cluster-node'][.//*[normalize-space()='{}']]",
         By.XPATH,
     ),
     "dr-topology-cluster-click": (
-        "//*[contains(@class,'topology__node__label')]"
-        "//*[contains(text(), '{}')]/..",
+        "//*[@data-type='cluster-node']"
+        "[.//*[normalize-space()='{}']]"
+        "//*[contains(@class,'pf-topology__node__background')]",
         By.XPATH,
     ),
     "dr-topology-sidebar-details-tab": (
@@ -1476,7 +1474,7 @@ acm_configuration_4_12 = {
         By.XPATH,
     ),
     "dr-topology-policy-name": (
-        "//*[contains(text(), '{}')]",
+        "//*[@data-type='pairing-box'][.//*[normalize-space()='{}']]",
         By.XPATH,
     ),
     "dr-topology-policy-click": (
@@ -1511,8 +1509,46 @@ acm_configuration_4_12 = {
         "//button[contains(.,'Cluster name') or contains(.,'Policy')]",
         By.XPATH,
     ),
+    "dr-topology-filter-selected": (
+        "//button[contains(.,'{}')]",
+        By.XPATH,
+    ),
     "dr-topology-filter-option": (
         "//li//*[normalize-space()='{}']",
+        By.XPATH,
+    ),
+    "dr-topology-drpc-click": (
+        "//*[contains(@class,'topology__node__label')]"
+        "[.//*[contains(text(),'{}')]]"
+        "[ancestor::*[.//*[contains(text(),'{}')]]]/..",
+        By.XPATH,
+    ),
+    "dr-topology-sidebar-app-table-header-name": (
+        "//th[normalize-space()='Name']",
+        By.XPATH,
+    ),
+    "dr-topology-sidebar-app-table-header-dr-status": (
+        "//th[normalize-space()='DR Status']",
+        By.XPATH,
+    ),
+    "dr-topology-sidebar-app-table-header-policy": (
+        "//th[normalize-space()='Policy']",
+        By.XPATH,
+    ),
+    "dr-topology-sidebar-app-row": (
+        "//tr[.//*[contains(text(), '{}')]]",
+        By.XPATH,
+    ),
+    "dr-topology-sidebar-app-row-name": (
+        "//tr[.//*[normalize-space()='{}']]/td[1]",
+        By.XPATH,
+    ),
+    "dr-topology-sidebar-app-row-status": (
+        "//tr[.//*[normalize-space()='{}']]/td[2]",
+        By.XPATH,
+    ),
+    "dr-topology-sidebar-app-row-policy": (
+        "//tr[.//*[normalize-space()='{}']]/td[3]",
         By.XPATH,
     ),
     "drpolicy-status": ("//*[text()='Validated']", By.XPATH),

--- a/tests/functional/disaster-recovery/regional-dr/test_dr_topology_view_ui.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_dr_topology_view_ui.py
@@ -1,0 +1,125 @@
+"""
+UI tests for Disaster recovery Topology view (ODF 4.22+).
+"""
+
+import logging
+
+from ocs_ci.framework.pytest_customization.marks import rdr, turquoise_squad
+from ocs_ci.framework.testlib import skipif_ocs_version, tier1
+from ocs_ci.helpers import dr_helpers
+from ocs_ci.helpers.dr_helpers_ui import (
+    close_dr_topology_sidebar,
+    navigate_to_dr_topology_tab,
+    open_dr_topology_cluster_sidebar,
+    open_dr_topology_policy_sidebar,
+    verify_df_cluster_listing_on_topology_view,
+    verify_dr_topology_cluster_sidebar_open,
+    verify_dr_topology_cluster_name_search_filter,
+    verify_dr_topology_policy_search_filter,
+    verify_dr_topology_policy_sidebar_open,
+)
+from ocs_ci.ocs.acm.acm import AcmAddClusters
+from ocs_ci.ocs.ui.validation_ui import ValidationUI
+from ocs_ci.ocs.utils import enable_mco_console_plugin
+
+logger = logging.getLogger(__name__)
+
+
+@rdr
+@tier1
+@turquoise_squad
+@skipif_ocs_version("<4.22")
+class TestDRTopologyViewUI:
+    """
+    Test class for Disaster recovery Topology view UI validation
+    """
+
+    def test_dr_topology_view_ui(
+        self,
+        setup_acm_ui,
+        dr_workload,
+        discovered_apps_dr_workload,
+    ):
+        """
+        End-to-end DR Topology view UI validation.
+
+        Phase 1:
+            1. Verify only Data Foundation clusters are displayed on the Topology tab
+            2. Verify clicking a cluster node opens the cluster sidebar
+            3. Verify clicking a DRPolicy opens the policy sidebar
+            4. Verify Cluster name and Policy search filters on the topology view
+            5. Deploy and DR protect one ApplicationSet and one discovered application
+            6. Wait until DR setup is healthy
+
+        """
+        enable_mco_console_plugin()
+
+        expected_df_clusters = dr_helpers.get_dr_topology_clusters()
+        logger.info(f"Expected Data Foundation clusters from CLI: {expected_df_clusters}")
+
+        page_nav = ValidationUI()
+        page_nav.refresh_web_console()
+
+        acm_obj = AcmAddClusters()
+        navigate_to_dr_topology_tab(acm_obj)
+        verified_clusters = verify_df_cluster_listing_on_topology_view(
+            acm_obj,
+            expected_clusters=expected_df_clusters,
+        )
+        assert verified_clusters == expected_df_clusters, (
+            "Data Foundation clusters on Topology UI do not match CLI output"
+        )
+        logger.info(
+            f"DR Topology lists expected Data Foundation clusters: {verified_clusters}"
+        )
+
+        cluster_name = verified_clusters[0]
+        open_dr_topology_cluster_sidebar(acm_obj, cluster_name)
+        verify_dr_topology_cluster_sidebar_open(acm_obj, cluster_name)
+        close_dr_topology_sidebar(acm_obj)
+        logger.info(f"Cluster sidebar validation completed for '{cluster_name}'")
+
+        policy_details = dr_helpers.get_dr_topology_policy_details()
+        open_dr_topology_policy_sidebar(acm_obj, policy_details["name"])
+        verify_dr_topology_policy_sidebar_open(
+            acm_obj,
+            policy_details["name"],
+            policy_details["connected_clusters"],
+            policy_details["scheduling_interval"],
+        )
+        close_dr_topology_sidebar(acm_obj)
+        logger.info(
+            f"Policy sidebar validation completed for '{policy_details['name']}'"
+        )
+
+        import pdb; pdb.set_trace()
+        hidden_clusters = [
+            name for name in verified_clusters if name != cluster_name
+        ]
+        verify_dr_topology_cluster_name_search_filter(
+            acm_obj, cluster_name, hidden_clusters
+        )
+        verify_dr_topology_policy_search_filter(
+            acm_obj,
+            policy_details["name"],
+            policy_details["connected_clusters"],
+        )
+        logger.info("DR Topology search and filter validation completed")
+
+        # appset_workloads = dr_workload(num_of_subscription=0, num_of_appset=1)
+        # discovered_workloads = discovered_apps_dr_workload(kubeobject=1)
+        # workloads = appset_workloads + discovered_workloads
+        # logger.info(
+        #     f"Deployed DR workloads: appset={len(appset_workloads)}, "
+        #     f"discovered={len(discovered_workloads)}"
+        # )
+        # dr_helpers.set_current_primary_cluster_context(
+        #     appset_workloads[0].workload_namespace
+        # )
+        # scheduling_interval = dr_helpers.get_scheduling_interval(
+        #     appset_workloads[0].workload_namespace
+        # )
+        # wait_for_dr_topology_workloads_healthy(
+        #     workloads=workloads,
+        #     scheduling_interval=scheduling_interval,
+        # )

--- a/tests/functional/disaster-recovery/regional-dr/test_dr_topology_view_ui.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_dr_topology_view_ui.py
@@ -4,6 +4,8 @@ UI tests for Disaster recovery Topology view (ODF 4.22+).
 
 import logging
 
+import pytest
+
 from ocs_ci.framework.pytest_customization.marks import rdr, turquoise_squad
 from ocs_ci.framework.testlib import skipif_ocs_version, tier1
 from ocs_ci.helpers import dr_helpers
@@ -11,13 +13,17 @@ from ocs_ci.helpers.dr_helpers_ui import (
     close_dr_topology_sidebar,
     navigate_to_dr_topology_tab,
     open_dr_topology_cluster_sidebar,
+    open_dr_topology_drpc_sidebar,
     open_dr_topology_policy_sidebar,
     verify_df_cluster_listing_on_topology_view,
+    verify_dr_topology_applications_sidebar,
     verify_dr_topology_cluster_sidebar_open,
     verify_dr_topology_cluster_name_search_filter,
     verify_dr_topology_policy_search_filter,
     verify_dr_topology_policy_sidebar_open,
+    wait_for_dr_topology_workloads_healthy,
 )
+from ocs_ci.ocs import constants
 from ocs_ci.ocs.acm.acm import AcmAddClusters
 from ocs_ci.ocs.ui.validation_ui import ValidationUI
 from ocs_ci.ocs.utils import enable_mco_console_plugin
@@ -34,6 +40,7 @@ class TestDRTopologyViewUI:
     Test class for Disaster recovery Topology view UI validation
     """
 
+    @pytest.mark.polarion_id("OCS-8026")
     def test_dr_topology_view_ui(
         self,
         setup_acm_ui,
@@ -50,12 +57,19 @@ class TestDRTopologyViewUI:
             4. Verify Cluster name and Policy search filters on the topology view
             5. Deploy and DR protect one ApplicationSet and one discovered application
             6. Wait until DR setup is healthy
+            7. Verify clicking DRPC status opens the Applications sidebar
 
         """
         enable_mco_console_plugin()
 
-        expected_df_clusters = dr_helpers.get_dr_topology_clusters()
-        logger.info(f"Expected Data Foundation clusters from CLI: {expected_df_clusters}")
+        expected_df_clusters = sorted(
+            name
+            for name in dr_helpers.get_dr_topology_clusters()
+            if name != constants.ACM_LOCAL_CLUSTER
+        )
+        logger.info(
+            f"Expected Data Foundation clusters from CLI: {expected_df_clusters}"
+        )
 
         page_nav = ValidationUI()
         page_nav.refresh_web_console()
@@ -66,9 +80,9 @@ class TestDRTopologyViewUI:
             acm_obj,
             expected_clusters=expected_df_clusters,
         )
-        assert verified_clusters == expected_df_clusters, (
-            "Data Foundation clusters on Topology UI do not match CLI output"
-        )
+        assert (
+            verified_clusters == expected_df_clusters
+        ), "Data Foundation clusters on Topology UI do not match CLI output"
         logger.info(
             f"DR Topology lists expected Data Foundation clusters: {verified_clusters}"
         )
@@ -92,10 +106,7 @@ class TestDRTopologyViewUI:
             f"Policy sidebar validation completed for '{policy_details['name']}'"
         )
 
-        import pdb; pdb.set_trace()
-        hidden_clusters = [
-            name for name in verified_clusters if name != cluster_name
-        ]
+        hidden_clusters = [name for name in verified_clusters if name != cluster_name]
         verify_dr_topology_cluster_name_search_filter(
             acm_obj, cluster_name, hidden_clusters
         )
@@ -106,20 +117,35 @@ class TestDRTopologyViewUI:
         )
         logger.info("DR Topology search and filter validation completed")
 
-        # appset_workloads = dr_workload(num_of_subscription=0, num_of_appset=1)
-        # discovered_workloads = discovered_apps_dr_workload(kubeobject=1)
-        # workloads = appset_workloads + discovered_workloads
-        # logger.info(
-        #     f"Deployed DR workloads: appset={len(appset_workloads)}, "
-        #     f"discovered={len(discovered_workloads)}"
-        # )
-        # dr_helpers.set_current_primary_cluster_context(
-        #     appset_workloads[0].workload_namespace
-        # )
-        # scheduling_interval = dr_helpers.get_scheduling_interval(
-        #     appset_workloads[0].workload_namespace
-        # )
-        # wait_for_dr_topology_workloads_healthy(
-        #     workloads=workloads,
-        #     scheduling_interval=scheduling_interval,
-        # )
+        appset_workloads = dr_workload(num_of_subscription=0, num_of_appset=1)
+        discovered_workloads = discovered_apps_dr_workload(kubeobject=1)
+        workloads = appset_workloads + discovered_workloads
+        logger.info(
+            f"Deployed DR workloads: appset={len(appset_workloads)}, "
+            f"discovered={len(discovered_workloads)}"
+        )
+        scheduling_interval = dr_helpers.get_scheduling_interval(
+            appset_workloads[0].workload_namespace,
+            workload_type=constants.APPLICATION_SET,
+        )
+        dr_helpers.set_current_primary_cluster_context(
+            appset_workloads[0].workload_namespace,
+            workload_type=constants.APPLICATION_SET,
+        )
+        wait_for_dr_topology_workloads_healthy(
+            workloads=workloads,
+            scheduling_interval=2 * scheduling_interval,
+        )
+
+        protected_apps = dr_helpers.get_dr_topology_protected_apps(workloads)
+        primary_cluster_name = dr_helpers.get_current_primary_cluster_name(
+            appset_workloads[0].workload_namespace,
+            workload_type=constants.APPLICATION_SET,
+        )
+        open_dr_topology_drpc_sidebar(acm_obj, primary_cluster_name)
+        verify_dr_topology_applications_sidebar(acm_obj, protected_apps)
+        close_dr_topology_sidebar(acm_obj)
+        logger.info(
+            f"Applications sidebar validation completed for cluster "
+            f"'{primary_cluster_name}'"
+        )


### PR DESCRIPTION
## Summary
- Add UI locators and helpers for DR Topology view (clusters, policies, DRPC Applications sidebar)
- Add CLI helpers for topology cluster/policy/protected-app data
- Add E2E test `test_dr_topology_view_ui` for RDR (ODF 4.22+)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded Disaster Recovery Topology UI automation to validate cluster eligibility, DRPolicy sidebar details (connected clusters and scheduling interval), and protected Applications (name/status/policy), including cluster and policy search plus reset flows.
  * Added DRPC “Ready/Healthy” UI constants for more reliable UI assertions.
* **Tests**
  * Added an end-to-end functional UI test for DR Topology (ODF 4.22+) covering topology listing, sidebar open/close, search visibility, and Applications validation, including workload health synchronization.
* **Chores**
  * Improved UI automation robustness with enhanced Selenium timeout handling and expanded DR Topology locators/interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->