### PR TITLE
Add external IPv6 deployment config for vSphere UPI

### DIFF
--- a/conf/deployment/vsphere/upi_1az_rhcos_vsan_external_ipv6_3m_3w.yaml
+++ b/conf/deployment/vsphere/upi_1az_rhcos_vsan_external_ipv6_3m_3w.yaml
@@ -1,0 +1,23 @@
+---
+DEPLOYMENT:
+  external_mode: True
+  force_download_client: True
+  # WA for issue: https://github.com/red-hat-storage/ocs-ci/issues/2861
+  min_noobaa_endpoints: 1
+  ipv6: true
+ENV_DATA:
+  platform: 'vsphere'
+  deployment_type: 'upi'
+  worker_replicas: 3
+  master_replicas: 3
+  storage_cluster_name: 'ocs-external-storagecluster'
+
+EXTERNAL_MODE:
+  # base64 encoded data of json output
+  # from exporter script
+  # https://github.com/rook/rook/blob/master/cluster/examples/kubernetes/ceph/create-external-cluster-resources.py
+  external_cluster_details: PLACE_HOLDER
+
+REPORTING:
+  polarion:
+    deployment_id: 'OCS-2563'


### PR DESCRIPTION
## Summary
- Add deployment configuration for external mode Ceph cluster with IPv6 support on vSphere UPI (3 masters, 3 workers)
- New file: `conf/deployment/vsphere/upi_1az_rhcos_vsan_external_ipv6_3m_3w.yaml`

## Test plan
- [ ] Verify deployment config is picked up correctly by ocs-ci framework
- [ ] Run external mode deployment with IPv6 Ceph cluster on vSphere UPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new deployment configuration for vSphere UPI using external mode with IPv6 support.
  * Included settings for a 3-master, 3-worker deployment and external storage cluster details.
  * Added reporting metadata for deployment tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->