### PR TITLE
fix: use case-insensitive matching in get_plugin_provisioner_leader

### DIFF
--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -2258,11 +2258,16 @@ def get_plugin_provisioner_leader(interface, namespace=None, leader_type="provis
         for log_msg in log_list:
             # Check for last occurrence of leader message
             # This will be the first occurrence in reversed list.
-            if (lease_renew_msg in log_msg) or (lease_acq_msg in log_msg):
+            # Use case-insensitive comparison to handle both old (lowercase)
+            # and new structured-logging (Title-case) leaderelection messages.
+            log_msg_lower = log_msg.lower()
+            if (lease_renew_msg in log_msg_lower) or (lease_acq_msg in log_msg_lower):
                 curr_index = log_list.index(log_msg)
                 # Ensure that there is no non leader message logged after
                 # the last occurrence of leader message
-                if not any(non_leader_msg in msg for msg in log_list[:curr_index]):
+                if not any(
+                    non_leader_msg in msg.lower() for msg in log_list[:curr_index]
+                ):
                     leader_pod = pod
                 break
     assert leader_pod, "Couldn't identify plugin provisioner leader pod."


### PR DESCRIPTION
## What this PR does
Fixes `get_plugin_provisioner_leader()` failing to identify the CSI RBD/CephFS
provisioner leader pod on ODF >= 4.19 clusters.

## Root cause
Kubernetes structured logging changed leaderelection messages from lowercase:
  - `successfully renewed lease`
  - `failed to acquire lease`

to Title-case:
  - `Successfully renewed lease`
  - `Failed to acquire lease`

The code performed a **case-sensitive** Python `in` check against lowercase
strings, so no log line ever matched, `leader_pod` stayed empty, and the
`assert leader_pod` raised:

AssertionError: Couldn't identify plugin provisioner leader pod.


## Fix
Lower-case each log line before comparison in `get_plugin_provisioner_leader()`.
The search strings are already lowercase so no other change is needed.
Backward-compatible with older clusters.

Fixes: #15574 

## How to reproduce
Run on a cluster with ODF >= 4.19:

pytest 'tests/functional/workloads/app/amq/test_amq_pod_respin.py::TestAMQPodRespin::test_run_amq_respin_pod[rbdplugin_provisioner]'

Before fix → `AssertionError: Couldn't identify plugin provisioner leader pod.`
After fix  → leader pod identified correctly, test proceeds.

## Verification
```bash
# Confirm the Title-case messages exist in the actual logs
oc logs -n openshift-storage <ctrlplugin-pod> -c csi-provisioner \
  | grep -i "successfully renewed lease"

Files changed
ocs_ci/ocs/resources/pod.py — get_plugin_provisioner_leader(): 2 lines changed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved leader-detection reliability by making log matching case-insensitive.
  * Reduced false negatives when checking for leader acquisition and renewal messages in pod logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->