### PR TITLE
Read default backingstore numVolumes dynamically in verify_mcg_only_pods

### DIFF
--- a/ocs_ci/ocs/resources/storage_cluster.py
+++ b/ocs_ci/ocs/resources/storage_cluster.py
@@ -1773,9 +1773,18 @@ def verify_mcg_only_pods():
     if config.ENV_DATA.get("noobaa_external_pgsql"):
         del resources_dict[constants.NOOBAA_DB_LABEL_47_AND_ABOVE]
     if config.ENV_DATA["platform"].lower() == constants.VSPHERE_PLATFORM:
+        default_bs = OCP(
+            kind="backingstore",
+            namespace=config.ENV_DATA["cluster_namespace"],
+            resource_name=constants.DEFAULT_NOOBAA_BACKINGSTORE,
+        )
+        default_bs_data = default_bs.get()
+        num_volumes = (
+            default_bs_data.get("spec", {}).get("pvPool", {}).get("numVolumes", 1)
+        )
         resources_dict.update(
             {
-                constants.NOOBAA_DEFAULT_BACKINGSTORE_LABEL: 1,
+                constants.NOOBAA_DEFAULT_BACKINGSTORE_LABEL: num_volumes,
             }
         )
     if ocs_version >= version.VERSION_4_15:


### PR DESCRIPTION
## Summary
- Read the default PV-pool backingstore `numVolumes` from the actual
  backingstore CR instead of hardcoding 1 in `verify_mcg_only_pods()`

## Changes
The NooBaa operator now creates the default PV-pool backingstore with
`numVolumes=3` on new deployments (previously 1), driven by the new
`performanceProfile` feature ([RHSTOR-9144](https://redhat.atlassian.net/browse/RHSTOR-9144),
[noobaa-operator#1953](https://github.com/noobaa/noobaa-operator/pull/1953)).

The hardcoded pod count of 1 for `NOOBAA_DEFAULT_BACKINGSTORE_LABEL`
would cause `verify_mcg_only_pods()` to fail on fresh 4.23+ deployments
where the default backingstore gets 3 PV-pool agent pods.

This fix reads `spec.pvPool.numVolumes` from the `noobaa-default-backing-store`
CR dynamically, so it works for both existing deployments (numVolumes=1)
and new ones (numVolumes=3).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved verification for multi-cloud gateway-only pods on vSphere by matching the expected backing store volume count to the cluster’s configured default value.
  * This helps avoid incorrect validation results when the backing store uses a non-default number of volumes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->