### PR TITLE
Removed HPCS condition since we are not using it

### DIFF
--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -887,6 +887,12 @@ vault_kms_deployment_required = pytest.mark.skipif(
     reason="This test requires both Vault or HPCS KMS deployment to be enabled and a valid KMS provider.",
 )
 
+vault_only_kms_deployment_required = pytest.mark.skipif(
+    not config.DEPLOYMENT.get("kms_deployment", False)
+    or config.ENV_DATA.get("KMS_PROVIDER", "") != VAULT_KMS_PROVIDER,
+    reason="This test requires Vault KMS deployment to be enabled with a valid Vault provider.",
+)
+
 ui = compose(skipif_ibm_cloud_managed, pytest.mark.ui)
 
 skipif_lean_deployment = pytest.mark.skipif(

--- a/tests/functional/encryption/test_encryption_keyrotation.py
+++ b/tests/functional/encryption/test_encryption_keyrotation.py
@@ -11,6 +11,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_kms_deployment,
     skipif_external_mode,
     vault_kms_deployment_required,
+    vault_only_kms_deployment_required,
 )
 from ocs_ci.framework.testlib import skipif_disconnected_cluster
 from ocs_ci.helpers.keyrotation_helper import (
@@ -285,7 +286,7 @@ class TestEncryptionKeyrotation:
 @green_squad
 @tier1
 @encryption_at_rest_required
-@vault_kms_deployment_required
+@vault_only_kms_deployment_required
 @skipif_external_mode
 @skipif_disconnected_cluster
 class TestOSDKeyrotationWithKMS:

--- a/tests/functional/pv/pv_encryption/test_pv_keyrotation.py
+++ b/tests/functional/pv/pv_encryption/test_pv_keyrotation.py
@@ -12,7 +12,6 @@ from ocs_ci.framework.testlib import (
     skipif_hci_provider_and_client,
     skipif_disconnected_cluster,
     skipif_proxy_cluster,
-    config,
     vault_kms_deployment_required,
 )
 from ocs_ci.ocs import constants
@@ -21,46 +20,17 @@ from ocs_ci.helpers.keyrotation_helper import PVKeyrotation
 
 log = logging.getLogger(__name__)
 
-# Set the arg values based on KMS provider.
-if config.ENV_DATA["KMS_PROVIDER"].lower() == constants.HPCS_KMS_PROVIDER:
-    kmsprovider = constants.HPCS_KMS_PROVIDER
-    argnames = ["kv_version", "kms_provider"]
-    argvalues = [
-        pytest.param("v1", kmsprovider),
-    ]
-else:
-    kmsprovider = constants.VAULT_KMS_PROVIDER
-    argnames = ["kv_version", "kms_provider", "use_vault_namespace"]
-    if config.ENV_DATA.get("vault_hcp"):
-        argvalues = [
-            pytest.param(
-                "v1",
-                kmsprovider,
-                True,
-                marks=[tier2, pytest.mark.polarion_id("OCS-6179")],
-            ),
-            pytest.param(
-                "v2",
-                kmsprovider,
-                True,
-                marks=[tier1, pytest.mark.polarion_id("OCS-6180")],
-            ),
-        ]
-    else:
-        argvalues = [
-            pytest.param(
-                "v1",
-                kmsprovider,
-                False,
-                marks=[tier2, pytest.mark.polarion_id("OCS-6181")],
-            ),
-            pytest.param(
-                "v2",
-                kmsprovider,
-                False,
-                marks=[tier1, pytest.mark.polarion_id("OCS-6182")],
-            ),
-        ]
+argnames = ["kv_version"]
+argvalues = [
+    pytest.param(
+        "v1",
+        marks=[tier2, pytest.mark.polarion_id("OCS-6181")],
+    ),
+    pytest.param(
+        "v2",
+        marks=[tier1, pytest.mark.polarion_id("OCS-6182")],
+    ),
+]
 
 
 @green_squad
@@ -81,7 +51,6 @@ class TestPVKeyRotationWithVaultKMS(ManageTest):
     def setup(
         self,
         kv_version,
-        use_vault_namespace,
         pv_encryption_kms_setup_factory,
     ):
         """
@@ -89,7 +58,7 @@ class TestPVKeyRotationWithVaultKMS(ManageTest):
 
         """
         log.info("Setting up csi-kms-connection-details configmap")
-        self.kms = pv_encryption_kms_setup_factory(kv_version, use_vault_namespace)
+        self.kms = pv_encryption_kms_setup_factory(kv_version)
         log.info("csi-kms-connection-details setup successful")
 
     @pytest.mark.parametrize(
@@ -98,7 +67,6 @@ class TestPVKeyRotationWithVaultKMS(ManageTest):
     )
     def test_encrypted_pvc_key_rotation(
         self,
-        kms_provider,
         project_factory,
         storageclass_factory,
         pvc_factory,
@@ -131,10 +99,9 @@ class TestPVKeyRotationWithVaultKMS(ManageTest):
             allow_volume_expansion=False,
         )
 
-        if kms_provider == constants.VAULT_KMS_PROVIDER:
-            # Create ceph-csi-kms-token in the tenant namespace
-            self.kms.vault_path_token = self.kms.generate_vault_token()
-            self.kms.create_vault_csi_kms_token(namespace=proj_obj.namespace)
+        # Create ceph-csi-kms-token in the tenant namespace
+        self.kms.vault_path_token = self.kms.generate_vault_token()
+        self.kms.create_vault_csi_kms_token(namespace=proj_obj.namespace)
 
         # Annotate Storageclass for keyrotation.
         pvk_obj = PVKeyrotation(sc_obj)


### PR DESCRIPTION
Removed HPCS condition since we are not using it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Narrowed encryption test coverage to run only in Vault-only KMS environments, reducing false passes in broader KMS setups.
  * Simplified encrypted PVC key-rotation test setup for more consistent Vault-based validation.

* **Tests**
  * Updated key-rotation coverage to use streamlined test parameters and always prepare the required Vault CSI KMS token flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->