### PR TITLE
download hcp binary - self heal

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -543,7 +543,7 @@
         "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 7165,
+        "line_number": 7163,
         "type": "Private Key",
         "verified_result": null
       }

--- a/ocs_ci/deployment/helpers/hypershift_base.py
+++ b/ocs_ci/deployment/helpers/hypershift_base.py
@@ -506,6 +506,27 @@ class HyperShiftBase:
 
         return os.path.isfile(self.hypershift_binary_path)
 
+    def ensure_hcp_binaries(self, download_hcp_binary=False):
+        """
+        Ensure hcp and hypershift binaries are available.
+
+        Downloads them if explicitly requested or if they are missing (self-heal
+        for partial dependency setups that failed before completing the download).
+
+        Args:
+            download_hcp_binary (bool): If True, always download/update the binaries.
+
+        """
+        if download_hcp_binary:
+            self.update_hcp_binary()
+        elif not (self.hcp_binary_exists() and self.hypershift_binary_exists()):
+            logger.warning(
+                "HCP/hypershift binary not found but download_hcp_binary=False. "
+                "This may happen when a previous cluster's dependency setup failed "
+                "before completing the download. Downloading now."
+            )
+            self.update_hcp_binary()
+
     def install_hcp_and_hypershift_from_git(self, install_latest=False):
         """
         Install hcp binary from git

--- a/ocs_ci/deployment/hub_spoke.py
+++ b/ocs_ci/deployment/hub_spoke.py
@@ -2354,8 +2354,7 @@ class HypershiftHostedOCP(
 
         if deploy_metallb:
             self.deploy_lb()
-        if download_hcp_binary:
-            self.update_hcp_binary()
+        self.ensure_hcp_binaries(download_hcp_binary=download_hcp_binary)
 
         # Enable central infrastructure management service for agent
         if config.DEPLOYMENT.get("hosted_cluster_platform") == "agent":
@@ -3608,8 +3607,7 @@ class HypershiftAWSHostedOCP(SpokeOCP, HyperShiftBase, Deployment, MCEInstaller,
             self.deploy_mce()
             self.enable_hypershift_preview()
 
-        if download_hcp_binary:
-            self.update_hcp_binary()
+        self.ensure_hcp_binaries(download_hcp_binary=download_hcp_binary)
 
         log_step("Saving IDMS mirrors list to file for image-content-sources")
         self.save_mirrors_list_to_file()

--- a/ocs_ci/deployment/hyperconverged.py
+++ b/ocs_ci/deployment/hyperconverged.py
@@ -73,7 +73,13 @@ class HyperConverged:
                 constants.HYPERCONVERGED_OPERATOR_GROUP_YAML
             )
             operator_group_yaml = OCS(**operator_group_yaml_file)
-            operator_group_yaml.create()
+            try:
+                operator_group_yaml.create()
+            except CommandFailed as e:
+                if "AlreadyExists" in str(e):
+                    logger.info("OperatorGroup already exists, continuing")
+                else:
+                    raise
         return self.operator_group.check_resource_existence(
             should_exist=True,
             resource_name=constants.HYPERCONVERGED_OPERATOR_GROUP_NAME,


### PR DESCRIPTION
Fix 1: hyperconverged.py:76-84 — Idempotent OperatorGroup creation                                                                                                                 
                                                                                                                                                                                     
  The is_exist() check was querying the wrong namespace (openshift-storage via self.operator_group) while oc create targeted kubevirt-hyperconverged (from the YAML template). When  
  the resource already existed in the correct namespace, the check missed it and oc create blew up with AlreadyExists. Now the AlreadyExists error is caught and treated as success. 
                  
  Fix 2: hub_spoke.py:2359-2365 and hub_spoke.py:3620-3626 — Self-healing binary download

  Applied to both the base class (HypershiftHostedOCP) and the AWS subclass (HypershiftHostedOCPOnAWS). When download_hcp_binary=False (i.e., not the first cluster), the code now
  checks if the binaries actually exist. If they don't — because the first cluster's dependency setup failed before reaching the download step — it downloads them with a warning
  log, rather than proceeding to FileNotFoundError.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment reliability by automatically ensuring required HyperShift binaries are present, downloading/updating them when missing (even if prior steps were skipped or incomplete).
  * Prevented deployments from failing when an OperatorGroup already exists; the deployment now logs and continues instead of erroring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->