### PR TITLE
Skip acm-idms in disconnected cluster

### DIFF
--- a/tests/functional/deployment/test_acm.py
+++ b/tests/functional/deployment/test_acm.py
@@ -39,12 +39,13 @@ def test_acm_import():
     if version.compare_versions(f"{config.ENV_DATA.get('acm_version')} >= 2.14"):
         # Step 1: Apply IDMS to all clusters
         for cluster in config.clusters:
-            try:
-                apply_idms(cluster)
-            except Exception as e:
-                logger.error(
-                    f"Error applying IDMS on cluster index {cluster.MULTICLUSTER['multicluster_index']}: {e}"
-                )
+            if not cluster.DEPLOYMENT.get("disconnected", False):
+                try:
+                    apply_idms(cluster)
+                except Exception as e:
+                    logger.error(
+                        f"Error applying IDMS on cluster index {cluster.MULTICLUSTER['multicluster_index']}: {e}"
+                    )
 
         # Step 2: Wait for MCP update on all clusters
         for cluster in config.clusters:

--- a/tests/functional/deployment/test_acm.py
+++ b/tests/functional/deployment/test_acm.py
@@ -46,6 +46,11 @@ def test_acm_import():
                     logger.error(
                         f"Error applying IDMS on cluster index {cluster.MULTICLUSTER['multicluster_index']}: {e}"
                     )
+            else:
+                logger.info(
+                    f"Skipping IDMS application for disconnected cluster index "
+                    f"{cluster.MULTICLUSTER['multicluster_index']}"
+                )
 
         # Step 2: Wait for MCP update on all clusters
         for cluster in config.clusters:


### PR DESCRIPTION
IDMS named acm-idms is directly applied from yaml file which should be skipped in disconnected cluster.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ACM import behavior by skipping ImageDigestMirrorSet application on disconnected clusters.
  * Reduced unnecessary errors during cluster setup, while keeping existing error handling behavior unchanged.
  * Added an informational log when IDMS application is skipped for disconnected clusters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->