### PR TITLE
Fix test failure in test_enable_bucket_versioning

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -865,7 +865,7 @@
         "type": "Secret Keyword",
         "verified_result": null
       }
-    ],
+],
     "ocs_ci/ocs/resources/ocsconfigmaps.py": [
       {
         "hashed_secret": "347cd9c53ff77d41a7b22aa56c7b4efaf54658e3",

--- a/ocs_ci/ocs/ui/page_objects/buckets_tab.py
+++ b/ocs_ci/ocs/ui/page_objects/buckets_tab.py
@@ -613,16 +613,17 @@ class BucketsTab(ObjectStorage, ConfirmDialog):
             self.page_has_loaded(sleep_time=2)
             _check_three_dots_disabled("check three dots inactive after refresh")
 
-    def upload_folder_to_bucket(
-        self, folder_path: str, wait_time: int = 2, timeout: int = 30
-    ) -> None:
+    def upload_folder_to_bucket(self, folder_path: str, wait_time: int = 2) -> None:
         """
         Upload a folder to the bucket.
 
         Args:
             folder_path (str): Path to the folder to upload.
             wait_time (int): Time to wait after upload (default: 2 seconds).
-            timeout (int): Time to wait after upload (default: 30 seconds).
+
+        Raises:
+            exceptions.TimeoutExpiredError: If the folder does not appear
+                  in the bucket after upload.
         """
         file_input = self.driver.find_element(
             self.bucket_tab["file_input_directory"][1],
@@ -638,12 +639,13 @@ class BucketsTab(ObjectStorage, ConfirmDialog):
         folder_name = os.path.basename(folder_path)
         try:
             self.wait_for_element_to_be_present(
-                (f"//span[contains(text(), '{folder_name}')]", By.XPATH),
-                timeout=timeout,
+                (f"//span[contains(text(), '{folder_name}')]", By.XPATH)
             )
             logger.info(f"Upload verified: {folder_name} appears in bucket")
-        except TimeoutException:
-            raise Exception(f"Upload failed: {folder_name} not found after {timeout}s")
+        except TimeoutException as err:
+            raise exceptions.TimeoutExpiredError(
+                f"Upload failed: {folder_name} not found in bucket"
+            ) from err
 
     def navigate_to_bucket(self, bucket_name: str) -> None:
         """

--- a/ocs_ci/ocs/ui/page_objects/buckets_tab.py
+++ b/ocs_ci/ocs/ui/page_objects/buckets_tab.py
@@ -614,7 +614,7 @@ class BucketsTab(ObjectStorage, ConfirmDialog):
             _check_three_dots_disabled("check three dots inactive after refresh")
 
     def upload_folder_to_bucket(
-        self, folder_path: str, wait_time: int = 30, timeout: int = 30
+        self, folder_path: str, wait_time: int = 2, timeout: int = 30
     ) -> None:
         """
         Upload a folder to the bucket.

--- a/ocs_ci/ocs/ui/page_objects/buckets_tab.py
+++ b/ocs_ci/ocs/ui/page_objects/buckets_tab.py
@@ -12,7 +12,7 @@ from selenium.common.exceptions import (
     StaleElementReferenceException,
 )
 
-
+from ocs_ci.ocs.ui.helpers_ui import format_locator
 from ocs_ci.ocs.ocp import get_ocp_url
 from ocs_ci.ocs import exceptions
 from ocs_ci.ocs.ui.page_objects.confirm_dialog import ConfirmDialog
@@ -639,7 +639,7 @@ class BucketsTab(ObjectStorage, ConfirmDialog):
         folder_name = os.path.basename(folder_path)
         try:
             self.wait_for_element_to_be_present(
-                (f"//span[contains(text(), '{folder_name}')]", By.XPATH)
+                format_locator(self.bucket_tab["uploaded_folder_name"], folder_name),
             )
             logger.info(f"Upload verified: {folder_name} appears in bucket")
         except TimeoutException as err:

--- a/ocs_ci/ocs/ui/page_objects/buckets_tab.py
+++ b/ocs_ci/ocs/ui/page_objects/buckets_tab.py
@@ -613,13 +613,16 @@ class BucketsTab(ObjectStorage, ConfirmDialog):
             self.page_has_loaded(sleep_time=2)
             _check_three_dots_disabled("check three dots inactive after refresh")
 
-    def upload_folder_to_bucket(self, folder_path: str, wait_time: int = 2) -> None:
+    def upload_folder_to_bucket(
+        self, folder_path: str, wait_time: int = 30, timeout: int = 30
+    ) -> None:
         """
         Upload a folder to the bucket.
 
         Args:
             folder_path (str): Path to the folder to upload.
             wait_time (int): Time to wait after upload (default: 2 seconds).
+            timeout (int): Time to wait after upload (default: 30 seconds).
         """
         file_input = self.driver.find_element(
             self.bucket_tab["file_input_directory"][1],
@@ -632,6 +635,15 @@ class BucketsTab(ObjectStorage, ConfirmDialog):
         file_input.clear()
         file_input.send_keys(folder_path)
         time.sleep(wait_time)
+        folder_name = os.path.basename(folder_path)
+        try:
+            self.wait_for_element_to_be_present(
+                (f"//span[contains(text(), '{folder_name}')]", By.XPATH),
+                timeout=timeout,
+            )
+            logger.info(f"Upload verified: {folder_name} appears in bucket")
+        except TimeoutException:
+            raise Exception(f"Upload failed: {folder_name} not found after {timeout}s")
 
     def navigate_to_bucket(self, bucket_name: str) -> None:
         """

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -2952,6 +2952,10 @@ bucket_tab = {
         "//button[text()='Upload']",
         By.XPATH,
     ),
+    "uploaded_folder_name": (
+        "//span[contains(text(), '{}')]",
+        By.XPATH,
+    ),
     "create_bucket_button": (
         "//*[@id='yaml-create']",
         By.XPATH,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved folder upload confirmation by verifying the newly uploaded folder appears in the bucket UI after the upload completes.
  * Added a clearer failure response when the uploaded folder name isn’t detected within the allowed waiting period, including an explicit timeout error.
  * Updated the bucket UI locator configuration to reliably detect the uploaded folder name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->