### PR TITLE
[release-4.18] Cherry-pick: enhance replica-1 teardown (#13036)

### DIFF
--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -6250,3 +6250,58 @@ def set_rook_log_level():
     rook_log_level = config.DEPLOYMENT.get("rook_log_level")
     if rook_log_level:
         set_configmap_log_level_rook_ceph_operator(rook_log_level)
+
+
+def check_osds_down(osd_ids: list[str]) -> bool:
+    """
+    Check if specified OSDs are marked as 'down' in Ceph
+
+    Args:
+        osd_ids (list[str]): List of OSD IDs to check
+
+    Returns:
+        bool: True if all OSDs are down, False otherwise
+    """
+    log = logging.getLogger(__name__)
+    ceph_pod = pod.get_ceph_tools_pod()
+    osd_dump = ceph_pod.exec_ceph_cmd("ceph osd dump")
+
+    osds_status = {}
+    for osd in osd_dump["osds"]:
+        osd_id = str(osd["osd"])
+        if osd_id in osd_ids:
+            osds_status[osd_id] = {"up": osd["up"], "in": osd["in"]}
+
+    for osd_id, status in osds_status.items():
+        state = "up" if status["up"] == 1 else "down"
+        log.info(f"OSD {osd_id}: {state}")
+
+    all_down = all(status["up"] == 0 for status in osds_status.values())
+    return all_down
+
+
+def wait_for_osds_down(osd_ids: list[str], timeout: int = 300, sleep: int = 10) -> None:
+    """
+    Wait for OSDs to be marked as 'down' in Ceph using polling
+
+    Args:
+        osd_ids (list[str]): List of OSD IDs to wait for
+        timeout (int): Timeout in seconds (default: 300)
+        sleep (int): Sleep interval between checks (default: 10)
+
+    Raises:
+        TimeoutExpiredError: If OSDs don't go down within timeout
+    """
+    log = logging.getLogger(__name__)
+    log.info(f"Waiting for OSDs {osd_ids} to be marked as 'down' in Ceph")
+
+    sample = TimeoutSampler(
+        timeout=timeout, sleep=sleep, func=check_osds_down, osd_ids=osd_ids
+    )
+
+    if not sample.wait_for_func_status(result=True):
+        raise TimeoutExpiredError(
+            f"OSDs {osd_ids} did not go down within {timeout} seconds"
+        )
+
+    log.info(f"All OSDs {osd_ids} are now marked as 'down'")

--- a/ocs_ci/ocs/replica_one.py
+++ b/ocs_ci/ocs/replica_one.py
@@ -22,6 +22,7 @@ from ocs_ci.ocs.constants import (
     REPLICA1_STORAGECLASS,
 )
 from ocs_ci.ocs.exceptions import CommandFailed
+from ocs_ci.helpers.helpers import wait_for_osds_down
 
 
 log = getLogger(__name__)
@@ -79,9 +80,13 @@ def get_failures_domain_name() -> list[str]:
     return failure_domains
 
 
-def get_replica_1_osds() -> dict:
+def get_replica_1_osds(failure_domains: list[str] = None) -> dict:
     """
     Gets the names and IDs of OSD associated with replica1
+
+    Args:
+        failure_domains (list[str]): List of failure domain names.
+                                   If None, will fetch from get_failure_domains()
 
     Returns:
         dict: osd name(str): osd id(str)
@@ -89,7 +94,8 @@ def get_replica_1_osds() -> dict:
     """
     replica1_osds = dict()
     all_osds = get_pods_having_label(label=OSD_APP_LABEL)
-    for domain in get_failure_domains():
+    domains = failure_domains if failure_domains is not None else get_failure_domains()
+    for domain in domains:
         for osd in all_osds:
             if osd["metadata"]["labels"]["ceph.rook.io/DeviceSet"] == domain:
                 replica1_osds[osd["metadata"]["name"]] = osd["metadata"]["labels"][
@@ -176,23 +182,231 @@ def delete_replica_1_sc() -> None:
             raise CommandFailed(f"Failed to delete storage class: {str(e)}")
 
 
-def purge_replica1_osd():
+def purge_replica1_osd() -> None:
     """
     Purge OSDs associated with replica1
         1. scale down its deployments to 0
-        2. use OSD removal template
+        2. use OSD removal template (if OSDs are found)
 
     """
     deployments_name = get_replica1_osd_deployment()
     log.info(f"Deployments Name: {deployments_name}")
     scaledown_deployment(deployments_name)
     replica1_osds = get_replica_1_osds()
-    log.info(f"OSDS : {replica1_osds.keys()}")
-    log.info(f"OSD IDs: {replica1_osds.values()}")
+    log.info(f"Found replica-1 OSDs: {replica1_osds}")
+    log.info(f"OSD IDs: {list(replica1_osds.values())}")
+
+    if not replica1_osds:
+        log.warning("No replica-1 OSDs found – skipping OSD removal job")
+        return
+
     run_osd_removal_job(osd_ids=replica1_osds.values())
     verify_osd_removal_job_completed_successfully("4")
     sleep(120)
     delete_osd_removal_job()
+
+
+def _retry_osd_removal(osd_name: str, osd_id: str) -> bool:
+    """
+    Retry OSD removal after job cleanup for AlreadyExists errors
+
+    Args:
+        osd_name (str): Name of the OSD being removed
+        osd_id (str): ID of the OSD being removed
+
+    Returns:
+        bool: True if retry successful, False if failed
+
+    Raises:
+        CommandFailed: If cleanup or removal operations fail
+    """
+    log.info("Attempting additional job cleanup and retry")
+    try:
+        delete_osd_removal_job()
+        sleep(5)  # Brief wait
+        run_osd_removal_job(osd_ids=[osd_id])
+        verify_osd_removal_job_completed_successfully(osd_id)
+        delete_osd_removal_job()
+        log.info(f"Successfully removed OSD {osd_name} after retry")
+        return True
+    except CommandFailed as e:
+        log.error(f"Retry failed for OSD {osd_name}: {e}")
+        return False
+
+
+def sequential_remove_replica1_osds(failure_domains: list[str] = None) -> dict:
+    """
+    Sequentially remove OSDs associated with replica-1 for safer cluster operation.
+    Removes OSDs one by one with cluster health validation between removals.
+
+    Args:
+        failure_domains (list[str]): List of failure domain names.
+                                   If None, will fetch from get_failure_domains()
+
+    Returns:
+        dict: Summary of removal operation with counts and any failures
+    """
+    log.info("Starting sequential removal of replica-1 OSDs")
+
+    # Get all replica-1 OSDs and deployments
+    replica1_osds = get_replica_1_osds(failure_domains)
+    deployments_name = get_replica1_osd_deployment()
+
+    if not replica1_osds:
+        log.warning("No replica-1 OSDs found – skipping sequential OSD removal")
+        return {"removed": 0, "failed": 0, "skipped": 0}
+
+    log.info(f"Found {len(replica1_osds)} replica-1 OSDs to remove sequentially")
+    log.info(f"OSD deployments: {deployments_name}")
+    log.info(f"OSD names and IDs: {replica1_osds}")
+
+    removal_summary = {"removed": 0, "failed": 0, "skipped": 0, "failures": []}
+
+    # PHASE 1: Scale down ALL replica-1 OSD deployments first (bulk operation)
+    log.info("PHASE 1: Scaling down ALL replica-1 OSD deployments before removal")
+    deployment_obj = OCP(
+        kind=DEPLOYMENT, namespace=config.ENV_DATA["cluster_namespace"]
+    )
+
+    # Dual detection approach: Traditional + fallback
+    if deployments_name:
+        log.info(f"Scaling down deployments {deployments_name}")
+        scaledown_deployment(deployments_name)
+    else:
+        log.info(
+            "No replica-1 deployments found via failure domains. Using direct deployment targeting."
+        )
+        # Fallback: Direct deployment targeting by OSD ID
+        for osd_name, osd_id in replica1_osds.items():
+            deployment_name = f"rook-ceph-osd-{osd_id}"
+            try:
+                log.info(f"Scaling down deployment {deployment_name} to 0 replicas")
+                deployment_obj.exec_oc_cmd(
+                    f"scale deployment {deployment_name} --replicas=0"
+                )
+                log.info(f"Successfully scaled down {deployment_name}")
+            except CommandFailed as e:
+                log.warning(f"Failed to scale down {deployment_name}: {e}")
+
+    # PHASE 2: Wait for OSDs to go "down" in Ceph
+    log.info("PHASE 2: Waiting for OSDs to be marked as 'down' in Ceph")
+    target_osd_ids = list(replica1_osds.values())
+    wait_for_osds_down(osd_ids=target_osd_ids, timeout=300, sleep=10)
+    log.info("All deployments scaled down - OSDs are now 'down' and removable")
+
+    # PHASE 3: Sequential OSD removal with comprehensive job cleanup
+    log.info("PHASE 3: Starting sequential OSD removal")
+    for osd_name, osd_id in replica1_osds.items():
+        try:
+            log.info(f"Starting removal of OSD {osd_name} (ID: {osd_id})")
+
+            # Comprehensive job cleanup before each removal
+            log.info("Checking for existing OSD removal job...")
+            try:
+                job_ocp = OCP(
+                    kind="Job", namespace=config.ENV_DATA["cluster_namespace"]
+                )
+                existing_job = job_ocp.get(
+                    resource_name="ocs-osd-removal-job", dont_raise=True
+                )
+                if existing_job:
+                    log.warning("Found existing OSD removal job, deleting it first...")
+
+                    # Get logs from existing job pod before deleting (for debugging)
+                    try:
+                        job_pods = get_pods_having_label(
+                            label="job-name=ocs-osd-removal-job",
+                            namespace=config.ENV_DATA["cluster_namespace"],
+                        )
+                        if job_pods:
+                            pod_name = job_pods[0]["metadata"]["name"]
+                            log.info(f"Getting logs from existing job pod: {pod_name}")
+                            pod_logs = job_ocp.get_logs(name=pod_name)
+                            log.info(f"Existing job pod logs:\n{pod_logs}")
+                    except CommandFailed as e:
+                        log.warning(f"Could not get logs from existing job pod: {e}")
+
+                    # Delete the existing job
+                    delete_osd_removal_job()
+                    log.info("Existing OSD removal job deleted")
+            except CommandFailed as e:
+                log.warning(f"Error checking/cleaning existing job: {e}")
+
+            # Remove single OSD using removal job with enhanced error handling
+            log.info(f"Running OSD removal job for OSD {osd_id}")
+            try:
+                run_osd_removal_job(osd_ids=[osd_id])
+
+                # Verify removal completed
+                verify_osd_removal_job_completed_successfully(osd_id)  # Single OSD
+
+                # Clean up removal job
+                delete_osd_removal_job()
+
+                # Wait for cluster stabilization
+                log.info(
+                    f"OSD {osd_name} removed successfully, waiting for cluster stabilization"
+                )
+                sleep(30)  # Brief pause between removals
+
+                removal_summary["removed"] += 1
+                log.info(
+                    f"Successfully removed OSD {osd_name} ({removal_summary['removed']}/{len(replica1_osds)})"
+                )
+
+            except CommandFailed as e:
+                error_msg = str(e).lower()
+                if "alreadyexists" in error_msg:
+                    log.error(f"Job already exists error for OSD {osd_name}: {e}")
+
+                    if _retry_osd_removal(osd_name, osd_id):
+                        removal_summary["removed"] += 1
+                    else:
+                        removal_summary["failed"] += 1
+                        removal_summary["failures"].append(
+                            {
+                                "osd": osd_name,
+                                "error": "AlreadyExists + retry failed",
+                            }
+                        )
+
+                elif "osd is healthy" in error_msg:
+                    log.error(
+                        f"OSD {osd_name} is still healthy and cannot be removed: {e}"
+                    )
+                    log.warning(
+                        "This indicates deployment scaling may not have worked properly"
+                    )
+                    removal_summary["failed"] += 1
+                    removal_summary["failures"].append(
+                        {
+                            "osd": osd_name,
+                            "error": f"OSD healthy (deployment scaling issue): {e}",
+                        }
+                    )
+
+                else:
+                    log.error(f"Command failed for OSD {osd_name}: {e}")
+                    removal_summary["failed"] += 1
+                    removal_summary["failures"].append(
+                        {"osd": osd_name, "error": f"CommandFailed: {e}"}
+                    )
+
+        except CommandFailed as e:
+            log.error(f"Unexpected error removing OSD {osd_name}: {e}")
+            removal_summary["failed"] += 1
+            removal_summary["failures"].append(
+                {"osd": osd_name, "error": f"Unexpected: {e}"}
+            )
+            # Continue with next OSD even if this one fails
+
+    # Final summary
+    log.info(f"Sequential OSD removal completed: {removal_summary}")
+
+    if removal_summary["failed"] > 0:
+        log.warning(f"Some OSDs failed to remove: {removal_summary['failures']}")
+
+    return removal_summary
 
 
 def delete_replica1_cephblockpools_cr(cbp_object: OCP):

--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -2809,12 +2809,16 @@ def run_osd_removal_job(osd_ids=None):
     Run the ocs-osd-removal job
 
     Args:
-        osd_ids (list): The osd IDs.
+        osd_ids (list | None): The osd IDs.
 
     Returns:
-        ocs_ci.ocs.resources.ocs.OCS: The ocs-osd-removal job object
+        ocs_ci.ocs.resources.ocs.OCS | None: The ocs-osd-removal job object, or None if no OSDs provided
 
     """
+    if not osd_ids:
+        logger.warning("run_osd_removal_job called with empty osd_ids – nothing to do")
+        return None
+
     osd_ids_str = ",".join(map(str, osd_ids))
 
     cmd_params = "-p FORCE_OSD_REMOVAL=true"

--- a/ocs_ci/ocs/resources/pvc.py
+++ b/ocs_ci/ocs/resources/pvc.py
@@ -8,7 +8,11 @@ from concurrent.futures import ThreadPoolExecutor
 from uuid import uuid4
 
 from ocs_ci.ocs import constants
-from ocs_ci.ocs.exceptions import UnavailableResourceException, TimeoutExpiredError
+from ocs_ci.ocs.exceptions import (
+    UnavailableResourceException,
+    TimeoutExpiredError,
+    CommandFailed,
+)
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.resources.ocs import OCS
 from ocs_ci.ocs.resources import pod
@@ -765,3 +769,67 @@ def wait_for_pvcs_in_lvs_to_reach_status(
             f"expected status {expected_status} after {timeout} seconds"
         )
         return False
+
+
+def get_pvcs_using_storageclass(
+    storageclass_name: str, namespace: str = None
+) -> list[dict]:
+    """
+    Find all PVCs using a specific StorageClass
+
+    Args:
+        storageclass_name (str): Name of the StorageClass to search for
+        namespace (str): Namespace to search in. If None, searches all namespaces
+
+    Returns:
+        list[dict]: List of PVC information dictionaries containing name, namespace,
+                   storageclass, status, and size
+
+    Raises:
+        ValueError: If storageclass_name is empty or None
+        CommandFailed: If OCP API call fails
+    """
+    if not storageclass_name or not storageclass_name.strip():
+        raise ValueError("storageclass_name cannot be empty or None")
+
+    log.info(
+        f"Searching for PVCs using StorageClass '{storageclass_name}' in namespace: {namespace or 'all'}"
+    )
+
+    try:
+        ocp_obj = OCP(kind=constants.PVC, namespace=namespace)
+        all_pvcs = ocp_obj.get()
+
+        if not all_pvcs or "items" not in all_pvcs:
+            log.info("No PVCs found in the cluster")
+            return []
+
+        matching_pvcs = []
+        for pvc in all_pvcs["items"]:
+            pvc_spec = pvc.get("spec", {})
+            pvc_metadata = pvc.get("metadata", {})
+            pvc_status = pvc.get("status", {})
+
+            if pvc_spec.get("storageClassName") == storageclass_name:
+                pvc_info = {
+                    "name": pvc_metadata.get("name", "unknown"),
+                    "namespace": pvc_metadata.get("namespace", "unknown"),
+                    "storageclass": pvc_spec.get("storageClassName"),
+                    "status": pvc_status.get("phase", "unknown"),
+                    "size": pvc_spec.get("resources", {})
+                    .get("requests", {})
+                    .get("storage", "unknown"),
+                }
+                matching_pvcs.append(pvc_info)
+                log.info(
+                    f"Found PVC: {pvc_info['name']} in namespace {pvc_info['namespace']}"
+                )
+
+        log.info(
+            f"Found {len(matching_pvcs)} PVCs using StorageClass '{storageclass_name}'"
+        )
+        return matching_pvcs
+
+    except CommandFailed as e:
+        log.error(f"Failed to get PVCs: {e}")
+        raise

--- a/tests/functional/storageclass/test_replica1.py
+++ b/tests/functional/storageclass/test_replica1.py
@@ -1,5 +1,5 @@
-import pytest
 from logging import getLogger
+from typing import Dict, Optional
 
 from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import (
@@ -9,6 +9,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_external_mode,
 )
 from ocs_ci.ocs.ocp import OCP
+from ocs_ci.ocs.exceptions import CommandFailed
 from ocs_ci.ocs.resources.storage_cluster import (
     set_non_resilient_pool,
     validate_non_resilient_pool,
@@ -22,16 +23,18 @@ from ocs_ci.ocs.constants import (
     REPLICA1_STORAGECLASS,
     STATUS_RUNNING,
     VOLUME_MODE_BLOCK,
-    CSI_RBD_RAW_BLOCK_POD_YAML,
     DEFALUT_DEVICE_CLASS,
+    VSPHERE_PLATFORM,
+    RACK_LABEL,
+    ZONE_LABEL,
 )
-from ocs_ci.helpers.helpers import create_pvc
+from ocs_ci.helpers.helpers import create_pvc, create_pod, wait_for_resource_state
 from ocs_ci.utility.utils import validate_dict_values, compare_dictionaries
 from ocs_ci.ocs.replica_one import (
     delete_replica_1_sc,
     get_osd_pgs_used,
     get_replica_1_osds,
-    purge_replica1_osd,
+    sequential_remove_replica1_osds,
     delete_replica1_cephblockpools_cr,
     count_osd_pods,
     get_osd_kb_used_data,
@@ -39,32 +42,81 @@ from ocs_ci.ocs.replica_one import (
     get_all_osd_names_by_device_class,
     get_failure_domains,
 )
+from ocs_ci.ocs.resources.pvc import get_pvcs_using_storageclass
+from ocs_ci.ocs.node import get_worker_nodes, get_node_objs
 
 
 log = getLogger(__name__)
 
 
-def create_pod_on_failure_domain(project_factory, pod_factory, failure_domain: str):
+def _get_node_selector_for_failure_domain(
+    failure_domain: str,
+) -> Optional[Dict[str, str]]:
     """
-    Creates a pod on the specified failure domain.
+    Return a hard node selector if workers exist with the requested failure domain label.
 
     Args:
-        failure_domain (str): Failure domain to create the pod on.
+        failure_domain (str): The failure domain value to match.
 
     Returns:
-        Pod: Pod object
+        dict[str, str] | None: Hard node selector if workers found, None otherwise.
     """
-    proj_obj = project_factory()
-    proj = proj_obj.namespace
+    if config.ENV_DATA["platform"].lower() == VSPHERE_PLATFORM:
+        label_key = RACK_LABEL
+    else:
+        label_key = ZONE_LABEL
+
+    worker_names = get_worker_nodes()
+    workers = get_node_objs(worker_names)
+
+    workers_with_label = [
+        n for n in workers if label_key in n.data["metadata"]["labels"]
+    ]
+    workers_in_domain = [
+        n
+        for n in workers_with_label
+        if n.data["metadata"]["labels"][label_key] == failure_domain
+    ]
+
+    if workers_in_domain:
+        log.info(
+            f"Found worker(s) with {label_key}={failure_domain}, using hard node selector."
+        )
+        return {label_key: failure_domain}
+
+    log.warning(
+        f"No workers with {label_key}={failure_domain}. Pod will be created without node selector."
+    )
+    return None
+
+
+def create_pod_on_failure_domain(project_factory, failure_domain: str):
+    ns = project_factory().namespace
     pvc = create_pvc(
-        namespace=proj,
+        namespace=ns,
         sc_name=REPLICA1_STORAGECLASS,
         size="80G",
         access_mode=ACCESS_MODE_RWO,
     )
 
-    node = {"topology.kubernetes.io/zone": failure_domain}
-    return pod_factory(pvc=pvc, node_selector=node)
+    node_selector = _get_node_selector_for_failure_domain(failure_domain)
+
+    if node_selector:
+        log.info(f"Creating pod with node selector: {node_selector}")
+    else:
+        log.info(
+            f"Creating pod without node selector for failure domain: {failure_domain}"
+        )
+
+    pod_obj = create_pod(
+        interface_type=CEPHBLOCKPOOL,
+        pvc_name=pvc.name,
+        namespace=ns,
+        node_selector=node_selector,
+    )
+    wait_for_resource_state(pod_obj, STATUS_RUNNING, timeout=300)
+    pod_obj.reload()
+    return pod_obj
 
 
 @polarion_id("OCS-5720")
@@ -72,8 +124,12 @@ def create_pod_on_failure_domain(project_factory, pod_factory, failure_domain: s
 @tier1
 @skipif_external_mode
 class TestReplicaOne:
-    @pytest.fixture(scope="class")
     def replica1_setup(self):
+        # Initialize workload tracking for this test run
+        self.created_projects = []
+        self.created_pvcs = []
+        self.created_pods = []
+
         log.info("Setup function called")
         storage_cluster = StorageCluster(
             resource_name=config.ENV_DATA["storage_cluster_name"],
@@ -91,29 +147,139 @@ class TestReplicaOne:
             pod = OCP(
                 kind=POD,
                 namespace=config.ENV_DATA["cluster_namespace"],
-                resource_name=osd,
             )
-            pod.wait_for_resource(condition=STATUS_RUNNING, column="STATUS")
+            pod.wait_for_resource(
+                condition=STATUS_RUNNING, column="STATUS", resource_name=osd
+            )
 
         return storage_cluster
 
-    @pytest.fixture(scope="class")
-    def replica1_teardown(self, request, replica1_setup):
-        yield
-        log.info("Teardown function called")
-        storage_cluster = replica1_setup
+    def delete_replica1_pvcs(self):
+        """
+        Delete all PVCs created with replica-1 StorageClass.
+
+        Returns:
+            int: Number of PVCs deleted
+        """
+        log.info("Deleting PVCs created with replica-1 StorageClass")
+        try:
+            replica1_pvcs = get_pvcs_using_storageclass(REPLICA1_STORAGECLASS)
+            if replica1_pvcs:
+                log.info(
+                    f"Found {len(replica1_pvcs)} PVCs using {REPLICA1_STORAGECLASS}"
+                )
+                for pvc_info in replica1_pvcs:
+                    pvc_name = pvc_info["name"]
+                    pvc_namespace = pvc_info["namespace"]
+                    log.info(f"Deleting PVC {pvc_name} in namespace {pvc_namespace}")
+                    pvc_obj = OCP(kind="PersistentVolumeClaim", namespace=pvc_namespace)
+                    pvc_obj.delete(resource_name=pvc_name)
+                    log.info(f"PVC {pvc_name} deletion initiated")
+                return len(replica1_pvcs)
+            else:
+                log.info(f"No PVCs found using StorageClass {REPLICA1_STORAGECLASS}")
+                return 0
+        except (CommandFailed, ValueError) as e:
+            log.error(f"Failed to delete replica-1 PVCs: {e}")
+            raise
+
+    def delete_tracked_workloads(self):
+        """
+        Delete all workloads tracked during test execution.
+
+        Returns:
+            dict: Summary of deleted resources
+        """
+        log.info("Deleting tracked workloads created during test")
+        summary = {"pods": 0, "pvcs": 0, "projects": 0}
+
+        # Delete pods first
+        for pod in getattr(self, "created_pods", []):
+            try:
+                log.info(f"Deleting pod {pod.name} in namespace {pod.namespace}")
+                pod.delete()
+                summary["pods"] += 1
+            except CommandFailed as e:
+                log.warning(f"Failed to delete pod {pod.name}: {e}")
+
+        # Delete PVCs
+        for pvc in getattr(self, "created_pvcs", []):
+            try:
+                log.info(f"Deleting PVC {pvc.name} in namespace {pvc.namespace}")
+                pvc.delete()
+                summary["pvcs"] += 1
+            except CommandFailed as e:
+                log.warning(f"Failed to delete PVC {pvc.name}: {e}")
+
+        # Delete projects last
+        for project in getattr(self, "created_projects", []):
+            try:
+                log.info(f"Deleting project {project.namespace}")
+                project.delete()
+                summary["projects"] += 1
+            except CommandFailed as e:
+                log.warning(f"Failed to delete project {project.namespace}: {e}")
+
+        log.info(f"Workload deletion summary: {summary}")
+        return summary
+
+    def replica1_teardown(self, storage_cluster):
+        """
+        Comprehensive replica-1 teardown orchestrator following 7-step documentation.
+
+        Steps:
+        1. Delete workloads using replica-1 storage
+        2. Delete PVCs created with replica-1 StorageClass
+        3. Mark non-resilient pool for disabling
+        4. Delete replica-1 StorageClass
+        5. Delete replica-1 CephBlockPools
+        6. Remove replica-1 OSDs sequentially
+        """
+        log.info("Starting comprehensive replica-1 teardown orchestrator")
+
+        # Capture failure domains early before deleting CephBlockPools
+        log.info("Capturing failure domains before teardown")
+        failure_domains = get_failure_domains()
+        log.info(f"Captured failure domains: {failure_domains}")
+
+        # Step 1: Delete workloads using replica-1 storage
+        log.info("Step 1: Deleting workloads using replica-1 storage")
+        workload_summary = self.delete_tracked_workloads()
+        log.info(f"Step 1 completed: {workload_summary}")
+
+        # Step 2: Delete PVCs created with replica-1 StorageClass
+        log.info("Step 2: Deleting PVCs created with replica-1 StorageClass")
+        deleted_pvcs = self.delete_replica1_pvcs()
+        log.info(f"Step 2 completed: {deleted_pvcs} PVCs deleted")
+
+        # Step 3: Mark non-resilient pool for disabling
+        log.info("Step 3: Marking non-resilient pool for disabling")
+        set_non_resilient_pool(storage_cluster, enable=False)
+
+        # Step 4: Delete replica-1 StorageClass
+        log.info("Step 4: Deleting replica-1 StorageClass")
+        delete_replica_1_sc()
+        log.info("StorageClass Deleted")
+
+        # Step 5: Delete replica-1 CephBlockPools
+        log.info("Step 5: Deleting replica-1 CephBlockPools")
         cephblockpools = OCP(
             kind=CEPHBLOCKPOOL, namespace=config.ENV_DATA["cluster_namespace"]
         )
-        set_non_resilient_pool(storage_cluster, enable=False)
-        delete_replica_1_sc()
-        log.info("StorageClass Deleted")
         delete_replica1_cephblockpools_cr(cephblockpools)
         log.info("CephBlockPool CR Deleted")
-        purge_replica1_osd()
+
+        # Step 6: Remove replica-1 OSDs sequentially
+        log.info("Step 6: Removing replica-1 OSDs sequentially")
+        removal_summary = sequential_remove_replica1_osds(failure_domains)
+        log.info(f"Step 6 completed: {removal_summary}")
+
+        # Final verification
+        log.info("Waiting for storage cluster to return to ready state")
         storage_cluster.wait_for_resource(
             condition=STATUS_READY, column="PHASE", timeout=1800, sleep=60
         )
+        log.info("Replica-1 teardown orchestrator completed successfully")
 
     def test_cluster_before_configuration(
         self, pod_factory, pvc_factory, project_factory
@@ -128,9 +294,14 @@ class TestReplicaOne:
             interface=CEPHBLOCKPOOL,
             project=self.project,
             size="1",
+            access_mode=ACCESS_MODE_RWO,
             volume_mode=VOLUME_MODE_BLOCK,
         )
-        self.pod = pod_factory(pvc=self.pvc, pod_dict_path=CSI_RBD_RAW_BLOCK_POD_YAML)
+        self.pod = pod_factory(
+            interface=CEPHBLOCKPOOL,
+            pvc=self.pvc,
+            raw_block_pv=True,
+        )
 
         self.pod.run_io(storage_type="fs", size="100M")
         self.kb_after_workload = get_osd_kb_used_data()
@@ -146,16 +317,18 @@ class TestReplicaOne:
             for value in self.device_class_before_test.values()
         ), f"Device class is not as expected. expected 'ssd', actual: {self.device_class_before_test}"
 
-    def test_configure_replica1(
-        self, replica1_setup, project_factory, pod_factory, replica1_teardown
-    ):
+    def test_configure_replica1(self, project_factory, pod_factory):
         log.info("Starting Tier1 replica one test")
+
+        # Call setup function directly
+        storage_cluster = self.replica1_setup()
         failure_domains = get_failure_domains()
         testing_pod = create_pod_on_failure_domain(
             project_factory,
-            pod_factory,
             failure_domain=failure_domains[0],
         )
+        # Track the testing pod (note: create_pod_on_failure_domain also creates PVC but doesn't return it)
+        self.created_pods.append(testing_pod)
         log.info(testing_pod)
         pgs_before_workload = get_osd_pgs_used()
         kb_before_workload = get_osd_kb_used_data()
@@ -170,3 +343,7 @@ class TestReplicaOne:
         osd_number = get_all_osd_names_by_device_class(osds, failure_domains[0])
         diff = compare_dictionaries(kb_before_workload, kb_after_workload, osd_number)
         assert not diff, "KB amount in used OSD is not equal"
+
+        # Call teardown function directly
+        log.info("Test completed successfully, starting teardown")
+        self.replica1_teardown(storage_cluster)


### PR DESCRIPTION
- Cherry-pick of #13036 to release-4.18
- Fix teardown race condition: `purge_replica1_osd()` crashes with empty `FAILED_OSD_IDS` when Rook cleans up OSD pods before `get_replica_1_osds()` runs
- Add guard in `run_osd_removal_job` for empty `osd_ids`
- Rewrite teardown to capture failure domains early and use `sequential_remove_replica1_osds()`
- Add `get_pvcs_using_storageclass()` helper for PVC cleanup