### PR TITLE
Add ignore_leftovers to TestPodsCsiLogRotation

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -569,6 +569,7 @@
         "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
         "is_verified": false,
         "line_number": 334,
+        "line_number": 338,
         "type": "Secret Keyword",
         "verified_result": null,
         "is_secret": false
@@ -577,6 +578,7 @@
         "hashed_secret": "de19c40310ad831a71524cd279e6f5f0577fb09a",
         "is_verified": false,
         "line_number": 382,
+        "line_number": 386,
         "type": "Secret Keyword",
         "verified_result": null,
         "is_secret": false
@@ -661,6 +663,7 @@
         "hashed_secret": "03e227627ab8681281fdb8aa3d799b03f782d672",
         "is_verified": false,
         "line_number": 2053,
+        "line_number": 2060,
         "type": "Secret Keyword",
         "verified_result": null,
         "is_secret": false
@@ -669,6 +672,7 @@
         "hashed_secret": "ef5f3d909f23bd0aa02b4253f98350384f709c86",
         "is_verified": false,
         "line_number": 2160,
+        "line_number": 2167,
         "type": "Secret Keyword",
         "verified_result": null,
         "is_secret": false
@@ -677,6 +681,7 @@
         "hashed_secret": "cb1ae2b504c4615841d8144267a131231d2bd677",
         "is_verified": false,
         "line_number": 2161,
+        "line_number": 2168,
         "type": "Secret Keyword",
         "verified_result": null,
         "is_secret": false
@@ -685,6 +690,7 @@
         "hashed_secret": "1a1e70e87dd0452c42f33ce9bf74aa28134dba6b",
         "is_verified": false,
         "line_number": 2162,
+        "line_number": 2169,
         "type": "Secret Keyword",
         "verified_result": null,
         "is_secret": false
@@ -693,6 +699,7 @@
         "hashed_secret": "7b1ba2f04f2f1604dc4e3caffcadf9fcbce7df5b",
         "is_verified": false,
         "line_number": 2163,
+        "line_number": 2170,
         "type": "Secret Keyword",
         "verified_result": null,
         "is_secret": false
@@ -701,6 +708,7 @@
         "hashed_secret": "0fa3b21ced80146d752888f2b60ec80e0d4b8925",
         "is_verified": false,
         "line_number": 2175,
+        "line_number": 2182,
         "type": "Secret Keyword",
         "verified_result": null,
         "is_secret": false
@@ -709,6 +717,7 @@
         "hashed_secret": "f084f2068494b8d1cd06811dd97d02c3d85f40ee",
         "is_verified": false,
         "line_number": 2190,
+        "line_number": 2197,
         "type": "Secret Keyword",
         "verified_result": null,
         "is_secret": false
@@ -717,6 +726,7 @@
         "hashed_secret": "adfa401a3b0a733d8f00519ac8c6b3893a2e7e8e",
         "is_verified": false,
         "line_number": 2191,
+        "line_number": 2198,
         "type": "Secret Keyword",
         "verified_result": null,
         "is_secret": false
@@ -725,6 +735,7 @@
         "hashed_secret": "898e46bbadc12f87120548bd445eb4210c8407c8",
         "is_verified": false,
         "line_number": 2199,
+        "line_number": 2206,
         "type": "Secret Keyword",
         "verified_result": null,
         "is_secret": false
@@ -733,6 +744,7 @@
         "hashed_secret": "f57ccec6b8f7b12b635ab53d26c3bf7300247341",
         "is_verified": false,
         "line_number": 2200,
+        "line_number": 2207,
         "type": "Secret Keyword",
         "verified_result": null,
         "is_secret": false
@@ -741,6 +753,7 @@
         "hashed_secret": "77b044ea736f8cbe568d1954424186d901f89db9",
         "is_verified": false,
         "line_number": 2201,
+        "line_number": 2208,
         "type": "Secret Keyword",
         "verified_result": null,
         "is_secret": false
@@ -749,6 +762,7 @@
         "hashed_secret": "d64368f12ca17c69568c6a132f17d44d56e60660",
         "is_verified": false,
         "line_number": 2202,
+        "line_number": 2209,
         "type": "Secret Keyword",
         "verified_result": null,
         "is_secret": false
@@ -757,6 +771,7 @@
         "hashed_secret": "8f9ca35156c02cb6ba58c5b51230b9bedc38de4f",
         "is_verified": false,
         "line_number": 2203,
+        "line_number": 2210,
         "type": "Secret Keyword",
         "verified_result": null,
         "is_secret": false
@@ -765,6 +780,7 @@
         "hashed_secret": "9ec53cfd9929c70c3f87c210b6a7b77fb6d79d43",
         "is_verified": false,
         "line_number": 2800,
+        "line_number": 2807,
         "type": "Secret Keyword",
         "verified_result": null,
         "is_secret": false
@@ -773,6 +789,7 @@
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
         "is_verified": false,
         "line_number": 2966,
+        "line_number": 2972,
         "type": "Secret Keyword",
         "verified_result": null,
         "is_secret": false
@@ -781,6 +798,7 @@
         "hashed_secret": "adc1f5c8707f7d7aba3aabe13c15e5ef1151872e",
         "is_verified": false,
         "line_number": 2967,
+        "line_number": 2973,
         "type": "Secret Keyword",
         "verified_result": null,
         "is_secret": false
@@ -789,6 +807,7 @@
         "hashed_secret": "ee46262b2df945e46ea310b925ad087465dbd3f2",
         "is_verified": false,
         "line_number": 3688,
+        "line_number": 3694,
         "type": "Secret Keyword",
         "verified_result": null,
         "is_secret": false
@@ -797,6 +816,7 @@
         "hashed_secret": "f678cad4ab874d71b559a069d5e34a95fe38a480",
         "is_verified": false,
         "line_number": 3689,
+        "line_number": 3695,
         "type": "Secret Keyword",
         "verified_result": null,
         "is_secret": false

--- a/tests/functional/pod_and_daemons/test_csi_logs_rotation.py
+++ b/tests/functional/pod_and_daemons/test_csi_logs_rotation.py
@@ -12,6 +12,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     post_upgrade,
     skipif_ocs_version,
 )
+from ocs_ci.framework.testlib import ignore_leftovers
 from ocs_ci.ocs.resources.pod import get_pods_having_label, Pod
 from ocs_ci.utility.utils import TimeoutSampler
 from ocs_ci.ocs.exceptions import TimeoutExpiredError
@@ -26,6 +27,7 @@ SLEEP_BETWEEN_TRIES = 300  # seconds
 @post_upgrade
 @skipif_ocs_version("<4.17")
 @tier2
+@ignore_leftovers
 class TestPodsCsiLogRotation(BaseTest):
     def check_for_successful_log_rotation(
         self, pod_obj, gz_logs_num, current_log_file_size, logs_dir, log_file_name


### PR DESCRIPTION
- Add `@ignore_leftovers` to `TestPodsCsiLogRotation` to prevent false `ResourceLeftoversException` from CNPG scheduled backup VolumeSnapshots
- CNPG operator creates midnight backup snapshots (`noobaa-db-pg-cluster-scheduled-backup-*`) that appear during test runs and get flagged as leftovers by the environment checker
- The CSI log rotation test does not create or manage VolumeSnapshots

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved handling of leftover artifacts for a CSI log rotation test, making test runs cleaner and more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->