### PR TITLE
correct the parametrizations

### DIFF
--- a/ocs_ci/ocs/cluster.py
+++ b/ocs_ci/ocs/cluster.py
@@ -2439,6 +2439,45 @@ def is_ec_pool_supported():
     return True
 
 
+def get_erasure_coded_rbd_sc_params(param_configs):
+    """
+    Build pytest.param entries for erasure-coded RBD storage class test cases.
+
+    Returns an empty list when EC pools are not supported on the cluster,
+    so non-EC clusters run only the replicated-pool parametrizations without
+    skipped EC variants.
+
+    Args:
+        param_configs (list): Each dict must include ``replica`` and
+            ``polarion_id``. Optional keys: ``compression`` (default ``"none"``),
+            ``extra_marks`` (list of additional pytest marks).
+
+    Returns:
+        list: pytest.param objects for erasure_coded=True cases
+    """
+    import pytest
+
+    from ocs_ci.framework.pytest_customization.marks import ec_allowed
+
+    if not is_ec_pool_supported():
+        return []
+
+    params = []
+    for cfg in param_configs:
+        marks = [ec_allowed, pytest.mark.polarion_id(cfg["polarion_id"])]
+        if cfg.get("extra_marks"):
+            marks.extend(cfg["extra_marks"])
+        params.append(
+            pytest.param(
+                cfg["replica"],
+                cfg.get("compression", "none"),
+                True,
+                marks=marks,
+            )
+        )
+    return params
+
+
 def get_ec_metadata_pool_name():
     """
     Return the name of the replicated metadata pool for EC RBD StorageClasses

--- a/tests/functional/workloads/pvc_snapshot_and_clone/test_compressed_sc_and_support_snap_clone.py
+++ b/tests/functional/workloads/pvc_snapshot_and_clone/test_compressed_sc_and_support_snap_clone.py
@@ -1,8 +1,7 @@
 import logging
 import pytest
 
-from ocs_ci.framework.pytest_customization.marks import magenta_squad, ec_allowed
-from ocs_ci.ocs.cluster import is_ec_pool_supported
+from ocs_ci.framework.pytest_customization.marks import magenta_squad
 from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     skipif_ocp_version,
@@ -13,6 +12,7 @@ from ocs_ci.framework.testlib import (
     skipif_disconnected_cluster,
     skipif_proxy_cluster,
 )
+from ocs_ci.ocs.cluster import get_erasure_coded_rbd_sc_params
 from ocs_ci.ocs.benchmark_operator import BMO_NAME
 from ocs_ci.ocs.constants import (
     VOLUME_MODE_FILESYSTEM,
@@ -22,6 +22,19 @@ from ocs_ci.ocs.constants import (
 from ocs_ci.ocs.ocp import OCP
 
 log = logging.getLogger(__name__)
+
+_COMPRESSED_SC_SNAP_CLONE_PARAMS = [
+    pytest.param(*[3, "aggressive", False], marks=pytest.mark.polarion_id("OCS-2536")),
+    pytest.param(*[2, "aggressive", False], marks=pytest.mark.polarion_id("OCS-2305")),
+] + get_erasure_coded_rbd_sc_params(
+    [
+        {
+            "replica": 3,
+            "polarion_id": "OCS-7963",
+            "extra_marks": [tier2],
+        }
+    ]
+)
 
 
 @magenta_squad
@@ -114,26 +127,7 @@ class TestCompressedSCAndSupportSnapClone(E2ETest):
     @skipif_ocp_version("<4.6")
     @pytest.mark.parametrize(
         argnames=["replica", "compression", "erasure_coded"],
-        argvalues=[
-            pytest.param(
-                *[3, "aggressive", False], marks=pytest.mark.polarion_id("OCS-2536")
-            ),
-            pytest.param(
-                *[2, "aggressive", False], marks=pytest.mark.polarion_id("OCS-2305")
-            ),
-            pytest.param(
-                *[3, "none", True],
-                marks=[
-                    ec_allowed,
-                    tier2,
-                    pytest.mark.polarion_id("OCS-7963"),
-                    pytest.mark.skipif(
-                        not is_ec_pool_supported(),
-                        reason="Erasure coded pools are not supported on this cluster",
-                    ),
-                ],
-            ),
-        ],
+        argvalues=_COMPRESSED_SC_SNAP_CLONE_PARAMS,
     )
     def test_compressed_sc_and_support_snap_clone(
         self,

--- a/tests/functional/workloads/test_new_sc_rbd_e2e_workloads.py
+++ b/tests/functional/workloads/test_new_sc_rbd_e2e_workloads.py
@@ -3,7 +3,7 @@ import pytest
 from concurrent.futures import ThreadPoolExecutor
 
 from ocs_ci.ocs import constants
-from ocs_ci.framework.pytest_customization.marks import magenta_squad, ec_allowed
+from ocs_ci.framework.pytest_customization.marks import magenta_squad
 from ocs_ci.framework.testlib import (
     E2ETest,
     tier2,
@@ -14,13 +14,37 @@ from ocs_ci.framework.testlib import (
     skipif_proxy_cluster,
 )
 from ocs_ci.ocs.cluster import (
+    get_erasure_coded_rbd_sc_params,
     get_percent_used_capacity,
-    is_ec_pool_supported,
 )
 from ocs_ci.ocs import flowtest
 
 
 log = logging.getLogger(__name__)
+
+_RBD_SC_E2E_PARAMS = [
+    pytest.param(
+        *[3, "aggressive", False],
+        marks=pytest.mark.polarion_id("OCS-2347"),
+    ),
+    pytest.param(
+        *[2, "aggressive", False],
+        marks=pytest.mark.polarion_id("OCS-2345"),
+    ),
+    pytest.param(
+        *[3, "none", False],
+        marks=pytest.mark.polarion_id("OCS-2346"),
+    ),
+    pytest.param(
+        *[2, "none", False],
+        marks=pytest.mark.polarion_id("OCS-2344"),
+    ),
+] + get_erasure_coded_rbd_sc_params(
+    [
+        {"replica": 3, "polarion_id": "OCS-7959"},
+        {"replica": 2, "polarion_id": "OCS-7960"},
+    ]
+)
 
 
 @magenta_squad
@@ -33,46 +57,7 @@ log = logging.getLogger(__name__)
 class TestCreateNewScWithNeWRbDPoolE2EWorkloads(E2ETest):
     @pytest.mark.parametrize(
         argnames=["replica", "compression", "erasure_coded"],
-        argvalues=[
-            pytest.param(
-                *[3, "aggressive", False],
-                marks=pytest.mark.polarion_id("OCS-2347"),
-            ),
-            pytest.param(
-                *[2, "aggressive", False],
-                marks=pytest.mark.polarion_id("OCS-2345"),
-            ),
-            pytest.param(
-                *[3, "none", False],
-                marks=pytest.mark.polarion_id("OCS-2346"),
-            ),
-            pytest.param(
-                *[2, "none", False],
-                marks=pytest.mark.polarion_id("OCS-2344"),
-            ),
-            pytest.param(
-                *[3, "none", True],
-                marks=[
-                    ec_allowed,
-                    pytest.mark.polarion_id("OCS-7959"),
-                    pytest.mark.skipif(
-                        not is_ec_pool_supported(),
-                        reason="Erasure coded pools are not supported on this cluster",
-                    ),
-                ],
-            ),
-            pytest.param(
-                *[2, "none", True],
-                marks=[
-                    ec_allowed,
-                    pytest.mark.polarion_id("OCS-7960"),
-                    pytest.mark.skipif(
-                        not is_ec_pool_supported(),
-                        reason="Erasure coded pools are not supported on this cluster",
-                    ),
-                ],
-            ),
-        ],
+        argvalues=_RBD_SC_E2E_PARAMS,
     )
     def test_new_sc_new_rbd_pool_e2e_wl(
         self,


### PR DESCRIPTION
Problem: EC cases used pytest.mark.skipif(not is_ec_pool_supported(), ...), so on clusters without EC support those parametrizations were still collected and reported as SKIPPED, even though the replicated-pool cases (erasure_coded=False) should run.

Fix: Added get_erasure_coded_rbd_sc_params() in ocs_ci/ocs/cluster.py. It returns EC pytest.param entries only when is_ec_pool_supported() is true; otherwise it returns an empty list.

On a non-EC cluster, pytest tests/functional/workloads/test_new_sc_rbd_e2e_workloads.py --collect-only should show 4 collected tests. On an EC-capable cluster it should show 6.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded test coverage for erasure-coded RBD storage class scenarios in end-to-end and snapshot/clone workflows.
  * Added a shared way to generate parameter sets for storage class test variations.

* **Refactor**
  * Simplified test parameter setup by moving repeated configuration into shared reusable logic.
  * Reduced inline test markers and conditional setup, making the affected tests easier to maintain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->