### PR TITLE
fix(security): 2 improvements across 1 files

### DIFF
--- a/Docker_files/ocsci_container/scripts/edit_yaml.py
+++ b/Docker_files/ocsci_container/scripts/edit_yaml.py
@@ -2,6 +2,7 @@ import subprocess
 import yaml
 import sys
 import os
+import shlex
 
 from pathlib import Path
 
@@ -9,7 +10,9 @@ cli_args = sys.argv[1:]
 
 
 def send_cmd(cmd=None, out_yaml_format=False):
-    output = subprocess.check_output(cmd, shell=True, universal_newlines=True)
+    if isinstance(cmd, str):
+        cmd = shlex.split(cmd)
+    output = subprocess.check_output(cmd, shell=False, universal_newlines=True)
     if out_yaml_format:
         return yaml.safe_load(output)
     else:


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 1 files

## Problem

**Severity**: `High` | **File**: `Docker_files/ocsci_container/scripts/edit_yaml.py:L14`

The `send_cmd` function in `edit_yaml.py` uses `subprocess.check_output` with `shell=True`, which allows shell injection if user-controlled input is passed to the command. While the current usage appears to use hardcoded strings, this is a dangerous pattern that could be exploited if the function is ever called with dynamic input. The function should use `shell=False` with a list of arguments instead.

## Solution

Change `subprocess.check_output(cmd, shell=True, universal_newlines=True)` to use `shell=False` and pass command as a list. If shell features are needed, use `shlex.split()` to safely parse the command.

## Changes

- `Docker_files/ocsci_container/scripts/edit_yaml.py` (modified)