### PR TITLE
[release-4.15] Add expected ceph config values for ODF 4.15 z-stream

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -2113,6 +2113,21 @@ osd_memory_target_cgroup_limit_ratio = 0.8
 bluestore_prefer_deferred_size_hdd = 0
 """
 
+ROOK_CEPH_CONFIG_VALUES_415 = """
+[global]
+bdev_flock_retry = 20
+mon_osd_full_ratio = .85
+mon_osd_backfillfull_ratio = .8
+mon_osd_nearfull_ratio = .75
+mon_max_pg_per_osd = 600
+mon_pg_warn_max_object_skew = 0
+mon_data_avail_warn = 15
+mon_warn_on_pool_no_redundancy = false
+[osd]
+osd_memory_target_cgroup_limit_ratio = 0.8
+bluestore_prefer_deferred_size_hdd = 0
+"""
+
 ROOK_CEPH_CONFIG_VALUES_416 = """
 [global]
 bdev_flock_retry = 20

--- a/tests/functional/z_cluster/test_ceph_default_values_check.py
+++ b/tests/functional/z_cluster/test_ceph_default_values_check.py
@@ -125,8 +125,10 @@ class TestCephDefaultValuesCheck(ManageTest):
 
         if ocs_version == version.VERSION_4_12 or ocs_version == version.VERSION_4_13:
             stored_values = constants.ROOK_CEPH_CONFIG_VALUES_412.split("\n")
-        elif ocs_version == version.VERSION_4_14 or ocs_version == version.VERSION_4_15:
+        elif ocs_version == version.VERSION_4_14:
             stored_values = constants.ROOK_CEPH_CONFIG_VALUES_414.split("\n")
+        elif ocs_version == version.VERSION_4_15:
+            stored_values = constants.ROOK_CEPH_CONFIG_VALUES_415.split("\n")
         elif ocs_version >= version.VERSION_4_16:
             stored_values = constants.ROOK_CEPH_CONFIG_VALUES_416.split("\n")
         else:


### PR DESCRIPTION
Backport of #11848 to release-4.15.

- Add ROOK_CEPH_CONFIG_VALUES_415 constant with `mon_warn_on_pool_no_redundancy = false` (present in 4.15 z-streams but not in the 4.14 constant)
- Separate 4.14 and 4.15 version checks in test_validate_ceph_config_values_in_rook_config_override