### PR TITLE
[release-4.19] Fix s3_copy_object for when metadata is not provided

### DIFF
--- a/ocs_ci/ocs/bucket_utils.py
+++ b/ocs_ci/ocs/bucket_utils.py
@@ -1814,7 +1814,7 @@ def compare_directory(
     return all(comparisons)
 
 
-def s3_copy_object(s3_obj, bucketname, source, object_key, metadata=""):
+def s3_copy_object(s3_obj, bucketname, source, object_key, metadata=None):
     """
     Boto3 client based copy object
 
@@ -1823,11 +1823,15 @@ def s3_copy_object(s3_obj, bucketname, source, object_key, metadata=""):
         bucketname (str): Name of the bucket
         source (str): Source object key. eg: '<bucket>/<key>
         object_key (str): Unique object Identifier for copied object
+        metadata (dict): Metadata to be updated with the object
 
     Returns:
         dict : Copy object response
 
     """
+    # default to None; metadata={} in the signature would be shared across calls
+    metadata = {} if metadata is None else metadata
+
     return s3_obj.s3_client.copy_object(
         Bucket=bucketname, CopySource=source, Key=object_key, Metadata=metadata
     )


### PR DESCRIPTION
Cherry-pick of #12902 to release-4.19.

Fixes https://github.com/red-hat-storage/ocs-ci/issues/15043
  
The `metadata` parameter in `s3_copy_object` defaulted to `""` (empty string), but botocore's `copy_object` expects a `dict` for the `Metadata` kwarg. When tests call `s3_copy_object` without metadata, it fails with `ParamValidationError`. Fix changes the default to `None` and converts to `{}` before the API call.
