### PR TITLE
Fix race condition in ceph full thresholds verification

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -665,6 +665,7 @@
         "is_verified": false,
         "line_number": 2077,
         "line_number": 2075,
+        "line_number": 2060,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -674,6 +675,7 @@
         "is_verified": false,
         "line_number": 2184,
         "line_number": 2182,
+        "line_number": 2167,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -683,6 +685,7 @@
         "is_verified": false,
         "line_number": 2185,
         "line_number": 2183,
+        "line_number": 2168,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -692,6 +695,7 @@
         "is_verified": false,
         "line_number": 2186,
         "line_number": 2184,
+        "line_number": 2169,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -701,6 +705,7 @@
         "is_verified": false,
         "line_number": 2187,
         "line_number": 2185,
+        "line_number": 2170,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -710,6 +715,7 @@
         "is_verified": false,
         "line_number": 2199,
         "line_number": 2197,
+        "line_number": 2182,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -719,6 +725,7 @@
         "is_verified": false,
         "line_number": 2214,
         "line_number": 2212,
+        "line_number": 2197,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -728,6 +735,7 @@
         "is_verified": false,
         "line_number": 2215,
         "line_number": 2213,
+        "line_number": 2198,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -737,6 +745,7 @@
         "is_verified": false,
         "line_number": 2223,
         "line_number": 2221,
+        "line_number": 2206,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -746,6 +755,7 @@
         "is_verified": false,
         "line_number": 2224,
         "line_number": 2222,
+        "line_number": 2207,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -755,6 +765,7 @@
         "is_verified": false,
         "line_number": 2225,
         "line_number": 2223,
+        "line_number": 2208,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -764,6 +775,7 @@
         "is_verified": false,
         "line_number": 2226,
         "line_number": 2224,
+        "line_number": 2209,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -773,6 +785,7 @@
         "is_verified": false,
         "line_number": 2227,
         "line_number": 2225,
+        "line_number": 2210,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -782,6 +795,7 @@
         "is_verified": false,
         "line_number": 2824,
         "line_number": 2822,
+        "line_number": 2807,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -791,6 +805,7 @@
         "is_verified": false,
         "line_number": 2990,
         "line_number": 2988,
+        "line_number": 2972,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -800,6 +815,7 @@
         "is_verified": false,
         "line_number": 2991,
         "line_number": 2989,
+        "line_number": 2973,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -809,6 +825,7 @@
         "is_verified": false,
         "line_number": 3713,
         "line_number": 3737,
+        "line_number": 3694,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -818,6 +835,7 @@
         "is_verified": false,
         "line_number": 3714,
         "line_number": 3738,
+        "line_number": 3695,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -1507,6 +1507,23 @@ def verify_storage_cluster_version(storage_cluster):
                     raise e
 
 
+def get_cephcluster_storage_spec() -> Optional[dict]:
+    """
+    Fetch the CephCluster CR and return its spec.storage section.
+
+    Returns:
+        dict: The spec.storage section, or None if the key path is missing.
+
+    """
+    cephcluster = OCP(
+        kind="CephCluster",
+        namespace=config.ENV_DATA["cluster_namespace"],
+        resource_name=constants.CEPH_CLUSTER_NAME,
+    )
+    resource = cephcluster.get()
+    return resource.get("spec", {}).get("storage")
+
+
 def verify_storage_device_class(
     device_class,
     check_multiple_deviceclasses=False,

--- a/tests/functional/z_cluster/test_storagecluster_ceph_full_thresholds_params.py
+++ b/tests/functional/z_cluster/test_storagecluster_ceph_full_thresholds_params.py
@@ -1,13 +1,13 @@
 import logging
-import time
 
 import pytest
 
-from ocs_ci.ocs import constants, ocp
-from ocs_ci.framework import config
-from ocs_ci.helpers.helpers import run_cmd_verify_cli_output
+from ocs_ci.helpers.helpers import (
+    configure_cephcluster_params_in_storagecluster_cr,
+    run_cmd_verify_cli_output,
+)
 from ocs_ci.utility.utils import TimeoutSampler
-from ocs_ci.helpers.helpers import configure_cephcluster_params_in_storagecluster_cr
+from ocs_ci.ocs.resources.storage_cluster import get_cephcluster_storage_spec
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier2,
@@ -65,31 +65,48 @@ class TestStorageClusterCephFullThresholdsParams(ManageTest):
 
     """
 
+    CEPHCLUSTER_RECONCILE_TIMEOUT = 60
+    CEPH_OSD_DUMP_TIMEOUT = 600
+
     def setup_thresholds_params(self):
         configure_cephcluster_params_in_storagecluster_cr(
             params=THRESHOLDS, default_values=False
         )
 
-        logger.info("Wait 2 sec the cephcluster will updated")
-        time.sleep(2)
-
     def verify_thresholds_params(self):
         logger.info(
-            "Verify upgrade parameters on cephcluster CR and storagecluster CR are same"
+            "Verify threshold parameters propagated from StorageCluster to CephCluster CR"
         )
-        cephcluster_obj = ocp.OCP(
-            kind=constants.CEPH_CLUSTER,
-            namespace=config.ENV_DATA["cluster_namespace"],
-            resource_name=constants.CEPH_CLUSTER_NAME,
-        )
-        for parameter in THRESHOLDS:
-            actual_value = cephcluster_obj.data["spec"]["storage"][parameter["sc_key"]]
-            assert (
-                str(actual_value).lower() == str(parameter["value"]).lower()
-            ), f"The value of {parameter['sc_key']} is {actual_value}, the expected value is {parameter['value']}"
+        for storage_spec in TimeoutSampler(
+            timeout=self.CEPHCLUSTER_RECONCILE_TIMEOUT,
+            sleep=5,
+            func=get_cephcluster_storage_spec,
+        ):
+            if storage_spec is None:
+                continue
+            mismatches = {}
+            for parameter in THRESHOLDS:
+                key = parameter["sc_key"]
+                actual = storage_spec.get(key)
+                if actual is None or str(actual).lower() != parameter["value"]:
+                    mismatches[key] = actual
+            if not mismatches:
+                logger.info("All threshold parameters reconciled to CephCluster CR")
+                break
+            logger.info(
+                "Waiting for CephCluster reconciliation, pending: %s", mismatches
+            )
 
+        for parameter in THRESHOLDS:
+            actual_value = storage_spec.get(parameter["sc_key"])
+            assert str(actual_value).lower() == str(parameter["value"]).lower(), (
+                f"The value of {parameter['sc_key']} is {actual_value}, "
+                f"the expected value is {parameter['value']}"
+            )
+
+        logger.info("Verify threshold parameters with ceph CLI 'ceph osd dump'")
         sample = TimeoutSampler(
-            timeout=600,
+            timeout=self.CEPH_OSD_DUMP_TIMEOUT,
             sleep=10,
             func=run_cmd_verify_cli_output,
             cmd="ceph osd dump",
@@ -112,10 +129,9 @@ class TestStorageClusterCephFullThresholdsParams(ManageTest):
         """
         Procedure:
         1.Configure storagecluster CR
-        2.Wait 2 seconds
-        3.Verify ceph full thresholds parameters on cephcluster CR and storagecluster CR are same
-        4.Verify parameters with ceph CLI 'ceph osd dump'
-        5.Configure the default params on storagecluster [treardown]
+        2.Verify ceph full thresholds parameters on cephcluster CR and storagecluster CR are same
+        3.Verify parameters with ceph CLI 'ceph osd dump'
+        4.Configure the default params on storagecluster [teardown]
 
         """
         self.setup_thresholds_params()
@@ -126,9 +142,8 @@ class TestStorageClusterCephFullThresholdsParams(ManageTest):
         """
         Procedure:
         1.Configure storagecluster CR
-        2.Wait 2 seconds
-        3.Verify ceph full thresholds parameters on cephcluster CR and storagecluster CR are same
-        4.Verify parameters with ceph CLI 'ceph osd dump'
+        2.Verify ceph full thresholds parameters on cephcluster CR and storagecluster CR are same
+        3.Verify parameters with ceph CLI 'ceph osd dump'
 
         """
         self.setup_thresholds_params()


### PR DESCRIPTION
- Replace `time.sleep(2)` with `TimeoutSampler` polling (60s timeout) for CephCluster CR reconciliation check
- Add `get_cephcluster_storage_spec()` to `storage_cluster.py` for fresh CephCluster `spec.storage` fetches
- Extract timeout magic numbers to named constants (`CEPHCLUSTER_RECONCILE_TIMEOUT`, `CEPH_OSD_DUMP_TIMEOUT`)
- Clean up unused imports and merge duplicate `helpers` imports
- Fix docstring typo ("treardown" → "teardown")

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of StorageCluster full/near/full-backfill threshold settings by waiting for reconciliation before checking values.
  * Enhanced verification by using a more reliable method to read the Ceph cluster’s storage spec during test assertions.
* **Tests**
  * Updated threshold verification logic to poll until expected parameters are applied.
  * Increased reconciliation and Ceph OSD dump verification timeouts to improve stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->