### PR TITLE
EC-test_cephfs_rwx_pvc_ec_pool_create_io_delete

### DIFF
--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -7520,3 +7520,113 @@ def wait_for_osds_down(osd_ids: list[str], timeout: int = 300, sleep: int = 10) 
         )
 
     log.info(f"All OSDs {osd_ids} are now marked as 'down'")
+
+
+def create_cephfs_ec_pool(pool_name, data_chunks, coding_chunks):
+    """
+    Add an EC data pool to the CephFilesystem via StorageCluster patch.
+
+    Patches spec.managedResources.cephFilesystems.additionalDataPools
+    and waits for the Ceph pool to appear.
+
+    Args:
+        pool_name (str): Short pool name (e.g. "test-ec-fs")
+        data_chunks (int): Number of data chunks (k)
+        coding_chunks (int): Number of coding chunks (m)
+
+    Returns:
+        str: Full pool name (e.g. "ocs-storagecluster-cephfilesystem-test-ec-fs")
+    """
+    from ocs_ci.ocs.resources.storage_cluster import get_storage_cluster
+
+    sc_obj = get_storage_cluster(namespace=config.ENV_DATA["cluster_namespace"])
+    sc_data = sc_obj.get()["items"][0]
+    sc_name = sc_data["metadata"]["name"]
+
+    current_pools = (
+        sc_data.get("spec", {})
+        .get("managedResources", {})
+        .get("cephFilesystems", {})
+        .get("additionalDataPools", [])
+    )
+
+    new_entry = {
+        "name": pool_name,
+        "erasureCoded": {"dataChunks": data_chunks, "codingChunks": coding_chunks},
+    }
+    updated_pools = current_pools + [new_entry]
+
+    patch = {
+        "spec": {
+            "managedResources": {
+                "cephFilesystems": {"additionalDataPools": updated_pools}
+            }
+        }
+    }
+    logger.info(f"Patching StorageCluster to add CephFS EC pool '{pool_name}'")
+    sc_obj.patch(resource_name=sc_name, params=json.dumps(patch), format_type="merge")
+
+    fs_name = get_cephfs_name()
+    full_pool_name = f"{fs_name}-{pool_name}"
+
+    ct_pod = pod.get_ceph_tools_pod()
+    logger.info(f"Waiting for Ceph pool '{full_pool_name}' to appear")
+    for pools in TimeoutSampler(300, 10, ct_pod.exec_ceph_cmd, "ceph osd pool ls"):
+        if full_pool_name in pools:
+            logger.info(f"Ceph pool '{full_pool_name}' created successfully")
+            break
+
+    return full_pool_name
+
+
+def delete_cephfs_ec_pool(pool_name):
+    """
+    Remove an EC data pool from CephFilesystem via StorageCluster patch.
+
+    Removes the entry with matching name from
+    spec.managedResources.cephFilesystems.additionalDataPools
+    and waits for the Ceph pool to disappear.
+
+    Args:
+        pool_name (str): Short pool name (e.g. "test-ec-fs")
+    """
+    from ocs_ci.ocs.resources.storage_cluster import get_storage_cluster
+
+    sc_obj = get_storage_cluster(namespace=config.ENV_DATA["cluster_namespace"])
+    sc_data = sc_obj.get()["items"][0]
+    sc_name = sc_data["metadata"]["name"]
+
+    current_pools = (
+        sc_data.get("spec", {})
+        .get("managedResources", {})
+        .get("cephFilesystems", {})
+        .get("additionalDataPools", [])
+    )
+
+    updated_pools = [p for p in current_pools if p.get("name") != pool_name]
+
+    patch = {
+        "spec": {
+            "managedResources": {
+                "cephFilesystems": {"additionalDataPools": updated_pools}
+            }
+        }
+    }
+    logger.info(f"Patching StorageCluster to remove CephFS EC pool '{pool_name}'")
+    sc_obj.patch(resource_name=sc_name, params=json.dumps(patch), format_type="merge")
+
+    fs_name = get_cephfs_name()
+    full_pool_name = f"{fs_name}-{pool_name}"
+
+    ct_pod = pod.get_ceph_tools_pod()
+    logger.info(f"Waiting for Ceph pool '{full_pool_name}' to be removed")
+    try:
+        for pools in TimeoutSampler(600, 15, ct_pod.exec_ceph_cmd, "ceph osd pool ls"):
+            if full_pool_name not in pools:
+                logger.info(f"Ceph pool '{full_pool_name}' removed successfully")
+                break
+    except TimeoutExpiredError:
+        logger.warning(
+            f"Ceph pool '{full_pool_name}' was not removed within timeout. "
+            "The pool entry was already removed from StorageCluster CR."
+        )

--- a/tests/functional/pv/pv_services/test_cephfs_rwx_pvc_ec_pool_lifecycle.py
+++ b/tests/functional/pv/pv_services/test_cephfs_rwx_pvc_ec_pool_lifecycle.py
@@ -1,0 +1,137 @@
+import logging
+
+import pytest
+
+from ocs_ci.framework.pytest_customization.marks import (
+    green_squad,
+    ec_allowed,
+    skipif_external_mode,
+)
+from ocs_ci.framework.testlib import ManageTest, tier2, polarion_id
+from ocs_ci.helpers import helpers
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.cluster import is_ec_pool_supported
+from ocs_ci.ocs.resources import pod as pod_helpers
+
+log = logging.getLogger(__name__)
+
+EC_POOL_NAME = "test-ec-fs"
+EC_DATA_CHUNKS = 2
+EC_CODING_CHUNKS = 2
+
+
+@pytest.fixture()
+def cephfs_ec_pool_and_sc(request):
+    """
+    Create a CephFS EC data pool via StorageCluster patch
+    and a StorageClass that targets it.
+
+    Yields:
+        tuple: (OCS StorageClass object, full Ceph pool name)
+    """
+    full_pool_name = helpers.create_cephfs_ec_pool(
+        EC_POOL_NAME, EC_DATA_CHUNKS, EC_CODING_CHUNKS
+    )
+
+    secret_obj = helpers.create_secret(interface_type=constants.CEPHFILESYSTEM)
+    sc_obj = helpers.create_storage_class(
+        interface_type=constants.CEPHFILESYSTEM,
+        interface_name=full_pool_name,
+        secret_name=secret_obj.name,
+    )
+    log.info(
+        f"Created CephFS EC StorageClass '{sc_obj.name}' with pool '{full_pool_name}'"
+    )
+
+    def finalizer():
+        log.info("Cleaning up CephFS EC StorageClass and pool")
+        sc_obj.delete()
+        sc_obj.ocp.wait_for_delete(sc_obj.name)
+        secret_obj.delete()
+        secret_obj.ocp.wait_for_delete(secret_obj.name)
+        helpers.delete_cephfs_ec_pool(EC_POOL_NAME)
+
+    request.addfinalizer(finalizer)
+    return sc_obj, full_pool_name
+
+
+@green_squad
+@tier2
+@ec_allowed
+@skipif_external_mode
+@pytest.mark.skipif(
+    not is_ec_pool_supported(),
+    reason="Erasure coded pools are not supported on this cluster",
+)
+@polarion_id("OCS-8031")
+class TestCephfsRwxPvcEcPoolLifecycle(ManageTest):
+    """
+    Test CephFS RWX PVC lifecycle on an erasure-coded data pool.
+    """
+
+    def test_cephfs_rwx_pvc_ec_pool_create_io_delete(
+        self, cephfs_ec_pool_and_sc, pvc_factory, pod_factory
+    ):
+        """
+        Steps:
+        1. Create CephFS EC pool and StorageClass (fixture)
+        2. Create RWX PVC on the EC StorageClass
+        3. Create pod and run IO
+        4. Verify EC pool usage increased
+        5. Delete pod and PVC
+        6. Verify subvolume deleted in backend
+        """
+        sc_obj, full_pool_name = cephfs_ec_pool_and_sc
+
+        # Capture baseline pool usage
+        baseline_usage = helpers.fetch_used_size(full_pool_name)
+        log.info(f"Baseline EC pool usage: {baseline_usage} GB")
+
+        # Create RWX PVC
+        pvc_obj = pvc_factory(
+            interface=constants.CEPHFILESYSTEM,
+            storageclass=sc_obj,
+            access_mode=constants.ACCESS_MODE_RWX,
+            size=10,
+        )
+        log.info(f"PVC '{pvc_obj.name}' created and bound")
+
+        # Get subvolume name for later verification
+        subvol_name = pvc_obj.get_cephfs_subvolume_name
+        log.info(f"CephFS subvolume: {subvol_name}")
+
+        # Get the image UUID from the PV volume handle
+        pv_obj = pvc_obj.backed_pv_obj
+        volume_handle = pv_obj.get()["spec"]["csi"]["volumeHandle"]
+        image_uuid = volume_handle.split("-", 4)[-1]
+        log.info(f"Volume handle: {volume_handle}, image UUID: {image_uuid}")
+
+        # Create pod and run IO
+        pod_obj = pod_factory(interface=constants.CEPHFILESYSTEM, pvc=pvc_obj)
+        log.info(f"Pod '{pod_obj.name}' created and running")
+
+        pod_helpers.run_io_and_verify_mount_point(pod_obj, bs="10M", count="500")
+        log.info("IO completed successfully (5 GB written)")
+
+        # Verify pool usage increased
+        post_io_usage = helpers.fetch_used_size(full_pool_name)
+        log.info(f"Post-IO EC pool usage: {post_io_usage} GB")
+        assert post_io_usage > baseline_usage, (
+            f"EC pool usage did not increase after IO. "
+            f"Baseline: {baseline_usage} GB, Current: {post_io_usage} GB"
+        )
+
+        # Delete pod
+        pod_obj.delete(wait=True)
+        log.info("Pod deleted")
+
+        # Delete PVC
+        pvc_obj.delete(wait=True)
+        pvc_obj.ocp.wait_for_delete(pvc_obj.name)
+        log.info("PVC deleted")
+
+        # Verify subvolume is deleted in backend
+        assert helpers.verify_volume_deleted_in_backend(
+            interface=constants.CEPHFILESYSTEM, image_uuid=image_uuid
+        ), f"Subvolume {image_uuid} was not deleted from backend"
+        log.info("Subvolume verified deleted in backend")


### PR DESCRIPTION
 Steps:

  1. Add an EC data pool (2+2) to the CephFilesystem by patching StorageCluster CR spec.managedResources.cephFilesystems.additionalDataPools
  2. Wait for the Ceph pool to be created by the ODF operator
  3. Create a CephFS StorageClass targeting the new EC data pool
  4. Create a 10Gi RWX PVC using the EC-backed StorageClass
  5. Verify PVC is Bound and CephFS subvolume is created
  6. Create a pod mounting the PVC and write 5 GB of data
  7. Verify EC pool usage increased via rados df
  8. Delete the pod and PVC
  9. Verify the CephFS subvolume is deleted in the backend
  10. Clean up: delete StorageClass, remove EC pool entry from StorageCluster CR

  Expected Results:

  - EC data pool is created and appears in ceph osd pool ls
  - PVC binds successfully on the EC-backed StorageClass
  - IO completes and pool usage grows on the EC data pool
  - After PVC deletion, the subvolume is removed from the backend
  - After cleanup, the EC pool is removed from the StorageCluster CR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for creating and removing CephFS erasure-coded data pools through the app’s helper workflows.
  * Introduced end-to-end validation for RWX PVCs backed by an erasure-coded CephFS pool.

* **Bug Fixes**
  * Improved cleanup behavior so pool removal is verified and non-critical timeout cases are handled gracefully.

* **Tests**
  * Added functional coverage for PVC creation, IO, mount verification, and backend cleanup on CephFS EC-backed storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->