### PR TITLE
Force-delete pods on unreachable nodes in delete_resources()

### DIFF
--- a/ocs_ci/helpers/sanity_helpers.py
+++ b/ocs_ci/helpers/sanity_helpers.py
@@ -139,17 +139,49 @@ class Sanity:
                     tries=noobaa_health_check_tries
                 )
 
-    def delete_resources(self):
+    def delete_resources(self, force_on_unreachable_node=False):
         """
         Sanity validation - Delete resources (pods, PVCs and OBCs)
+
+        Args:
+            force_on_unreachable_node (bool): If True, force-delete pods running
+                on unreachable (NotReady) nodes instead of waiting for graceful
+                termination that can never complete without kubelet.
 
         """
         logger.info("Deleting resources as a sanity functional validation")
 
+        force_deleted_pods = set()
         for pod_obj in self.pod_objs:
+            if force_on_unreachable_node:
+                from ocs_ci.ocs.resources.pod import get_pod_node
+                from ocs_ci.ocs.exceptions import CommandFailed, NotFoundError
+
+                try:
+                    pod_node = get_pod_node(pod_obj)
+                    node_status = node.get_node_status(pod_node)
+                    if node_status is None:
+                        logger.warning(
+                            f"Could not determine node status for pod "
+                            f"{pod_obj.name}. Falling back to normal delete"
+                        )
+                    elif node_status != constants.NODE_READY:
+                        logger.info(
+                            f"Node {pod_node.name} is {node_status}, "
+                            f"force-deleting pod {pod_obj.name}"
+                        )
+                        pod_obj.delete(force=True)
+                        force_deleted_pods.add(pod_obj.name)
+                        continue
+                except (CommandFailed, NotFoundError, IndexError) as e:
+                    logger.warning(
+                        f"Could not determine node status for pod "
+                        f"{pod_obj.name}: {e}. Falling back to normal delete"
+                    )
             pod_obj.delete()
         for pod_obj in self.pod_objs:
-            pod_obj.ocp.wait_for_delete(pod_obj.name)
+            if pod_obj.name not in force_deleted_pods:
+                pod_obj.ocp.wait_for_delete(pod_obj.name)
         for pvc_obj in self.pvc_objs:
             pvc_obj.delete()
         for pvc_obj in self.pvc_objs:

--- a/tests/functional/z_cluster/nodes/test_nodes_restart.py
+++ b/tests/functional/z_cluster/nodes/test_nodes_restart.py
@@ -288,7 +288,7 @@ class TestNodesRestart(ManageTest):
             )
         elif operation == "delete_resources":
             # Cluster validation (resources creation and IO running)
-            self.sanity_helpers.delete_resources()
+            self.sanity_helpers.delete_resources(force_on_unreachable_node=True)
 
         # Starting the nodes
         nodes.start_nodes(nodes=[provisioner_node])
@@ -418,7 +418,7 @@ class TestNodesRestart(ManageTest):
             )
         elif operation == "delete_resources":
             # Cluster validation (resources creation and IO running)
-            self.sanity_helpers.delete_resources()
+            self.sanity_helpers.delete_resources(force_on_unreachable_node=True)
 
         # Starting the nodes
         nodes.start_nodes(nodes=[operator_node])


### PR DESCRIPTION
## Summary
- Add opt-in `force_on_unreachable_node` param to `sanity_helpers.delete_resources()`
- When enabled, checks each pod's node status before deletion — if the node is NotReady, uses `--grace-period=0 --force` instead of waiting for kubelet confirmation that can never come
- Enable the flag in `test_nodes_restart.py` for both `stop_provisioner_pod_node` and `stop_rook_operator_pod_node` tests, which call `delete_resources()` while a node is deliberately stopped

## Test plan
- [x] Run `test_pv_provisioning_under_degraded_state_stop_provisioner_pod_node[rbd-delete_resources]` — should no longer hang on pod deletion when the test pod lands on the stopped node
- [x] Verify pods on healthy nodes still use normal (non-force) deletion
- [x] Verify `delete_resources()` without the flag behaves identically to before (default False)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource cleanup when nodes are unreachable during validation and recovery workflows.
  * Pods located on non-ready nodes are now force-deleted to prevent teardown from stalling.
  * Teardown now avoids waiting on pods that were already force-deleted, improving reliability and reducing cleanup time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->