### PR TITLE
Add scale test for multiple STS backingstores and namespacestores

### DIFF
--- a/tests/functional/object/mcg/test_sts_bucket.py
+++ b/tests/functional/object/mcg/test_sts_bucket.py
@@ -5,6 +5,7 @@ import pytest
 from ocs_ci.framework.pytest_customization.marks import (
     tier1,
     tier2,
+    tier3,
     sts_deployment_required,
     aws_platform_required,
     azure_platform_required,
@@ -15,6 +16,7 @@ from ocs_ci.framework.pytest_customization.marks import (
 from ocs_ci.ocs.bucket_utils import (
     write_random_test_objects_to_bucket,
     s3_delete_objects,
+    s3_list_objects_v2,
     sync_object_directory,
     compare_directory,
     check_if_objects_expired,
@@ -27,7 +29,6 @@ logger = logging.getLogger(__name__)
 @red_squad
 @sts_deployment_required
 class TestSTSBucket:
-    @polarion_id("OCS-5479")
     @pytest.mark.parametrize(
         argnames=["bucketclass"],
         argvalues=[
@@ -38,7 +39,7 @@ class TestSTSBucket:
                         "backingstore_dict": {"aws-sts": [(1, "eu-central-1")]},
                     },
                 ],
-                marks=[tier2, aws_platform_required],
+                marks=[tier2, aws_platform_required, polarion_id("OCS-5479")],
             ),
             pytest.param(
                 *[
@@ -134,3 +135,117 @@ class TestSTSBucket:
             bucket_name=bucketname,
         ), "Objects are not deleted"
         logger.info("Objects are deleted successfully from the bucket")
+
+    @pytest.mark.parametrize(
+        argnames=["platform", "region"],
+        argvalues=[
+            pytest.param(
+                "aws-sts",
+                "eu-central-1",
+                marks=[tier3, aws_platform_required, polarion_id("OCS-8039")],
+            ),
+            pytest.param(
+                "azure-sts",
+                None,
+                marks=[tier3, azure_platform_required, polarion_id("OCS-8038")],
+            ),
+        ],
+        ids=["AWS-STS", "AZURE-STS"],
+    )
+    def test_scale_sts_stores(
+        self,
+        backingstore_factory,
+        namespace_store_factory,
+        bucket_factory,
+        awscli_pod_session,
+        test_directory_setup,
+        mcg_obj_session,
+        platform,
+        region,
+    ):
+        """
+        1. Create 3 STS backingstores via CLI
+        2. Create 3 STS namespacestores via CLI
+        3. Create a bucketclass backed by one backingstore and an OBC from it,
+           and a namespace bucketclass backed by one namespacestore and an OBC from it
+        4. Upload objects to both buckets, download, and verify data integrity
+        """
+        # 1. Create 3 STS backingstores via CLI
+        logger.test_step(f"Create 3 {platform} backingstores via CLI")
+        backingstores = backingstore_factory("cli", {platform: [(3, region)]})
+
+        # 2. Create 3 STS namespacestores via CLI
+        logger.test_step(f"Create 3 {platform} namespacestores via CLI")
+        namespacestores = namespace_store_factory("cli", {platform: [(3, region)]})
+
+        # 3. Create buckets backed by one BS and one NSS
+        logger.test_step(
+            "Create buckets backed by one backingstore and one namespacestore"
+        )
+        bucketclass_dicts = [
+            {
+                "interface": "CLI",
+                "backingstores": [backingstores[0]],
+            },
+            {
+                "interface": "CLI",
+                "namespace_policy_dict": {
+                    "type": "Single",
+                    "namespacestores": [namespacestores[0]],
+                },
+            },
+        ]
+        bucketnames = [
+            bucket_factory(bucketclass=bc)[0].name for bc in bucketclass_dicts
+        ]
+        logger.info(f"Created buckets: {bucketnames}")
+
+        # 4. Upload, download, and verify data integrity on each bucket
+        logger.test_step("Upload, download, and verify data integrity on each bucket")
+        for bucketname in bucketnames:
+            awscli_pod_session.exec_cmd_on_pod(
+                f"rm -rf '{test_directory_setup.origin_dir}'"
+                f" '{test_directory_setup.result_dir}'"
+            )
+
+            obj_list = write_random_test_objects_to_bucket(
+                io_pod=awscli_pod_session,
+                bucket_to_write=bucketname,
+                file_dir=test_directory_setup.origin_dir,
+                amount=5,
+                pattern="Random-Obj",
+                mcg_obj=mcg_obj_session,
+            )
+
+            sync_object_directory(
+                podobj=awscli_pod_session,
+                src=f"s3://{bucketname}",
+                target=test_directory_setup.result_dir,
+                s3_obj=mcg_obj_session,
+            )
+
+            assert compare_directory(
+                awscli_pod=awscli_pod_session,
+                original_dir=test_directory_setup.origin_dir,
+                result_dir=test_directory_setup.result_dir,
+                amount=5,
+                pattern="Random-Obj",
+            ), f"Data integrity check failed for bucket {bucketname}"
+
+            s3_delete_objects(
+                mcg_obj_session,
+                bucketname=bucketname,
+                object_keys=[{"Key": f"{obj}"} for obj in obj_list],
+            )
+
+            remaining = s3_list_objects_v2(
+                s3_obj=mcg_obj_session, bucketname=bucketname
+            )
+            logger.assertion(
+                f"Bucket emptied after delete: bucket='{bucketname}', "
+                f"remaining_objects={remaining.get('KeyCount', 0)}"
+            )
+            assert (
+                remaining.get("KeyCount", 0) == 0
+            ), f"Bucket {bucketname} still has objects after deletion"
+            logger.info(f"IO round-trip verified for bucket {bucketname}")

--- a/tests/functional/object/mcg/test_sts_bucket.py
+++ b/tests/functional/object/mcg/test_sts_bucket.py
@@ -39,7 +39,7 @@ class TestSTSBucket:
                         "backingstore_dict": {"aws-sts": [(1, "eu-central-1")]},
                     },
                 ],
-                marks=[tier2, aws_platform_required, polarion_id("OCS-5479")],
+                marks=[tier2, aws_platform_required, polarion_id("OCS-5610")],
             ),
             pytest.param(
                 *[
@@ -64,9 +64,7 @@ class TestSTSBucket:
             ),
             pytest.param(
                 *[None],
-                marks=[
-                    tier1,
-                ],
+                marks=[tier1, polarion_id("OCS-5609")],
             ),
         ],
         ids=[

--- a/tests/functional/object/mcg/test_sts_bucket.py
+++ b/tests/functional/object/mcg/test_sts_bucket.py
@@ -166,9 +166,8 @@ class TestSTSBucket:
         """
         1. Create 3 STS backingstores via CLI
         2. Create 3 STS namespacestores via CLI
-        3. Create a bucketclass backed by one backingstore and an OBC from it,
-           and a namespace bucketclass backed by one namespacestore and an OBC from it
-        4. Upload objects to both buckets, download, and verify data integrity
+        3. Create a bucketclass and OBC for each backingstore and namespacestore
+        4. Upload objects to all buckets, download, and verify data integrity
         """
         # 1. Create 3 STS backingstores via CLI
         logger.test_step(f"Create 3 {platform} backingstores via CLI")
@@ -178,22 +177,25 @@ class TestSTSBucket:
         logger.test_step(f"Create 3 {platform} namespacestores via CLI")
         namespacestores = namespace_store_factory("cli", {platform: [(3, region)]})
 
-        # 3. Create buckets backed by one BS and one NSS
+        # 3. Create a bucketclass and OBC for each store
         logger.test_step(
-            "Create buckets backed by one backingstore and one namespacestore"
+            "Create a bucketclass and OBC for each backingstore and namespacestore"
         )
         bucketclass_dicts = [
             {
                 "interface": "CLI",
-                "backingstores": [backingstores[0]],
-            },
+                "backingstores": [bs],
+            }
+            for bs in backingstores
+        ] + [
             {
                 "interface": "CLI",
                 "namespace_policy_dict": {
                     "type": "Single",
-                    "namespacestores": [namespacestores[0]],
+                    "namespacestores": [nss],
                 },
-            },
+            }
+            for nss in namespacestores
         ]
         bucketnames = [
             bucket_factory(bucketclass=bc)[0].name for bc in bucketclass_dicts


### PR DESCRIPTION
## Summary
- Add `test_scale_sts_stores` to validate that multiple STS backingstores and namespacestores can coexist on the same cluster ([RHSTOR-5085](https://redhat.atlassian.net/browse/RHSTOR-5085))
- Parametrized for both AWS STS and Azure STS platforms, gated by platform markers
- Creates 3 backingstores + 3 namespacestores via CLI, then verifies IO through buckets backed by them

## Changes
- New test `test_scale_sts_stores` in `tests/functional/object/mcg/test_sts_bucket.py` with two parametrized variants:
  - `AWS-STS` (tier3, `aws_platform_required`, OCS-8039)
  - `AZURE-STS` (tier3, `azure_platform_required`, OCS-8038)
- Moved `polarion_id("OCS-5479")` from function-level decorator to the AWS-STS pytest.param marks on `test_sts_bucket_ops` for consistency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded end-to-end STS bucket coverage to include both AWS and Azure scenarios with improved parametrization and clearer per-case identifiers.
  * Added a stronger scale test that creates multiple STS backingstores and namespacestores, uploads random objects, performs sync/download validation, and verifies data integrity.
  * After deleting objects, now explicitly confirms buckets are empty via post-deletion listing to ensure cleanup is fully effective.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->