### PR TITLE
Force GCP deployments to use CCO passthrough mode

### DIFF
--- a/ocs_ci/deployment/gcp.py
+++ b/ocs_ci/deployment/gcp.py
@@ -5,10 +5,13 @@ on Google Cloud Platform (aka GCP).
 """
 
 import logging
+import os
 
+import yaml
 from libcloud.compute.types import NodeState
 
 from ocs_ci.deployment.cloud import CloudDeploymentBase, IPIOCPDeployment
+from ocs_ci.framework import config
 from ocs_ci.utility.gcp import GoogleCloudUtil
 
 
@@ -71,7 +74,21 @@ class GCPIPI(GCPBase):
     A class to handle GCP IPI specific deployment
     """
 
-    OCPDeployment = IPIOCPDeployment
+    class OCPDeployment(IPIOCPDeployment):
+        def deploy_prereq(self):
+            super().deploy_prereq()
+            # TODO: Remove after ~2026-07-18 when GCP finishes purging deleted
+            # custom IAM roles from the odf-dev-test project. Until then, mint
+            # mode fails with FailedPrecondition because the role IDs are locked.
+            install_config = os.path.join(
+                config.ENV_DATA["cluster_path"], "install-config.yaml"
+            )
+            with open(install_config) as f:
+                install_config_data = yaml.safe_load(f)
+            install_config_data["credentialsMode"] = "Passthrough"
+            with open(install_config, "w") as f:
+                yaml.dump(install_config_data, f)
+            logger.info("Set credentialsMode to Passthrough (GCP workaround)")
 
     def __init__(self):
         self.name = self.__class__.__name__


### PR DESCRIPTION
## Summary
- Deleted custom IAM roles in the `odf-dev-test` GCP project are stuck in GCP's 37-day permanent deletion pipeline (deleted June 11, 2026). Until GCP finishes purging the role IDs (~July 18), CCO mint mode fails with `FailedPrecondition` on `CreateRole`.
- This workaround forces passthrough mode for all GCP IPI deployments, which copies the admin credential to all components instead of creating per-component custom roles and service accounts.
- Marked with a TODO for removal after ~2026-07-18.

## Changes
- Added `OCPDeployment` inner class to `GCPIPI` that overrides `deploy_prereq()` to inject `credentialsMode: Passthrough` into the install-config after generation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GCP cluster setup by automatically adjusting the install configuration during deployment prerequisites.
  * Updated the cluster configuration to use a more compatible credentials mode, helping deployments complete successfully on GCP.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->