### PR TITLE
Run capacity alert tests near end of suite

### DIFF
--- a/tests/functional/monitoring/prometheus/alerts/test_capacity.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_capacity.py
@@ -24,6 +24,9 @@ log = logging.getLogger(__name__)
 )
 @skipif_managed_service
 @runs_on_provider
+@pytest.mark.order(
+    "second_to_last"
+)  # Fills cluster to 97%; run late to avoid impacting other tests
 def test_rbd_capacity_workload_alerts(
     workload_storageutilization_97p_rbd, threading_lock
 ):
@@ -160,6 +163,9 @@ def test_rbd_capacity_workload_alerts(
 )
 @skipif_managed_service
 @runs_on_provider
+@pytest.mark.order(
+    "second_to_last"
+)  # Fills cluster to 97%; run late to avoid impacting other tests
 def test_cephfs_capacity_workload_alerts(
     workload_storageutilization_97p_cephfs, threading_lock
 ):


### PR DESCRIPTION
## Summary
- Add `@pytest.mark.order("second_to_last")` to `test_rbd_capacity_workload_alerts` and `test_cephfs_capacity_workload_alerts`
- These tests fill the cluster to 97% utilization via FIO, which can leave OSDs full and pools blocked if cleanup fails
- Running them near the end of the suite prevents cascading failures in subsequent tests (observed ~30 MCG test failures caused by this in launch [#51628](https://reportportal-ocs4.apps.dno.ocp-hub.prod.psi.redhat.com/ui/#ocs/launches/all/51628))

## Changes
- `tests/functional/monitoring/prometheus/alerts/test_capacity.py`: added `order("second_to_last")` marker to both capacity alert tests, matching the existing pattern used by other destructive tests like `test_add_capacity` and `test_resize_osd`