### PR TITLE
Add expected ceph config values for ODF 4.18 z-stream backports

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -646,6 +646,7 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 857,
+        "line_number": 855,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -654,6 +655,7 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 866,
+        "line_number": 864,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -662,6 +664,7 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 2077,
+        "line_number": 2075,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -670,6 +673,7 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 2184,
+        "line_number": 2182,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -678,6 +682,7 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 2185,
+        "line_number": 2183,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -686,6 +691,7 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 2186,
+        "line_number": 2184,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -694,6 +700,7 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 2187,
+        "line_number": 2185,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -702,6 +709,7 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 2199,
+        "line_number": 2197,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -710,6 +718,7 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 2214,
+        "line_number": 2212,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -718,6 +727,7 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 2215,
+        "line_number": 2213,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -726,6 +736,7 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 2223,
+        "line_number": 2221,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -734,6 +745,7 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 2224,
+        "line_number": 2222,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -742,6 +754,7 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 2225,
+        "line_number": 2223,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -750,6 +763,7 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 2226,
+        "line_number": 2224,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -758,6 +772,7 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 2227,
+        "line_number": 2225,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -766,6 +781,7 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 2824,
+        "line_number": 2822,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -774,6 +790,7 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 2990,
+        "line_number": 2988,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -782,6 +799,7 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 2991,
+        "line_number": 2989,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -790,6 +808,7 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 3713,
+        "line_number": 3737,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -798,6 +817,7 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 3714,
+        "line_number": 3738,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -3121,6 +3121,32 @@ osd_memory_target_cgroup_limit_ratio = 0.8
 bluestore_prefer_deferred_size_hdd = 0
 """
 
+ROOK_CEPH_CONFIG_VALUES_418 = r"""
+[global]
+bdev_flock_retry = 20
+mon_osd_full_ratio = .85
+mon_osd_backfillfull_ratio = .8
+mon_osd_nearfull_ratio = .75
+mon_max_pg_per_osd = 600
+mon_pg_warn_max_object_skew = 0
+mon_data_avail_warn = 15
+mon_warn_on_pool_no_redundancy = false
+bluestore_prefer_deferred_size_hdd = 0
+bluestore_slow_ops_warn_lifetime = 0
+[osd]
+osd_memory_target_cgroup_limit_ratio = 0.8
+[client.rbd-mirror.a]
+debug_ms = 1
+debug_rbd = 15
+debug_rbd_mirror = 30
+log_file = /var/log/ceph/\$cluster-\$name.log
+[client.rbd-mirror-peer]
+debug_ms = 1
+debug_rbd = 15
+debug_rbd_mirror = 30
+log_file = /var/log/ceph/\$cluster-\$name.log
+"""
+
 ROOK_CEPH_CONFIG_VALUES_419 = r"""
 [global]
 bdev_flock_retry = 20

--- a/tests/functional/z_cluster/test_ceph_default_values_check.py
+++ b/tests/functional/z_cluster/test_ceph_default_values_check.py
@@ -128,12 +128,10 @@ class TestCephDefaultValuesCheck(ManageTest):
             stored_values = constants.ROOK_CEPH_CONFIG_VALUES_414.split("\n")
         elif ocs_version == version.VERSION_4_15:
             stored_values = constants.ROOK_CEPH_CONFIG_VALUES_415.split("\n")
-        elif ocs_version in [
-            version.VERSION_4_16,
-            version.VERSION_4_17,
-            version.VERSION_4_18,
-        ]:
+        elif ocs_version in [version.VERSION_4_16, version.VERSION_4_17]:
             stored_values = constants.ROOK_CEPH_CONFIG_VALUES_416.split("\n")
+        elif ocs_version == version.VERSION_4_18:
+            stored_values = constants.ROOK_CEPH_CONFIG_VALUES_418.split("\n")
         elif ocs_version == version.VERSION_4_19:
             stored_values = constants.ROOK_CEPH_CONFIG_VALUES_419.split("\n")
         else:


### PR DESCRIPTION
- Add ROOK_CEPH_CONFIG_VALUES_418 constant reflecting backported ceph config changes from ocs-operator z-stream PRs
- Use new constant for ODF 4.18 version check in test_validate_ceph_config_values_in_rook_config_override

Backported ocs-operator changes included:
- `bluestore_slow_ops_warn_lifetime = 0` — [ocs-operator PR #3347](https://github.com/red-hat-storage/ocs-operator/pull/3347) ([DFBUGS-2906](https://redhat.atlassian.net/browse/DFBUGS-2906))
- `bluestore_prefer_deferred_size_hdd` moved from `[osd]` to `[global]` — same PR
- rbd-mirror debug logging (`[client.rbd-mirror.a]`, `[client.rbd-mirror-peer]`) — [ocs-operator PR #3209](https://github.com/red-hat-storage/ocs-operator/pull/3209) ([DFBUGS-2431](https://redhat.atlassian.net/browse/DFBUGS-2431))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected version-specific Ceph default configuration validation to align with the intended OpenShift Storage releases.
  * Added/adjusted the Ceph configuration profile used for the latest supported release, including updated OSD global settings and improved rbd-mirror debug logging expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->