### PR TITLE
Add UI tests TC2 and TC3: CephFS subvolume metrics (RHSTOR-7679)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-"plugins_used": [
+  "plugins_used": [
     {
       "name": "AWSKeyDetector"
     },

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,9 +1,9 @@
 {
   "exclude": {
-    "files": null,
+    "files": "^.secrets.baseline$",
     "lines": null
   },
-  "plugins_used": [
+"plugins_used": [
     {
       "name": "AWSKeyDetector"
     },
@@ -79,1323 +79,1303 @@
     "conf/deployment/ibmcloud/ibm_cloud_managed_3az_0m_3w_vpc_cluster.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 25,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 23,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_hpcs_external.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 25,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_stage.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 22,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_without_cos.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 21,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_without_cos_stage.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 23,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_zone_eu_de_1.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 23,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_zone_eu_de_2.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 23,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_zone_eu_de_3.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 23,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_zone_jp_tok_1.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 23,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_zone_jp_tok_2.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 23,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_zone_jp_tok_3.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 23,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_zone_us_east_1.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 23,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_zone_us_east_2.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 23,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_zone_us_east_3.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 23,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ipi_1az_us_east1_rhcos_3m_3w.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 24,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ipi_1az_us_east1_rhcos_custom_vpc_3m_3w.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 27,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ipi_1az_us_east2_rhcos_3m_3w.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 24,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ipi_1az_us_east3_rhcos_3m_3w.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 24,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ipi_1az_us_south1_rhcos_custom_vpc_3m_3w.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 27,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ipi_3az_rhcos_3m_3w.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 28,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ipi_3az_rhcos_3m_6w.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 29,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ipi_3az_rhcos_compactmode_3m_0w.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 28,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ipi_3az_rhcos_lowerreq_3m_3w.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 28,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/rhv/ipi_1az_rhcos_3m_3w.yaml": [
       {
         "hashed_secret": "ff55435345834a3fe224936776c2aa15f6ed5358",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 21,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/rhv/ipi_1az_rhcos_lso_3m_3w.yaml": [
       {
         "hashed_secret": "ff55435345834a3fe224936776c2aa15f6ed5358",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 30,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/vsphere/upi_1az_rhcos_vsan_3m_3w_disconnected_flexy.yaml": [
       {
         "hashed_secret": "66a1db0d75c1b2302b441a31b75b4d5a9f291d22",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 21,
         "type": "Base64 High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/vsphere/upi_1az_rhcos_vsan_lso_vmdk_3m_3w_disconnected_flexy.yaml": [
       {
         "hashed_secret": "66a1db0d75c1b2302b441a31b75b4d5a9f291d22",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 24,
         "type": "Base64 High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/examples/hpcs_external_standalone_mode.yaml": [
       {
         "hashed_secret": "fc4a8593743fd8a94fce1b137d964432bb1a9e91",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 13,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/ocsci/disconnected_cluster.yaml.example": [
       {
         "hashed_secret": "1dee91010328c9606757a6ddb538d608b6d89d1c",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 6,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 9,
         "type": "Basic Auth Credentials",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/ocsci/dr_workload.yaml": [
       {
         "hashed_secret": "3bb712fd293d3816c7c111dffc96dffc5c873602",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 345,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/ocsci/hpcs_external_standalone_mode.yaml": [
       {
         "hashed_secret": "fc4a8593743fd8a94fce1b137d964432bb1a9e91",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 12,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/ocsci/mdr_workload.yaml": [
       {
         "hashed_secret": "3bb712fd293d3816c7c111dffc96dffc5c873602",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 119,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/ocsci/noobaa_external_pgsql.yaml": [
       {
         "hashed_secret": "6cb6eb9fabad447f4ec9965879927661143bdfed",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 12,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/ocsci/openshift_dedicated.yaml": [
       {
         "hashed_secret": "66b2fcbc520c25a8087712aa85e95516a2b6c79b",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 14,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/ocsci/vsphere_upi_vars.yaml.example": [
       {
         "hashed_secret": "e894b36b7cdd92461cad391cf01f52c9e53c41ad",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 26,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/ocsci/vsphere_upi_vars.yaml.skeleton": [
       {
         "hashed_secret": "d63f8d34ad75f338f5b42b331e2fd883576a29bd",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 10,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "e894b36b7cdd92461cad391cf01f52c9e53c41ad",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 27,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "docs/getting_started.md": [
       {
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 174,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "docs/logging_guide.md": [
       {
         "hashed_secret": "605cf0632d1f0b7aebb3c0cd5c51a92145bb28a6",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 1421,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "docs/supported_platforms.md": [
       {
         "hashed_secret": "6eae3a5b062c6d0d79f070c26e6d62486b40cb46",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 30,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 171,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "docs/usage.md": [
       {
         "hashed_secret": "89a519cc7786f3290ad671412d92f325f9ef2a57",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 98,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "cfcafdd35cb253bd1a95060758e671abe510920a",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 347,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/deployment/aws.py": [
       {
         "hashed_secret": "134f379c01b1cf36e5ee172c37ffeca5c679a5ee",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 802,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/deployment/flexy.py": [
       {
         "hashed_secret": "bea1af2a15561a266eda3472673d24cb4f2020d4",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 241,
+        "line_number": 242,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/deployment/hub_spoke.py": [
       {
         "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 7164,
+        "line_number": 7165,
         "type": "Private Key",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/framework/conf/default_config.yaml": [
       {
         "hashed_secret": "613fb9979a1ab677719426dd2e81a60fad637cf2",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 28,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "eea97d7f2f305e7afdc0b9bf64859b660cd09232",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 31,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 334,
         "line_number": 338,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "de19c40310ad831a71524cd279e6f5f0577fb09a",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 382,
         "line_number": 386,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/helpers/cluster_exp_helpers.py": [
       {
         "hashed_secret": "fa3798e69b10954419dfdcf70da00dce77b1416e",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 57,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/helpers/helpers.py": [
       {
         "hashed_secret": "66a36e77fd002579809717841f998f4d21cd5913",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 2925,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/krkn_chaos/template/krkn_global_config.yaml.j2": [
       {
         "hashed_secret": "d2e2ab0f407e4ee3cf2ab87d61c31b25a74085e5",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 50,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/krkn_chaos/template/scenarios/keknctl/plan.json.j2": [
       {
         "hashed_secret": "d2e2ab0f407e4ee3cf2ab87d61c31b25a74085e5",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 760,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/ocs/clients.py": [
       {
         "hashed_secret": "a8c1dc105c415cc7ccb286ecdb1156ebd9f957fb",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 14,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/ocs/constants.py": [
       {
         "hashed_secret": "b7e9a6e2e04ed3edbf8b4e21def4beccbb6eb6b1",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 233,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "a12337323b638ab044b1166bff4b1a1f83162819",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 840,
+        "line_number": 857,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "fb947972c92f052c0a08866d182be0075a2b601b",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 849,
+        "line_number": 866,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "03e227627ab8681281fdb8aa3d799b03f782d672",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 2053,
-        "line_number": 2060,
+        "line_number": 2077,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "ef5f3d909f23bd0aa02b4253f98350384f709c86",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 2160,
-        "line_number": 2167,
+        "line_number": 2184,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "cb1ae2b504c4615841d8144267a131231d2bd677",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 2161,
-        "line_number": 2168,
+        "line_number": 2185,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "1a1e70e87dd0452c42f33ce9bf74aa28134dba6b",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 2162,
-        "line_number": 2169,
+        "line_number": 2186,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "7b1ba2f04f2f1604dc4e3caffcadf9fcbce7df5b",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 2163,
-        "line_number": 2170,
+        "line_number": 2187,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "0fa3b21ced80146d752888f2b60ec80e0d4b8925",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 2175,
-        "line_number": 2182,
+        "line_number": 2199,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "f084f2068494b8d1cd06811dd97d02c3d85f40ee",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 2190,
-        "line_number": 2197,
+        "line_number": 2214,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "adfa401a3b0a733d8f00519ac8c6b3893a2e7e8e",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 2191,
-        "line_number": 2198,
+        "line_number": 2215,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "898e46bbadc12f87120548bd445eb4210c8407c8",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 2199,
-        "line_number": 2206,
+        "line_number": 2223,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "f57ccec6b8f7b12b635ab53d26c3bf7300247341",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 2200,
-        "line_number": 2207,
+        "line_number": 2224,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "77b044ea736f8cbe568d1954424186d901f89db9",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 2201,
-        "line_number": 2208,
+        "line_number": 2225,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "d64368f12ca17c69568c6a132f17d44d56e60660",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 2202,
-        "line_number": 2209,
+        "line_number": 2226,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "8f9ca35156c02cb6ba58c5b51230b9bedc38de4f",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 2203,
-        "line_number": 2210,
+        "line_number": 2227,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "9ec53cfd9929c70c3f87c210b6a7b77fb6d79d43",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 2800,
-        "line_number": 2807,
+        "line_number": 2824,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 2966,
-        "line_number": 2972,
+        "line_number": 2990,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "adc1f5c8707f7d7aba3aabe13c15e5ef1151872e",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 2967,
-        "line_number": 2973,
+        "line_number": 2991,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "ee46262b2df945e46ea310b925ad087465dbd3f2",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 3688,
-        "line_number": 3694,
+        "line_number": 3713,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "f678cad4ab874d71b559a069d5e34a95fe38a480",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 3689,
-        "line_number": 3695,
+        "line_number": 3714,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/ocs/defaults.py": [
       {
         "hashed_secret": "ca4dbbee191f1e04318439e30e4e9f55134e4513",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 123,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "9125b9994805d74d9545e381b9d5a90e65e2d63e",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 124,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "637138e061a7c9dc22f301dfcf7a43b638a2e1d8",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 125,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/ocs/external_ceph.py": [
       {
         "hashed_secret": "d2137e76c2c4f75fe37e8c0a03670d3715849389",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 473,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "30274c47903bd1bac7633bbf09743149ebab805f",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 474,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/ocs/fusion.py": [
       {
         "hashed_secret": "6eae3a5b062c6d0d79f070c26e6d62486b40cb46",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 97,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/ocs/platform_nodes.py": [
       {
         "hashed_secret": "134f379c01b1cf36e5ee172c37ffeca5c679a5ee",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 1269,
+        "line_number": 1273,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/ocs/resources/ocsconfigmaps.py": [
       {
         "hashed_secret": "347cd9c53ff77d41a7b22aa56c7b4efaf54658e3",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 404,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/ocs/utils.py": [
       {
         "hashed_secret": "f2dde9105675b76e1f542230a642933ccffd8a8e",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 331,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "8f57c0c672ec244816d827f57ea488c2d609efc9",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 643,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "30274c47903bd1bac7633bbf09743149ebab805f",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 644,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/templates/CSI/rbd/csi-kms-connection-details.yaml": [
       {
         "hashed_secret": "214d02537c8b2382bd599e97b100b78d1f9614aa",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 4,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/templates/ocs-deployment/external-pgsql-noobaa-secret.yaml": [
       {
         "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 9,
         "type": "Basic Auth Credentials",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/templates/ocs-deployment/multicluster/odr_s3_secret.yaml": [
       {
         "hashed_secret": "d3045fb7f8faed786bb7694d7d4ca06e357eea24",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 5,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/templates/openshift-infra/hpcs/ibm-kp-kms-secret.yaml": [
       {
         "hashed_secret": "021b53ce46b72837170446bee4e579c4801bc67a",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 8,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/templates/workloads/couchbase/server/couchbase-worker-secret.yaml": [
       {
         "hashed_secret": "7cf7ed86e8f660ade5996a1072d74cd35def47af",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 9,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/templates/workloads/couchbase/server/couchbase-worker.yaml": [
       {
         "hashed_secret": "8d6478f5d35b469b1568d41c393b3e08d30e7a2e",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 27,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/templates/workloads/hsbench/hsbench_obj.yaml": [
       {
         "hashed_secret": "7a9a4af7de5c6536e46cbee0856f11b46cdde7c9",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 5,
         "type": "Base64 High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/templates/workloads/quay/quay_registry.yaml": [
       {
         "hashed_secret": "83f7cd4240b0182d4e26f6f5aa845d3d29e4adfb",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 7,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/utility/managedservice.py": [
       {
         "hashed_secret": "6eae3a5b062c6d0d79f070c26e6d62486b40cb46",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 95,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "be4fc4886bd949b369d5e092eb87494f12e57e5b",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 169,
         "type": "Private Key",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/utility/rosa.py": [
       {
         "hashed_secret": "6eae3a5b062c6d0d79f070c26e6d62486b40cb46",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 687,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/utility/storage_cluster_setup.py": [
       {
         "hashed_secret": "f0e2d8610edefa0c02b673dcac7964b02ce3e890",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 748,
         "type": "Basic Auth Credentials",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "terraform/ai/vsphere/terraform.tfvars.example": [
       {
         "hashed_secret": "42a818da3bb789755a56f06412ebba442bf41edf",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 12,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "tests/cross_functional/kcs/test_noobaadb_pw_reset.py": [
       {
         "hashed_secret": "95b0665e64fa24c375f1db3797739dc833a01be1",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 87,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "tests/functional/ui/test_alert_text.py": [
       {
         "hashed_secret": "deed437581abf6a8a8c3f908a00739ec66bd1907",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 26,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "d3c7cf8a52f042f5ad10e7e04c6efa9b3edfc091",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 27,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "0e47f8d47cf71626c411322d5cc46463bb9ee63a",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 28,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "def6a0eb64808cbdf3e3985b380d06019ccaf15c",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 29,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "1eb02d1de1c583c352016b765c4470f14688c27f",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 30,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "beb03c56370648a8018847b7eb6f0ff17e2ec17d",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 31,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "c8a3e4b73af4fc164a18209fa3248cace0376de6",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 32,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "3b793d3c8f6140791030db45900185a24bc0f8d6",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 33,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "5e10a523088617ee53c02a050ecb4f3c02ff36a6",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 34,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "67cec59154e2b4dbc161ab590ea9836833a03879",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 35,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "a7051bbf0cbb04fbd58fea9202861924cf476965",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 36,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "711167a9e39213a023177fb6f8726eed4ae87724",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 37,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "62f46554adcad52e1b59156746059e8fe2b68114",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 38,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "6b6660ec37abef577585e08fbadd66a1daa126ad",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 39,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "ba9fdcab8f3a1c05e545c90657adeeca92457819",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 40,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "d92508b7e8714361d780028189182ccc838905fd",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 41,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "5d831603558fae694509e52443867d9d0fe15dab",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 42,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "70444c50c0b30525a518f749e570c2b5ab2ea159",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 43,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "b3a6d9ed97f183a3ed70fe50f8f5a1ab84eccfb5",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 44,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "d94d7c9ec8c812df775f85cf53d44fe0dacb153c",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 45,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "7fbab5f66d94793e754adf5eec572dd69895add7",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 46,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "d5164d922808f83e1bb2fb7ef4ae43a8fdc2d63a",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 47,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "474e5f07c32a4837e6685a64fb86c3b80ed14ef5",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 48,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "aee98b1d4cdc9ea965426edfff3e89413d648f28",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 49,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "cb44fa15b838b5bd5bb7cf855c8b65b83575b049",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 50,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "bfcb7bd33a4d476579e23a6ab6bef8270fd359a6",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 51,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "9109e09e3881791c6e7245a3e4dc3e9dd23305ec",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 52,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "44ac318f0525c62193986773a822397d9cd65220",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 53,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "a34ddb5f6561f1c681ea9d6369f2bf5ea5435bbf",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 54,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "a0f8bc5793f4cc0b1173b8e65c824e80bba32ec3",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 55,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "11b02033ace8079c90a25fe5dfef319b19363e56",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 56,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "c3bce19887dde7c21edbcc997f70e2d9b67a7845",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 57,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "918b8462281c3884363c68bd466e90e34bcb7b4f",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 58,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "5d279aca1022ec52d2f595199e74490d75bf3940",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 59,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "a9c2f9fb9293eac7f7055dc5ad8510ed89446890",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 60,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "6828bcb400541dcb69f04098c046c36947a664be",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 61,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "a7f8c0d263a1263d2f858d388e0f6ed799c3ed85",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 62,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "e7aac35a54098dff672130afc60ba0395f339089",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 63,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "642e4f0372448c534f32262a96e7d9f2b27b47d2",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 64,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "3bdd128c4f1e6c4d3ade5eb86dcfecc387e13a38",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 65,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "8308b864c9c12f694be52639f16fc312929c268a",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 68,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "64d5413c9629cf6c976224d145450a839f213b96",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 69,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ]
   },

--- a/ocs_ci/helpers/cephfs_stress_helpers.py
+++ b/ocs_ci/helpers/cephfs_stress_helpers.py
@@ -1494,6 +1494,9 @@ def create_cephfs_subvolume_workloads(
         list[tuple]: One ``(project_obj, pvc_obj, pod_obj)`` tuple per
             workload, in creation order.
     """
+    if count < 1:
+        raise ValueError(f"count must be >= 1, got {count}")
+
     workloads = []
     for i in range(count):
         project_name = f"{project_name_prefix}-{i}"

--- a/ocs_ci/helpers/cephfs_stress_helpers.py
+++ b/ocs_ci/helpers/cephfs_stress_helpers.py
@@ -32,6 +32,7 @@ from ocs_ci.helpers.helpers import (
     validate_pod_oomkilled,
     get_mon_db_size_in_kb,
     create_pod,
+    create_project,
     create_pvc,
     wait_for_resource_state,
     get_current_test_name,
@@ -1403,3 +1404,107 @@ def verify_no_filesystem_hangs(stress_manager=None):
         raise Exception(error_msg)
     logger.info("No filesystem hangs detected")
     return True
+
+
+def create_cephfs_subvolume_workload(
+    teardown_project_factory=None,
+    project_name="cephfs-subvolume-metrics-test",
+    pvc_size="5Gi",
+    fio_size="5GB",
+    fio_rate="100m",
+    fio_runtime=360,
+):
+    """
+    Create a CephFS subvolume workload: namespace, PVC, pod, and running FIO.
+
+    Provisions a CephFS subvolume by creating a namespace and RWX PVC, then
+    starts FIO on a pod so that Prometheus scrapes non-zero subvolume metrics.
+
+    Args:
+        teardown_project_factory (callable, optional): Pytest fixture that
+            registers the project for deletion at test teardown. Pass the
+            ``teardown_project_factory`` fixture from the test function.
+        project_name (str): Name of the namespace/project to create.
+        pvc_size (str): PVC capacity (e.g. '5Gi').
+        fio_size (str): Total IO size for the FIO workload (e.g. '5GB').
+        fio_rate (str): FIO target rate (e.g. '100m' for 100 MB/s). A higher
+            rate makes the subvolume appear in the top-10 subvolume list.
+        fio_runtime (int): FIO ``--runtime`` in seconds. Must be long enough
+            to still be running when the UI is checked; default 360 s (6 min)
+            covers the typical setup + 2-min Prometheus wait + UI assertions.
+
+    Returns:
+        tuple: (project_obj, pvc_obj, pod_obj)
+    """
+    project_obj = create_project(project_name=project_name)
+    if teardown_project_factory:
+        teardown_project_factory(project_obj)
+
+    pvc_obj = create_pvc(
+        sc_name=constants.CEPHFILESYSTEM_SC,
+        namespace=project_obj.namespace,
+        size=pvc_size,
+        access_mode=constants.ACCESS_MODE_RWX,
+    )
+
+    pod_obj = create_pod(
+        pvc_name=pvc_obj.name,
+        namespace=project_obj.namespace,
+        interface_type=constants.CEPHFILESYSTEM,
+    )
+    wait_for_resource_state(pod_obj, state=STATUS_RUNNING, timeout=300)
+    pod_obj.run_io(
+        storage_type=constants.WORKLOAD_STORAGE_TYPE_FS,
+        size=fio_size,
+        rate=fio_rate,
+        runtime=fio_runtime,
+    )
+
+    return project_obj, pvc_obj, pod_obj
+
+
+def create_cephfs_subvolume_workloads(
+    count=3,
+    teardown_project_factory=None,
+    project_name_prefix="cephfs-subvolume-metrics-test",
+    pvc_size="5Gi",
+    fio_size="5GB",
+    fio_rate="100m",
+    fio_runtime=360,
+):
+    """
+    Create multiple CephFS subvolume workloads by calling
+    :func:`create_cephfs_subvolume_workload` ``count`` times.
+
+    Each workload gets its own namespace named
+    ``<project_name_prefix>-<index>`` (e.g.
+    ``cephfs-subvolume-metrics-test-0``).
+
+    Args:
+        count (int): Number of workloads (subvolumes) to create.
+        teardown_project_factory (callable, optional): Pytest fixture that
+            registers each project for deletion at test teardown.
+        project_name_prefix (str): Common prefix for namespace names.
+        pvc_size (str): PVC capacity for each workload (e.g. '5Gi').
+        fio_size (str): Total IO size per FIO workload (e.g. '5GB').
+        fio_rate (str): FIO target rate per workload (e.g. '100m').
+        fio_runtime (int): FIO ``--runtime`` in seconds (default 360).
+
+    Returns:
+        list[tuple]: One ``(project_obj, pvc_obj, pod_obj)`` tuple per
+            workload, in creation order.
+    """
+    workloads = []
+    for i in range(count):
+        project_name = f"{project_name_prefix}-{i}"
+        workloads.append(
+            create_cephfs_subvolume_workload(
+                teardown_project_factory=teardown_project_factory,
+                project_name=project_name,
+                pvc_size=pvc_size,
+                fio_size=fio_size,
+                fio_rate=fio_rate,
+                fio_runtime=fio_runtime,
+            )
+        )
+    return workloads

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -649,6 +649,8 @@ CEPHFS_SUBVOLUME_POPOVER_TEXT = (
     "Use subvolumes to find pods with poor performing workloads"
 )
 CEPHFS_SUBVOLUME_DEFAULT_METRIC = "Total IOPS"
+CEPHFS_SUBVOLUME_METRIC_LATENCY = "Total Latency"
+CEPHFS_SUBVOLUME_METRIC_THROUGHPUT = "Total Throughput"
 
 # hyperconverged defaults
 HYPERCONVERGED_NAMESPACE = "kubevirt-hyperconverged"

--- a/ocs_ci/ocs/ui/page_objects/cephfs_subvolume_metrics.py
+++ b/ocs_ci/ocs/ui/page_objects/cephfs_subvolume_metrics.py
@@ -147,8 +147,10 @@ class CephFSSubvolumeMetricsCard(BlockAndFile):
             str: e.g. '13 IOPS' (Total IOPS), '5 ms' (Total Latency),
                 '100 MBps' (Total Throughput; UI may auto-scale Bps/KBps/MBps/GBps).
         """
-        self.wait_for_element_to_be_present(self.first_row_value_loc, timeout=timeout)
-        return self.get_element_text(self.first_row_value_loc).strip()
+        metric = self.get_cephfs_subvolume_metric_toggle_text()
+        loc = format_locator(self.first_row_value_loc, metric)
+        self.wait_for_element_to_be_present(loc, timeout=timeout)
+        return self.get_element_text(loc).strip()
 
     def get_cephfs_subvolume_row_count(self, timeout=30):
         """
@@ -292,7 +294,8 @@ class CephFSSubvolumeMetricsCard(BlockAndFile):
         logger.info(
             "Reading metric value for namespace '%s' from subvolume table", namespace
         )
-        loc = format_locator(self.value_by_namespace_loc, namespace)
+        metric = self.get_cephfs_subvolume_metric_toggle_text()
+        loc = format_locator(self.value_by_namespace_loc, namespace, metric)
         self.wait_for_element_to_be_present(loc, timeout=timeout)
         return self.get_element_text(loc).strip()
 

--- a/ocs_ci/ocs/ui/page_objects/cephfs_subvolume_metrics.py
+++ b/ocs_ci/ocs/ui/page_objects/cephfs_subvolume_metrics.py
@@ -1,5 +1,8 @@
 import logging
+import re
 
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.exceptions import TimeoutExpiredError
 from ocs_ci.ocs.ui.helpers_ui import format_locator
 from ocs_ci.ocs.ui.page_objects.block_and_file import BlockAndFile
 from ocs_ci.utility.utils import TimeoutSampler
@@ -298,6 +301,56 @@ class CephFSSubvolumeMetricsCard(BlockAndFile):
         loc = format_locator(self.value_by_namespace_loc, namespace, metric)
         self.wait_for_element_to_be_present(loc, timeout=timeout)
         return self.get_element_text(loc).strip()
+
+    def wait_for_valid_metric_value_for_namespace(
+        self, namespace, metric, timeout=120, sleep=30
+    ):
+        """
+        Return True if a valid metric value for namespace is found.
+
+        The validation strategy depends on the metric:
+
+        * **Total Throughput**: FIO data writes bypass MDS and go directly to
+          OSD, so MDS-tracked throughput may legitimately be 0 Bps.  The value
+          is read once and considered valid if it is non-empty and contains a
+          Bps unit suffix (Bps / KBps / MBps / GBps).
+
+        * **Other metrics (IOPS, Latency)**: the ODF console refreshes
+          Prometheus-backed metrics every ~30 s, so a single read can
+          transiently return 0 between scrape windows even when FIO is active.
+          This method polls every `sleep` seconds for up to `timeout` seconds
+          until the numeric part of the value is > 0.
+
+        Args:
+            namespace (str): namespace whose metric value to check.
+            metric (str): active metric label (e.g.
+                ``constants.CEPHFS_SUBVOLUME_DEFAULT_METRIC``).
+            timeout (int): maximum seconds to poll for a non-zero value
+                (non-throughput metrics only; default 120).
+            sleep (int): seconds between polls
+                (non-throughput metrics only; default 30).
+
+        Returns:
+            bool: True if a valid value was found within the allowed time.
+        """
+        if metric == constants.CEPHFS_SUBVOLUME_METRIC_THROUGHPUT:
+            value = self.get_cephfs_subvolume_value_for_namespace(namespace)
+            return bool(value) and "Bps" in value
+        try:
+            for value in TimeoutSampler(
+                timeout=timeout,
+                sleep=sleep,
+                func=self.get_cephfs_subvolume_value_for_namespace,
+                namespace=namespace,
+            ):
+                if value:
+                    token = value.replace(",", "").split()[0]
+                    numeric = re.match(r"^\d+(?:\.\d+)?", token)
+                    if numeric and float(numeric.group(0)) > 0:
+                        return True
+        except TimeoutExpiredError:
+            pass
+        return False
 
     def verify_cephfs_subvolume_view_all_link_visible(self, timeout=10):
         """

--- a/ocs_ci/ocs/ui/page_objects/cephfs_subvolume_metrics.py
+++ b/ocs_ci/ocs/ui/page_objects/cephfs_subvolume_metrics.py
@@ -74,17 +74,25 @@ class CephFSSubvolumeMetricsCard(BlockAndFile):
         logger.info("Reading active metric from CephFS subvolume dropdown")
         return self.get_element_text(self.metric_toggle_loc).strip()
 
-    def switch_cephfs_subvolume_metric(self, metric_label):
+    def switch_cephfs_subvolume_metric(self, metric_label, timeout=15):
         """
-        Select a metric from the CephFS subvolume dropdown.
+        Select a metric from the CephFS subvolume dropdown and wait until
+        the toggle reflects the new selection before returning.
+
+        Waiting for the toggle text to update ensures the table has begun
+        re-rendering with the new metric data before callers read cell values.
 
         Args:
             metric_label (str): One of 'Total IOPS', 'Total Latency',
                 'Total Throughput'.
+            timeout (int): Maximum seconds to wait for the toggle to update.
         """
         logger.info("Switching CephFS subvolume metric to: %s", metric_label)
         self.do_click(self.metric_toggle_loc)
         self.do_click(format_locator(self.metric_option_loc, metric_label))
+        self.wait_until_expected_text_is_found(
+            self.metric_toggle_loc, metric_label, timeout=timeout
+        )
 
     def click_cephfs_subvolume_help_button(self):
         """Click the help (?) button next to the CephFS subvolume card title."""

--- a/ocs_ci/ocs/ui/page_objects/cephfs_subvolume_metrics.py
+++ b/ocs_ci/ocs/ui/page_objects/cephfs_subvolume_metrics.py
@@ -23,6 +23,26 @@ class CephFSSubvolumeMetricsCard(BlockAndFile):
         self.help_button_loc = self.validation_loc["cephfs_subvolume_help_button"]
         self.popover_body_loc = self.validation_loc["cephfs_subvolume_popover_body"]
         self.col_headers_loc = self.validation_loc["cephfs_subvolume_col_headers"]
+        self.first_row_value_loc = self.validation_loc[
+            "cephfs_subvolume_first_row_value"
+        ]
+        self.first_row_name_button_loc = self.validation_loc[
+            "cephfs_subvolume_first_row_name_button"
+        ]
+        self.name_popover_loc = self.validation_loc["cephfs_subvolume_name_popover"]
+        self.related_pods_header_loc = self.validation_loc[
+            "cephfs_subvolume_related_pods_header"
+        ]
+        self.related_pods_links_loc = self.validation_loc[
+            "cephfs_subvolume_related_pods_links"
+        ]
+        self.view_all_link_loc = self.validation_loc["cephfs_subvolume_view_all_link"]
+        self.row_by_namespace_loc = self.validation_loc[
+            "cephfs_subvolume_row_by_namespace"
+        ]
+        self.value_by_namespace_loc = self.validation_loc[
+            "cephfs_subvolume_value_by_namespace"
+        ]
 
     def navigate_to_cephfs_subvolume_section(self):
         """Scroll the Block and File tab to bring the CephFS subvolume card into view."""
@@ -104,6 +124,23 @@ class CephFSSubvolumeMetricsCard(BlockAndFile):
         headers = self.get_elements(self.col_headers_loc)
         return [h.text.strip() for h in headers]
 
+    def get_cephfs_subvolume_first_row_value(self, timeout=30):
+        """
+        Return the metric value cell text from the first table row.
+
+        Waits up to `timeout` seconds for the cell to be present after a
+        metric switch (the table re-renders on selection change).
+
+        Args:
+            timeout (int): Maximum seconds to wait for the value cell.
+
+        Returns:
+            str: e.g. '13 IOPS' (Total IOPS), '5 ms' (Total Latency),
+                '100 Mbps' (Total Throughput).
+        """
+        self.wait_for_element_to_be_present(self.first_row_value_loc, timeout=timeout)
+        return self.get_element_text(self.first_row_value_loc).strip()
+
     def get_cephfs_subvolume_row_count(self, timeout=30):
         """
         Return the number of rows currently displayed in the subvolume table.
@@ -121,3 +158,95 @@ class CephFSSubvolumeMetricsCard(BlockAndFile):
         rows = self.get_elements(self.table_rows_loc)
         logger.info("CephFS subvolume table row count: %d", len(rows))
         return len(rows)
+
+    def click_cephfs_subvolume_first_row_name(self):
+        """
+        Click the 'Show related pods' button in the Name cell of the first row.
+
+        The Name column renders a <button aria-label='Show related pods'> (not
+        an <a> tag). Clicking it opens the 'Related pods' popover.
+        """
+        logger.info("Clicking first-row name button to open Related pods popover")
+        self.do_click(self.first_row_name_button_loc)
+
+    def verify_cephfs_subvolume_related_pods_visible(self, timeout=10):
+        """
+        Verify the 'Related pods' header is present in the name popover.
+
+        Args:
+            timeout (int): Seconds to wait for the header element.
+
+        Returns:
+            bool: True if the <header> containing 'Related pods' is found.
+        """
+        self.wait_for_element_to_be_present(
+            self.related_pods_header_loc, timeout=timeout
+        )
+        return len(self.get_elements(self.related_pods_header_loc)) > 0
+
+    def get_cephfs_subvolume_related_pod_links(self):
+        """
+        Return the text of all pod links listed in the name popover.
+
+        Excludes the 'View all' link; pod links sit inside
+        c-popover__body > ul.c-list > li > span > a.
+
+        Returns:
+            list[str]: Pod link labels, e.g.
+                ['image-registry-55757b755-cfq71', 'image-registry-55757b755-q7g6c'].
+        """
+        links = self.get_elements(self.related_pods_links_loc)
+        return [link.text.strip() for link in links]
+
+    def verify_namespace_in_subvolume_table(self, namespace, timeout=60):
+        """
+        Verify a row with the given namespace is visible in the subvolume table.
+
+        Waits up to `timeout` seconds because a newly provisioned subvolume may
+        need one or two Prometheus scrape intervals (~30 s each) to appear.
+
+        Args:
+            namespace (str): Kubernetes namespace to look for, e.g.
+                'cephfs-subvolume-metrics-test'.
+            timeout (int): Maximum seconds to wait for the row to appear.
+
+        Returns:
+            bool: True if at least one row with that namespace is found.
+        """
+        logger.info(
+            "Waiting for namespace '%s' to appear in subvolume table", namespace
+        )
+        loc = format_locator(self.row_by_namespace_loc, namespace)
+        self.wait_for_element_to_be_present(loc, timeout=timeout)
+        return len(self.get_elements(loc)) > 0
+
+    def get_cephfs_subvolume_value_for_namespace(self, namespace, timeout=60):
+        """
+        Return the metric value cell text for the row matching the given namespace.
+
+        Args:
+            namespace (str): Kubernetes namespace of the target subvolume row.
+            timeout (int): Maximum seconds to wait for the value cell.
+
+        Returns:
+            str: e.g. '13 IOPS', '5 ms', '100 Mbps'.
+        """
+        logger.info(
+            "Reading metric value for namespace '%s' from subvolume table", namespace
+        )
+        loc = format_locator(self.value_by_namespace_loc, namespace)
+        self.wait_for_element_to_be_present(loc, timeout=timeout)
+        return self.get_element_text(loc).strip()
+
+    def verify_cephfs_subvolume_view_all_link_visible(self, timeout=10):
+        """
+        Verify the 'View all' link is present at the bottom of the name popover.
+
+        Args:
+            timeout (int): Seconds to wait for the link element.
+
+        Returns:
+            bool: True if the 'View all' <a> is found within timeout.
+        """
+        self.wait_for_element_to_be_present(self.view_all_link_loc, timeout=timeout)
+        return len(self.get_elements(self.view_all_link_loc)) > 0

--- a/ocs_ci/ocs/ui/page_objects/cephfs_subvolume_metrics.py
+++ b/ocs_ci/ocs/ui/page_objects/cephfs_subvolume_metrics.py
@@ -2,6 +2,7 @@ import logging
 
 from ocs_ci.ocs.ui.helpers_ui import format_locator
 from ocs_ci.ocs.ui.page_objects.block_and_file import BlockAndFile
+from ocs_ci.utility.utils import TimeoutSampler
 
 logger = logging.getLogger(__name__)
 
@@ -136,7 +137,7 @@ class CephFSSubvolumeMetricsCard(BlockAndFile):
 
         Returns:
             str: e.g. '13 IOPS' (Total IOPS), '5 ms' (Total Latency),
-                '100 Mbps' (Total Throughput).
+                '100 MBps' (Total Throughput; UI may auto-scale Bps/KBps/MBps/GBps).
         """
         self.wait_for_element_to_be_present(self.first_row_value_loc, timeout=timeout)
         return self.get_element_text(self.first_row_value_loc).strip()
@@ -220,6 +221,55 @@ class CephFSSubvolumeMetricsCard(BlockAndFile):
         self.wait_for_element_to_be_present(loc, timeout=timeout)
         return len(self.get_elements(loc)) > 0
 
+    def _all_namespaces_visible(self, namespaces):
+        """
+        Return True if every namespace in `namespaces` has at least one row
+        in the subvolume table, False otherwise.
+
+        Args:
+            namespaces (list[str]): Kubernetes namespaces to check.
+
+        Returns:
+            bool: True if all namespace rows are present.
+        """
+        return all(
+            bool(self.get_elements(format_locator(self.row_by_namespace_loc, ns)))
+            for ns in namespaces
+        )
+
+    def wait_for_namespaces_in_subvolume_table(self, namespaces, timeout=360, sleep=20):
+        """
+        Wait until every namespace in `namespaces` appears as a row in the
+        subvolume table.
+
+        Polls every `sleep` seconds for up to `timeout` seconds using
+        :class:`~ocs_ci.utility.utils.TimeoutSampler`.
+
+        Args:
+            namespaces (list[str]): Kubernetes namespaces to wait for.
+            timeout (int): Maximum seconds to wait (default 360).
+            sleep (int): Seconds between polls (default 20).
+
+        Raises:
+            TimeoutExpiredError: If any namespace is not visible within timeout.
+        """
+        logger.info(
+            "Waiting up to %ds for namespaces %s to appear in subvolume table",
+            timeout,
+            namespaces,
+        )
+        for sample in TimeoutSampler(
+            timeout=timeout,
+            sleep=sleep,
+            func=self._all_namespaces_visible,
+            namespaces=namespaces,
+        ):
+            if sample:
+                logger.info(
+                    "All %d namespaces visible in subvolume table", len(namespaces)
+                )
+                return
+
     def get_cephfs_subvolume_value_for_namespace(self, namespace, timeout=60):
         """
         Return the metric value cell text for the row matching the given namespace.
@@ -229,7 +279,7 @@ class CephFSSubvolumeMetricsCard(BlockAndFile):
             timeout (int): Maximum seconds to wait for the value cell.
 
         Returns:
-            str: e.g. '13 IOPS', '5 ms', '100 Mbps'.
+            str: e.g. '13 IOPS', '5 ms', '100 MBps' (auto-scaled Bps family).
         """
         logger.info(
             "Reading metric value for namespace '%s' from subvolume table", namespace

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -2598,6 +2598,66 @@ validation_4_22 = {
         "//table/thead/tr/th",
         By.XPATH,
     ),
+    "cephfs_subvolume_first_row_value": (
+        f"//div[contains(text(),'{constants.CEPHFS_SUBVOLUME_METRICS_CARD_TITLE}')]"
+        "/following::div[contains(@class,'odf-loading-box')]"
+        "//table/tbody/tr[1]/td[3]",
+        By.XPATH,
+    ),
+    # Name cell uses <button aria-label="Show related pods">, not an <a> tag.
+    # Clicking it opens the "Related pods" popover.
+    "cephfs_subvolume_first_row_name_button": (
+        f"//div[contains(text(),'{constants.CEPHFS_SUBVOLUME_METRICS_CARD_TITLE}')]"
+        "/following::div[contains(@class,'odf-loading-box')]"
+        "//table/tbody/tr[1]//button[@aria-label='Show related pods']",
+        By.XPATH,
+    ),
+    # "Related pods" popover: role=dialog without aria-label='Help'
+    # (the help popover carries aria-label='Help'; the name popover uses
+    # aria-labelledby instead, so the absence of aria-label distinguishes it).
+    "cephfs_subvolume_name_popover": (
+        "//div[contains(@class,'c-popover') and @role='dialog'"
+        " and not(@aria-label='Help')]",
+        By.XPATH,
+    ),
+    # <header class="pf-v6-c-popover__header"> inside the name popover;
+    # its text content is "Related pods".
+    "cephfs_subvolume_related_pods_header": (
+        "//div[contains(@class,'c-popover') and @role='dialog'"
+        " and not(@aria-label='Help')]"
+        "//header[contains(@class,'c-popover__header')]",
+        By.XPATH,
+    ),
+    # Pod <a> links inside pf-v6-c-popover__body > ul.c-list > li > span > a.
+    # Excludes the "View all" link which lives outside the <ul>.
+    "cephfs_subvolume_related_pods_links": (
+        "//div[contains(@class,'c-popover__body')]"
+        "//a[not(normalize-space(text())='View all')]",
+        By.XPATH,
+    ),
+    # "View all" <a> inside <div class="pf-v6-u-mt-sm"> at the popover bottom.
+    "cephfs_subvolume_view_all_link": (
+        "//div[contains(@class,'c-popover__body')]"
+        "//a[normalize-space(text())='View all']",
+        By.XPATH,
+    ),
+    # Table row whose Namespace cell matches the given namespace (format arg).
+    # The Namespace td carries data-label='Namespace' and contains an <a>.
+    "cephfs_subvolume_row_by_namespace": (
+        f"//div[contains(text(),'{constants.CEPHFS_SUBVOLUME_METRICS_CARD_TITLE}')]"
+        "/following::div[contains(@class,'odf-loading-box')]"
+        "//table/tbody/tr"
+        "[.//td[@data-label='Namespace']//a[normalize-space(text())='{0}']]",
+        By.XPATH,
+    ),
+    # Metric value cell (td[3]) in the row for the given namespace (format arg).
+    "cephfs_subvolume_value_by_namespace": (
+        f"//div[contains(text(),'{constants.CEPHFS_SUBVOLUME_METRICS_CARD_TITLE}')]"
+        "/following::div[contains(@class,'odf-loading-box')]"
+        "//table/tbody/tr"
+        "[.//td[@data-label='Namespace']//a[normalize-space(text())='{0}']]/td[3]",
+        By.XPATH,
+    ),
 }
 
 topology = {

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -2598,10 +2598,11 @@ validation_4_22 = {
         "//table/thead/tr/th",
         By.XPATH,
     ),
+    # {0} = active metric label, e.g. 'Total IOPS'
     "cephfs_subvolume_first_row_value": (
         f"//div[contains(text(),'{constants.CEPHFS_SUBVOLUME_METRICS_CARD_TITLE}')]"
         "/following::div[contains(@class,'odf-loading-box')]"
-        "//table/tbody/tr[1]/td[3]",
+        "//table/tbody/tr[1]/td[@data-label='{0}']",
         By.XPATH,
     ),
     # Name cell uses <button aria-label="Show related pods">, not an <a> tag.
@@ -2649,12 +2650,13 @@ validation_4_22 = {
         "[.//td[@data-label='Namespace']//a[normalize-space(text())='{0}']]",
         By.XPATH,
     ),
-    # Metric value cell (td[3]) in the row for the given namespace (format arg).
+    # {0} = namespace, {1} = active metric label, e.g. 'Total IOPS'
     "cephfs_subvolume_value_by_namespace": (
         f"//div[contains(text(),'{constants.CEPHFS_SUBVOLUME_METRICS_CARD_TITLE}')]"
         "/following::div[contains(@class,'odf-loading-box')]"
         "//table/tbody/tr"
-        "[.//td[@data-label='Namespace']//a[normalize-space(text())='{0}']]/td[3]",
+        "[.//td[@data-label='Namespace']//a[normalize-space(text())='{0}']]"
+        "/td[@data-label='{1}']",
         By.XPATH,
     ),
 }

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -2612,33 +2612,32 @@ validation_4_22 = {
         "//table/tbody/tr[1]//button[@aria-label='Show related pods']",
         By.XPATH,
     ),
-    # "Related pods" popover: role=dialog without aria-label='Help'
-    # (the help popover carries aria-label='Help'; the name popover uses
-    # aria-labelledby instead, so the absence of aria-label distinguishes it).
+    # "Related pods" popover: anchored by role=dialog + header text.
+    # The help popover carries aria-label='Help'; this one uses aria-labelledby.
     "cephfs_subvolume_name_popover": (
-        "//div[contains(@class,'c-popover') and @role='dialog'"
-        " and not(@aria-label='Help')]",
+        "//div[@role='dialog'" " and .//header[normalize-space(.)='Related pods']]",
         By.XPATH,
     ),
-    # <header class="pf-v6-c-popover__header"> inside the name popover;
-    # its text content is "Related pods".
+    # <header> inside the name popover; text content is "Related pods".
     "cephfs_subvolume_related_pods_header": (
-        "//div[contains(@class,'c-popover') and @role='dialog'"
-        " and not(@aria-label='Help')]"
-        "//header[contains(@class,'c-popover__header')]",
+        "//div[@role='dialog'"
+        " and .//header[normalize-space(.)='Related pods']]"
+        "//header[normalize-space(.)='Related pods']",
         By.XPATH,
     ),
-    # Pod <a> links inside pf-v6-c-popover__body > ul.c-list > li > span > a.
-    # Excludes the "View all" link which lives outside the <ul>.
+    # Pod <a> links inside the popover body ul > li > span > a.
+    # Scoped to the specific popover; excludes the "View all" link.
     "cephfs_subvolume_related_pods_links": (
-        "//div[contains(@class,'c-popover__body')]"
-        "//a[not(normalize-space(text())='View all')]",
+        "//div[@role='dialog'"
+        " and .//header[normalize-space(.)='Related pods']]"
+        "//a[normalize-space(.) and not(normalize-space(.)='View all')]",
         By.XPATH,
     ),
     # "View all" <a> inside <div class="pf-v6-u-mt-sm"> at the popover bottom.
     "cephfs_subvolume_view_all_link": (
-        "//div[contains(@class,'c-popover__body')]"
-        "//a[normalize-space(text())='View all']",
+        "//div[@role='dialog'"
+        " and .//header[normalize-space(.)='Related pods']]"
+        "//a[normalize-space(.)='View all']",
         By.XPATH,
     ),
     # Table row whose Namespace cell matches the given namespace (format arg).

--- a/tests/functional/ui/test_cephfs_subvolume_metrics.py
+++ b/tests/functional/ui/test_cephfs_subvolume_metrics.py
@@ -5,7 +5,6 @@ Requires ODF 4.22+ (Ceph 9.0) for subvolume-level MDS metrics.
 """
 
 import logging
-import re
 
 from ocs_ci.framework.testlib import (
     ManageTest,
@@ -163,7 +162,8 @@ class TestCephFSSubvolumeMetricsLoadWithActiveWorkload(ManageTest):
         5. Switch to 'Total IOPS': verify column header and that all 3 test
            namespaces appear with non-zero values.
         6. Switch to 'Total Latency': verify column header and non-zero
-           values for all 3 test namespace rows.
+           values for all 3 test namespace rows (polls up to 2 minutes
+           to tolerate transient zero readings between Prometheus scrapes).
         7. Switch to 'Total Throughput': verify column header and that
            values carry a Bps unit suffix (Bps/KBps/MBps/GBps).
         """
@@ -189,9 +189,6 @@ class TestCephFSSubvolumeMetricsLoadWithActiveWorkload(ManageTest):
         logger.test_step("Wait until subvolume rows are visible (max 6 minutes)")
         subvolume_metrics_card.wait_for_namespaces_in_subvolume_table(namespaces)
 
-        is_throughput_metric = {
-            constants.CEPHFS_SUBVOLUME_METRIC_THROUGHPUT,
-        }
         for metric in [
             constants.CEPHFS_SUBVOLUME_DEFAULT_METRIC,
             constants.CEPHFS_SUBVOLUME_METRIC_LATENCY,
@@ -213,33 +210,16 @@ class TestCephFSSubvolumeMetricsLoadWithActiveWorkload(ManageTest):
                     f"Namespace '{namespace}' not found in subvolume table "
                     f"for metric '{metric}'"
                 )
+                assert subvolume_metrics_card.wait_for_valid_metric_value_for_namespace(
+                    namespace, metric
+                ), (
+                    f"Metric '{metric}' did not show a valid value "
+                    f"for namespace '{namespace}'"
+                )
                 value = subvolume_metrics_card.get_cephfs_subvolume_value_for_namespace(
                     namespace
                 )
                 logger.info("Metric '%s', namespace '%s': %s", metric, namespace, value)
-                assert value, (
-                    f"Metric value is empty for namespace '{namespace}', "
-                    f"metric '{metric}'"
-                )
-                if metric in is_throughput_metric:
-                    # FIO data writes bypass MDS and go directly to OSD, so
-                    # MDS-tracked throughput may legitimately be 0 Bps.
-                    # Verify format only (value carries a Bps unit suffix).
-                    assert "Bps" in value, (
-                        f"Throughput value '{value}' for namespace "
-                        f"'{namespace}' missing Bps unit suffix"
-                    )
-                else:
-                    # Strip commas and take the first whitespace-delimited
-                    # token, then extract the leading number via regex so
-                    # values like "1.5KBps" (no space before unit) don't
-                    # cause float() to raise ValueError.
-                    token = value.replace(",", "").split()[0]
-                    numeric = re.match(r"^\d+(?:\.\d+)?", token)
-                    assert numeric and float(numeric.group(0)) > 0, (
-                        f"Metric '{metric}' is zero for namespace "
-                        f"'{namespace}': '{value}'"
-                    )
 
 
 @green_squad

--- a/tests/functional/ui/test_cephfs_subvolume_metrics.py
+++ b/tests/functional/ui/test_cephfs_subvolume_metrics.py
@@ -43,9 +43,9 @@ class TestCephFSSubvolumeMetricsSectionReachable(ManageTest):
     Testcase: Metrics presence and correctness - Subvolume metrics section reachable
     """
 
-    @polarion_id("OCS-8010")
     @tier1
     @ui
+    @polarion_id("OCS-8010")
     def test_cephfs_subvolume_metrics_section_reachable(self, setup_ui_class):
         """
         Navigate to Storage Cluster > Block and File, scroll to the CephFS
@@ -139,6 +139,7 @@ class TestCephFSSubvolumeMetricsLoadWithActiveWorkload(ManageTest):
 
     @tier2
     @ui
+    @polarion_id("OCS-8023")
     def test_cephfs_subvolume_metrics_load_with_active_workload(
         self, setup_ui_class, teardown_project_factory
     ):
@@ -234,6 +235,7 @@ class TestCephFSSubvolumeMetricUnitsAndLabels(ManageTest):
 
     @tier2
     @ui
+    @polarion_id("OCS-8025")
     def test_cephfs_subvolume_metric_units_and_labels(self, setup_ui_class):
         """
         Switch through all three metric options and confirm column headers

--- a/tests/functional/ui/test_cephfs_subvolume_metrics.py
+++ b/tests/functional/ui/test_cephfs_subvolume_metrics.py
@@ -5,14 +5,17 @@ Requires ODF 4.22+ (Ceph 9.0) for subvolume-level MDS metrics.
 """
 
 import logging
+import time
 
 from ocs_ci.framework.testlib import (
     ManageTest,
     polarion_id,
     skipif_ocs_version,
     tier1,
+    tier2,
     ui,
 )
+from ocs_ci.helpers.cephfs_stress_helpers import create_cephfs_subvolume_workloads
 from ocs_ci.framework.pytest_customization.marks import (
     green_squad,
     skipif_external_mode,
@@ -119,3 +122,173 @@ class TestCephFSSubvolumeMetricsSectionReachable(ManageTest):
         assert (
             row_count > 0
         ), "CephFS subvolume table has no rows; expected at least one subvolume"
+
+
+@green_squad
+@skipif_ocs_version("<4.22")
+@skipif_mcg_only
+@skipif_external_mode
+class TestCephFSSubvolumeMetricsLoadWithActiveWorkload(ManageTest):
+    """
+    TC2 — Verify CephFS subvolume metrics populate with non-zero values
+    when a CephFS workload is active.
+
+    Testcase: Metrics presence and correctness - Metrics Load with Active
+    CephFS Workloads
+    """
+
+    @tier2
+    @ui
+    def test_cephfs_subvolume_metrics_load_with_active_workload(
+        self, setup_ui_class, teardown_project_factory
+    ):
+        """
+        Create a CephFS PVC with an IO-generating pod, wait for Prometheus
+        to scrape subvolume metrics, then verify the metrics card shows the
+        test namespace row with non-zero values for all three metric types.
+
+        Steps:
+        1. Create 3 test namespaces, each with a CephFS PVC and FIO running
+           at 100 MB/s so all 3 subvolumes appear in the top-10 list.
+        2. Wait 2 minutes for Prometheus to scrape subvolume metrics.
+        3. Navigate to Storage Cluster > Block and File tab.
+        4. Verify the subvolume card is visible.
+        5. Switch to 'Total IOPS': verify column header and that all 3 test
+           namespaces appear with non-zero values.
+        6. Switch to 'Total Latency': verify column header and non-zero
+           values for all 3 test namespace rows.
+        7. Switch to 'Total Throughput': verify column header and non-zero
+           values for all 3 test namespace rows.
+        """
+        logger.test_step(
+            "Create 3 CephFS subvolume workloads (namespace + PVC + FIO each)"
+        )
+        workloads = create_cephfs_subvolume_workloads(
+            count=3, teardown_project_factory=teardown_project_factory
+        )
+        namespaces = [project_obj.namespace for project_obj, _, _ in workloads]
+
+        # MDS scrape interval is ~30 s; 2 min ensures at least 3 scrapes.
+        logger.test_step("Wait 2 minutes for Prometheus to scrape subvolume metrics")
+        time.sleep(120)
+
+        logger.test_step("Navigate to Storage Cluster > Block and File tab")
+        storage_cluster_page = PageNavigator().nav_storage_cluster_default_page()
+        storage_cluster_page.validate_block_and_file_tab_active()
+
+        subvolume_metrics_card = CephFSSubvolumeMetricsCard()
+
+        logger.test_step("Verify CephFS subvolume metrics card is visible")
+        assert (
+            subvolume_metrics_card.verify_cephfs_subvolume_section_visible()
+        ), "CephFS subvolume metrics card not visible after IO workload"
+
+        for metric in [
+            constants.CEPHFS_SUBVOLUME_DEFAULT_METRIC,
+            constants.CEPHFS_SUBVOLUME_METRIC_LATENCY,
+            constants.CEPHFS_SUBVOLUME_METRIC_THROUGHPUT,
+        ]:
+            logger.test_step(
+                f"Switch to '{metric}' and verify all 3 test namespace "
+                "rows are present with non-zero values"
+            )
+            subvolume_metrics_card.switch_cephfs_subvolume_metric(metric)
+            col_headers = subvolume_metrics_card.get_cephfs_subvolume_column_headers()
+            assert col_headers[-1] == metric, (
+                f"Column header after switching to '{metric}' is "
+                f"'{col_headers[-1]}'"
+            )
+            for namespace in namespaces:
+                assert subvolume_metrics_card.verify_namespace_in_subvolume_table(
+                    namespace
+                ), (
+                    f"Namespace '{namespace}' not found in subvolume table "
+                    f"for metric '{metric}'"
+                )
+                value = subvolume_metrics_card.get_cephfs_subvolume_value_for_namespace(
+                    namespace
+                )
+                logger.info("Metric '%s', namespace '%s': %s", metric, namespace, value)
+                assert value, (
+                    f"Metric value is empty for namespace '{namespace}', "
+                    f"metric '{metric}'"
+                )
+                numeric = value.replace(",", "").split()[0]
+                assert float(numeric) > 0, (
+                    f"Metric '{metric}' is zero for namespace "
+                    f"'{namespace}': '{value}'"
+                )
+
+
+@green_squad
+@skipif_ocs_version("<4.22")
+@skipif_mcg_only
+@skipif_external_mode
+class TestCephFSSubvolumeMetricUnitsAndLabels(ManageTest):
+    """
+    TC3 — Verify the CephFS subvolume metrics card uses human-friendly
+    labels and correct unit suffixes for each metric type.
+
+    Testcase: Metrics presence and correctness - Metric Units and Labels
+    """
+
+    @tier2
+    @ui
+    def test_cephfs_subvolume_metric_units_and_labels(self, setup_ui_class):
+        """
+        Switch through all three metric options and confirm column headers
+        use human-friendly labels and displayed values carry the expected
+        unit suffix per the design specification (no raw Prometheus names).
+
+        Steps:
+        1. Navigate to Storage Cluster > Block and File tab.
+        2. Switch to 'Total IOPS': verify column header and that the value
+           carries the 'IOPS' unit suffix.
+        3. Switch to 'Total Latency': verify column header and that the
+           value contains 'ms'.
+        4. Switch to 'Total Throughput': verify column header and that the
+           value contains 'Bps' (the console auto-scales: Bps / KBps /
+           MBps / GBps depending on the current throughput level).
+        """
+        logger.test_step("Navigate to Storage Cluster > Block and File tab")
+        storage_cluster_page = PageNavigator().nav_storage_cluster_default_page()
+        storage_cluster_page.validate_block_and_file_tab_active()
+
+        subvolume_metrics_card = CephFSSubvolumeMetricsCard()
+        subvolume_metrics_card.navigate_to_cephfs_subvolume_section()
+
+        metrics_and_units = [
+            (constants.CEPHFS_SUBVOLUME_DEFAULT_METRIC, "IOPS"),
+            (constants.CEPHFS_SUBVOLUME_METRIC_LATENCY, "ms"),
+            # "Bps" appears in all console-scaled variants: Bps, KBps, MBps, GBps.
+            (constants.CEPHFS_SUBVOLUME_METRIC_THROUGHPUT, "Bps"),
+        ]
+        for metric, expected_unit in metrics_and_units:
+            logger.test_step(f"Switch to '{metric}' and verify label and unit format")
+            subvolume_metrics_card.switch_cephfs_subvolume_metric(metric)
+            col_headers = subvolume_metrics_card.get_cephfs_subvolume_column_headers()
+            assert (
+                col_headers[-1] == metric
+            ), f"Expected column header '{metric}', got '{col_headers[-1]}'"
+
+            row_count = subvolume_metrics_card.get_cephfs_subvolume_row_count(
+                timeout=10
+            )
+            if row_count == 0:
+                logger.warning(
+                    "No rows for metric '%s'; skipping value format check",
+                    metric,
+                )
+                continue
+
+            first_value = subvolume_metrics_card.get_cephfs_subvolume_first_row_value()
+            logger.info(
+                "Metric '%s': column='%s', sample value='%s'",
+                metric,
+                col_headers[-1],
+                first_value,
+            )
+            assert expected_unit in first_value, (
+                f"Expected unit '{expected_unit}' in value "
+                f"'{first_value}' for metric '{metric}'"
+            )

--- a/tests/functional/ui/test_cephfs_subvolume_metrics.py
+++ b/tests/functional/ui/test_cephfs_subvolume_metrics.py
@@ -5,6 +5,7 @@ Requires ODF 4.22+ (Ceph 9.0) for subvolume-level MDS metrics.
 """
 
 import logging
+import re
 
 from ocs_ci.framework.testlib import (
     ManageTest,
@@ -229,8 +230,13 @@ class TestCephFSSubvolumeMetricsLoadWithActiveWorkload(ManageTest):
                         f"'{namespace}' missing Bps unit suffix"
                     )
                 else:
-                    numeric = value.replace(",", "").split()[0]
-                    assert float(numeric) > 0, (
+                    # Strip commas and take the first whitespace-delimited
+                    # token, then extract the leading number via regex so
+                    # values like "1.5KBps" (no space before unit) don't
+                    # cause float() to raise ValueError.
+                    token = value.replace(",", "").split()[0]
+                    numeric = re.match(r"^\d+(?:\.\d+)?", token)
+                    assert numeric and float(numeric.group(0)) > 0, (
                         f"Metric '{metric}' is zero for namespace "
                         f"'{namespace}': '{value}'"
                     )

--- a/tests/functional/ui/test_cephfs_subvolume_metrics.py
+++ b/tests/functional/ui/test_cephfs_subvolume_metrics.py
@@ -5,7 +5,6 @@ Requires ODF 4.22+ (Ceph 9.0) for subvolume-level MDS metrics.
 """
 
 import logging
-import time
 
 from ocs_ci.framework.testlib import (
     ManageTest,
@@ -146,20 +145,26 @@ class TestCephFSSubvolumeMetricsLoadWithActiveWorkload(ManageTest):
         """
         Create a CephFS PVC with an IO-generating pod, wait for Prometheus
         to scrape subvolume metrics, then verify the metrics card shows the
-        test namespace row with non-zero values for all three metric types.
+        test namespace row with values for all three metric types.
+
+        Note: 'Total Throughput' tracks MDS-level byte flow. FIO data writes
+        bypass MDS and go directly to OSD, so throughput may legitimately
+        read 0 Bps with an FIO workload. For Throughput the test verifies
+        the value is correctly formatted (has a Bps unit suffix) rather than
+        asserting > 0.
 
         Steps:
         1. Create 3 test namespaces, each with a CephFS PVC and FIO running
            at 100 MB/s so all 3 subvolumes appear in the top-10 list.
-        2. Wait 2 minutes for Prometheus to scrape subvolume metrics.
-        3. Navigate to Storage Cluster > Block and File tab.
+        2. Navigate to Storage Cluster > Block and File tab.
+        3. Poll until all 3 test namespace rows appear (max 6 minutes).
         4. Verify the subvolume card is visible.
         5. Switch to 'Total IOPS': verify column header and that all 3 test
            namespaces appear with non-zero values.
         6. Switch to 'Total Latency': verify column header and non-zero
            values for all 3 test namespace rows.
-        7. Switch to 'Total Throughput': verify column header and non-zero
-           values for all 3 test namespace rows.
+        7. Switch to 'Total Throughput': verify column header and that
+           values carry a Bps unit suffix (Bps/KBps/MBps/GBps).
         """
         logger.test_step(
             "Create 3 CephFS subvolume workloads (namespace + PVC + FIO each)"
@@ -168,10 +173,6 @@ class TestCephFSSubvolumeMetricsLoadWithActiveWorkload(ManageTest):
             count=3, teardown_project_factory=teardown_project_factory
         )
         namespaces = [project_obj.namespace for project_obj, _, _ in workloads]
-
-        # MDS scrape interval is ~30 s; 2 min ensures at least 3 scrapes.
-        logger.test_step("Wait 2 minutes for Prometheus to scrape subvolume metrics")
-        time.sleep(120)
 
         logger.test_step("Navigate to Storage Cluster > Block and File tab")
         storage_cluster_page = PageNavigator().nav_storage_cluster_default_page()
@@ -184,14 +185,19 @@ class TestCephFSSubvolumeMetricsLoadWithActiveWorkload(ManageTest):
             subvolume_metrics_card.verify_cephfs_subvolume_section_visible()
         ), "CephFS subvolume metrics card not visible after IO workload"
 
+        logger.test_step("Wait until subvolume rows are visible (max 6 minutes)")
+        subvolume_metrics_card.wait_for_namespaces_in_subvolume_table(namespaces)
+
+        is_throughput_metric = {
+            constants.CEPHFS_SUBVOLUME_METRIC_THROUGHPUT,
+        }
         for metric in [
             constants.CEPHFS_SUBVOLUME_DEFAULT_METRIC,
             constants.CEPHFS_SUBVOLUME_METRIC_LATENCY,
             constants.CEPHFS_SUBVOLUME_METRIC_THROUGHPUT,
         ]:
             logger.test_step(
-                f"Switch to '{metric}' and verify all 3 test namespace "
-                "rows are present with non-zero values"
+                f"Switch to '{metric}' and verify all 3 test namespace rows"
             )
             subvolume_metrics_card.switch_cephfs_subvolume_metric(metric)
             col_headers = subvolume_metrics_card.get_cephfs_subvolume_column_headers()
@@ -214,11 +220,20 @@ class TestCephFSSubvolumeMetricsLoadWithActiveWorkload(ManageTest):
                     f"Metric value is empty for namespace '{namespace}', "
                     f"metric '{metric}'"
                 )
-                numeric = value.replace(",", "").split()[0]
-                assert float(numeric) > 0, (
-                    f"Metric '{metric}' is zero for namespace "
-                    f"'{namespace}': '{value}'"
-                )
+                if metric in is_throughput_metric:
+                    # FIO data writes bypass MDS and go directly to OSD, so
+                    # MDS-tracked throughput may legitimately be 0 Bps.
+                    # Verify format only (value carries a Bps unit suffix).
+                    assert "Bps" in value, (
+                        f"Throughput value '{value}' for namespace "
+                        f"'{namespace}' missing Bps unit suffix"
+                    )
+                else:
+                    numeric = value.replace(",", "").split()[0]
+                    assert float(numeric) > 0, (
+                        f"Metric '{metric}' is zero for namespace "
+                        f"'{namespace}': '{value}'"
+                    )
 
 
 @green_squad
@@ -274,14 +289,12 @@ class TestCephFSSubvolumeMetricUnitsAndLabels(ManageTest):
             ), f"Expected column header '{metric}', got '{col_headers[-1]}'"
 
             row_count = subvolume_metrics_card.get_cephfs_subvolume_row_count(
-                timeout=10
+                timeout=30
             )
-            if row_count == 0:
-                logger.warning(
-                    "No rows for metric '%s'; skipping value format check",
-                    metric,
-                )
-                continue
+            assert row_count > 0, (
+                f"No rows available for metric '{metric}';"
+                " cannot validate unit suffix"
+            )
 
             first_value = subvolume_metrics_card.get_cephfs_subvolume_first_row_value()
             logger.info(


### PR DESCRIPTION
## Summary
  
  - **TC2** (`TestCephFSSubvolumeMetricsLoadWithActiveWorkload`): creates 3
    CephFS workloads at 100 MB/s and asserts each test namespace appears by
    name in the "Current top 10 subvolumes" table with non-zero values for
    all three metric types (IOPS, Latency, Throughput)
  - **TC3** (`TestCephFSSubvolumeMetricUnitsAndLabels`): verifies unit
    suffixes match the live UI — `'IOPS'` for Total IOPS, `'ms'` for Total
    Latency, `'Bps'` for Total Throughput (console auto-scales: Bps/KBps/
    MBps/GBps)
  - Adds `create_cephfs_subvolume_workload` / `create_cephfs_subvolume_workloads`
    helpers to `cephfs_stress_helpers.py`
  - Adds namespace-scoped table locators and name-click popover locators to
    `views.py` and `cephfs_subvolume_metrics.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded CephFS subvolume metrics UI to support additional metric labels for **“Total Latency”** and **“Total Throughput.”**
  * Enhanced metrics card interactions, including reliable first-row value reads and richer **Related pods** popover details (including pod links and “View all”), plus namespace-specific row/value checks.
* **Tests**
  * Added tier2 functional UI coverage for CephFS subvolume metrics with active workloads, validating metric mode switching and that values are present and sensible by unit (IOPS, ms, Bps).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->