### PR TITLE
Update path as per ocs-workloads

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -568,7 +568,6 @@
       {
         "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
         "is_verified": false,
-        "line_number": 334,
         "line_number": 338,
         "type": "Secret Keyword",
         "verified_result": null,
@@ -577,7 +576,6 @@
       {
         "hashed_secret": "de19c40310ad831a71524cd279e6f5f0577fb09a",
         "is_verified": false,
-        "line_number": 382,
         "line_number": 386,
         "type": "Secret Keyword",
         "verified_result": null,
@@ -662,7 +660,6 @@
       {
         "hashed_secret": "03e227627ab8681281fdb8aa3d799b03f782d672",
         "is_verified": false,
-        "line_number": 2053,
         "line_number": 2060,
         "type": "Secret Keyword",
         "verified_result": null,
@@ -671,7 +668,6 @@
       {
         "hashed_secret": "ef5f3d909f23bd0aa02b4253f98350384f709c86",
         "is_verified": false,
-        "line_number": 2160,
         "line_number": 2167,
         "type": "Secret Keyword",
         "verified_result": null,
@@ -680,7 +676,6 @@
       {
         "hashed_secret": "cb1ae2b504c4615841d8144267a131231d2bd677",
         "is_verified": false,
-        "line_number": 2161,
         "line_number": 2168,
         "type": "Secret Keyword",
         "verified_result": null,
@@ -689,7 +684,6 @@
       {
         "hashed_secret": "1a1e70e87dd0452c42f33ce9bf74aa28134dba6b",
         "is_verified": false,
-        "line_number": 2162,
         "line_number": 2169,
         "type": "Secret Keyword",
         "verified_result": null,
@@ -698,7 +692,6 @@
       {
         "hashed_secret": "7b1ba2f04f2f1604dc4e3caffcadf9fcbce7df5b",
         "is_verified": false,
-        "line_number": 2163,
         "line_number": 2170,
         "type": "Secret Keyword",
         "verified_result": null,
@@ -707,7 +700,6 @@
       {
         "hashed_secret": "0fa3b21ced80146d752888f2b60ec80e0d4b8925",
         "is_verified": false,
-        "line_number": 2175,
         "line_number": 2182,
         "type": "Secret Keyword",
         "verified_result": null,
@@ -716,7 +708,6 @@
       {
         "hashed_secret": "f084f2068494b8d1cd06811dd97d02c3d85f40ee",
         "is_verified": false,
-        "line_number": 2190,
         "line_number": 2197,
         "type": "Secret Keyword",
         "verified_result": null,
@@ -725,7 +716,6 @@
       {
         "hashed_secret": "adfa401a3b0a733d8f00519ac8c6b3893a2e7e8e",
         "is_verified": false,
-        "line_number": 2191,
         "line_number": 2198,
         "type": "Secret Keyword",
         "verified_result": null,
@@ -734,7 +724,6 @@
       {
         "hashed_secret": "898e46bbadc12f87120548bd445eb4210c8407c8",
         "is_verified": false,
-        "line_number": 2199,
         "line_number": 2206,
         "type": "Secret Keyword",
         "verified_result": null,
@@ -743,7 +732,6 @@
       {
         "hashed_secret": "f57ccec6b8f7b12b635ab53d26c3bf7300247341",
         "is_verified": false,
-        "line_number": 2200,
         "line_number": 2207,
         "type": "Secret Keyword",
         "verified_result": null,
@@ -752,7 +740,6 @@
       {
         "hashed_secret": "77b044ea736f8cbe568d1954424186d901f89db9",
         "is_verified": false,
-        "line_number": 2201,
         "line_number": 2208,
         "type": "Secret Keyword",
         "verified_result": null,
@@ -761,7 +748,6 @@
       {
         "hashed_secret": "d64368f12ca17c69568c6a132f17d44d56e60660",
         "is_verified": false,
-        "line_number": 2202,
         "line_number": 2209,
         "type": "Secret Keyword",
         "verified_result": null,
@@ -770,7 +756,6 @@
       {
         "hashed_secret": "8f9ca35156c02cb6ba58c5b51230b9bedc38de4f",
         "is_verified": false,
-        "line_number": 2203,
         "line_number": 2210,
         "type": "Secret Keyword",
         "verified_result": null,
@@ -779,7 +764,6 @@
       {
         "hashed_secret": "9ec53cfd9929c70c3f87c210b6a7b77fb6d79d43",
         "is_verified": false,
-        "line_number": 2800,
         "line_number": 2807,
         "type": "Secret Keyword",
         "verified_result": null,
@@ -788,7 +772,6 @@
       {
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
         "is_verified": false,
-        "line_number": 2966,
         "line_number": 2972,
         "type": "Secret Keyword",
         "verified_result": null,
@@ -797,7 +780,6 @@
       {
         "hashed_secret": "adc1f5c8707f7d7aba3aabe13c15e5ef1151872e",
         "is_verified": false,
-        "line_number": 2967,
         "line_number": 2973,
         "type": "Secret Keyword",
         "verified_result": null,
@@ -806,7 +788,6 @@
       {
         "hashed_secret": "ee46262b2df945e46ea310b925ad087465dbd3f2",
         "is_verified": false,
-        "line_number": 3688,
         "line_number": 3694,
         "type": "Secret Keyword",
         "verified_result": null,
@@ -815,7 +796,6 @@
       {
         "hashed_secret": "f678cad4ab874d71b559a069d5e34a95fe38a480",
         "is_verified": false,
-        "line_number": 3689,
         "line_number": 3695,
         "type": "Secret Keyword",
         "verified_result": null,

--- a/conf/ocsci/dr_workload.yaml
+++ b/conf/ocsci/dr_workload.yaml
@@ -24,35 +24,35 @@ ENV_DATA:
     },
   ]
   dr_workload_appset_rbd: [
-    { name: "appset-busybox-1", workload_dir: "rdr/busybox/rbd/appset/appset-busybox-1.yaml",
+    { name: "appset-busybox-1", workload_dir: "rdr/busybox/rbd/appset/deployments/appset-busybox-1.yaml",
       dr_workload_app_placement_name: "busybox-1-placement",
       dr_workload_app_pvc_selector: {'appname': 'busybox_app1'}, pod_count: 10, pvc_count: 10,
-      workload_path: "rdr/busybox/rbd/workloads/app-busybox-1"
+      workload_path: "rdr/busybox/rbd/workloads/deployments/app-busybox-1"
     },
-    { name: "appset-busybox-2", workload_dir: "rdr/busybox/rbd/appset/appset-busybox-2.yaml",
+    { name: "appset-busybox-2", workload_dir: "rdr/busybox/rbd/appset/deployments/appset-busybox-2.yaml",
       dr_workload_app_placement_name: "busybox-2-placement",
       dr_workload_app_pvc_selector: {'appname': 'busybox_app2'}, pod_count: 10, pvc_count: 10,
-      workload_path: "rdr/busybox/rbd/workloads/app-busybox-2"
+      workload_path: "rdr/busybox/rbd/workloads/deployments/app-busybox-2"
     },
-    { name: "appset-busybox-3", workload_dir: "rdr/busybox/rbd/appset/appset-busybox-3.yaml",
+    { name: "appset-busybox-3", workload_dir: "rdr/busybox/rbd/appset/deployments/appset-busybox-3.yaml",
       dr_workload_app_placement_name: "busybox-3-placement",
       dr_workload_app_pvc_selector: {'appname': 'busybox_app3'}, pod_count: 10, pvc_count: 10,
-      workload_path: "rdr/busybox/rbd/workloads/app-busybox-3"
+      workload_path: "rdr/busybox/rbd/workloads/deployments/app-busybox-3"
     },
-    { name: "appset-busybox-4", workload_dir: "rdr/busybox/rbd/appset/appset-busybox-4.yaml",
+    { name: "appset-busybox-4", workload_dir: "rdr/busybox/rbd/appset/deployments/appset-busybox-4.yaml",
       dr_workload_app_placement_name: "busybox-4-placement",
       dr_workload_app_pvc_selector: {'appname': 'busybox_app4'}, pod_count: 10, pvc_count: 10,
-      workload_path: "rdr/busybox/rbd/workloads/app-busybox-4"
+      workload_path: "rdr/busybox/rbd/workloads/deployments/app-busybox-4"
     },
-    { name: "appset-busybox-5", workload_dir: "rdr/busybox/rbd/appset/appset-busybox-5.yaml",
+    { name: "appset-busybox-5", workload_dir: "rdr/busybox/rbd/appset/deployments/appset-busybox-5.yaml",
       dr_workload_app_placement_name: "busybox-5-placement",
       dr_workload_app_pvc_selector: {'appname': 'busybox_app5'}, pod_count: 10, pvc_count: 10,
-      workload_path: "rdr/busybox/rbd/workloads/app-busybox-5"
+      workload_path: "rdr/busybox/rbd/workloads/deployments/app-busybox-5"
     },
-    { name: "appset-busybox-6", workload_dir: "rdr/busybox/rbd/appset/appset-busybox-6.yaml",
+    { name: "appset-busybox-6", workload_dir: "rdr/busybox/rbd/appset/deployments/appset-busybox-6.yaml",
       dr_workload_app_placement_name: "busybox-6-placement",
       dr_workload_app_pvc_selector: { 'appname': 'busybox_app6' }, pod_count: 10, pvc_count: 10,
-      workload_path: "rdr/busybox/rbd/workloads/app-busybox-6"
+      workload_path: "rdr/busybox/rbd/workloads/deployments/app-busybox-6"
     },
   ]
 
@@ -72,25 +72,25 @@ ENV_DATA:
   ]
 
   dr_workload_appset_cephfs: [
-    { name: "appset-busybox-1", workload_dir: "rdr/busybox/cephfs/appset/appset-busybox-1-cephfs.yaml",
+    { name: "appset-busybox-1", workload_dir: "rdr/busybox/cephfs/appset/deployments/appset-busybox-1-cephfs.yaml",
       dr_workload_app_placement_name: "busybox-1-placement-cephfs",
       dr_workload_app_pvc_selector: { 'appname': 'busybox_app1_cephfs' }, pod_count: 10, pvc_count: 10,
-      workload_path: "rdr/busybox/cephfs/workloads/app-busybox-1"
+      workload_path: "rdr/busybox/cephfs/workloads/deployments/app-busybox-1"
     },
-    { name: "appset-busybox-2", workload_dir: "rdr/busybox/cephfs/appset/appset-busybox-2-cephfs.yaml",
+    { name: "appset-busybox-2", workload_dir: "rdr/busybox/cephfs/appset/deployments/appset-busybox-2-cephfs.yaml",
       dr_workload_app_placement_name: "busybox-2-placement-cephfs",
       dr_workload_app_pvc_selector: { 'appname': 'busybox_app2_cephfs' }, pod_count: 10, pvc_count: 10,
-      workload_path: "rdr/busybox/cephfs/workloads/app-busybox-2"
+      workload_path: "rdr/busybox/cephfs/workloads/deployments/app-busybox-2"
     },
-    { name: "appset-busybox-3", workload_dir: "rdr/busybox/cephfs/appset/appset-busybox-3-cephfs.yaml",
+    { name: "appset-busybox-3", workload_dir: "rdr/busybox/cephfs/appset/deployments/appset-busybox-3-cephfs.yaml",
       dr_workload_app_placement_name: "busybox-3-placement-cephfs",
       dr_workload_app_pvc_selector: { 'appname': 'busybox_app3_cephfs' }, pod_count: 10, pvc_count: 10,
-      workload_path: "rdr/busybox/cephfs/workloads/app-busybox-3"
+      workload_path: "rdr/busybox/cephfs/workloads/deployments/app-busybox-3"
     },
-    { name: "appset-busybox-4", workload_dir: "rdr/busybox/cephfs/appset/appset-busybox-4-cephfs.yaml",
+    { name: "appset-busybox-4", workload_dir: "rdr/busybox/cephfs/appset/deployments/appset-busybox-4-cephfs.yaml",
       dr_workload_app_placement_name: "busybox-4-placement-cephfs",
       dr_workload_app_pvc_selector: { 'appname': 'busybox_app3_cephfs' }, pod_count: 10, pvc_count: 10,
-      workload_path: "rdr/busybox/cephfs/workloads/app-busybox-4"
+      workload_path: "rdr/busybox/cephfs/workloads/deployments/app-busybox-4"
     },
   ]
 
@@ -160,7 +160,7 @@ ENV_DATA:
     },
   ]
   dr_workload_discovered_apps_rbd: [
-    { name: "busybox-dict-1-rbd", workload_dir: "rdr/busybox/rbd/workloads/app-busybox-1",
+    { name: "busybox-dict-1-rbd", workload_dir: "rdr/busybox/rbd/workloads/deployments/app-busybox-1",
       pod_count: 10, pvc_count: 10,
       dr_workload_app_pod_selector_key: "workloadpattern",
       dr_workload_app_pod_selector_value: "simple_io",
@@ -176,7 +176,7 @@ ENV_DATA:
       dr_workload_app_recipe_namespace_value: "busybox-dict-1",
       dr_workload_app_recipe_name_selector_value: "busybox-*",
     },
-     { name: "busybox-dict-2-rbd", workload_dir: "rdr/busybox/rbd/workloads/app-busybox-2",
+     { name: "busybox-dict-2-rbd", workload_dir: "rdr/busybox/rbd/workloads/deployments/app-busybox-2",
        pod_count: 10, pvc_count: 10,
        dr_workload_app_pod_selector_key: "workloadpattern",
        dr_workload_app_pod_selector_value: "simple_io",
@@ -189,7 +189,7 @@ ENV_DATA:
      }
   ]
   dr_workload_discovered_apps_cephfs: [
-    { name: "busybox-dict-1-cephfs", workload_dir: "rdr/busybox/cephfs/workloads/app-busybox-1",
+    { name: "busybox-dict-1-cephfs", workload_dir: "rdr/busybox/cephfs/workloads/deployments/app-busybox-1",
       pod_count: 10, pvc_count: 10,
       dr_workload_app_pod_selector_key: "workloadpattern",
       dr_workload_app_pod_selector_value: "simple_io",
@@ -205,7 +205,7 @@ ENV_DATA:
       dr_workload_app_recipe_namespace_value: "busybox-dict-1",
       dr_workload_app_recipe_name_selector_value: "busybox-*",
     },
-    { name: "busybox-dict-2-cephfs", workload_dir: "rdr/busybox/cephfs/workloads/app-busybox-2",
+    { name: "busybox-dict-2-cephfs", workload_dir: "rdr/busybox/cephfs/workloads/deployments/app-busybox-2",
       pod_count: 10, pvc_count: 10,
       dr_workload_app_pod_selector_key: "workloadpattern",
       dr_workload_app_pod_selector_value: "simple_io",
@@ -218,57 +218,57 @@ ENV_DATA:
     },
   ]
   dr_workload_subscription_placement_rbd: [
-    { name: "busybox-1", workload_dir: "rdr/busybox/rbd/subscription_with_placement/app-busybox-1",
+    { name: "busybox-1", workload_dir: "rdr/busybox/rbd/subscription_with_placement/deployments/app-busybox-1",
       pod_count: 10, pvc_count: 10, is_placement: True,
       dr_workload_app_pvc_selector: { "appname": "busybox_app1" },
-      workload_path: "rdr/busybox/rbd/workloads/app-busybox-1",
+      workload_path: "rdr/busybox/rbd/workloads/deployments/app-busybox-1",
     },
-    { name: "busybox-2", workload_dir: "rdr/busybox/rbd/subscription_with_placement/app-busybox-2",
+    { name: "busybox-2", workload_dir: "rdr/busybox/rbd/subscription_with_placement/deployments/app-busybox-2",
       pod_count: 10, pvc_count: 10, is_placement: True,
       dr_workload_app_pvc_selector: { "appname": "busybox_app2" },
-      workload_path: "rdr/busybox/rbd/workloads/app-busybox-2",
+      workload_path: "rdr/busybox/rbd/workloads/deployments/app-busybox-2",
     },
-    { name: "busybox-3", workload_dir: "rdr/busybox/rbd/subscription_with_placement/app-busybox-3",
+    { name: "busybox-3", workload_dir: "rdr/busybox/rbd/subscription_with_placement/deployments/app-busybox-3",
       pod_count: 10, pvc_count: 10, is_placement: True,
       dr_workload_app_pvc_selector: { "appname": "busybox_app3" },
-      workload_path: "rdr/busybox/rbd/workloads/app-busybox-3",
+      workload_path: "rdr/busybox/rbd/workloads/deployments/app-busybox-3",
     },
-    { name: "busybox-4", workload_dir: "rdr/busybox/rbd/subscription_with_placement/app-busybox-4",
+    { name: "busybox-4", workload_dir: "rdr/busybox/rbd/subscription_with_placement/deployments/app-busybox-4",
       pod_count: 10, pvc_count: 10, is_placement: True,
       dr_workload_app_pvc_selector: { "appname": "busybox_app4" },
-      workload_path: "rdr/busybox/rbd/workloads/app-busybox-4",
+      workload_path: "rdr/busybox/rbd/workloads/deployments/app-busybox-4",
     },
-    { name: "busybox-5", workload_dir: "rdr/busybox/rbd/subscription_with_placement/app-busybox-5",
+    { name: "busybox-5", workload_dir: "rdr/busybox/rbd/subscription_with_placement/deployments/app-busybox-5",
       pod_count: 10, pvc_count: 10, is_placement: True,
       dr_workload_app_pvc_selector: { "appname": "busybox_app5" },
-      workload_path: "rdr/busybox/rbd/workloads/app-busybox-5",
+      workload_path: "rdr/busybox/rbd/workloads/deployments/app-busybox-5",
     },
-    { name: "busybox-6", workload_dir: "rdr/busybox/rbd/subscription_with_placement/app-busybox-6",
+    { name: "busybox-6", workload_dir: "rdr/busybox/rbd/subscription_with_placement/deployments/app-busybox-6",
       pod_count: 10, pvc_count: 10, is_placement: True,
       dr_workload_app_pvc_selector: { "appname": "busybox_app6" },
-      workload_path: "rdr/busybox/rbd/workloads/app-busybox-6",
+      workload_path: "rdr/busybox/rbd/workloads/deployments/app-busybox-6",
     },
   ]
   dr_workload_subscription_placement_cephfs: [
-    { name: "busybox-1", workload_dir: "rdr/busybox/cephfs/subscription_with_placement/app-busybox-1",
+    { name: "busybox-1", workload_dir: "rdr/busybox/cephfs/subscription_with_placement/deployments/app-busybox-1",
       pod_count: 10, pvc_count: 10, is_placement: True,
       dr_workload_app_pvc_selector: { "appname": "busybox_app1_cephfs" },
-      workload_path: "rdr/busybox/cephfs/workloads/app-busybox-1"
+      workload_path: "rdr/busybox/cephfs/workloads/deployments/app-busybox-1"
     },
-    { name: "busybox-2", workload_dir: "rdr/busybox/cephfs/subscription_with_placement/app-busybox-2",
+    { name: "busybox-2", workload_dir: "rdr/busybox/cephfs/subscription_with_placement/deployments/app-busybox-2",
       pod_count: 10, pvc_count: 10, is_placement: True,
       dr_workload_app_pvc_selector: { "appname": "busybox_app2_cephfs" },
-      workload_path: "rdr/busybox/cephfs/workloads/app-busybox-2"
+      workload_path: "rdr/busybox/cephfs/workloads/deployments/app-busybox-2"
     },
-    { name: "busybox-3", workload_dir: "rdr/busybox/cephfs/subscription_with_placement/app-busybox-3",
+    { name: "busybox-3", workload_dir: "rdr/busybox/cephfs/subscription_with_placement/deployments/app-busybox-3",
       pod_count: 10, pvc_count: 10, is_placement: True,
       dr_workload_app_pvc_selector: { "appname": "busybox_app3_cephfs" },
-      workload_path: "rdr/busybox/cephfs/workloads/app-busybox-3"
+      workload_path: "rdr/busybox/cephfs/workloads/deployments/app-busybox-3"
     },
-    { name: "busybox-4", workload_dir: "rdr/busybox/cephfs/subscription_with_placement/app-busybox-4",
+    { name: "busybox-4", workload_dir: "rdr/busybox/cephfs/subscription_with_placement/deployments/app-busybox-4",
       pod_count: 10, pvc_count: 10, is_placement: True,
       dr_workload_app_pvc_selector: { "appname": "busybox_app4_cephfs" },
-      workload_path: "rdr/busybox/cephfs/workloads/app-busybox-4"
+      workload_path: "rdr/busybox/cephfs/workloads/deployments/app-busybox-4"
     },
   ]
   dr_cnv_discovered_apps: [

--- a/conf/ocsci/dr_workload.yaml
+++ b/conf/ocsci/dr_workload.yaml
@@ -2,7 +2,7 @@ ENV_DATA:
   deploy_via_cli: True
   cg_enabled: True
   dr_workload_repo_url: "https://github.com/red-hat-storage/ocs-workloads.git"
-  dr_workload_repo_branch: "ss_apps"
+  dr_workload_repo_branch: "master"
   dr_workload_subscription_rbd: [
     {name: "busybox-1", workload_dir: "rdr/busybox/rbd/subscription_with_placementrule/app-busybox-1",
      pod_count: 10, pvc_count: 10

--- a/conf/ocsci/dr_workload.yaml
+++ b/conf/ocsci/dr_workload.yaml
@@ -2,7 +2,7 @@ ENV_DATA:
   deploy_via_cli: True
   cg_enabled: True
   dr_workload_repo_url: "https://github.com/red-hat-storage/ocs-workloads.git"
-  dr_workload_repo_branch: "master"
+  dr_workload_repo_branch: "ss_apps"
   dr_workload_subscription_rbd: [
     {name: "busybox-1", workload_dir: "rdr/busybox/rbd/subscription_with_placementrule/app-busybox-1",
      pod_count: 10, pvc_count: 10


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated BusyBox workload paths and directories across disaster-recovery scenarios to match the deployment layout.
  * Corrected discovered-app and subscription-with-placement workload references for deployment-based workloads.
* **New Features**
  * Added disaster-recovery workload configurations for BusyBox StatefulSets in AppSet and subscription-with-placement scenarios.
  * Added support for StatefulSet workloads with five pods and five persistent volume claims in applicable scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->