### PR TITLE
Add ignore_leftovers to TestStorageclusterUpgradeParams

### DIFF
--- a/tests/functional/upgrade/test_storagecluster_upgrade_params.py
+++ b/tests/functional/upgrade/test_storagecluster_upgrade_params.py
@@ -12,6 +12,7 @@ from ocs_ci.framework.testlib import (
     tier2,
     skipif_external_mode,
     brown_squad,
+    ignore_leftovers,
 )
 
 logger = logging.getLogger(__name__)
@@ -20,6 +21,7 @@ logger = logging.getLogger(__name__)
 @tier2
 @brown_squad
 @skipif_external_mode
+@ignore_leftovers
 @pytest.mark.polarion_id("OCS-6225")
 class TestStorageclusterUpgradeParams(ManageTest):
     """


### PR DESCRIPTION
- Add `@ignore_leftovers` marker to `TestStorageclusterUpgradeParams`
- Post-upgrade pod churn (NFS CSI deployment, OSD PVC resize rollouts) triggers `ResourceLeftoversException` even though the test body passes
- Other upgrade tests (`test_resources.py`, `test_upgrade_ocp.py`) already have this marker

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an additional test marker to the storage cluster upgrade parameter coverage to improve stability when leftover artifacts are present during execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->