### PR TITLE
[release-4.20] resolve client profile mapping for non-default storage ns

### DIFF
--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -1521,6 +1521,9 @@ class Deployment(object):
                 key_secret = config.AUTH["ibmcloud"]["ibm_cos_secret_access_key"]
                 cos_secret_data["data"]["IBM_COS_ACCESS_KEY_ID"] = key_id
                 cos_secret_data["data"]["IBM_COS_SECRET_ACCESS_KEY"] = key_secret
+                cos_secret_data["metadata"]["namespace"] = config.ENV_DATA[
+                    "cluster_namespace"
+                ]
                 cos_secret_data_yaml = tempfile.NamedTemporaryFile(
                     mode="w+", prefix="cos_secret", delete=False
                 )

--- a/ocs_ci/ocs/resources/storageconsumer.py
+++ b/ocs_ci/ocs/resources/storageconsumer.py
@@ -738,6 +738,23 @@ def verify_consumer_configmap(
     disable_blockpools = config.COMPONENTS["disable_blockpools"]
     disable_cephfs = config.COMPONENTS["disable_cephfs"]
 
+    # Get the actual CSI ClientProfile name from the cluster.
+    # The ClientProfile name is a stable CSI identity (e.g. "openshift-storage") that
+    # may differ from cluster_namespace (e.g. "odf-storage" in ROSA HCP odf deployments).
+    client_profile_items = (
+        ocp.OCP(
+            kind=constants.CLIENT_PROFILE,
+            namespace=config.cluster_ctx.ENV_DATA["cluster_namespace"],
+        )
+        .get()
+        .get("items", [])
+    )
+    csi_client_profile_name = (
+        client_profile_items[0]["metadata"]["name"]
+        if client_profile_items
+        else config.cluster_ctx.ENV_DATA["cluster_namespace"]
+    )
+
     def convergence_ver(version):
         return get_semantic_version(
             version, only_major_minor=True
@@ -844,11 +861,10 @@ def verify_consumer_configmap(
         )
         ceph_data_on_consumer_match_arg["csiop-cephfs-client-profile"] = (
             ceph_data_arg.get("csiop-cephfs-client-profile", "")
-            == config.cluster_ctx.ENV_DATA["cluster_namespace"]
+            == csi_client_profile_name
         )
         ceph_data_on_consumer_match_arg["csiop-rbd-client-profile"] = (
-            ceph_data_arg.get("csiop-rbd-client-profile", "")
-            == config.cluster_ctx.ENV_DATA["cluster_namespace"]
+            ceph_data_arg.get("csiop-rbd-client-profile", "") == csi_client_profile_name
         )
 
     if internal_consumer and not (disable_blockpools or disable_cephfs):


### PR DESCRIPTION
## Summary
Cherry-pick of #15519 to release-4.20.

Instead of assuming the ClientProfile name equals the namespace, fetch the actual ClientProfile name from the cluster. Fixes StorageConsumer configmap verification failures on clusters where cluster_namespace differs from CSI ClientProfile name (e.g. ROSA HCP odf deployments).

Also fixes IBM Cloud COS secret generation to include correct namespace metadata.

Signed-off-by: Daniel Osypenko <danielosypenko@redhat.com>