### PR TITLE
Update create_multiclusterservice condition to skip when host networking

### DIFF
--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -562,6 +562,7 @@ class Deployment(object):
                                 get_provider_service_type() != "NodePort"
                                 and cluster.ENV_DATA.get("cluster_type", "").lower()
                                 != constants.HCI_CLIENT
+                                and not config.DEPLOYMENT.get("host_network")
                             ):
                                 create_multiclusterservice_dr()
                             ocs_registry_image = config.DEPLOYMENT.get(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment behavior for regional DR setups by avoiding an automatic cluster creation step when host networking is enabled.
  * This helps prevent unexpected configuration conflicts during deployment in supported environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->