### PR TITLE
Adding OCP 4.23 config files

### DIFF
--- a/ocs_ci/framework/conf/ocp_version/ocp-4.23-config.yaml
+++ b/ocs_ci/framework/conf/ocp_version/ocp-4.23-config.yaml
@@ -1,0 +1,26 @@
+---
+# Config file for nightly OCP 4.23
+RUN:
+  client_version: "4.23.0-0.nightly"
+DEPLOYMENT:
+  installer_version: "4.23.0-0.nightly"
+  terraform_version: "1.0.11"
+  # ignition_version can be found here
+  # https://docs.openshift.com/container-platform/4.7/post_installation_configuration/machine-configuration-tasks.html#machine-config-overview-post-install-machine-configuration-tasks
+  ignition_version: "3.2.0" # TODO: We might want to update to 3.5 or later: https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/release_notes/ocp-4-19-release-notes
+ENV_DATA:
+  # Dictionary of available RHCOS templates by major version
+  # To use RHCOS 10, set rhcos_version: "10" in your custom config
+  vm_templates:
+    "9": "rhcos-9.8.20260428-0-vmware.x86_64"
+    "10": "rhcos-10.2.20260423-0-vmware.x86_64"
+  # Legacy single template (fallback if vm_templates not defined)
+  vm_template: "rhcos-10.2.20260423-0-vmware.x86_64"
+  rhcos_version: "10"
+  acm_hub_channel: "release-2.17"
+  acm_version: "2.17"
+  mce_version: "2.17"
+  submariner_version: "0.23.1"
+  submariner_image: "quay.io/redhat-user-workloads/submariner-tenant/submariner-fbc-4-21@sha256:1585a2a6c372f8a66b7644e742d95356b577072dfc83492c14759f6b2372b609"
+  # Below values needs to be changed when acm and submariner are GAed
+  oadp_version: "1.6"

--- a/ocs_ci/framework/conf/ocp_version/ocp-4.23-upgrade.yaml
+++ b/ocs_ci/framework/conf/ocp_version/ocp-4.23-upgrade.yaml
@@ -1,0 +1,6 @@
+---
+# Use this config for upgrading of OCP 4.22 to 4.23 cluster
+UPGRADE:
+  ocp_upgrade_version: "4.23.0-0.nightly"
+  ocp_upgrade_path: "registry.ci.openshift.org/ocp/release"
+  ocp_channel: "stable-4.23"

--- a/ocs_ci/framework/conf/ocp_version/ocp-5.0-upgrade.yaml
+++ b/ocs_ci/framework/conf/ocp_version/ocp-5.0-upgrade.yaml
@@ -1,0 +1,6 @@
+---
+# Use this config for upgrading of OCP 4.22/4.23 to 5.0 cluster
+UPGRADE:
+  ocp_upgrade_version: "5.0.0-0.nightly"
+  ocp_upgrade_path: "registry.ci.openshift.org/ocp/release"
+  ocp_channel: "stable-5.0"


### PR DESCRIPTION
Signed-off-by: vavuthu [vavuthu@redhat.com](mailto:vavuthu@redhat.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support configuration for OpenShift 4.23 nightly environments, including client/installer versions, ignition and component/image pinning, and RHCOS VM template images (with legacy fallback).
  * Added upgrade configuration to move clusters from OpenShift 4.22 to 4.23 using the stable 4.23 channel.
  * Added upgrade configuration to move supported clusters to OpenShift 5.0 using the stable 5.0 channel.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->