### PR TITLE
Fix CephCrashMonitor join() failure on Python 3.11+

### DIFF
--- a/ocs_ci/resiliency/resiliency_tools.py
+++ b/ocs_ci/resiliency/resiliency_tools.py
@@ -252,7 +252,8 @@ class CephCrashMonitor(threading.Thread):
         super().__init__(daemon=True, name="ceph-crash-monitor")
         self.interval = interval
         self.context = context
-        self._stop = threading.Event()
+        # Avoid ``_stop`` — it shadows Thread._stop and breaks join() on Python 3.11+.
+        self._stop_event = threading.Event()
         self.crash_error = None
 
     def run(self):
@@ -285,12 +286,12 @@ class CephCrashMonitor(threading.Thread):
 
         if not _check_once():
             return
-        while not self._stop.wait(self.interval):
+        while not self._stop_event.wait(self.interval):
             if not _check_once():
                 break
 
     def stop(self):
-        self._stop.set()
+        self._stop_event.set()
 
     def raise_if_crash_detected(self):
         """Re-raise any crash detected by the background thread."""


### PR DESCRIPTION
Rename _stop to _stop_event in CephCrashMonitor so the shutdown event does not shadow threading.Thread._stop, which caused TypeError during monitor.join() in resiliency test teardown.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved crash monitoring shutdown so background checks stop cleanly and reliably.
  * Reduced the chance of hangs or errors when stopping resilience-related monitoring tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->