### PR TITLE
Skip force-delete of PDB-protected Ceph daemon pods during OCP upgrad…

### DIFF
--- a/ocs_ci/ocs/ocs_upgrade.py
+++ b/ocs_ci/ocs/ocs_upgrade.py
@@ -762,7 +762,16 @@ class OCSUpgrade(object):
             if not ocs_catalog.is_exist():
                 log.info("OCS catalog source doesn't exist. Creating new one.")
                 create_catalog_source(self.ocs_registry_image, ignore_upgrade=True)
-                prune_old_df_repo_idms()
+                if not config.ENV_DATA.get("platform", "").lower() in (
+                    constants.HCI_PROVIDER_CLIENT_PLATFORMS
+                ):
+                    prune_old_df_repo_idms()
+                else:
+                    log.info(
+                        "Skipping IDMS pruning during upgrade on "
+                        "provider/client platform to avoid "
+                        "simultaneous MCP rollout on all workers"
+                    )
                 # We can return here as new CatalogSource contains right images
                 return
             image_url = ocs_catalog.get_image_url()
@@ -788,7 +797,16 @@ class OCSUpgrade(object):
                 if not config.DEPLOYMENT.get("disconnected"):
                     # on Disconnected cluster, ICSP /IDMS from the ocs-registry image is not needed/valid
                     get_and_apply_idms_from_catalog(f"{image_url}:{new_image_tag}")
-                    prune_old_df_repo_idms()
+                    if not config.ENV_DATA.get("platform", "").lower() in (
+                        constants.HCI_PROVIDER_CLIENT_PLATFORMS
+                    ):
+                        prune_old_df_repo_idms()
+                    else:
+                        log.info(
+                            "Skipping IDMS pruning during upgrade on "
+                            "provider/client platform to avoid "
+                            "simultaneous MCP rollout on all workers"
+                        )
 
                 # Wait for catalog source to be ready
                 log.info("Waiting for catalog source to be ready after update.")

--- a/ocs_ci/ocs/ocs_upgrade.py
+++ b/ocs_ci/ocs/ocs_upgrade.py
@@ -762,7 +762,7 @@ class OCSUpgrade(object):
             if not ocs_catalog.is_exist():
                 log.info("OCS catalog source doesn't exist. Creating new one.")
                 create_catalog_source(self.ocs_registry_image, ignore_upgrade=True)
-                if not config.ENV_DATA.get("platform", "").lower() in (
+                if config.ENV_DATA.get("platform", "").lower() not in (
                     constants.HCI_PROVIDER_CLIENT_PLATFORMS
                 ):
                     prune_old_df_repo_idms()
@@ -797,7 +797,7 @@ class OCSUpgrade(object):
                 if not config.DEPLOYMENT.get("disconnected"):
                     # on Disconnected cluster, ICSP /IDMS from the ocs-registry image is not needed/valid
                     get_and_apply_idms_from_catalog(f"{image_url}:{new_image_tag}")
-                    if not config.ENV_DATA.get("platform", "").lower() in (
+                    if config.ENV_DATA.get("platform", "").lower() not in (
                         constants.HCI_PROVIDER_CLIENT_PLATFORMS
                     ):
                         prune_old_df_repo_idms()

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -7080,6 +7080,27 @@ def clean_up_pods_for_provider(node_type, max_retries=45, retry_delay_seconds=30
                         f"Eviction error found '{pod_name_to_delete}' in namespace '{ns_to_delete_from}'"
                         f"(related {node.name} being stuck)."
                     )
+                    # Ceph OSD, MON, MDS and MGR pods are protected by PodDisruptionBudgets.
+                    # Force-deleting them bypasses PDB protection and can cause data
+                    # inconsistency or stalled Ceph recovery. The MCO drain controller
+                    # retries automatically once PDB headroom opens up.
+                    pdb_protected_prefixes = (
+                        "rook-ceph-osd-",
+                        "rook-ceph-mon-",
+                        "rook-ceph-mds-",
+                        "rook-ceph-mgr-",
+                    )
+                    if any(
+                        pod_name_to_delete.startswith(prefix)
+                        for prefix in pdb_protected_prefixes
+                    ):
+                        log.warning(
+                            f"Skipping force-delete of '{pod_name_to_delete}': "
+                            f"Ceph daemon pods are protected by PodDisruptionBudget. "
+                            f"The MCO drain controller will retry automatically once "
+                            f"Ceph recovers."
+                        )
+                        continue
                     try:
                         # Prefer using the ocs_ci resource object for deletion
                         pod_to_delete_obj = OCP(

--- a/tests/functional/upgrade/test_upgrade_ocp.py
+++ b/tests/functional/upgrade/test_upgrade_ocp.py
@@ -363,9 +363,14 @@ class TestUpgradeOCP(ManageTest):
         # load new config file
         self.load_ocp_version_config_file(ocp_upgrade_version)
 
+        acm_cluster = config.multicluster and is_acm_cluster(config)
+        hci_client = (
+            config.ENV_DATA.get("cluster_type", "").lower() == constants.HCI_CLIENT
+        )
         if (
             not config.ENV_DATA["mcg_only_deployment"]
-            and not config.multicluster
+            and not acm_cluster
+            and not hci_client
             and not config.DEPLOYMENT.get("ocp_only_upgrade")
         ):
             new_ceph_cluster = CephCluster()


### PR DESCRIPTION
…e drain

clean_up_pods_for_provider() force-deleted Ceph OSD/MON/MDS/MGR pods when the MCC reported them as blocking node drain, bypassing PodDisruptionBudget protection. This caused data inconsistency and node recovery failures during OCP upgrade on Baremetal clusters.

Add a prefix check to skip force-deletion of rook-ceph-osd-*, rook-ceph-mon-*, rook-ceph-mds-*, and rook-ceph-mgr-* pods. The MCO drain controller retries automatically once Ceph recovers and PDB headroom opens. Other pods in openshift-storage (NooBaa, CSI sidecars) are still force-deleted as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pod cleanup during eviction-related drain issues by avoiding force-deletion of disruption-budget-protected Ceph daemon pods (OSD/MON/MDS/MGR).
  * Protected Ceph pods are now preserved with a warning, allowing drains to retry safely later.
* **Improvements**
  * Updated OCS upgrade catalog source handling to skip old repository pruning on specific platform types, with an informational log when skipped.
* **Tests**
  * Refined upgrade pre-check gating logic to better cover multicluster and HCI client scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->