### PR TITLE
Add test for bound CephFS snapshot delete rejection (RHSTOR-7731)

### DIFF
--- a/ocs_ci/helpers/odf_cephfs_snap.py
+++ b/ocs_ci/helpers/odf_cephfs_snap.py
@@ -320,12 +320,14 @@ def wait_and_verify_snapshot_bound(snap_runner, snap_data, timeout=30, sleep=5):
         sleep (int): Seconds between polls (default 5).
 
     Raises:
-        AssertionError: If the snapshot disappears or transitions out of
-            Bound state at any point during the sampling window.
+        AssertionError: If the snapshot disappears or is not in Bound state
+            when first observed after the delete attempt.
+        TimeoutExpiredError: If ``get_cephfs_snap_entries`` keeps failing
+            for the entire ``timeout`` window.
     """
     ceph_snap_name = snap_data["ceph_snap_name"]
     log.info(
-        "Polling to confirm snapshot '%s' remains in Bound state",
+        "Polling to confirm snapshot '%s' is in Bound state",
         ceph_snap_name,
     )
     for snap_entries in TimeoutSampler(
@@ -345,8 +347,9 @@ def wait_and_verify_snapshot_bound(snap_runner, snap_data, timeout=30, sleep=5):
         assert state == constants.CEPHFS_SNAPSHOT_STATE_BOUND, (
             f"Snapshot '{ceph_snap_name}' is in '{state}' state, " f"expected Bound"
         )
+        break
     log.info(
-        "Snapshot '%s' remained in '%s' state throughout the polling window",
+        "Snapshot '%s' confirmed in '%s' state after delete rejection",
         ceph_snap_name,
         constants.CEPHFS_SNAPSHOT_STATE_BOUND,
     )

--- a/ocs_ci/helpers/odf_cephfs_snap.py
+++ b/ocs_ci/helpers/odf_cephfs_snap.py
@@ -1,9 +1,11 @@
 import json
 import logging
+import re
 
 from ocs_ci.framework import config
 from ocs_ci.helpers.helpers import get_snapshot_content_obj
 from ocs_ci.ocs import constants, ocp
+from ocs_ci.ocs.exceptions import CommandFailed
 from ocs_ci.utility import templating
 from ocs_ci.ocs.resources import ocs
 from ocs_ci.ocs.resources.storageconsumer import find_consumer_for_storage_client
@@ -72,6 +74,11 @@ def create_provider_retain_cephfs_snapclass(snapclass_name, storage_client_name)
     if not config.multicluster:
         return _create_standalone_retain_snapclass(snapclass_name)
 
+    # Capture the client cluster name before switching to provider context
+    # so find_consumer_for_storage_client can disambiguate when multiple
+    # consumers share the same storage-client name.
+    client_cluster_name = config.ENV_DATA.get("cluster_name")
+
     with config.RunWithProviderConfigContextIfAvailable():
         snapclass_data = templating.load_yaml(constants.CSI_CEPHFS_SNAPSHOTCLASS_YAML)
         snapclass_data["metadata"]["name"] = snapclass_name
@@ -92,7 +99,8 @@ def create_provider_retain_cephfs_snapclass(snapclass_name, storage_client_name)
         log.info("Created VolumeSnapshotClass %s on provider", snapclass_name)
 
         consumer_name, consumer_data = find_consumer_for_storage_client(
-            storage_client_name
+            storage_client_name,
+            client_cluster_name=client_cluster_name,
         )
         consumer_ocp = ocp.OCP(
             kind=constants.STORAGECONSUMER,
@@ -244,3 +252,110 @@ def delete_volumesnaps_volumesnapcontents(snap_list_names):
         snap_obj.ocp.wait_for_delete(snap_obj.name)
         snapcontent_obj.delete()
         snapcontent_obj.ocp.wait_for_delete(snapcontent_obj.name)
+
+
+def verify_bound_snapshot_delete_rejected(snap_runner, snap_data):
+    """
+    Attempt to delete a Bound CephFS snapshot via the odf CLI and
+    verify the operation does not remove it.
+
+    Two CLI behaviours are handled:
+    - Non-zero exit code → ``CommandFailed`` is raised (expected path).
+    - Exit code 0 without actually deleting the snapshot (tolerated).
+
+    In either case the rejection error message must appear in the CLI
+    output.
+
+    Args:
+        snap_runner: Initialised ``ODFCLICephfsSnapRunner`` instance.
+        snap_data (dict): Snapshot data dict with keys ``"subvolume"``
+            and ``"ceph_snap_name"``.
+
+    Raises:
+        AssertionError: If the expected rejection message is absent.
+    """
+    rejection_pattern = re.compile(r"(?=.*\bbound\b)(?=.*\bdelet)", re.IGNORECASE)
+    ceph_snap_name = snap_data["ceph_snap_name"]
+    subvolume = snap_data["subvolume"]
+
+    delete_raised = False
+    delete_result = None
+    try:
+        delete_result = snap_runner.delete(subvolume, ceph_snap_name)
+    except CommandFailed as ex:
+        delete_raised = True
+        assert rejection_pattern.search(str(ex)), (
+            f"Expected rejection pattern (bound + delet*) not found "
+            f"in CommandFailed output: {ex}"
+        )
+        log.info(
+            "Delete of bound snapshot '%s' rejected as expected. Error: %s",
+            ceph_snap_name,
+            ex,
+        )
+
+    if not delete_raised:
+        stderr_out = delete_result.stderr.decode() if delete_result is not None else ""
+        assert rejection_pattern.search(stderr_out), (
+            f"Expected rejection pattern (bound + delet*) not found "
+            f"in delete stderr: {stderr_out}"
+        )
+        log.info(
+            "Delete of bound snapshot '%s' rejected as expected (exit 0). " "Error: %s",
+            ceph_snap_name,
+            stderr_out.strip(),
+        )
+
+
+def wait_and_verify_snapshot_bound(snap_runner, snap_data, timeout=30, sleep=5):
+    """
+    Poll ``odf cephfs-snap ls`` to confirm that ``snap_data`` remains
+    in Bound state, then do a final explicit assertion.
+
+    Args:
+        snap_runner: Initialised ``ODFCLICephfsSnapRunner`` instance.
+        snap_data (dict): Snapshot data dict with a ``"ceph_snap_name"``
+            key.
+        timeout (int): Maximum seconds to poll (default 30).
+        sleep (int): Seconds between polls (default 5).
+
+    Raises:
+        AssertionError: If the snapshot disappears or transitions out of
+            Bound state during or after the sampling window.
+    """
+    ceph_snap_name = snap_data["ceph_snap_name"]
+    log.info(
+        "Polling to confirm snapshot '%s' remains in Bound state",
+        ceph_snap_name,
+    )
+    for snap_entries in TimeoutSampler(
+        timeout=timeout,
+        sleep=sleep,
+        func=get_cephfs_snap_entries,
+        snap_runner=snap_runner,
+    ):
+        entry = next(
+            (e for e in snap_entries if e["snapshot"] == ceph_snap_name),
+            None,
+        )
+        assert entry is not None, (
+            f"Snapshot '{ceph_snap_name}' disappeared after " f"failed delete attempt"
+        )
+        state = entry["state"]
+        assert state == constants.CEPHFS_SNAPSHOT_STATE_BOUND, (
+            f"Snapshot '{ceph_snap_name}' is in '{state}' state, " f"expected Bound"
+        )
+        break
+
+    snap_entries = get_cephfs_snap_entries(snap_runner)
+    entry = get_cephfs_snap_by_name(snap_entries, ceph_snap_name)
+    assert entry["state"] == constants.CEPHFS_SNAPSHOT_STATE_BOUND, (
+        f"Expected state '{constants.CEPHFS_SNAPSHOT_STATE_BOUND}' "
+        f"for snapshot '{ceph_snap_name}', "
+        f"got '{entry['state']}'"
+    )
+    log.info(
+        "Snapshot '%s' is in '%s' state as expected",
+        ceph_snap_name,
+        constants.CEPHFS_SNAPSHOT_STATE_BOUND,
+    )

--- a/ocs_ci/helpers/odf_cephfs_snap.py
+++ b/ocs_ci/helpers/odf_cephfs_snap.py
@@ -5,7 +5,7 @@ import re
 from ocs_ci.framework import config
 from ocs_ci.helpers.helpers import get_snapshot_content_obj
 from ocs_ci.ocs import constants, ocp
-from ocs_ci.ocs.exceptions import CommandFailed
+from ocs_ci.ocs.exceptions import CommandFailed, TimeoutExpiredError
 from ocs_ci.utility import templating
 from ocs_ci.ocs.resources import ocs
 from ocs_ci.ocs.resources.storageconsumer import find_consumer_for_storage_client
@@ -307,49 +307,60 @@ def verify_bound_snapshot_delete_rejected(snap_runner, snap_data):
         )
 
 
-def wait_and_verify_snapshot_bound(snap_runner, snap_data, timeout=30, sleep=5):
+def wait_and_verify_snapshot_bound(snap_runner, snap_data, timeout=60, sleep=5):
     """
-    Poll ``odf cephfs-snap ls`` to confirm that ``snap_data`` remains
-    in Bound state, then do a final explicit assertion.
+    Poll ``odf cephfs-snap ls`` for the full ``timeout`` window and assert
+    the snapshot is in Bound state at the end.
+
+    ``TimeoutSampler`` retries ``get_cephfs_snap_entries`` on failure but
+    does not retry exceptions raised from the loop body, so assertions are
+    kept outside the loop. The sampler runs until ``TimeoutExpiredError`` is
+    caught, then the last observed state is verified.
 
     Args:
         snap_runner: Initialised ``ODFCLICephfsSnapRunner`` instance.
         snap_data (dict): Snapshot data dict with a ``"ceph_snap_name"``
             key.
-        timeout (int): Maximum seconds to poll (default 30).
+        timeout (int): Seconds to poll (default 60).
         sleep (int): Seconds between polls (default 5).
 
     Raises:
-        AssertionError: If the snapshot disappears or is not in Bound state
-            when first observed after the delete attempt.
-        TimeoutExpiredError: If ``get_cephfs_snap_entries`` keeps failing
-            for the entire ``timeout`` window.
+        AssertionError: If the snapshot is not found or not in Bound state
+            at the end of the polling window.
     """
     ceph_snap_name = snap_data["ceph_snap_name"]
     log.info(
-        "Polling to confirm snapshot '%s' is in Bound state",
+        "Polling for %ds to confirm snapshot '%s' remains in Bound state",
+        timeout,
         ceph_snap_name,
     )
-    for snap_entries in TimeoutSampler(
-        timeout=timeout,
-        sleep=sleep,
-        func=get_cephfs_snap_entries,
-        snap_runner=snap_runner,
-    ):
-        entry = next(
-            (e for e in snap_entries if e["snapshot"] == ceph_snap_name),
-            None,
-        )
-        assert entry is not None, (
-            f"Snapshot '{ceph_snap_name}' disappeared after " f"failed delete attempt"
-        )
-        state = entry["state"]
-        assert state == constants.CEPHFS_SNAPSHOT_STATE_BOUND, (
-            f"Snapshot '{ceph_snap_name}' is in '{state}' state, " f"expected Bound"
-        )
-        break
+    last_entry = None
+    try:
+        for snap_entries in TimeoutSampler(
+            timeout=timeout,
+            sleep=sleep,
+            func=get_cephfs_snap_entries,
+            snap_runner=snap_runner,
+        ):
+            entry = next(
+                (e for e in snap_entries if e["snapshot"] == ceph_snap_name),
+                None,
+            )
+            if entry is not None:
+                last_entry = entry
+    except TimeoutExpiredError:
+        pass
+    assert last_entry is not None, (
+        f"Snapshot '{ceph_snap_name}' was never observed during the "
+        f"{timeout}s polling window after failed delete attempt"
+    )
+    assert last_entry["state"] == constants.CEPHFS_SNAPSHOT_STATE_BOUND, (
+        f"Snapshot '{ceph_snap_name}' ended in '{last_entry['state']}' "
+        f"state after {timeout}s polling window, expected Bound"
+    )
     log.info(
-        "Snapshot '%s' confirmed in '%s' state after delete rejection",
+        "Snapshot '%s' confirmed in '%s' state after %ds polling window",
         ceph_snap_name,
         constants.CEPHFS_SNAPSHOT_STATE_BOUND,
+        timeout,
     )

--- a/ocs_ci/helpers/odf_cephfs_snap.py
+++ b/ocs_ci/helpers/odf_cephfs_snap.py
@@ -346,8 +346,7 @@ def wait_and_verify_snapshot_bound(snap_runner, snap_data, timeout=60, sleep=5):
                 (e for e in snap_entries if e["snapshot"] == ceph_snap_name),
                 None,
             )
-            if entry is not None:
-                last_entry = entry
+            last_entry = entry
     except TimeoutExpiredError:
         pass
     assert last_entry is not None, (

--- a/ocs_ci/helpers/odf_cephfs_snap.py
+++ b/ocs_ci/helpers/odf_cephfs_snap.py
@@ -321,7 +321,7 @@ def wait_and_verify_snapshot_bound(snap_runner, snap_data, timeout=30, sleep=5):
 
     Raises:
         AssertionError: If the snapshot disappears or transitions out of
-            Bound state during or after the sampling window.
+            Bound state at any point during the sampling window.
     """
     ceph_snap_name = snap_data["ceph_snap_name"]
     log.info(
@@ -345,17 +345,8 @@ def wait_and_verify_snapshot_bound(snap_runner, snap_data, timeout=30, sleep=5):
         assert state == constants.CEPHFS_SNAPSHOT_STATE_BOUND, (
             f"Snapshot '{ceph_snap_name}' is in '{state}' state, " f"expected Bound"
         )
-        break
-
-    snap_entries = get_cephfs_snap_entries(snap_runner)
-    entry = get_cephfs_snap_by_name(snap_entries, ceph_snap_name)
-    assert entry["state"] == constants.CEPHFS_SNAPSHOT_STATE_BOUND, (
-        f"Expected state '{constants.CEPHFS_SNAPSHOT_STATE_BOUND}' "
-        f"for snapshot '{ceph_snap_name}', "
-        f"got '{entry['state']}'"
-    )
     log.info(
-        "Snapshot '%s' is in '%s' state as expected",
+        "Snapshot '%s' remained in '%s' state throughout the polling window",
         ceph_snap_name,
         constants.CEPHFS_SNAPSHOT_STATE_BOUND,
     )

--- a/ocs_ci/ocs/resources/storageconsumer.py
+++ b/ocs_ci/ocs/resources/storageconsumer.py
@@ -1015,18 +1015,26 @@ def get_ready_consumers_names():
     return [consumer.name for consumer in ready_consumers]
 
 
-def find_consumer_for_storage_client(storage_client_name):
+def find_consumer_for_storage_client(storage_client_name, client_cluster_name=None):
     """
-    Find the StorageConsumer CR on the provider that owns ``storage_client_name``.
+    Find the StorageConsumer CR on the provider that owns
+    ``storage_client_name``.
 
     Must be called within an active provider config context.
 
     Args:
-        storage_client_name (str): StorageClient CR name on the client cluster.
+        storage_client_name (str): StorageClient CR name on the client
+            cluster.
+        client_cluster_name (str or None): When multiple consumers share
+            the same storage-client name, pass the client cluster name
+            (e.g. ``config.ENV_DATA["cluster_name"]``) to disambiguate.
+            The value is matched against the prefix of the consumer's
+            ``status.client.clusterName`` field.  When ``None`` the first
+            name-only match is returned (original behaviour).
 
     Returns:
-        tuple[str, dict]: ``(consumer_name, consumer_data)`` for the matching
-            StorageConsumer.
+        tuple[str, dict]: ``(consumer_name, consumer_data)`` for the
+            matching StorageConsumer.
 
     Raises:
         AssertionError: If no matching StorageConsumer is found.
@@ -1035,17 +1043,22 @@ def find_consumer_for_storage_client(storage_client_name):
     consumer_ocp = ocp.OCP(kind=constants.STORAGECONSUMER, namespace=consumer_ns)
     for name in get_consumer_names():
         consumer_data = consumer_ocp.get(resource_name=name)
-        if (
-            consumer_data.get("status", {}).get("client", {}).get("name")
-            == storage_client_name
-        ):
-            return name, consumer_data
+        client_info = consumer_data.get("status", {}).get("client", {})
+        if client_info.get("name") != storage_client_name:
+            continue
+        if client_cluster_name:
+            cluster_name_field = client_info.get("clusterName", "")
+            if not cluster_name_field.startswith(client_cluster_name + "."):
+                continue
+        return name, consumer_data
     raise AssertionError(
-        f"No StorageConsumer found for storage client '{storage_client_name}'"
+        f"No StorageConsumer found for storage client "
+        f"'{storage_client_name}'"
+        + (f" on cluster '{client_cluster_name}'" if client_cluster_name else "")
     )
 
 
-def get_consumer_svg_on_provider(storage_client_name):
+def get_consumer_svg_on_provider(storage_client_name, client_cluster_name=None):
     """
     Return the CephFS subvolume group name for a storage client on the
     provider cluster.
@@ -1056,6 +1069,9 @@ def get_consumer_svg_on_provider(storage_client_name):
     Args:
         storage_client_name (str): StorageClient CR name on the client
             cluster.
+        client_cluster_name (str or None): Pass ``config.ENV_DATA["cluster_name"]``
+            from the client context when multiple consumers share the same
+            storage-client name, to ensure the correct consumer is found.
 
     Returns:
         str: Subvolume group name on the provider cluster.
@@ -1063,7 +1079,10 @@ def get_consumer_svg_on_provider(storage_client_name):
     Raises:
         AssertionError: If no matching StorageConsumer is found.
     """
-    consumer_name, _ = find_consumer_for_storage_client(storage_client_name)
+    consumer_name, _ = find_consumer_for_storage_client(
+        storage_client_name,
+        client_cluster_name=client_cluster_name,
+    )
     # The CephFS subvolume group name on the provider equals the
     # StorageConsumer CR name (this mapping may change in future versions).
     return consumer_name

--- a/tests/functional/pv/pvc_snapshot/test_cephfs_orphaned_snapshot_alert.py
+++ b/tests/functional/pv/pvc_snapshot/test_cephfs_orphaned_snapshot_alert.py
@@ -478,8 +478,9 @@ class TestCephFSOrphanedSnapshotAlert(ManageTest):
         7. Verify the delete operation fails (CommandFailed is raised)
            and a non-empty error message is returned.
         8. Verify the targeted bound snapshot still exists in Bound state.
-        9. List all CephFS snapshots and confirm the bound snapshot is
-           present and unchanged.
+        9. List all CephFS snapshots and confirm the full set of bound
+           snapshots is identical to the set captured before the delete
+           attempt (proves the delete was a complete no-op).
         """
         num_of_orphaned = 1
         num_of_bound = 2
@@ -516,6 +517,8 @@ class TestCephFSOrphanedSnapshotAlert(ManageTest):
         self.verify_cephfs_snapshots_bound(bound_snaps)
 
         target_snap = bound_snaps[0]
+        bound_names_before = {s["ceph_snap_name"] for s in bound_snaps}
+
         log.test_step(
             "Attempt to delete bound snapshot '%s' via odf CLI",
             target_snap["ceph_snap_name"],
@@ -528,19 +531,21 @@ class TestCephFSOrphanedSnapshotAlert(ManageTest):
         )
         wait_and_verify_snapshot_bound(self._snap_runner, target_snap)
 
-        log.test_step("List CephFS snapshots and confirm bound snapshot is unchanged")
+        log.test_step(
+            "List CephFS snapshots and confirm all bound snapshots are unchanged"
+        )
         snap_entries = get_cephfs_snap_entries(self._snap_runner)
-        bound_names = {
+        bound_names_after = {
             e["snapshot"]
             for e in snap_entries
             if e["state"] == constants.CEPHFS_SNAPSHOT_STATE_BOUND
         }
-        assert target_snap["ceph_snap_name"] in bound_names, (
-            f"Bound snapshot '{target_snap['ceph_snap_name']}' not "
-            f"found in snapshot list after failed delete attempt"
+        assert bound_names_after == bound_names_before, (
+            f"Bound snapshot set changed after failed delete attempt: "
+            f"before={bound_names_before}, after={bound_names_after}"
         )
         log.info(
-            "Confirmed: bound snapshot '%s' is unchanged after "
+            "Confirmed: all %d bound snapshot(s) are unchanged after "
             "failed delete attempt",
-            target_snap["ceph_snap_name"],
+            len(bound_names_before),
         )

--- a/tests/functional/pv/pvc_snapshot/test_cephfs_orphaned_snapshot_alert.py
+++ b/tests/functional/pv/pvc_snapshot/test_cephfs_orphaned_snapshot_alert.py
@@ -478,9 +478,9 @@ class TestCephFSOrphanedSnapshotAlert(ManageTest):
         7. Verify the delete operation fails (CommandFailed is raised)
            and a non-empty error message is returned.
         8. Verify the targeted bound snapshot still exists in Bound state.
-        9. List all CephFS snapshots and confirm the full set of bound
-           snapshots is identical to the set captured before the delete
-           attempt (proves the delete was a complete no-op).
+        9. List all CephFS snapshots and confirm the full snapshot set
+           (names and states) is identical to a fresh capture taken
+           just before the delete attempt (proves a complete no-op).
         """
         num_of_orphaned = 1
         num_of_bound = 2
@@ -517,7 +517,10 @@ class TestCephFSOrphanedSnapshotAlert(ManageTest):
         self.verify_cephfs_snapshots_bound(bound_snaps)
 
         target_snap = bound_snaps[0]
-        bound_names_before = {s["ceph_snap_name"] for s in bound_snaps}
+        snap_state_before = {
+            e["snapshot"]: e["state"]
+            for e in get_cephfs_snap_entries(self._snap_runner)
+        }
 
         log.test_step(
             "Attempt to delete bound snapshot '%s' via odf CLI",
@@ -532,20 +535,18 @@ class TestCephFSOrphanedSnapshotAlert(ManageTest):
         wait_and_verify_snapshot_bound(self._snap_runner, target_snap)
 
         log.test_step(
-            "List CephFS snapshots and confirm all bound snapshots are unchanged"
+            "List CephFS snapshots and confirm the full snapshot set is unchanged"
         )
-        snap_entries = get_cephfs_snap_entries(self._snap_runner)
-        bound_names_after = {
-            e["snapshot"]
-            for e in snap_entries
-            if e["state"] == constants.CEPHFS_SNAPSHOT_STATE_BOUND
+        snap_state_after = {
+            e["snapshot"]: e["state"]
+            for e in get_cephfs_snap_entries(self._snap_runner)
         }
-        assert bound_names_after == bound_names_before, (
-            f"Bound snapshot set changed after failed delete attempt: "
-            f"before={bound_names_before}, after={bound_names_after}"
+        assert snap_state_after == snap_state_before, (
+            f"Snapshot set changed after failed delete attempt: "
+            f"before={snap_state_before}, after={snap_state_after}"
         )
         log.info(
-            "Confirmed: all %d bound snapshot(s) are unchanged after "
+            "Confirmed: all %d snapshot(s) are unchanged after "
             "failed delete attempt",
-            len(bound_names_before),
+            len(snap_state_before),
         )

--- a/tests/functional/pv/pvc_snapshot/test_cephfs_orphaned_snapshot_alert.py
+++ b/tests/functional/pv/pvc_snapshot/test_cephfs_orphaned_snapshot_alert.py
@@ -10,14 +10,17 @@ from ocs_ci.framework.testlib import (
     ManageTest,
     hci_provider_and_client_required,
     tier1,
+    tier2,
 )
 from ocs_ci.helpers import helpers
 from ocs_ci.helpers.helpers import get_cephfs_subvolumegroup
 from ocs_ci.helpers.odf_cephfs_snap import (
+    verify_bound_snapshot_delete_rejected,
     create_provider_retain_cephfs_snapclass,
     delete_volumesnaps_volumesnapcontents,
     get_cephfs_snap_by_name,
     get_cephfs_snap_entries,
+    wait_and_verify_snapshot_bound,
 )
 from ocs_ci.ocs.resources.storageconsumer import get_consumer_svg_on_provider
 from ocs_ci.helpers.odf_cli import odf_cli_cephfs_snap_setup_helper
@@ -337,8 +340,12 @@ class TestCephFSOrphanedSnapshotAlert(ManageTest):
         """
         if svg_param == "consumer_svg_on_provider":
             storage_client_name = get_storage_client().resource_name
+            client_cluster_name = config.ENV_DATA.get("cluster_name")
             with config.RunWithProviderConfigContextIfAvailable():
-                svg = get_consumer_svg_on_provider(storage_client_name)
+                svg = get_consumer_svg_on_provider(
+                    storage_client_name,
+                    client_cluster_name=client_cluster_name,
+                )
             log.info("Using consumer SVG on provider: %s", svg)
         elif svg_param == "default_svg":
             svg = get_cephfs_subvolumegroup()
@@ -450,3 +457,90 @@ class TestCephFSOrphanedSnapshotAlert(ManageTest):
 
         log.test_step("Wait for CephFSOrphanedSnapshot alerts to clear")
         self._wait_for_orphaned_alert_cleared()
+
+    @tier2
+    @polarion_id("OCS-8027")
+    def test_cephfs_bound_snapshot_delete_rejected(self):
+        """
+        Verify that attempting to delete a Bound CephFS snapshot via the
+        odf CLI is rejected with an error and the snapshot is preserved.
+
+        Steps:
+        1. Resolve the odf-cli --svg value (no explicit svg).
+        2. Verify no CephFS snapshots exist.
+        3. Create snapshots with Retain policy: 1 to be orphaned,
+           2 to remain bound.
+        4. Delete VolumeSnapshot/VolumeSnapshotContent for the orphaned
+           snapshot so it becomes orphaned; bound snapshots remain bound.
+        5. Verify the orphaned snapshot is orphaned and the bound
+           snapshots remain bound.
+        6. Attempt to delete a bound snapshot via odf cephfs-snap delete.
+        7. Verify the delete operation fails (CommandFailed is raised)
+           and a non-empty error message is returned.
+        8. Verify the targeted bound snapshot still exists in Bound state.
+        9. List all CephFS snapshots and confirm the bound snapshot is
+           present and unchanged.
+        """
+        num_of_orphaned = 1
+        num_of_bound = 2
+
+        log.test_step("Resolve odf-cli --svg (no explicit svg)")
+        self._resolve_svg(None)
+
+        log.test_step("Verify no CephFS snapshots exist")
+        assert not get_cephfs_snap_entries(
+            self._snap_runner
+        ), "Expected no CephFS snapshots before the test"
+
+        log.test_step(
+            "Create %d CephFS VolumeSnapshots with Retain policy",
+            num_of_orphaned + num_of_bound,
+        )
+        self.create_retain_cephfs_snapshots(num_of_orphaned + num_of_bound)
+        orphaned_snaps = self.snap_list_names[:num_of_orphaned]
+        bound_snaps = self.snap_list_names[num_of_orphaned:]
+
+        log.test_step(
+            "Delete VolumeSnapshot/VolumeSnapshotContent for "
+            "%d orphaned snapshot(s)",
+            num_of_orphaned,
+        )
+        delete_volumesnaps_volumesnapcontents(orphaned_snaps)
+
+        log.test_step(
+            "Verify %d snapshot(s) are orphaned and " "%d snapshot(s) remain bound",
+            num_of_orphaned,
+            num_of_bound,
+        )
+        self.verify_cephfs_snapshots_orphaned(orphaned_snaps)
+        self.verify_cephfs_snapshots_bound(bound_snaps)
+
+        target_snap = bound_snaps[0]
+        log.test_step(
+            "Attempt to delete bound snapshot '%s' via odf CLI",
+            target_snap["ceph_snap_name"],
+        )
+        verify_bound_snapshot_delete_rejected(self._snap_runner, target_snap)
+
+        log.test_step(
+            "Verify bound snapshot '%s' still exists in Bound state",
+            target_snap["ceph_snap_name"],
+        )
+        wait_and_verify_snapshot_bound(self._snap_runner, target_snap)
+
+        log.test_step("List CephFS snapshots and confirm bound snapshot is unchanged")
+        snap_entries = get_cephfs_snap_entries(self._snap_runner)
+        bound_names = {
+            e["snapshot"]
+            for e in snap_entries
+            if e["state"] == constants.CEPHFS_SNAPSHOT_STATE_BOUND
+        }
+        assert target_snap["ceph_snap_name"] in bound_names, (
+            f"Bound snapshot '{target_snap['ceph_snap_name']}' not "
+            f"found in snapshot list after failed delete attempt"
+        )
+        log.info(
+            "Confirmed: bound snapshot '%s' is unchanged after "
+            "failed delete attempt",
+            target_snap["ceph_snap_name"],
+        )

--- a/tests/functional/pv/pvc_snapshot/test_cephfs_orphaned_snapshot_alert.py
+++ b/tests/functional/pv/pvc_snapshot/test_cephfs_orphaned_snapshot_alert.py
@@ -48,6 +48,24 @@ class TestCephFSOrphanedSnapshotAlert(ManageTest):
 
     retain_snapclass_name = "test-cephfs-retain-snapclass"
 
+    @property
+    def api(self):
+        if self._api is None:
+            self._api = PrometheusAPI(
+                threading_lock=self._threading_lock,
+                cluster_context=(config.RunWithFirstConsumerConfigContextIfAvailable),
+            )
+        return self._api
+
+    @property
+    def provider_api(self):
+        if self._provider_api is None and config.multicluster:
+            self._provider_api = PrometheusAPI(
+                threading_lock=self._threading_lock,
+                cluster_context=(config.RunWithProviderConfigContextIfAvailable),
+            )
+        return self._provider_api
+
     @pytest.fixture(autouse=True)
     def setup(self, request, pvc_factory, threading_lock):
         """
@@ -86,17 +104,9 @@ class TestCephFSOrphanedSnapshotAlert(ManageTest):
             storage_client=storage_client
         )
 
-        self.api = PrometheusAPI(
-            threading_lock=threading_lock,
-            cluster_context=config.RunWithFirstConsumerConfigContextIfAvailable,
-        )
-
-        self.provider_api = None
-        if config.multicluster:
-            self.provider_api = PrometheusAPI(
-                threading_lock=threading_lock,
-                cluster_context=config.RunWithProviderConfigContextIfAvailable,
-            )
+        self._threading_lock = threading_lock
+        self._api = None
+        self._provider_api = None
 
         self.snap_list_names = []
 


### PR DESCRIPTION
Add `test_cephfs_bound_snapshot_delete_rejected` to verify that the odf CLI rejects deletion of a Bound CephFS snapshot. The test reuses the existing setup fixture (Retain snapclass, bound and orphaned snapshots) and asserts the CLI fails or leaves the snapshot intact, then confirms the snapshot remains in Bound state via a short TimeoutSampler poll.

Extract two helpers into `odf_cephfs_snap.py`:
- `verify_bound_snapshot_delete_rejected`: tries the CLI delete, handles both CommandFailed (expected path) and silent no-op (fallback check).
- `wait_and_verify_snapshot_bound`: polls with TimeoutSampler then does a final explicit Bound-state assertion.

Fix `find_consumer_for_storage_client` and `get_consumer_svg_on_provider` in `storageconsumer.py` to accept an optional `client_cluster_name` parameter. When multiple consumers share the same storage-client name, the caller passes `config.ENV_DATA["cluster_name"]` (captured before switching to the provider context) so the correct consumer is found by matching the prefix of `status.client.clusterName`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end negative test coverage ensuring deletion attempts for **Bound** CephFS snapshots are correctly rejected and the snapshot set remains unchanged.
  * Improved multicluster SVG resolution by using the client cluster context to select the correct provider mapping.

* **Bug Fixes**
  * Strengthened verification that **Bound** CephFS snapshot deletions are rejected, including more robust CLI output matching.
  * Added polling-based confirmation that the target snapshot remains in **Bound** state after the failed delete attempt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->