### PR TITLE
Add BareMetal bluestore OSD simulation conf files for encrypted scenarios

### DIFF
--- a/conf/deployment/baremetal/upi_1az_rhcos_nvme_intel_3m_3w_encrypted_to_encrypted.yaml
+++ b/conf/deployment/baremetal/upi_1az_rhcos_nvme_intel_3m_3w_encrypted_to_encrypted.yaml
@@ -21,4 +21,4 @@ ENV_DATA:
   encryption_at_rest: true
 REPORTING:
   polarion:
-    deployment_id: ''
+    deployment_id: 'OCS-8036'

--- a/conf/deployment/baremetal/upi_1az_rhcos_nvme_intel_3m_3w_encrypted_to_encrypted.yaml
+++ b/conf/deployment/baremetal/upi_1az_rhcos_nvme_intel_3m_3w_encrypted_to_encrypted.yaml
@@ -1,0 +1,24 @@
+---
+# Deploys an LSO-backed ODF cluster via CLI on BareMetal UPI (NVMe, 3m/3w).
+# After LSO installs and provisions PVs from clean disks, the LSO operator is
+# scaled down and LUKS headers are written to the backing disks
+# (simulate_bluestore_label_dmcrypt). LSO stays down while the StorageCluster
+# is deployed with wipeDevicesFromOtherClusters so Rook wipes the LUKS headers
+# and provisions new encrypted OSDs. LSO is restored once OSD pods are Running.
+DEPLOYMENT:
+  allow_lower_instance_requirements: false
+  local_storage: true
+  ui_deployment: false
+ENV_DATA:
+  platform: 'baremetal'
+  deployment_type: 'upi'
+  worker_replicas: 3
+  master_replicas: 3
+  mon_type: 'hostpath'
+  osd_type: 'nvme'
+  simulate_bluestore_label_dmcrypt: true
+  wipe_devices_from_other_clusters: true
+  encryption_at_rest: true
+REPORTING:
+  polarion:
+    deployment_id: ''

--- a/conf/deployment/baremetal/upi_1az_rhcos_nvme_intel_3m_3w_encrypted_to_unencrypted.yaml
+++ b/conf/deployment/baremetal/upi_1az_rhcos_nvme_intel_3m_3w_encrypted_to_unencrypted.yaml
@@ -21,4 +21,4 @@ ENV_DATA:
   encryption_at_rest: false
 REPORTING:
   polarion:
-    deployment_id: ''
+    deployment_id: 'OCS-8037'

--- a/conf/deployment/baremetal/upi_1az_rhcos_nvme_intel_3m_3w_encrypted_to_unencrypted.yaml
+++ b/conf/deployment/baremetal/upi_1az_rhcos_nvme_intel_3m_3w_encrypted_to_unencrypted.yaml
@@ -1,0 +1,24 @@
+---
+# Deploys an LSO-backed ODF cluster via CLI on BareMetal UPI (NVMe, 3m/3w).
+# After LSO installs and provisions PVs from clean disks, the LSO operator is
+# scaled down and LUKS headers are written to the backing disks
+# (simulate_bluestore_label_dmcrypt). LSO stays down while the StorageCluster
+# is deployed with wipeDevicesFromOtherClusters so Rook wipes the LUKS headers
+# and provisions new unencrypted OSDs. LSO is restored once OSD pods are Running.
+DEPLOYMENT:
+  allow_lower_instance_requirements: false
+  local_storage: true
+  ui_deployment: false
+ENV_DATA:
+  platform: 'baremetal'
+  deployment_type: 'upi'
+  worker_replicas: 3
+  master_replicas: 3
+  mon_type: 'hostpath'
+  osd_type: 'nvme'
+  simulate_bluestore_label_dmcrypt: true
+  wipe_devices_from_other_clusters: true
+  encryption_at_rest: false
+REPORTING:
+  polarion:
+    deployment_id: ''

--- a/scripts/bash/install_minimal_ceph_cluster.sh
+++ b/scripts/bash/install_minimal_ceph_cluster.sh
@@ -31,7 +31,7 @@ else
     # an internal auth error that is non-fatal — the MON and bootstrap-osd
     # key are fully operational despite it.
     cephadm bootstrap --mon-ip ${NODE_IP} --skip-monitoring-stack \
-        --no-cleanup-on-failure || true
+        --allow-fqdn-hostname --no-cleanup-on-failure || true
 fi
 
 if cephadm shell -- ceph health | grep -qE 'HEALTH_OK|HEALTH_WARN'; then


### PR DESCRIPTION
See more details in the related Jira issue: https://redhat.atlassian.net/browse/OCSQE-5132 and in the Jira epic: https://redhat.atlassian.net/browse/RHSTOR-8102.

Add two LSO conf files for simulating BareMetal bluestore OSD encryption
  migration on a 3-master / 3-worker UPI single-AZ RHCOS Intel NVMe cluster:

  - `upi_1az_rhcos_nvme_intel_3m_3w_encrypted_to_encrypted.yaml`
  - `upi_1az_rhcos_nvme_intel_3m_3w_encrypted_to_unencrypted.yaml`

  Also adds `--allow-fqdn-hostname` to the cephadm bootstrap options in
  `install_minimal_ceph_cluster.sh`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two new bare-metal deployment options for 3 master / 3 worker clusters, covering both encrypted and unencrypted storage setups.
  * Expanded initial cluster setup support to handle hostnames that use fully qualified domain names.

* **Bug Fixes**
  * Improved storage provisioning flow for encrypted environments to better support disk cleanup and re-encryption during deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->