### PR TITLE
Resume running bucket creation/deletion performance tests

### DIFF
--- a/tests/functional/object/mcg/test_bucket_creation_deletion.py
+++ b/tests/functional/object/mcg/test_bucket_creation_deletion.py
@@ -36,8 +36,6 @@ class TestBucketCreationAndDeletion(MCGTest):
     Test creation of a bucket
     """
 
-    ERRATIC_TIMEOUTS_SKIP_REASON = "Skipped because of erratic timeouts"
-
     @pytest.mark.parametrize(
         argnames="amount,interface,bucketclass_dict",
         argvalues=[
@@ -67,7 +65,6 @@ class TestBucketCreationAndDeletion(MCGTest):
             pytest.param(
                 *[100, "OC", None],
                 marks=[
-                    pytest.mark.skip(ERRATIC_TIMEOUTS_SKIP_REASON),
                     performance,
                     pytest.mark.polarion_id("OCS-1826"),
                 ],
@@ -75,7 +72,6 @@ class TestBucketCreationAndDeletion(MCGTest):
             pytest.param(
                 *[1000, "OC", None],
                 marks=[
-                    pytest.mark.skip(ERRATIC_TIMEOUTS_SKIP_REASON),
                     performance,
                     pytest.mark.polarion_id("OCS-1827"),
                 ],


### PR DESCRIPTION
## Summary
- Remove the `pytest.mark.skip` for the 100 and 1000 bucket parametrizations of `test_bucket_creation_deletion` that were previously skipped due to erratic timeouts
- Remove the now-unused `ERRATIC_TIMEOUTS_SKIP_REASON` constant

## Changes
- `tests/functional/object/mcg/test_bucket_creation_deletion.py`: Removed `pytest.mark.skip(ERRATIC_TIMEOUTS_SKIP_REASON)` from `100-OC-DEFAULT-BACKINGSTORE` and `1000-OC-DEFAULT-BACKINGSTORE` parametrizations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * A previously skipped bucket creation/deletion test case now runs as part of the functional test suite.
  * Removed a timeout-based skip from one scenario, increasing test coverage for bucket lifecycle behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->