### PR TITLE
use RHCOS in OCP 5.0

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -865,7 +865,7 @@
         "type": "Secret Keyword",
         "verified_result": null
       }
-],
+    ],
     "ocs_ci/ocs/resources/ocsconfigmaps.py": [
       {
         "hashed_secret": "347cd9c53ff77d41a7b22aa56c7b4efaf54658e3",

--- a/ocs_ci/framework/conf/ocp_version/ocp-5.0-config.yaml
+++ b/ocs_ci/framework/conf/ocp_version/ocp-5.0-config.yaml
@@ -9,7 +9,13 @@ DEPLOYMENT:
   # https://docs.openshift.com/container-platform/4.7/post_installation_configuration/machine-configuration-tasks.html#machine-config-overview-post-install-machine-configuration-tasks
   ignition_version: "3.2.0" # TODO: We might want to update to 3.5 or later: https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/release_notes/ocp-4-19-release-notes
 ENV_DATA:
-  vm_template: "scos-10.0.20251103-0-vmware.x86_64"
+  # Dictionary of available RHCOS templates by major version
+  # To use RHCOS 10, set rhcos_version: "10" in your custom config
+  vm_templates:
+    "9": "rhcos-9.8.20260428-0-vmware.x86_64"
+    "10": "rhcos-10.2.20260423-0-vmware.x86_64"
+  # Legacy single template (fallback if vm_templates not defined)
+  vm_template: "rhcos-10.2.20260423-0-vmware.x86_64"
   acm_hub_channel: "release-2.17"
   acm_version: "2.17"
   mce_version: "2.17"


### PR DESCRIPTION
Signed-off-by: vavuthu [vavuthu@redhat.com](mailto:vavuthu@redhat.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the OCP 5.0 nightly environment to use the latest RHCOS 10 virtual machine template.
  * Improved VM template selection to support multiple RHCOS major versions via a version-keyed template mapping, with a corrected legacy fallback.
* **Documentation**
  * Added in-config guidance indicating how to select the RHCOS 10 template using the appropriate RHCOS version setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->