### PR TITLE
patch-metadata-pool-EC-day-2-FIX

### DIFF
--- a/ocs_ci/ocs/cluster.py
+++ b/ocs_ci/ocs/cluster.py
@@ -2515,7 +2515,7 @@ def ensure_ec_metadata_pool_exists(
     }
     sc_obj.patch(
         resource_name=sc_name,
-        params=patch,
+        params=json.dumps(patch),
         format_type="merge",
     )
 


### PR DESCRIPTION
resolve issue

```
2026-06-26 14:25:11  07:25:11 - MainThread - ocs_ci.utility.utils - INFO - C[prsurve-gdr21-c1] - Executing command: oc --kubeconfig /home/jenkins/clusters/prsurve-gdr21-c1/openshift-cluster-dir/auth/kubeconfig -n openshift-storage patch storagecluster ocs-storagecluster -n openshift-storage -p '{spec: {managedResources: {cephBlockPools: {erasureCodedMetadataPool: replicated-metadata-pool}}}}' --type merge
2026-06-26 14:25:11  07:25:11 - MainThread - ocs_ci.utility.utils - WARNING - C[prsurve-gdr21-c1] - Command stderr: Error from server (BadRequest): error decoding patch: invalid character 's' looking for beginning of object key string
2026-06-26 14:25:11  
2026-06-26 14:25:12  07:25:12 - MainThread - ocs_ci.framework.pytest_customization.reports - INFO - C[prsurve-gdr21-c1] - duration reported by tests/functional/disaster-recovery/regional-dr/test_cnv_failover_and_relocate_discovered_apps.py::TestCNVFailoverAndRelocateWithDiscoveredApps::test_cnv_failover_and_relocate_discovered_apps[custom_pool_erasure_coding_without_compression] immediately after test execution: 6.35
2026-06-26 14:25:12  FAILED
2026-06-26 14:25:12  _ TestCNVFailoverAndRelocateWithDiscoveredApps.test_cnv_failover_and_relocate_discovered_apps[custom_pool_erasure_coding_without_compression] _
2026-06-26 14:25:12  
2026-06-26 14:25:12  self = <test_cnv_failover_and_relocate_discovered_apps.TestCNVFailoverAndRelocateWithDiscoveredApps object at 0x7f1513edddd0>
2026-06-26 14:25:12  custom_sc = True, replica = 3, compression = None, erasure_coding = True
2026-06-26 14:25:12  cnv_custom_storage_class = <function cnv_custom_storage_class.<locals>.factory at 0x7f151ace1d00>
2026-06-26 14:25:12  discovered_apps_dr_workload_cnv = <function discovered_apps_dr_workload_cnv.<locals>.factory at 0x7f151ace22a0>
2026-06-26 14:25:12  nodes_multicluster = [<ocs_ci.ocs.platform_nodes.VMWareUPINodes object at 0x7f151afa0890>, <ocs_ci.ocs.platform_nodes.VMWareLSONodes object at 0x7f151aa5c1d0>, <ocs_ci.ocs.platform_nodes.VMWareUPINodes object at 0x7f151afa3610>]
2026-06-26 14:25:12  node_restart_teardown = None
2026-06-26 14:25:12  
2026-06-26 14:25:12      @pytest.mark.parametrize(
2026-06-26 14:25:12          argnames=["custom_sc", "replica", "compression", "erasure_coding"],
2026-06-26 14:25:12          argvalues=[
2026-06-26 14:25:12              pytest.param(
2026-06-26 14:25:12                  False,
2026-06-26 14:25:12                  3,
2026-06-26 14:25:12                  None,
2026-06-26 14:25:12                  False,
2026-06-26 14:25:12                  marks=pytest.mark.polarion_id("OCS-6266"),
2026-06-26 14:25:12                  id="default_pool_replica3_without_compression",
2026-06-26 14:25:12              ),
2026-06-26 14:25:12              pytest.param(
2026-06-26 14:25:12                  True,
2026-06-26 14:25:12                  2,
2026-06-26 14:25:12                  None,
2026-06-26 14:25:12                  False,
2026-06-26 14:25:12                  # marks=pytest.mark.polarion_id("OCS-XXXX"),
2026-06-26 14:25:12                  id="custom_pool_replica2_without_compression",
2026-06-26 14:25:12              ),
2026-06-26 14:25:12              # TODO: ADD Polarion ID for Custom SC test
2026-06-26 14:25:12              pytest.param(
2026-06-26 14:25:12                  True,
2026-06-26 14:25:12                  3,
2026-06-26 14:25:12                  "aggressive",
2026-06-26 14:25:12                  False,
2026-06-26 14:25:12                  # marks=pytest.mark.polarion_id("OCS-XXXX"),
2026-06-26 14:25:12                  id="custom_pool_replica3_with_compression",
2026-06-26 14:25:12              ),
2026-06-26 14:25:12              # TODO: ADD Polarion ID for Custom SC test
2026-06-26 14:25:12              pytest.param(
2026-06-26 14:25:12                  True,
2026-06-26 14:25:12                  2,
2026-06-26 14:25:12                  "aggressive",
2026-06-26 14:25:12                  False,
2026-06-26 14:25:12                  # marks=pytest.mark.polarion_id("OCS-XXXX"),
2026-06-26 14:25:12                  id="custom_pool_replica2_with_compression",
2026-06-26 14:25:12              ),
2026-06-26 14:25:12              # TODO: ADD Polarion ID for Custom SC test
2026-06-26 14:25:12              pytest.param(
2026-06-26 14:25:12                  True,
2026-06-26 14:25:12                  3,
2026-06-26 14:25:12                  None,
2026-06-26 14:25:12                  False,
2026-06-26 14:25:12                  # marks=pytest.mark.polarion_id("OCS-XXXX"),
2026-06-26 14:25:12                  id="custom_pool_replica3_without_compression",
2026-06-26 14:25:12              ),
2026-06-26 14:25:12              # TODO: ADD Polarion ID for Custom SC test
2026-06-26 14:25:12              pytest.param(
2026-06-26 14:25:12                  True,
2026-06-26 14:25:12                  3,
2026-06-26 14:25:12                  None,
2026-06-26 14:25:12                  True,
2026-06-26 14:25:12                  # marks=pytest.mark.polarion_id("OCS-XXXX"),
2026-06-26 14:25:12                  id="custom_pool_erasure_coding_without_compression",
2026-06-26 14:25:12              ),
2026-06-26 14:25:12              # TODO: ADD Polarion ID for Custom SC test
2026-06-26 14:25:12          ],
2026-06-26 14:25:12      )
2026-06-26 14:25:12      def test_cnv_failover_and_relocate_discovered_apps(
2026-06-26 14:25:12          self,
2026-06-26 14:25:12          custom_sc,
2026-06-26 14:25:12          replica,
2026-06-26 14:25:12          compression,
2026-06-26 14:25:12          erasure_coding,
2026-06-26 14:25:12          cnv_custom_storage_class,
2026-06-26 14:25:12          discovered_apps_dr_workload_cnv,
2026-06-26 14:25:12          nodes_multicluster,
2026-06-26 14:25:12          node_restart_teardown,
2026-06-26 14:25:12      ):
2026-06-26 14:25:12          """
2026-06-26 14:25:12          Tests to verify cnv application failover and Relocate with Discovered Apps
2026-06-26 14:25:12          There are two test cases:
2026-06-26 14:25:12              1) Failover to secondary cluster when primary cluster is down. Primary managed cluster is failed
2026-06-26 14:25:12              before failover operation and recovered after successful failover.
2026-06-26 14:25:12              2) Relocate back to primary
2026-06-26 14:25:12      
2026-06-26 14:25:12          Test is parametrized to run with Custom RBD Storage Class and Pool of Replica-2.
2026-06-26 14:25:12      
2026-06-26 14:25:12          """
2026-06-26 14:25:12      
2026-06-26 14:25:12          md5sum_original = []
2026-06-26 14:25:12          md5sum_failover = []
2026-06-26 14:25:12          vm_filepaths = ["/dd_file1.txt", "/dd_file2.txt", "/dd_file3.txt"]
2026-06-26 14:25:12      
2026-06-26 14:25:12          if custom_sc:
2026-06-26 14:25:12              logger.info("Calling fixture to create Custom Pool/SC..")
2026-06-26 14:25:12  >           cnv_custom_storage_class(
2026-06-26 14:25:12                  replica=replica, compression=compression, erasure_coded=erasure_coding
2026-06-26 14:25:12              )
2026-06-26 14:25:12  
2026-06-26 14:25:12  tests/functional/disaster-recovery/regional-dr/test_cnv_failover_and_relocate_discovered_apps.py:119: 
2026-06-26 14:25:12  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2026-06-26 14:25:12  tests/functional/disaster-recovery/regional-dr/conftest.py:153: in factory
2026-06-26 14:25:12      pool_obj = ceph_pool_factory(
2026-06-26 14:25:12  tests/conftest.py:1119: in factory
2026-06-26 14:25:12      ceph_pool_obj = helpers.create_ceph_block_pool(
2026-06-26 14:25:12  ocs_ci/helpers/helpers.py:795: in create_ceph_block_pool
2026-06-26 14:25:12      ensure_ec_metadata_pool_exists()
2026-06-26 14:25:12  ocs_ci/ocs/cluster.py:2516: in ensure_ec_metadata_pool_exists
2026-06-26 14:25:12      sc_obj.patch(
2026-06-26 14:25:12  ocs_ci/ocs/ocp.py:549: in patch
2026-06-26 14:25:12      result = self.exec_oc_cmd(command)
2026-06-26 14:25:12  ocs_ci/ocs/ocp.py:216: in exec_oc_cmd
2026-06-26 14:25:12      out = run_cmd(
2026-06-26 14:25:12  ocs_ci/utility/utils.py:632: in run_cmd
2026-06-26 14:25:12      completed_process = exec_cmd(
2026-06-26 14:25:12  ocs_ci/utility/retry.py:79: in f_retry
2026-06-26 14:25:12      return f(*args, **kwargs)
2026-06-26 14:25:12  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2026-06-26 14:25:12  
2026-06-26 14:25:12  cmd = ['oc', '--kubeconfig', '/home/jenkins/clusters/prsurve-gdr21-c1/openshift-cluster-dir/auth/kubeconfig', '-n', 'openshift-storage', 'patch', ...]
2026-06-26 14:25:12  secrets = None, timeout = 600, ignore_error = False, threading_lock = None
2026-06-26 14:25:12  silent = False
2026-06-26 14:25:12  cluster_config = <ocs_ci.framework.MultiClusterConfig object at 0x7f154560ba90>
2026-06-26 14:25:12  lock_timeout = 7200, output_file = None, kwargs = {}
2026-06-26 14:25:12  _env = {'ANTHROPIC_VERTEX_PROJECT_ID': 'itpc-gcp-core-pe-eng-claude', 'BASH_FUNC_which%%': '() {  ( alias;\n eval ${which_dec...ions --show-tilde --show-dot $@\n}', 'BUILD_DISPLAY_NAME': '#4993 - pratik-2az-jun24-t5 test', 'BUILD_ID': '4993', ...}
2026-06-26 14:25:12  kubeconfig_path = '/home/jenkins/clusters/prsurve-gdr21-c1/openshift-cluster-dir/auth/kubeconfig'
2026-06-26 14:25:12  
2026-06-26 14:25:12      @retry(
2026-06-26 14:25:12          CommandFailed,
2026-06-26 14:25:12          tries=6,
2026-06-26 14:25:12          delay=10,
2026-06-26 14:25:12          backoff=1,
2026-06-26 14:25:12          text_in_exception="client connection lost",
2026-06-26 14:25:12      )
2026-06-26 14:25:12      def exec_cmd(
2026-06-26 14:25:12          cmd,
2026-06-26 14:25:12          secrets=None,
2026-06-26 14:25:12          timeout=600,
2026-06-26 14:25:12          ignore_error=False,
2026-06-26 14:25:12          threading_lock=None,
2026-06-26 14:25:12          silent=False,
2026-06-26 14:25:12          cluster_config=None,
2026-06-26 14:25:12          lock_timeout=7200,
2026-06-26 14:25:12          output_file=None,
2026-06-26 14:25:12          **kwargs,
2026-06-26 14:25:12      ):
2026-06-26 14:25:12          """
2026-06-26 14:25:12          Run an arbitrary command locally
2026-06-26 14:25:12      
2026-06-26 14:25:12          If the command is grep and matching pattern is not found, then this function
2026-06-26 14:25:12          returns "command terminated with exit code 1" in stderr.
2026-06-26 14:25:12      
2026-06-26 14:25:12          Args:
2026-06-26 14:25:12              cmd (str): command to run
2026-06-26 14:25:12              secrets (list): A list of secrets to be masked with asterisks
2026-06-26 14:25:12                  This kwarg is popped in order to not interfere with
2026-06-26 14:25:12                  subprocess.run(``**kwargs``)
2026-06-26 14:25:12              timeout (int): Timeout for the command, defaults to 600 seconds.
2026-06-26 14:25:12              ignore_error (bool): True if ignore non zero return code and do not
2026-06-26 14:25:12                  raise the exception.
2026-06-26 14:25:12              threading_lock (threading.RLock): threading.RLock object that is used
2026-06-26 14:25:12                  for handling concurrent oc commands
2026-06-26 14:25:12              silent (bool): If True will silent errors from the server, default false
2026-06-26 14:25:12              cluster_config (MultiClusterConfig): In case of multicluster environment this object
2026-06-26 14:25:12                      will be non-null
2026-06-26 14:25:12              lock_timeout (int): maximum timeout to wait for lock to prevent deadlocks (default 2 hours)
2026-06-26 14:25:12              output_file (str): path where to write output of stderr from command - apply only when silent mode is True
2026-06-26 14:25:12      
2026-06-26 14:25:12          Raises:
2026-06-26 14:25:12              CommandFailed: In case the command execution fails
2026-06-26 14:25:12      
2026-06-26 14:25:12          Returns:
2026-06-26 14:25:12              (CompletedProcess) A CompletedProcess object of the command that was executed
2026-06-26 14:25:12              CompletedProcess attributes:
2026-06-26 14:25:12              args: The list or str args passed to run().
2026-06-26 14:25:12              returncode (str): The exit code of the process, negative for signals.
2026-06-26 14:25:12              stdout     (str): The standard output (None if not captured).
2026-06-26 14:25:12              stderr     (str): The standard error (None if not captured).
2026-06-26 14:25:12      
2026-06-26 14:25:12          """
2026-06-26 14:25:12          _env = kwargs.pop("env", os.environ.copy())
2026-06-26 14:25:12          kubeconfig_path = config.RUN.get("kubeconfig")
2026-06-26 14:25:12          if kubeconfig_path:
2026-06-26 14:25:12              _env["KUBECONFIG"] = kubeconfig_path
2026-06-26 14:25:12          if cluster_config:
2026-06-26 14:25:12              kubeconfig_path = cluster_config.RUN.get("kubeconfig")
2026-06-26 14:25:12              if kubeconfig_path:
2026-06-26 14:25:12                  _env["KUBECONFIG"] = cluster_config.RUN.get("kubeconfig")
2026-06-26 14:25:12          if isinstance(cmd, str) and not kwargs.get("shell"):
2026-06-26 14:25:12              cmd = shlex.split(cmd)
2026-06-26 14:25:12          if (
2026-06-26 14:25:12              kubeconfig_path
2026-06-26 14:25:12              and cmd[0] == "oc"
2026-06-26 14:25:12              and "--kubeconfig" not in cmd
2026-06-26 14:25:12              and "mirror" not in cmd
2026-06-26 14:25:12          ):
2026-06-26 14:25:12              kube_index = 1
2026-06-26 14:25:12              # check if we have an oc plugin in the command
2026-06-26 14:25:12              global _oc_plugin_list_cache
2026-06-26 14:25:12              if _oc_plugin_list_cache is None:
2026-06-26 14:25:12                  cp = subprocess.run(
2026-06-26 14:25:12                      shlex.split("oc plugin list"),
2026-06-26 14:25:12                      stdout=subprocess.PIPE,
2026-06-26 14:25:12                      stderr=subprocess.PIPE,
2026-06-26 14:25:12                  )
2026-06-26 14:25:12                  if cp.returncode == 0:
2026-06-26 14:25:12                      _oc_plugin_list_cache = cp.stdout.decode().splitlines()
2026-06-26 14:25:12      
2026-06-26 14:25:12              subcmd = cmd[1].split("-")
2026-06-26 14:25:12              if len(subcmd) > 1:
2026-06-26 14:25:12                  subcmd = "_".join(subcmd)
2026-06-26 14:25:12              if not isinstance(subcmd, str) and isinstance(subcmd, list):
2026-06-26 14:25:12                  subcmd = str(subcmd[0])
2026-06-26 14:25:12      
2026-06-26 14:25:12              plugin_lines = _oc_plugin_list_cache or []
2026-06-26 14:25:12              for l in plugin_lines:
2026-06-26 14:25:12                  if subcmd in l:
2026-06-26 14:25:12                      kube_index = 2
2026-06-26 14:25:12                      log.info(f"Found oc plugin {subcmd}")
2026-06-26 14:25:12              cmd = list_insert_at_position(cmd, kube_index, ["--kubeconfig"])
2026-06-26 14:25:12              cmd = list_insert_at_position(cmd, kube_index + 1, [kubeconfig_path])
2026-06-26 14:25:12          try:
2026-06-26 14:25:12              if kwargs.get("shell"):
2026-06-26 14:25:12                  masked_cmd = mask_secrets(cmd, secrets)
2026-06-26 14:25:12              else:
2026-06-26 14:25:12                  masked_cmd = shlex.join(mask_secrets(cmd, secrets))
2026-06-26 14:25:12              log.info(f"Executing command: {masked_cmd}")
2026-06-26 14:25:12              if threading_lock and cmd[0] == "oc":
2026-06-26 14:25:12                  threading_lock.acquire(timeout=lock_timeout)
2026-06-26 14:25:12              run_kw = {
2026-06-26 14:25:12                  "stdout": subprocess.PIPE,
2026-06-26 14:25:12                  "stderr": subprocess.PIPE,
2026-06-26 14:25:12                  "timeout": timeout,
2026-06-26 14:25:12                  "env": _env,
2026-06-26 14:25:12              }
2026-06-26 14:25:12              # subprocess.run forbids stdin= and input= together; when callers pass input,
2026-06-26 14:25:12              # stdin is managed internally. Do not inject stdin=PIPE if the caller set stdin.
2026-06-26 14:25:12              if "input" not in kwargs and "stdin" not in kwargs:
2026-06-26 14:25:12                  run_kw["stdin"] = subprocess.PIPE
2026-06-26 14:25:12              completed_process = subprocess.run(cmd, **run_kw, **kwargs)
2026-06-26 14:25:12          finally:
2026-06-26 14:25:12              if threading_lock and cmd[0] == "oc":
2026-06-26 14:25:12                  threading_lock.release()
2026-06-26 14:25:12          masked_stdout = mask_secrets(completed_process.stdout.decode(), secrets)
2026-06-26 14:25:12          truncated_stdout = truncate_long_lines(masked_stdout)
2026-06-26 14:25:12          if len(completed_process.stdout) > 0:
2026-06-26 14:25:12              truncated_stdout = truncate_large_base64(truncated_stdout)
2026-06-26 14:25:12              log.debug(f"Command stdout: {truncated_stdout}")
2026-06-26 14:25:12          else:
2026-06-26 14:25:12              log.debug("Command stdout is empty")
2026-06-26 14:25:12      
2026-06-26 14:25:12          masked_stderr = mask_secrets(completed_process.stderr.decode(), secrets)
2026-06-26 14:25:12          if len(completed_process.stderr) > 0:
2026-06-26 14:25:12              if not silent:
2026-06-26 14:25:12                  truncated_stderr = truncate_large_base64(masked_stderr)
2026-06-26 14:25:12                  log.warning(f"Command stderr: {truncated_stderr}")
2026-06-26 14:25:12              else:
2026-06-26 14:25:12                  if output_file:
2026-06-26 14:25:12                      with open(output_file, "a") as out_fd:
2026-06-26 14:25:12                          out_fd.write(masked_stderr)
2026-06-26 14:25:12          else:
2026-06-26 14:25:12              if not silent:
2026-06-26 14:25:12                  log.debug("Command stderr is empty")
2026-06-26 14:25:12          log.debug(f"Command return code: {completed_process.returncode}")
2026-06-26 14:25:12          if completed_process.returncode and not ignore_error:
2026-06-26 14:25:12              masked_stderr = bin_xml_escape(filter_out_emojis(masked_stderr))
2026-06-26 14:25:12              if (
2026-06-26 14:25:12                  "grep" in masked_cmd
2026-06-26 14:25:12                  and b"command terminated with exit code 1" in completed_process.stderr
2026-06-26 14:25:12              ):
2026-06-26 14:25:12                  log.info(f"No results found for grep command: {masked_cmd}")
2026-06-26 14:25:12              else:
2026-06-26 14:25:12  >               raise CommandFailed(
2026-06-26 14:25:12                      f"Error during execution of command: {masked_cmd}."
2026-06-26 14:25:12                      f"\nError is {masked_stderr}"
2026-06-26 14:25:12                  )
2026-06-26 14:25:12  E               ocs_ci.ocs.exceptions.CommandFailed: Error during execution of command: oc --kubeconfig /home/jenkins/clusters/prsurve-gdr21-c1/openshift-cluster-dir/auth/kubeconfig -n openshift-storage patch storagecluster ocs-storagecluster -n openshift-storage -p '{spec: {managedResources: {cephBlockPools: {erasureCodedMetadataPool: replicated-metadata-pool}}}}' --type merge.
2026-06-26 14:25:12  E               Error is Error from server (BadRequest): error decoding patch: invalid character 's' looking for beginning of object key string
2026-06-26 14:25:12  
2026-06-26 14:25:12  ocs_ci/utility/utils.py:885: CommandFailed
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how storage cluster settings are sent so metadata pool configuration is applied more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->