### PR TITLE
Update polarion deployment_id for external IPv6 config

### DIFF
--- a/conf/deployment/vsphere/upi_1az_rhcos_vsan_external_ipv6_3m_3w.yaml
+++ b/conf/deployment/vsphere/upi_1az_rhcos_vsan_external_ipv6_3m_3w.yaml
@@ -20,4 +20,4 @@ EXTERNAL_MODE:
 
 REPORTING:
   polarion:
-    deployment_id: 'OCS-2563'
+    deployment_id: 'OCS-8040'

--- a/conf/ocsci/external_rhcs_cluster_ipv6.yaml
+++ b/conf/ocsci/external_rhcs_cluster_ipv6.yaml
@@ -15,4 +15,4 @@ EXTERNAL_MODE:
 
 REPORTING:
   polarion:
-    deployment_id: 'OCS-2563'
+    deployment_id: 'OCS-8040'


### PR DESCRIPTION
## Summary
- Update polarion `deployment_id` from `OCS-2563` to `OCS-8040` in `conf/deployment/vsphere/upi_1az_rhcos_vsan_external_ipv6_3m_3w.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the deployment reporting reference to use the latest tracking ID.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->