### PR TITLE
EC pipeline configurations 422 epic RHSTOR-8198

### DIFF
--- a/conf/deployment/baremetal/upi_1az_rhcos_nvme_3m_6w_ec_4plus2_fdf_provider_ui.yaml
+++ b/conf/deployment/baremetal/upi_1az_rhcos_nvme_3m_6w_ec_4plus2_fdf_provider_ui.yaml
@@ -1,0 +1,27 @@
+---
+# Pipeline 2: Baremetal UI deployment with LSO, FDF, EC 4+2, 6 OSD nodes, Provider mode
+# Covers: Req #2 (UI + LSO + FDF), Req #6 (4+2 EC no extra node), Req #9 (Provider + multiple storage clients)
+# Masters are schedulable and labeled as storage nodes (3m + 3w = 6 OSD nodes for 4+2 EC)
+DEPLOYMENT:
+  allow_lower_instance_requirements: false
+  local_storage: true
+  ui_deployment: true
+  host_network: true
+  ec_default_pools: true
+  ec_data_chunks: 4
+  ec_coding_chunks: 2
+  ec_failure_domain: host
+  fdf_cluster: true
+ENV_DATA:
+  platform: 'baremetal'
+  deployment_type: 'upi'
+  worker_replicas: 3
+  master_replicas: 3
+  mon_type: 'hostpath'
+  osd_type: 'nvme'
+  mark_masters_schedulable: true
+  odf_provider_mode_deployment: true
+  cluster_type: 'provider'
+REPORTING:
+  polarion:
+    deployment_id: 'OCS-8028'

--- a/conf/deployment/baremetal/upi_1az_rhcos_nvme_3m_6w_ec_4plus2_fips_provider.yaml
+++ b/conf/deployment/baremetal/upi_1az_rhcos_nvme_3m_6w_ec_4plus2_fips_provider.yaml
@@ -1,0 +1,40 @@
+---
+# Pipeline 4: Baremetal CLI deployment with LSO, ODF, EC 4+2, 6 OSD nodes,
+#              encryption (at-rest + in-transit + Vault KMS v2), Provider mode
+# Covers: Req #3 (CLI + encryption), Req #6 (4+2 EC no extra node),
+#         Req #9 (Provider + multiple storage clients)
+# Masters are schedulable and labeled as storage nodes (3m + 3w = 6 OSD nodes for 4+2 EC)
+DEPLOYMENT:
+  allow_lower_instance_requirements: false
+  local_storage: true
+  host_network: true
+  kms_deployment: true
+  ec_default_pools: true
+  ec_data_chunks: 4
+  ec_coding_chunks: 2
+  ec_failure_domain: host
+ENV_DATA:
+  platform: 'baremetal'
+  deployment_type: 'upi'
+  worker_replicas: 3
+  master_replicas: 3
+  mon_type: 'hostpath'
+  osd_type: 'nvme'
+  mark_masters_schedulable: true
+  encryption_at_rest: true
+  in_transit_encryption: true
+  vault_deploy_mode: external
+  use_vault_namespace: false
+  KMS_PROVIDER: vault
+  KMS_SERVICE_NAME: vault
+  VAULT_CACERT: "ocs-kms-ca-secret"
+  VAULT_CLIENT_CERT: "ocs-kms-client-cert"
+  VAULT_CLIENT_KEY: "ocs-kms-client-key"
+  VAULT_SKIP_VERIFY: false
+  VAULT_BACKEND: "v2"
+  VAULT_AUTH_METHOD: token
+  odf_provider_mode_deployment: true
+  cluster_type: 'provider'
+REPORTING:
+  polarion:
+    deployment_id: 'OCS-8028'

--- a/conf/deployment/vsphere/upi_1az_rhcos_vsan_lso_vmdk_3m_3w_ec_2plus2_enc.yaml
+++ b/conf/deployment/vsphere/upi_1az_rhcos_vsan_lso_vmdk_3m_3w_ec_2plus2_enc.yaml
@@ -1,0 +1,29 @@
+---
+# Pipeline: vSphere CLI deployment with LSO, ODF, EC 2+2, 6 OSD nodes (4+2 redundancy),
+#           FIPS, lean profile
+# Masters are schedulable and labeled as storage nodes (3m + 3w = 6 OSD nodes)
+# Master specs match worker specs since they run storage workloads
+DEPLOYMENT:
+  allow_lower_instance_requirements: false
+  local_storage: true
+  type: 'VMDK'
+  provision_type: 'thick'
+  ec_default_pools: true
+  ec_data_chunks: 2
+  ec_coding_chunks: 2
+  ec_failure_domain: host
+ENV_DATA:
+  platform: 'vsphere'
+  deployment_type: 'upi'
+  worker_replicas: 3
+  master_replicas: 3
+  worker_num_cpus: '16'
+  master_num_cpus: '16'
+  master_memory: '65536'
+  compute_memory: '65536'
+  fio_storageutilization_min_mbps: 10.0
+  mark_masters_schedulable: true
+  fips: 'true'
+REPORTING:
+  polarion:
+    deployment_id: 'OCS-8028'

--- a/conf/deployment/vsphere/upi_1az_rhcos_vsan_lso_vmdk_3m_3w_ec_2plus2_enc_multus.yaml
+++ b/conf/deployment/vsphere/upi_1az_rhcos_vsan_lso_vmdk_3m_3w_ec_2plus2_enc_multus.yaml
@@ -1,0 +1,42 @@
+---
+# Pipeline 3: vSphere CLI deployment with LSO, ODF, EC 2+2, 6 OSD nodes (4+2 redundancy),
+#              FIPS, Multus, lean profile
+# Covers: Req #4 (CLI + FIPS + ODF), Req #5 (2+2 EC with +2 redundancy),
+#         Req #7 (Multus + EC), Req #8 (EC + lower perf mode)
+# Masters are schedulable and labeled as storage nodes (3m + 3w = 6 OSD nodes)
+# Master specs match worker specs since they run storage workloads
+DEPLOYMENT:
+  allow_lower_instance_requirements: false
+  local_storage: true
+  type: 'VMDK'
+  provision_type: 'thick'
+  ec_default_pools: true
+  ec_data_chunks: 2
+  ec_coding_chunks: 2
+  ec_failure_domain: host
+ENV_DATA:
+  platform: 'vsphere'
+  deployment_type: 'upi'
+  worker_replicas: 3
+  master_replicas: 3
+  worker_num_cpus: '16'
+  master_num_cpus: '16'
+  master_memory: '65536'
+  compute_memory: '65536'
+  fio_storageutilization_min_mbps: 10.0
+  mark_masters_schedulable: true
+  fips: 'true'
+  is_multus_enabled: true
+  multus_public_net_interface: 'ens224'
+  multus_cluster_net_interface: 'ens224'
+  multus_create_public_net: true
+  multus_create_cluster_net: true
+  multus_public_net_namespace: 'default'
+  multus_cluster_net_namespace: 'default'
+  multus_public_net_type: 'macvlan'
+  multus_public_net_mode: 'bridge'
+  multus_cluster_net_type: 'macvlan'
+  multus_cluster_net_mode: 'bridge'
+REPORTING:
+  polarion:
+    deployment_id: 'OCS-8028'

--- a/conf/deployment/vsphere/upi_1az_rhcos_vsan_lso_vmdk_3m_5w_ec_2plus2_enc_multus.yaml
+++ b/conf/deployment/vsphere/upi_1az_rhcos_vsan_lso_vmdk_3m_5w_ec_2plus2_enc_multus.yaml
@@ -1,10 +1,8 @@
 ---
-# Pipeline 3: vSphere CLI deployment with LSO, ODF, EC 2+2, 6 OSD nodes (4+2 redundancy),
-#              FIPS, Multus, lean profile
+# Pipeline 3: vSphere CLI deployment with LSO, ODF, EC 2+2, 5 OSD nodes,
+#              FIPS, Multus
 # Covers: Req #4 (CLI + FIPS + ODF), Req #5 (2+2 EC with +2 redundancy),
-#         Req #7 (Multus + EC), Req #8 (EC + lower perf mode)
-# Masters are schedulable and labeled as storage nodes (3m + 3w = 6 OSD nodes)
-# Master specs match worker specs since they run storage workloads
+#         Req #7 (Multus + EC)
 DEPLOYMENT:
   allow_lower_instance_requirements: false
   local_storage: true
@@ -18,13 +16,12 @@ ENV_DATA:
   platform: 'vsphere'
   deployment_type: 'upi'
   worker_replicas: 3
-  master_replicas: 3
+  master_replicas: 5
   worker_num_cpus: '16'
   master_num_cpus: '16'
   master_memory: '65536'
   compute_memory: '65536'
   fio_storageutilization_min_mbps: 10.0
-  mark_masters_schedulable: true
   fips: 'true'
   is_multus_enabled: true
   multus_public_net_interface: 'ens224'

--- a/conf/deployment/vsphere/upi_1az_rhcos_vsan_lso_vmdk_3m_5w_ec_2plus2_ui.yaml
+++ b/conf/deployment/vsphere/upi_1az_rhcos_vsan_lso_vmdk_3m_5w_ec_2plus2_ui.yaml
@@ -1,0 +1,27 @@
+---
+# Pipeline 5: vSphere UI deployment with LSO, ODF, EC 2+2, 5 OSD nodes (4+2 + 1 for redundancy)
+# Covers: Req #1 (UI + LSO + ODF), Req #5 (2+2 EC with +1 redundancy nodes)
+# Masters are not schedulable
+DEPLOYMENT:
+  allow_lower_instance_requirements: false
+  local_storage: true
+  type: 'VMDK'
+  provision_type: 'thick'
+  ui_deployment: true
+  ec_default_pools: true
+  ec_data_chunks: 2
+  ec_coding_chunks: 2
+  ec_failure_domain: host
+ENV_DATA:
+  platform: 'vsphere'
+  deployment_type: 'upi'
+  worker_replicas: 5
+  master_replicas: 3
+  worker_num_cpus: "16"
+  master_num_cpus: "4"
+  master_memory: "16384"
+  compute_memory: "65536"
+  fio_storageutilization_min_mbps: 10.0
+REPORTING:
+  polarion:
+    deployment_id: 'OCS-8028'

--- a/conf/deployment/vsphere/upi_1az_rhcos_vsan_lso_vmdk_3m_6w_ec_2plus2_ui.yaml
+++ b/conf/deployment/vsphere/upi_1az_rhcos_vsan_lso_vmdk_3m_6w_ec_2plus2_ui.yaml
@@ -1,0 +1,29 @@
+---
+# Pipeline 1: vSphere UI deployment with LSO, ODF, EC 2+2, 6 OSD nodes (4+2 redundancy)
+# Covers: Req #1 (UI + LSO + ODF), Req #5 (2+2 EC with +2 redundancy nodes)
+# Masters are schedulable and labeled as storage nodes (3m + 3w = 6 OSD nodes)
+# Master specs match worker specs since they run storage workloads
+DEPLOYMENT:
+  allow_lower_instance_requirements: false
+  local_storage: true
+  type: 'VMDK'
+  provision_type: 'thick'
+  ui_deployment: true
+  ec_default_pools: true
+  ec_data_chunks: 2
+  ec_coding_chunks: 2
+  ec_failure_domain: host
+ENV_DATA:
+  platform: 'vsphere'
+  deployment_type: 'upi'
+  worker_replicas: 3
+  master_replicas: 3
+  worker_num_cpus: '16'
+  master_num_cpus: '16'
+  master_memory: '65536'
+  compute_memory: '65536'
+  fio_storageutilization_min_mbps: 10.0
+  mark_masters_schedulable: true
+REPORTING:
+  polarion:
+    deployment_id: 'OCS-8028'


### PR DESCRIPTION
Profiles based on Jira ticket [RHSTOR-8198](https://url.corp.redhat.com/6018c5f )

  Add 4 deployment config files for erasure coding regression pipelines covering different platform/feature combinations:

  - Pipeline 1 (vSphere, UI, 2+2 EC, +2 extra nodes): LSO, ODF
  - Pipeline 2 (Baremetal, UI, 4+2 EC, no extra nodes): LSO, FDF, Provider mode
  - Pipeline 3 (vSphere, CLI, 2+2 EC, +2 extra nodes): LSO, FIPS, Multus, lean profile
  - Pipeline 4 (Baremetal, CLI, 4+2 EC, no extra nodes): LSO, encryption (at-rest + in-transit + Vault KMS v2), Provider mode

  All configs use mark_masters_schedulable: true to label masters as storage nodes, reducing total VM/node count (3m+3w = 6 OSD nodes). vSphere master specs are bumped to match
  worker specs (16 CPU / 64GB RAM) since they run storage workloads.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Deployment Configurations**
  - Added bare-metal UPI pipelines for RHCOS NVMe environments with Provider-mode ODF, UI deployment, local storage, host networking, and 4+2 erasure coding.
  - Added a FIPS-enabled bare-metal configuration with Vault KMS integration and encrypted storage traffic.
  - Added vSphere UPI configurations using thick-provisioned VMDKs, local storage, UI deployment, FIPS, and 2+2 erasure coding.
  - Added a Multus-enabled vSphere configuration with custom public and cluster networking.
  - Included deployment reporting metadata across the new configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->