### PR TITLE
Fix pod placement in node stop degraded state tests

### DIFF
--- a/ocs_ci/ocs/platform_nodes.py
+++ b/ocs_ci/ocs/platform_nodes.py
@@ -2170,16 +2170,17 @@ class BaremetalNodes(NodesBase):
         """
         self.baremetal.start_baremetal_machines(nodes, wait=wait)
 
-    def restart_nodes(self, nodes, force=True):
+    def restart_nodes(self, nodes, force=True, wait=True):
         """
         Restart Baremetal Machine
 
         Args:
             nodes (list): The OCS objects of the nodes
             force (bool): True for force BM stop, False otherwise
+            wait (bool): Wait for BMs to start
 
         """
-        self.baremetal.restart_baremetal_machines(nodes, force=force)
+        self.baremetal.restart_baremetal_machines(nodes, force=force, wait=wait)
 
     def restart_nodes_by_stop_and_start(self, nodes, force=True):
         """

--- a/ocs_ci/utility/baremetal.py
+++ b/ocs_ci/utility/baremetal.py
@@ -214,7 +214,7 @@ class BAREMETAL(object):
             node_names=get_worker_nodes(), status=constants.NODE_READY, timeout=800
         )
 
-    def restart_baremetal_machines(self, baremetal_machine, force=True):
+    def restart_baremetal_machines(self, baremetal_machine, force=True, wait=True):
         """
 
         Restart Baremetal Machines
@@ -223,10 +223,11 @@ class BAREMETAL(object):
             baremetal_machine (list): BM objects
             force (bool): True for BM ungraceful power off, False for
                 graceful BM shutdown
+            wait (bool): Wait for BMs to start
 
         """
         self.stop_baremetal_machines(baremetal_machine, force=force)
-        self.start_baremetal_machines(baremetal_machine)
+        self.start_baremetal_machines(baremetal_machine, wait=wait)
 
     def get_nodes_ipmi_ctx(self, baremetal_machine):
         """

--- a/tests/functional/z_cluster/nodes/test_nodes_restart.py
+++ b/tests/functional/z_cluster/nodes/test_nodes_restart.py
@@ -1,4 +1,6 @@
 import logging
+from functools import partial
+
 import pytest
 
 from ocs_ci.framework.pytest_customization.marks import brown_squad
@@ -191,12 +193,6 @@ class TestNodesRestart(ManageTest):
         - Check cluster and Ceph health
 
         """
-        if operation == "delete_resources":
-            # Create resources that their deletion will be tested later
-            self.sanity_helpers.create_resources(
-                pvc_factory, pod_factory, bucket_factory, rgw_bucket_factory
-            )
-
         provisioner_pods = None
         # Get the provisioner pod according to the interface
         if interface == "rbd":
@@ -223,6 +219,22 @@ class TestNodesRestart(ManageTest):
         logger.info(
             f"{interface} provisioner pod is running on node {provisioner_node_name}"
         )
+
+        if operation == "delete_resources":
+            # Create resources on a node that won't be stopped, so
+            # delete_resources() doesn't hang on a terminated kubelet
+            worker_nodes = get_nodes(node_type=constants.WORKER_MACHINE)
+            safe_node = next(
+                (n.name for n in worker_nodes if n.name != provisioner_node_name),
+                None,
+            )
+            assert (
+                safe_node
+            ), f"No safe worker node found (all workers match {provisioner_node_name})"
+            safe_pod_factory = partial(pod_factory, node_name=safe_node)
+            self.sanity_helpers.create_resources(
+                pvc_factory, safe_pod_factory, bucket_factory, rgw_bucket_factory
+            )
 
         # Stopping the nodes
         nodes.stop_nodes(nodes=[provisioner_node])
@@ -315,12 +327,6 @@ class TestNodesRestart(ManageTest):
         - Start the worker node
         - Check cluster and Ceph health
         """
-        if operation == "delete_resources":
-            # Create resources that their deletion will be tested later
-            self.sanity_helpers.create_resources(
-                pvc_factory, pod_factory, bucket_factory, rgw_bucket_factory
-            )
-
         rook_operator_pods = pod.get_operator_pods()
         rook_operator_pod = rook_operator_pods[0]
 
@@ -333,6 +339,22 @@ class TestNodesRestart(ManageTest):
         logger.info(
             f"{rook_operator_pod_name} pod is running on node {operator_node_name}"
         )
+
+        if operation == "delete_resources":
+            # Create resources on a node that won't be stopped, so
+            # delete_resources() doesn't hang on a terminated kubelet
+            worker_nodes = get_nodes(node_type=constants.WORKER_MACHINE)
+            safe_node = next(
+                (n.name for n in worker_nodes if n.name != operator_node_name),
+                None,
+            )
+            assert (
+                safe_node
+            ), f"No safe worker node found (all workers match {operator_node_name})"
+            safe_pod_factory = partial(pod_factory, node_name=safe_node)
+            self.sanity_helpers.create_resources(
+                pvc_factory, safe_pod_factory, bucket_factory, rgw_bucket_factory
+            )
 
         # Stopping the node
         nodes.stop_nodes(nodes=[operator_node])


### PR DESCRIPTION
- Identify target node BEFORE creating test resources in `delete_resources` variants of `test_pv_provisioning_under_degraded_state_stop_rook_operator_pod_node` and `test_pv_provisioning_under_degraded_state_stop_provisioner_pod_node`
- Pin test pods to a safe worker node using `functools.partial(pod_factory, node_name=safe_node)` to avoid the node that will be stopped
- Prevents `TimeoutExpired` during `delete_resources()` when test pods coincidentally land on the stopped node
- Only affects `delete_resources` parametrize variant; `create_resources` variant is unchanged (pods created after node stop)
- Add `wait` parameter to `BaremetalNodes.restart_nodes()` / `BAREMETAL.restart_baremetal_machines()`, fixing a `TypeError` on bare metal for tests calling `nodes.restart_nodes(wait=False)` (e.g. `test_rolling_nodes_restart`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of node-restart workflows by provisioning and deleting resources from a stable node when the target node is being stopped.
  * Prevented hangs and stuck cleanup during degraded-state storage provisioning when nodes become unavailable.
* **Improvements**
  * Enhanced restart behavior with a configurable “wait” option, giving more predictable completion timing for automation.
* **Tests**
  * Updated functional coverage for degraded-state scenarios to align with the safer restart flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->