### PR TITLE
resolve client profile mapping for non-default storage ns

### DIFF
--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -1735,6 +1735,9 @@ class Deployment(object):
                 key_secret = config.AUTH["ibmcloud"]["ibm_cos_secret_access_key"]
                 cos_secret_data["data"]["IBM_COS_ACCESS_KEY_ID"] = key_id
                 cos_secret_data["data"]["IBM_COS_SECRET_ACCESS_KEY"] = key_secret
+                cos_secret_data["metadata"]["namespace"] = config.ENV_DATA[
+                    "cluster_namespace"
+                ]
                 cos_secret_data_yaml = tempfile.NamedTemporaryFile(
                     mode="w+", prefix="cos_secret", delete=False
                 )

--- a/ocs_ci/ocs/resources/storageconsumer.py
+++ b/ocs_ci/ocs/resources/storageconsumer.py
@@ -754,6 +754,23 @@ def verify_consumer_configmap(
     disable_blockpools = config.COMPONENTS["disable_blockpools"]
     disable_cephfs = config.COMPONENTS["disable_cephfs"]
 
+    # Get the actual CSI ClientProfile name from the cluster.
+    # The ClientProfile name is a stable CSI identity (e.g. "openshift-storage") that
+    # may differ from cluster_namespace (e.g. "odf-storage" in ROSA HCP odf deployments).
+    client_profile_items = (
+        ocp.OCP(
+            kind=constants.CLIENT_PROFILE,
+            namespace=config.cluster_ctx.ENV_DATA["cluster_namespace"],
+        )
+        .get()
+        .get("items", [])
+    )
+    csi_client_profile_name = (
+        client_profile_items[0]["metadata"]["name"]
+        if client_profile_items
+        else config.cluster_ctx.ENV_DATA["cluster_namespace"]
+    )
+
     def convergence_ver(version):
         return get_semantic_version(
             version, only_major_minor=True
@@ -860,11 +877,10 @@ def verify_consumer_configmap(
         )
         ceph_data_on_consumer_match_arg["csiop-cephfs-client-profile"] = (
             ceph_data_arg.get("csiop-cephfs-client-profile", "")
-            == config.cluster_ctx.ENV_DATA["cluster_namespace"]
+            == csi_client_profile_name
         )
         ceph_data_on_consumer_match_arg["csiop-rbd-client-profile"] = (
-            ceph_data_arg.get("csiop-rbd-client-profile", "")
-            == config.cluster_ctx.ENV_DATA["cluster_namespace"]
+            ceph_data_arg.get("csiop-rbd-client-profile", "") == csi_client_profile_name
         )
 
     if internal_consumer and not (disable_blockpools or disable_cephfs):
@@ -909,8 +925,7 @@ def verify_consumer_configmap(
             == "rook-csi-rbd-provisioner"
         )
         ceph_data_on_consumer_match["csiop-rbd-client-profile"] = (
-            ceph_data.get("csiop-rbd-client-profile", "")
-            == config.cluster_ctx.ENV_DATA["cluster_namespace"]
+            ceph_data.get("csiop-rbd-client-profile", "") == csi_client_profile_name
         )
     elif (
         not internal_consumer


### PR DESCRIPTION
 Instead of assuming the ClientProfile name equals the namespace, fetch the actual ClientProfile name from the cluster
Assumption is `ConfigMap value == ClientProfile name`, which happens to be true on problematic cluster, based on MG logs

Fix the problem, seen in run 21678, 21715
```
2026-06-20 13:09:48  >       assert all(ceph_data_on_consumer_match.values()), (
2026-06-20 13:09:48              f"StorageConsumer config map data does not match expected values. Consumer name: {consumer_name};"
2026-06-20 13:09:48              f"ODF Operator upgraded: {is_cluster_y_version_upgraded()}; "
2026-06-20 13:09:48          )
2026-06-20 13:09:48  E       AssertionError: StorageConsumer config map data does not match expected values. Consumer name: internal;ODF Operator upgraded:
```
https://url.corp.redhat.com/83f4224

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved storage configuration verification by deriving the CSI ClientProfile stable name dynamically from existing `CLIENT_PROFILE` entries, with a fallback when none are found.
  * Updated internal-client post-convergence checks to use the derived ClientProfile name consistently, including when CephFS is disabled.
  * Fixed IBM Cloud COS secret generation by ensuring the secret manifest includes the correct cluster namespace metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->