### PR TITLE
EC node operations. Gradual and bulk shut-down. 422

### DIFF
--- a/ocs_ci/helpers/ceph_helpers.py
+++ b/ocs_ci/helpers/ceph_helpers.py
@@ -1,8 +1,16 @@
 import logging
 
-from ocs_ci.ocs.cluster import get_percent_used_capacity, get_ceph_used_capacity
+from ocs_ci.ocs.cluster import (
+    get_percent_used_capacity,
+    get_ceph_used_capacity,
+    get_ceph_pool_property,
+)
 from ocs_ci.ocs.exceptions import TimeoutExpiredError
+from ocs_ci.ocs.node import get_osd_running_nodes
+from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.resources.pod import get_ceph_tools_pod
+from ocs_ci.helpers.helpers import get_failure_domain
+from ocs_ci.utility.decorators import switch_to_provider_for_function
 from ocs_ci.utility.utils import TimeoutSampler
 from ocs_ci.ocs import constants
 
@@ -174,6 +182,65 @@ def get_mon_quorum_count() -> int:
     """
     mon_quorum_ranks = get_mon_quorum_ranks()
     return len(mon_quorum_ranks)
+
+
+@switch_to_provider_for_function
+def get_ec_drain_thresholds(pool_name=None):
+    """
+    Calculate how many OSD-host shutdowns an EC pool can tolerate at each tier.
+
+    Args:
+        pool_name (str): CephBlockPool CR name. Defaults to DEFAULT_CEPHBLOCKPOOL.
+
+    Returns:
+        dict: Threshold values with keys k, m, size (k+m), min_size,
+            failure_domain, total_osd_hosts, max_drain_io_ok, and
+            min_drain_io_stops.
+
+    Raises:
+        ValueError: If the pool is not erasure-coded.
+
+    """
+    from ocs_ci.framework import config
+
+    pool_name = pool_name or constants.DEFAULT_CEPHBLOCKPOOL
+    namespace = config.ENV_DATA["cluster_namespace"]
+
+    cbp = OCP(kind="CephBlockPool", namespace=namespace, resource_name=pool_name).get()
+    ec_spec = cbp.get("spec", {}).get("erasureCoded", {})
+    k = ec_spec.get("dataChunks")
+    m = ec_spec.get("codingChunks")
+    if not k or not m:
+        raise ValueError(
+            f"Pool {pool_name} is not erasure-coded " f"(erasureCoded spec: {ec_spec})"
+        )
+
+    size = int(get_ceph_pool_property(pool_name, "size"))
+    min_size = int(get_ceph_pool_property(pool_name, "min_size"))
+    failure_domain = get_failure_domain()
+    total_osd_hosts = len(get_osd_running_nodes())
+
+    if failure_domain != "host":
+        logger.warning(
+            f"Failure domain is '{failure_domain}', not 'host'. "
+            f"Host-based drain thresholds may not be accurate."
+        )
+
+    max_drain_io_ok = total_osd_hosts - min_size
+    min_drain_io_stops = max_drain_io_ok + 1
+
+    result = {
+        "k": k,
+        "m": m,
+        "size": size,
+        "min_size": min_size,
+        "failure_domain": failure_domain,
+        "total_osd_hosts": total_osd_hosts,
+        "max_drain_io_ok": max_drain_io_ok,
+        "min_drain_io_stops": min_drain_io_stops,
+    }
+    logger.info(f"EC drain thresholds for pool {pool_name}: {result}")
+    return result
 
 
 def wait_for_mons_in_quorum(expected_mon_count, timeout=300, sleep=20) -> None:

--- a/ocs_ci/helpers/ceph_helpers.py
+++ b/ocs_ci/helpers/ceph_helpers.py
@@ -215,19 +215,27 @@ def get_ec_drain_thresholds(pool_name=None):
             f"Pool {pool_name} is not erasure-coded " f"(erasureCoded spec: {ec_spec})"
         )
 
-    size = int(get_ceph_pool_property(pool_name, "size"))
-    min_size = int(get_ceph_pool_property(pool_name, "min_size"))
+    raw_size = get_ceph_pool_property(pool_name, "size")
+    raw_min_size = get_ceph_pool_property(pool_name, "min_size")
+    if raw_size is None:
+        raise ValueError(f"Pool {pool_name}: failed to resolve property 'size'")
+    if raw_min_size is None:
+        raise ValueError(f"Pool {pool_name}: failed to resolve property 'min_size'")
+    size = int(raw_size)
+    min_size = int(raw_min_size)
     failure_domain = get_failure_domain()
     total_osd_hosts = len(get_osd_running_nodes())
 
-    if failure_domain != "host":
+    if failure_domain == "host":
+        max_drain_io_ok = total_osd_hosts - min_size
+        min_drain_io_stops = max_drain_io_ok + 1
+    else:
         logger.warning(
             f"Failure domain is '{failure_domain}', not 'host'. "
-            f"Host-based drain thresholds may not be accurate."
+            f"Host-based drain thresholds are not applicable."
         )
-
-    max_drain_io_ok = total_osd_hosts - min_size
-    min_drain_io_stops = max_drain_io_ok + 1
+        max_drain_io_ok = 0
+        min_drain_io_stops = 1
 
     result = {
         "k": k,

--- a/tests/functional/z_cluster/nodes/test_nodes_maintenance.py
+++ b/tests/functional/z_cluster/nodes/test_nodes_maintenance.py
@@ -792,21 +792,24 @@ class TestECNodeOperations(ManageTest):
                 break
 
             # Check if remaining non-clean PGs are only topology-limited:
-            # active+undersized+degraded PGs can't recover while a host
-            # is down because CRUSH can't place all EC chunks on the
-            # remaining hosts. These resolve only when the node returns.
+            # PGs with "undersized" can't recover while a host is down
+            # because CRUSH can't place all EC chunks on the remaining
+            # hosts. These resolve only when the node returns. Match
+            # any active+undersized variant (may include degraded,
+            # remapped, etc.).
             topology_stuck = sum(
                 s["count"]
                 for s in pg_states
-                if s["state_name"] == "active+undersized+degraded"
+                if "active" in s["state_name"]
+                and "undersized" in s["state_name"]
+                and "clean" not in s["state_name"]
             )
             recoverable_dirty = total - clean_count - topology_stuck
             if recoverable_dirty == 0 and clean_count > 0:
                 log.info(
                     f"Recovery complete: {clean_count}/{total} PGs clean, "
                     f"{topology_stuck} PG(s) topology-limited "
-                    f"(active+undersized+degraded, will resolve when "
-                    f"node returns)"
+                    f"(undersized, will resolve when node returns)"
                 )
                 break
 
@@ -924,6 +927,143 @@ class TestECNodeOperations(ManageTest):
             n for n in eligible if n in mon_nodes
         ]
 
+    @switch_to_provider_for_function
+    def _create_workload_on_master(self, pvc_factory, pod_factory):
+        """Create a PVC + pod on a master node, write 256MB, return (pod, md5).
+
+        Places the workload on a master node so it is never shut down
+        during node failure tests. Uses the default RBD StorageClass
+        explicitly to avoid picking up day-2 SCs on HCI platforms.
+
+        Returns:
+            tuple: (pod_obj, original_md5)
+        """
+        from ocs_ci.ocs.resources.ocs import OCS
+
+        master_nodes = get_nodes(node_type=constants.MASTER_MACHINE)
+        master_node_name = master_nodes[0].name if master_nodes else None
+        sc_ocp = ocp.OCP(
+            kind="StorageClass",
+            resource_name=constants.DEFAULT_STORAGECLASS_RBD,
+        )
+        sc_obj = OCS(**sc_ocp.get())
+        pvc_obj = pvc_factory(
+            interface=constants.CEPHBLOCKPOOL,
+            size=5,
+            storageclass=sc_obj,
+        )
+        pod_obj = pod_factory(
+            pvc=pvc_obj,
+            interface=constants.CEPHBLOCKPOOL,
+            node_name=master_node_name,
+        )
+        pod_obj.run_io(
+            storage_type="fs",
+            size="256M",
+            io_direction="wo",
+            runtime=0,
+            bs="1M",
+        )
+        get_fio_rw_iops(pod_obj)
+        original_md5 = cal_md5sum(pod_obj, "fio-rand-write")
+        log.info(f"Baseline md5sum captured: {original_md5}")
+        return pod_obj, original_md5
+
+    @switch_to_provider_for_function
+    def _log_osd_distribution(self):
+        """Log ``ceph osd df tree`` and ``ceph osd df`` at INFO level."""
+        ct_pod = get_ceph_tools_pod()
+        osd_df_tree = ct_pod.exec_ceph_cmd("ceph osd df tree")
+        log.info(f"OSD df tree: {osd_df_tree}")
+        osd_df = ct_pod.exec_ceph_cmd("ceph osd df")
+        log.info(f"OSD df: {osd_df}")
+
+    @switch_to_provider_for_function
+    def _restart_and_recover_nodes(self, nodes):
+        """Log OSD state, restart stopped nodes, and wait for recovery.
+
+        Args:
+            nodes: The nodes fixture (provides start_nodes).
+        """
+        self._log_osd_distribution()
+
+        log.info(f"Restarting {len(self.stopped_node_objs)} stopped nodes")
+        nodes.start_nodes(self.stopped_node_objs)
+        wait_for_nodes_status([n.name for n in self.stopped_node_objs], timeout=600)
+        wait_for_storage_pods(timeout=600)
+        self._wait_for_clean_pgs()
+        self.stopped_node_objs.clear()
+
+    @switch_to_provider_for_function
+    def _unset_noout_if_needed(self):
+        """Unset the noout flag only if it is currently set.
+
+        Checks ``ceph health`` for the OSDMAP_FLAGS warning that
+        indicates noout is active before attempting to unset it.
+        """
+        ct_pod = get_ceph_tools_pod()
+        health = ct_pod.exec_ceph_cmd("ceph health")
+        if "noout" in str(health):
+            ct_pod.exec_ceph_cmd("ceph osd unset noout")
+            log.info("Unset noout flag (was active)")
+        else:
+            log.info("noout flag not set, skipping unset")
+
+    @switch_to_provider_for_function
+    def _cleanup_stale_pods_on_nodes(self, node_names, namespace=None):
+        """Force-delete pods stuck on unreachable nodes and clean up
+        stale VolumeAttachments so replacement pods can schedule.
+
+        When a node is powered off, pods enter Terminating but can't
+        complete because the kubelet is unreachable. RWO PVCs remain
+        "attached" to the dead node via VolumeAttachment resources,
+        blocking Multi-Attach on the new node.
+
+        Args:
+            node_names (list[str]): Names of the downed nodes
+            namespace (str): Namespace to scan. Defaults to cluster namespace.
+        """
+        namespace = namespace or config.ENV_DATA["cluster_namespace"]
+        node_set = set(node_names)
+
+        # Force-delete Terminating pods on downed nodes
+        ocp_pod = ocp.OCP(kind=constants.POD, namespace=namespace)
+        all_pods = ocp_pod.get().get("items", [])
+        for p in all_pods:
+            pod_node = p.get("spec", {}).get("nodeName", "")
+            pod_name = p["metadata"]["name"]
+            deletion_ts = p["metadata"].get("deletionTimestamp")
+            if pod_node in node_set and deletion_ts:
+                log.info(
+                    f"Force-deleting stuck pod {pod_name} " f"on downed node {pod_node}"
+                )
+                try:
+                    ocp_pod.exec_oc_cmd(
+                        f"delete pod {pod_name} -n {namespace} "
+                        f"--force --grace-period=0"
+                    )
+                except CommandFailed as e:
+                    log.warning(f"Failed to force-delete {pod_name}: {e}")
+
+        # Delete stale VolumeAttachments pointing to downed nodes
+        va_ocp = ocp.OCP(kind="VolumeAttachment")
+        try:
+            va_list = va_ocp.get().get("items", [])
+        except CommandFailed:
+            va_list = []
+        for va in va_list:
+            va_node = va.get("spec", {}).get("nodeName", "")
+            va_name = va["metadata"]["name"]
+            if va_node in node_set:
+                log.info(
+                    f"Deleting stale VolumeAttachment {va_name} "
+                    f"on downed node {va_node}"
+                )
+                try:
+                    va_ocp.exec_oc_cmd(f"delete volumeattachment {va_name}")
+                except CommandFailed as e:
+                    log.warning(f"Failed to delete VolumeAttachment " f"{va_name}: {e}")
+
     @tier4a
     @runs_on_provider
     @skipif_managed_service
@@ -955,33 +1095,9 @@ class TestECNodeOperations(ManageTest):
             ), f"Not enough OSD hosts ({total_hosts}) for EC pool (need {size})"
 
             # Phase 1: Create workload on a master node (never shut down)
-            master_nodes = get_nodes(node_type=constants.MASTER_MACHINE)
-            master_node_name = master_nodes[0].name if master_nodes else None
-            # Explicitly use the default RBD SC to avoid picking up
-            # leftover day-2 SCs on HCI platforms (the auto-detection
-            # picks the first SC matching the RBD provisioner).
-            from ocs_ci.ocs.resources.ocs import OCS
-
-            sc_ocp = ocp.OCP(
-                kind="StorageClass",
-                resource_name=constants.DEFAULT_STORAGECLASS_RBD,
+            pod_obj, original_md5 = self._create_workload_on_master(
+                pvc_factory, pod_factory
             )
-            sc_obj = OCS(**sc_ocp.get())
-            pvc_obj = pvc_factory(
-                interface=constants.CEPHBLOCKPOOL,
-                size=5,
-                storageclass=sc_obj,
-            )
-            pod_obj = pod_factory(
-                pvc=pvc_obj,
-                interface=constants.CEPHBLOCKPOOL,
-                node_name=master_node_name,
-            )
-            pod_obj.run_io(
-                storage_type="fs", size="256M", io_direction="wo", runtime=0, bs="1M"
-            )
-            get_fio_rw_iops(pod_obj)
-            original_md5 = cal_md5sum(pod_obj, "fio-rand-write")
 
             # Phase 2: Verify PG health + chunk distribution
             ceph_cluster = CephCluster()
@@ -1042,43 +1158,60 @@ class TestECNodeOperations(ManageTest):
                     )
                     break
 
-                # Power off the node. Add to stopped list first so the
-                # finalizer can restart it even if stop_nodes raises partway.
+                log.info(
+                    f"{'=' * 60}\n"
+                    f"  SHUTDOWN {i}/{max_shutdowns}: "
+                    f"Powering off {node_name} "
+                    f"({live_hosts} hosts will remain)\n"
+                    f"{'=' * 60}"
+                )
                 shutdown_node_obj = get_node_objs([node_name])[0]
                 self.stopped_node_objs.append(shutdown_node_obj)
-                log.info(
-                    f"Shutting down node {node_name} ({i}/{max_shutdowns}), "
-                    f"{live_hosts} hosts will remain"
-                )
                 nodes.stop_nodes([shutdown_node_obj])
 
-                # Refresh ceph tools pod — it may have been rescheduled
-                # if the previous one lived on a now-stopped node.
                 ct_pod = get_ceph_tools_pod(wait=True)
 
-                # Wait for Ceph to detect OSD failure before tier validation.
-                # OSD heartbeat timeout is ~20s; give extra margin.
-                log.info("Waiting for Ceph to detect OSD failure")
+                log.info(
+                    f"--- Waiting 30s for Ceph to detect OSD failure "
+                    f"on {node_name} ---"
+                )
                 time.sleep(30)
+
+                log.info("--- Cleanup: stale pods/VAs on downed nodes ---")
+                stopped_names = [n.name for n in self.stopped_node_objs]
+                self._cleanup_stale_pods_on_nodes(stopped_names)
+
+                self._unset_noout_if_needed()
 
                 # Tier-based validation
                 if live_hosts >= size:
-                    log.info(f"Tier 1: {live_hosts} live >= {size} (k+m)")
-                    # With EC pools, some PGs stay active+clean+remapped while
-                    # an OSD host is down. Wait for all PGs to be clean
-                    # (accepting remapped), then validate IO + integrity.
-                    self._wait_for_clean_pgs()
+                    log.info(
+                        f"--- Tier 1: {live_hosts} live >= {size} (k+m) "
+                        f"— waiting for full PG recovery ---"
+                    )
+                    # Ceph's mon_osd_down_out_interval (default 600s)
+                    # must elapse before OSDs are marked out and
+                    # recovery begins. Use a stall_timeout that
+                    # accommodates this delay.
+                    self._wait_for_clean_pgs(stall_timeout=2400)
+                    log.info("--- Tier 1: verifying IO + data integrity ---")
                     self._run_write_io(pod_obj)
                     verify_data_integrity(pod_obj, "fio-rand-write", original_md5)
 
                 elif live_hosts >= min_size:
-                    log.info(f"Tier 2: {min_size} <= {live_hosts} < {size}")
+                    log.info(
+                        f"--- Tier 2: {min_size} <= {live_hosts} < {size} "
+                        f"— degraded, writes should work ---"
+                    )
                     self._wait_for_stable_degraded(ct_pod)
                     self._run_write_io(pod_obj)
                     verify_data_integrity(pod_obj, "fio-rand-write", original_md5)
 
                 elif live_hosts >= k:
-                    log.info(f"Tier 3: {k} <= {live_hosts} < {min_size}")
+                    log.info(
+                        f"--- Tier 3: {k} <= {live_hosts} < {min_size} "
+                        f"— writes may be blocked ---"
+                    )
                     time.sleep(60)
                     write_ok = self._try_write_io(pod_obj)
                     if write_ok:
@@ -1092,19 +1225,27 @@ class TestECNodeOperations(ManageTest):
                     except (CommandFailed, AssertionError):
                         log.info("Read failed in tier 3 (can happen)")
 
-            # Recovery: start all stopped nodes
-            log.info(f"Starting {len(self.stopped_node_objs)} stopped nodes")
+                log.info(
+                    f"--- Shutdown {i}/{max_shutdowns} complete for " f"{node_name} ---"
+                )
+
+            log.info(
+                f"{'=' * 60}\n"
+                f"  RECOVERY: restarting "
+                f"{len(self.stopped_node_objs)} stopped nodes\n"
+                f"{'=' * 60}"
+            )
+            self._log_osd_distribution()
+
             nodes.start_nodes(self.stopped_node_objs)
             wait_for_nodes_status([n.name for n in self.stopped_node_objs], timeout=600)
             wait_for_storage_pods(timeout=600)
             assert ceph_cluster.wait_for_rebalance(
                 timeout=3600, repeat=3
             ), "Post-recovery rebalance did not complete"
-
-            # Clear the list so the finalizer does not re-start them
             self.stopped_node_objs.clear()
 
-            # Post-recovery: refresh tools pod and verify no chunk co-location
+            log.info("--- Post-recovery: verifying chunk distribution ---")
             ct_pod = get_ceph_tools_pod()
             osd_tree = ct_pod.exec_ceph_cmd("ceph osd tree")
             osd_to_host = {
@@ -1123,7 +1264,7 @@ class TestECNodeOperations(ManageTest):
                         f"{len(hosts)} hosts, need {size}"
                     )
 
-            # Data integrity after full recovery
+            log.info("--- Post-recovery: data integrity + health check ---")
             verify_data_integrity(pod_obj, "fio-rand-write", original_md5)
             self.sanity_helpers.health_check(tries=90)
 
@@ -1165,36 +1306,9 @@ class TestECNodeOperations(ManageTest):
             )
 
             # Phase 1: Create workload on a master node (never shut down)
-            master_nodes = get_nodes(node_type=constants.MASTER_MACHINE)
-            master_node_name = master_nodes[0].name if master_nodes else None
-
-            from ocs_ci.ocs.resources.ocs import OCS
-
-            sc_ocp = ocp.OCP(
-                kind="StorageClass",
-                resource_name=constants.DEFAULT_STORAGECLASS_RBD,
+            pod_obj, original_md5 = self._create_workload_on_master(
+                pvc_factory, pod_factory
             )
-            sc_obj = OCS(**sc_ocp.get())
-            pvc_obj = pvc_factory(
-                interface=constants.CEPHBLOCKPOOL,
-                size=5,
-                storageclass=sc_obj,
-            )
-            pod_obj = pod_factory(
-                pvc=pvc_obj,
-                interface=constants.CEPHBLOCKPOOL,
-                node_name=master_node_name,
-            )
-            pod_obj.run_io(
-                storage_type="fs",
-                size="256M",
-                io_direction="wo",
-                runtime=0,
-                bs="1M",
-            )
-            get_fio_rw_iops(pod_obj)
-            original_md5 = cal_md5sum(pod_obj, "fio-rand-write")
-            log.info(f"Baseline md5sum captured: {original_md5}")
 
             # Phase 2: Verify baseline PG health
             ceph_cluster = CephCluster()
@@ -1215,48 +1329,49 @@ class TestECNodeOperations(ManageTest):
                 f"{quorum_count} in quorum, {mons_on_targets} on targets"
             )
 
-            # Phase 4: Bulk shutdown — power off all M nodes at once
+            # Phase 4: Bulk shutdown
+            log.info(
+                f"{'=' * 60}\n"
+                f"  BULK SHUTDOWN: Powering off {m} nodes at once: "
+                f"{targets}\n"
+                f"{'=' * 60}"
+            )
             target_node_objs = get_node_objs(targets)
             self.stopped_node_objs.extend(target_node_objs)
-            log.info(f"Powering off {len(target_node_objs)} nodes simultaneously")
             nodes.stop_nodes(target_node_objs)
 
-            # Wait for Ceph to detect OSD failures
-            log.info("Waiting for Ceph to detect OSD failures")
+            log.info("--- Waiting 30s for Ceph to detect OSD failures ---")
             time.sleep(30)
 
-            # osdMaintenanceTimeout on CephCluster is set to 0 in
-            # setup, so Rook clears the noout flag immediately.
-            # Explicitly unset as well in case of any race.
-            ct_pod = get_ceph_tools_pod(wait=True)
-            try:
-                ct_pod.exec_ceph_cmd("ceph osd unset noout")
-                log.info("Unset noout flag to allow recovery")
-            except CommandFailed:
-                log.warning("Failed to unset noout (may not be set)")
+            log.info("--- Cleanup: stale pods/VAs on downed nodes ---")
+            self._cleanup_stale_pods_on_nodes(targets)
+
+            self._unset_noout_if_needed()
 
             # Phase 5: Verify data integrity while degraded
-            # With M nodes down, k data chunks are still available
-            # so reads should succeed
             log.info(
-                f"Verifying data integrity with {m} nodes down "
-                f"({total_hosts - m} hosts remaining)"
+                f"{'=' * 60}\n"
+                f"  DEGRADED STATE: {m} nodes down, "
+                f"{total_hosts - m} hosts remaining — "
+                f"verifying data integrity\n"
+                f"{'=' * 60}"
             )
+            ct_pod = get_ceph_tools_pod(wait=True)
             self._wait_for_stable_degraded(ct_pod)
             verify_data_integrity(pod_obj, "fio-rand-write", original_md5)
-            log.info("Data integrity verified in degraded state")
+            log.info("--- Data integrity verified in degraded state ---")
 
-            # Phase 6: Restart all stopped nodes
-            log.info(f"Restarting {len(self.stopped_node_objs)} stopped nodes")
-            nodes.start_nodes(self.stopped_node_objs)
-            wait_for_nodes_status([n.name for n in self.stopped_node_objs], timeout=600)
-            wait_for_storage_pods(timeout=600)
-            self._wait_for_clean_pgs()
-
-            # Clear the list so the finalizer does not re-start them
-            self.stopped_node_objs.clear()
+            # Phase 6: Restart all stopped nodes and wait for recovery
+            log.info(
+                f"{'=' * 60}\n"
+                f"  RECOVERY: restarting "
+                f"{len(self.stopped_node_objs)} stopped nodes\n"
+                f"{'=' * 60}"
+            )
+            self._restart_and_recover_nodes(nodes)
 
             # Phase 7: Post-recovery validation
+            log.info("--- Post-recovery: data integrity + health check ---")
             verify_data_integrity(pod_obj, "fio-rand-write", original_md5)
-            log.info("Data integrity verified after full recovery")
+            log.info("--- Data integrity verified after full recovery ---")
             self.sanity_helpers.health_check(tries=90)

--- a/tests/functional/z_cluster/nodes/test_nodes_maintenance.py
+++ b/tests/functional/z_cluster/nodes/test_nodes_maintenance.py
@@ -919,6 +919,17 @@ class TestECNodeOperations(ManageTest):
             time.sleep(interval)
 
     @switch_to_provider_for_function
+    def _log_ceph_status_on_io_failure(self):
+        """Log ceph status to help diagnose write IO failures."""
+        try:
+            ct_pod = self._get_resilient_ceph_tools_pod()
+            status = ct_pod.exec_ceph_cmd("ceph status")
+            log.warning(f"Ceph status at IO failure: {status}")
+        except (CommandFailed, TimeoutExpiredError):
+            log.warning("Could not retrieve ceph status after IO failure")
+
+    @switch_to_provider_for_function
+    @enable_high_recovery_during_rebalance_flag
     def _wait_for_stable_degraded(self, ct_pod, timeout=600, checks=3, interval=20):
         """Wait until PG states stabilize in a degraded condition."""
         stable_count = 0
@@ -947,16 +958,24 @@ class TestECNodeOperations(ManageTest):
 
     @switch_to_provider_for_function
     def _run_write_io(self, pod_obj):
-        """Run a small FIO write and wait for completion."""
-        pod_obj.run_io(
-            storage_type="fs",
-            size="64M",
-            io_direction="wo",
-            runtime=0,
-            bs="4K",
-            fio_filename="drain_write_test",
-        )
-        get_fio_rw_iops(pod_obj)
+        """Run a small FIO write and wait for completion.
+
+        On failure, logs ceph status for diagnostics before re-raising.
+        """
+        try:
+            pod_obj.run_io(
+                storage_type="fs",
+                size="64M",
+                io_direction="wo",
+                runtime=0,
+                bs="4K",
+                fio_filename="drain_write_test",
+            )
+            get_fio_rw_iops(pod_obj)
+        except (CommandFailed, TimeoutExpiredError, TimeoutError) as e:
+            log.warning(f"Write IO failed: {e}")
+            self._log_ceph_status_on_io_failure()
+            raise
 
     @switch_to_provider_for_function
     def _try_write_io(self, pod_obj):
@@ -974,6 +993,7 @@ class TestECNodeOperations(ManageTest):
             get_fio_rw_iops(pod_obj)
             return True
         except (CommandFailed, TimeoutExpiredError, TimeoutError):
+            self._log_ceph_status_on_io_failure()
             return False
 
     @switch_to_provider_for_function
@@ -1164,15 +1184,16 @@ class TestECNodeOperations(ManageTest):
                     f"on downed node {va_node}"
                 )
                 try:
-                    va_ocp.exec_oc_cmd(f"delete volumeattachment {va_name}")
+                    va_ocp.exec_oc_cmd(
+                        f"delete volumeattachment {va_name} --wait=false"
+                    )
                 except CommandFailed as e:
                     log.warning(f"Failed to delete VolumeAttachment " f"{va_name}: {e}")
 
     @tier4a
     @runs_on_provider
     @skipif_managed_service
-    @ignore_leftovers  # Pod/PVC cleanup may hang on degraded EC storage
-    @pytest.mark.polarion_id("OCS-XXXX")
+    @pytest.mark.polarion_id("OCS-8057")
     def test_ec_gradual_node_shutdown(
         self,
         request,
@@ -1312,14 +1333,14 @@ class TestECNodeOperations(ManageTest):
                     try:
                         retry(
                             (CommandFailed, TimeoutExpiredError, TimeoutError),
-                            tries=3,
+                            tries=5,
                             delay=30,
                             backoff=1,
                         )(self._run_write_io)(pod_obj)
                         log.info("Write succeeded in tier 2")
                     except (CommandFailed, TimeoutExpiredError, TimeoutError):
                         log.warning(
-                            f"!!! ALL 3 WRITE ATTEMPTS FAILED in tier 2 "
+                            f"!!! ALL 5 WRITE ATTEMPTS FAILED in tier 2 "
                             f"with {live_hosts} hosts "
                             f"(min_size={min_size}) — proceeding !!!"
                         )
@@ -1385,7 +1406,7 @@ class TestECNodeOperations(ManageTest):
     @runs_on_provider
     @skipif_managed_service
     @ignore_leftovers
-    @pytest.mark.polarion_id("OCS-YYYY")
+    @pytest.mark.polarion_id("OCS-8058")
     def test_ec_bulk_node_shutdown_data_integrity(
         self,
         request,
@@ -1408,16 +1429,20 @@ class TestECNodeOperations(ManageTest):
             thresholds = get_ec_drain_thresholds()
             m = thresholds["m"]
             size = thresholds["size"]
+            min_size = thresholds["min_size"]
             total_hosts = thresholds["total_osd_hosts"]
-            assert (
-                total_hosts >= size
-            ), f"Not enough OSD hosts ({total_hosts}) for EC pool (need {size})"
+            if total_hosts < size:
+                pytest.skip(
+                    f"Not enough OSD hosts ({total_hosts}) "
+                    f"for EC pool (need {size})"
+                )
 
             shutdown_order = self._get_eligible_shutdown_order()
-            assert len(shutdown_order) >= m, (
-                f"Need at least {m} eligible worker OSD nodes for bulk "
-                f"shutdown, only {len(shutdown_order)} available"
-            )
+            if len(shutdown_order) < m:
+                pytest.skip(
+                    f"Need at least {m} eligible worker OSD nodes for bulk "
+                    f"shutdown, only {len(shutdown_order)} available"
+                )
 
             # Phase 1: Create workload on a master node (never shut down)
             pod_obj, original_md5 = self._create_workload_on_master(
@@ -1439,10 +1464,11 @@ class TestECNodeOperations(ManageTest):
             for node_name in targets:
                 node_mons = get_node_mon_ids(node_name)
                 mons_on_targets += len(node_mons)
-            assert (quorum_count - mons_on_targets) >= 2, (
-                f"Bulk shutdown would break mon quorum: "
-                f"{quorum_count} in quorum, {mons_on_targets} on targets"
-            )
+            if (quorum_count - mons_on_targets) < 2:
+                pytest.skip(
+                    f"Bulk shutdown would break mon quorum: "
+                    f"{quorum_count} in quorum, {mons_on_targets} on targets"
+                )
 
             # Phase 4: Bulk shutdown
             self._log_banner(
@@ -1460,18 +1486,80 @@ class TestECNodeOperations(ManageTest):
 
             self._unset_noout_if_needed()
 
-            # Phase 5: Verify data integrity while degraded
+            # Phase 5: Wait for Ceph recovery to show positive progress
+            live_hosts = total_hosts - m
             self._log_banner(
                 f"DEGRADED STATE: {m} nodes down, "
-                f"{total_hosts - m} hosts remaining — "
-                f"verifying data integrity"
+                f"{live_hosts} hosts remaining — "
+                f"waiting for recovery progress"
             )
-            ct_pod = self._get_resilient_ceph_tools_pod()
-            self._wait_for_stable_degraded(ct_pod)
-            verify_data_integrity(pod_obj, "fio-rand-write", original_md5)
-            log.test_step("Data integrity verified in degraded state")
+            log.test_step("Waiting 3 min for Ceph to begin recovery")
+            time.sleep(180)
 
-            # Phase 6: Restart all stopped nodes and wait for recovery
+            log.test_step(
+                "Monitoring degraded objects for positive progress " "(up to 20 min)"
+            )
+            prev_degraded = None
+            progress_detected = False
+            start = time.time()
+            while time.time() - start < 1200:
+                try:
+                    ct_pod = self._get_resilient_ceph_tools_pod()
+                    status = ct_pod.exec_ceph_cmd("ceph status")
+                except (CommandFailed, TimeoutExpiredError):
+                    time.sleep(120)
+                    continue
+                pgmap = status.get("pgmap", {})
+                degraded_objects = pgmap.get("degraded_objects", 0)
+                degraded_ratio = pgmap.get("degraded_ratio", 0) * 100
+                recover_bps = pgmap.get("recovering_bytes_per_sec", 0)
+                misplaced = pgmap.get("misplaced_objects", 0)
+                recover_mb = recover_bps / 1024 / 1024 if recover_bps else 0
+                log.info(
+                    f"Degraded: {degraded_ratio:.1f}% "
+                    f"({degraded_objects} objects), "
+                    f"misplaced: {misplaced}, "
+                    f"recovery: {recover_mb:.0f} MiB/s"
+                )
+                if prev_degraded is not None and degraded_objects < prev_degraded:
+                    log.info(
+                        f"Positive progress: degraded objects decreased "
+                        f"from {prev_degraded} to {degraded_objects}"
+                    )
+                    progress_detected = True
+                    break
+                prev_degraded = degraded_objects
+                time.sleep(120)
+            assert progress_detected, (
+                "No positive progress in degraded objects after 20 min "
+                "— Ceph recovery did not start"
+            )
+
+            # Verify data integrity while degraded — the core EC
+            # guarantee: data is readable with up to M node failures.
+            # run in a retry after 30s to allow for any transient issues with the degraded state.
+            if live_hosts >= min_size:
+                log.test_step(
+                    f"Verifying data integrity while degraded "
+                    f"({live_hosts} hosts >= min_size {min_size})"
+                )
+                for _ in TimeoutSampler(
+                    timeout=3600,
+                    sleep=120,
+                    func=verify_data_integrity,
+                    pod_obj=pod_obj,
+                    file_name="fio-rand-write",
+                    original_md5sum=original_md5,
+                ):
+                    log.info("Data integrity verified in degraded state")
+                    break
+            else:
+                log.warning(
+                    f"Skipping degraded-state read: {live_hosts} hosts "
+                    f"< min_size {min_size} — PGs may be inactive"
+                )
+
+            # Phase 6: Restart all stopped nodes and wait for full recovery
             self._log_banner(
                 f"RECOVERY: restarting " f"{len(self.stopped_node_objs)} stopped nodes"
             )

--- a/tests/functional/z_cluster/nodes/test_nodes_maintenance.py
+++ b/tests/functional/z_cluster/nodes/test_nodes_maintenance.py
@@ -644,10 +644,14 @@ class TestECNodeOperations(ManageTest):
         Initialize sanity helpers and register a finalizer to restart
         any stopped nodes. Skip on client clusters.
 
-        Sets osdMaintenanceTimeout to 0 on the CephCluster CR so Rook's
-        disruption controller releases the noout flag immediately instead
-        of holding it for 30 minutes. Restores the original value in the
-        finalizer.
+        Adjusts two Ceph settings for EC node-failure testing:
+        - osdMaintenanceTimeout=0 on CephCluster CR so Rook releases
+          the noout flag immediately instead of holding it for 30 min.
+        - mon_osd_min_in_ratio=0.3 so Ceph can mark all down OSDs as
+          out even when >25% of OSDs are offline (default 0.75 blocks
+          the last OSD, stalling EC recovery).
+
+        Both are restored to their original values in the finalizer.
 
         """
         with config.RunWithProviderConfigContextIfAvailable():
@@ -659,10 +663,9 @@ class TestECNodeOperations(ManageTest):
             self.sanity_helpers = Sanity()
             self.stopped_node_objs = []
             self._nodes = nodes
+            self._test_pod = None
 
-            # Lower osdMaintenanceTimeout so Rook releases the noout
-            # flag immediately after detecting OSDs down, instead of
-            # holding it for the default 30 minutes.
+            # --- osdMaintenanceTimeout on CephCluster CR ---
             ceph_cluster_ocp = ocp.OCP(
                 kind=constants.CEPH_CLUSTER,
                 namespace=config.ENV_DATA["cluster_namespace"],
@@ -671,9 +674,7 @@ class TestECNodeOperations(ManageTest):
             ceph_cluster_cr = ceph_cluster_ocp.get()
             dm = ceph_cluster_cr.get("spec", {}).get("disruptionManagement", {})
             original_timeout = dm.get("osdMaintenanceTimeout")
-            log.info(
-                f"Setting osdMaintenanceTimeout to 0 " f"(was: {original_timeout})"
-            )
+            log.info(f"Setting osdMaintenanceTimeout to 0 (was: {original_timeout})")
             ceph_cluster_ocp.patch(
                 params='[{"op": "add", "path": '
                 '"/spec/disruptionManagement/osdMaintenanceTimeout", '
@@ -681,52 +682,123 @@ class TestECNodeOperations(ManageTest):
                 format_type="json",
             )
 
-            def finalizer():
+            # --- mon_osd_min_in_ratio via ceph config ---
+            # Default 0.75 blocks auto-out when >25% OSDs are down,
+            # leaving the last OSD as down+in and stalling EC recovery.
+            ct_pod = get_ceph_tools_pod()
+            original_min_in_ratio = ct_pod.exec_ceph_cmd(
+                "ceph config get mon mon_osd_min_in_ratio"
+            )
+            original_min_in_ratio = str(original_min_in_ratio).strip()
+            log.info(
+                f"Setting mon_osd_min_in_ratio to 0.3 "
+                f"(was: {original_min_in_ratio})"
+            )
+            ct_pod.exec_ceph_cmd("ceph config set mon mon_osd_min_in_ratio 0.3")
+
+            def settings_finalizer():
+                """Restore Ceph settings — runs LAST (registered first)."""
                 with config.RunWithProviderConfigContextIfAvailable():
-                    # Restore osdMaintenanceTimeout
-                    if original_timeout is not None:
-                        log.info(
-                            f"Finalizer: restoring osdMaintenanceTimeout "
-                            f"to {original_timeout}"
-                        )
-                        ceph_cluster_ocp.patch(
-                            params='[{"op": "replace", "path": '
-                            '"/spec/disruptionManagement/'
-                            'osdMaintenanceTimeout", '
-                            f'"value": {original_timeout}}}]',
-                            format_type="json",
-                        )
-                    else:
-                        log.info(
-                            "Finalizer: removing osdMaintenanceTimeout " "(was not set)"
-                        )
-                        ceph_cluster_ocp.patch(
-                            params='[{"op": "remove", "path": '
-                            '"/spec/disruptionManagement/'
-                            'osdMaintenanceTimeout"}]',
-                            format_type="json",
-                        )
-
-                    if self.stopped_node_objs:
-                        log.info(
-                            f"Finalizer: restarting "
-                            f"{len(self.stopped_node_objs)} stopped nodes"
-                        )
-                        try:
-                            self._nodes.start_nodes(self.stopped_node_objs)
+                    log.info("Finalizer: restoring cluster settings")
+                    try:
+                        if original_timeout is not None:
                             log.info(
-                                "Finalizer: waiting for storage pods and "
-                                "Ceph recovery after node restart"
+                                f"Finalizer: restoring osdMaintenanceTimeout "
+                                f"to {original_timeout}"
                             )
-                            wait_for_storage_pods(timeout=600)
-                        except (
-                            CommandFailed,
-                            ResourceWrongStatusException,
-                            TimeoutExpiredError,
-                        ) as e:
-                            log.error(f"Finalizer start_nodes failed: {e}")
+                            ceph_cluster_ocp.patch(
+                                params='[{"op": "replace", "path": '
+                                '"/spec/disruptionManagement/'
+                                'osdMaintenanceTimeout", '
+                                f'"value": {original_timeout}}}]',
+                                format_type="json",
+                            )
+                        else:
+                            log.info(
+                                "Finalizer: removing osdMaintenanceTimeout "
+                                "(was not set originally)"
+                            )
+                            try:
+                                ceph_cluster_ocp.patch(
+                                    params='[{"op": "remove", "path": '
+                                    '"/spec/disruptionManagement/'
+                                    'osdMaintenanceTimeout"}]',
+                                    format_type="json",
+                                )
+                            except CommandFailed:
+                                log.info(
+                                    "osdMaintenanceTimeout already absent, "
+                                    "skipping removal"
+                                )
+                    except CommandFailed as e:
+                        log.error(
+                            f"Finalizer: failed to restore "
+                            f"osdMaintenanceTimeout: {e}"
+                        )
 
-            request.addfinalizer(finalizer)
+                    try:
+                        restore_pod = get_ceph_tools_pod()
+                        log.info(
+                            f"Finalizer: restoring mon_osd_min_in_ratio "
+                            f"to {original_min_in_ratio}"
+                        )
+                        restore_pod.exec_ceph_cmd(
+                            f"ceph config set mon mon_osd_min_in_ratio "
+                            f"{original_min_in_ratio}"
+                        )
+                    except CommandFailed as e:
+                        log.error(
+                            f"Finalizer: failed to restore "
+                            f"mon_osd_min_in_ratio: {e}"
+                        )
+
+            request.addfinalizer(settings_finalizer)
+
+    def _register_node_restart_finalizer(self, request):
+        """Register a finalizer for node restart and pod cleanup.
+
+        Must be called from the test method AFTER pod_factory is used,
+        so LIFO ordering ensures this runs BEFORE pod_factory's
+        finalizer. This prevents pod delete from hanging on volume
+        detach while nodes are still down.
+        """
+
+        def node_restart_finalizer():
+            with config.RunWithProviderConfigContextIfAvailable():
+                # Force-delete the test pod so pod_factory's
+                # finalizer won't hang on volume detach.
+                if self._test_pod and not self._test_pod._is_deleted:
+                    log.info(
+                        f"Finalizer: force-deleting test pod " f"{self._test_pod.name}"
+                    )
+                    try:
+                        self._test_pod.delete(force=True)
+                        self._test_pod._is_deleted = True
+                    except CommandFailed:
+                        log.warning("Finalizer: test pod already deleted")
+                        self._test_pod._is_deleted = True
+
+                # Restart any stopped nodes
+                if self.stopped_node_objs:
+                    log.info(
+                        f"Finalizer: restarting "
+                        f"{len(self.stopped_node_objs)} stopped nodes"
+                    )
+                    try:
+                        self._nodes.start_nodes(self.stopped_node_objs)
+                        log.info(
+                            "Finalizer: waiting for storage pods and "
+                            "Ceph recovery after node restart"
+                        )
+                        wait_for_storage_pods(timeout=600)
+                    except (
+                        CommandFailed,
+                        ResourceWrongStatusException,
+                        TimeoutExpiredError,
+                    ) as e:
+                        log.error(f"Finalizer start_nodes failed: {e}")
+
+        request.addfinalizer(node_restart_finalizer)
 
     @enable_high_recovery_during_rebalance_flag
     @switch_to_provider_for_function
@@ -901,7 +973,7 @@ class TestECNodeOperations(ManageTest):
             )
             get_fio_rw_iops(pod_obj)
             return True
-        except (CommandFailed, TimeoutExpiredError):
+        except (CommandFailed, TimeoutExpiredError, TimeoutError):
             return False
 
     @switch_to_provider_for_function
@@ -967,12 +1039,44 @@ class TestECNodeOperations(ManageTest):
         get_fio_rw_iops(pod_obj)
         original_md5 = cal_md5sum(pod_obj, "fio-rand-write")
         log.info(f"Baseline md5sum captured: {original_md5}")
+        self._test_pod = pod_obj
         return pod_obj, original_md5
+
+    @staticmethod
+    def _log_banner(msg):
+        """Log a test step with separator lines."""
+        log.test_step(msg)
+
+    @switch_to_provider_for_function
+    def _get_resilient_ceph_tools_pod(self):
+        """Get a reachable Ceph tools pod, force-deleting if unreachable.
+
+        Retries up to 3 times to handle the tools pod being scheduled
+        on a downed node.
+        """
+        for attempt in range(3):
+            try:
+                ct_pod = get_ceph_tools_pod()
+                ct_pod.exec_ceph_cmd("ceph status")
+                return ct_pod
+            except (CommandFailed, TimeoutExpiredError) as e:
+                log.warning(
+                    f"Ceph tools pod unreachable (attempt {attempt + 1}/3), "
+                    f"force-deleting to trigger reschedule: {e}"
+                )
+                try:
+                    ct_pod.delete(force=True)
+                except (CommandFailed, TimeoutExpiredError):
+                    pass
+                time.sleep(30)
+        raise TimeoutExpiredError(
+            "Failed to get a reachable Ceph tools pod after 3 attempts"
+        )
 
     @switch_to_provider_for_function
     def _log_osd_distribution(self):
         """Log ``ceph osd df tree`` and ``ceph osd df`` at INFO level."""
-        ct_pod = get_ceph_tools_pod()
+        ct_pod = self._get_resilient_ceph_tools_pod()
         osd_df_tree = ct_pod.exec_ceph_cmd("ceph osd df tree")
         log.info(f"OSD df tree: {osd_df_tree}")
         osd_df = ct_pod.exec_ceph_cmd("ceph osd df")
@@ -1001,7 +1105,7 @@ class TestECNodeOperations(ManageTest):
         Checks ``ceph health`` for the OSDMAP_FLAGS warning that
         indicates noout is active before attempting to unset it.
         """
-        ct_pod = get_ceph_tools_pod()
+        ct_pod = self._get_resilient_ceph_tools_pod()
         health = ct_pod.exec_ceph_cmd("ceph health")
         if "noout" in str(health):
             ct_pod.exec_ceph_cmd("ceph osd unset noout")
@@ -1071,6 +1175,7 @@ class TestECNodeOperations(ManageTest):
     @pytest.mark.polarion_id("OCS-XXXX")
     def test_ec_gradual_node_shutdown(
         self,
+        request,
         nodes,
         node_restart_teardown,
         pvc_factory,
@@ -1098,6 +1203,9 @@ class TestECNodeOperations(ManageTest):
             pod_obj, original_md5 = self._create_workload_on_master(
                 pvc_factory, pod_factory
             )
+            # Register node restart finalizer AFTER pod_factory so
+            # LIFO runs it BEFORE pod_factory's delete finalizer.
+            self._register_node_restart_finalizer(request)
 
             # Phase 2: Verify PG health + chunk distribution
             ceph_cluster = CephCluster()
@@ -1158,26 +1266,21 @@ class TestECNodeOperations(ManageTest):
                     )
                     break
 
-                log.info(
-                    f"{'=' * 60}\n"
-                    f"  SHUTDOWN {i}/{max_shutdowns}: "
+                self._log_banner(
+                    f"SHUTDOWN {i}/{max_shutdowns}: "
                     f"Powering off {node_name} "
-                    f"({live_hosts} hosts will remain)\n"
-                    f"{'=' * 60}"
+                    f"({live_hosts} hosts will remain)"
                 )
                 shutdown_node_obj = get_node_objs([node_name])[0]
                 self.stopped_node_objs.append(shutdown_node_obj)
                 nodes.stop_nodes([shutdown_node_obj])
 
-                ct_pod = get_ceph_tools_pod(wait=True)
-
-                log.info(
-                    f"--- Waiting 30s for Ceph to detect OSD failure "
-                    f"on {node_name} ---"
+                log.test_step(
+                    f"Waiting 30s for Ceph to detect OSD failure " f"on {node_name}"
                 )
                 time.sleep(30)
 
-                log.info("--- Cleanup: stale pods/VAs on downed nodes ---")
+                log.test_step("Cleanup stale pods/VAs on downed nodes")
                 stopped_names = [n.name for n in self.stopped_node_objs]
                 self._cleanup_stale_pods_on_nodes(stopped_names)
 
@@ -1185,32 +1288,47 @@ class TestECNodeOperations(ManageTest):
 
                 # Tier-based validation
                 if live_hosts >= size:
-                    log.info(
-                        f"--- Tier 1: {live_hosts} live >= {size} (k+m) "
-                        f"— waiting for full PG recovery ---"
+                    log.test_step(
+                        f"Tier 1: {live_hosts} live >= {size} (k+m) "
+                        f"— waiting for full PG recovery"
                     )
                     # Ceph's mon_osd_down_out_interval (default 600s)
                     # must elapse before OSDs are marked out and
                     # recovery begins. Use a stall_timeout that
                     # accommodates this delay.
                     self._wait_for_clean_pgs(stall_timeout=2400)
-                    log.info("--- Tier 1: verifying IO + data integrity ---")
+                    log.test_step("Tier 1: verifying IO + data integrity")
                     self._run_write_io(pod_obj)
                     verify_data_integrity(pod_obj, "fio-rand-write", original_md5)
 
                 elif live_hosts >= min_size:
-                    log.info(
-                        f"--- Tier 2: {min_size} <= {live_hosts} < {size} "
-                        f"— degraded, writes should work ---"
+                    log.test_step(
+                        f"Tier 2: {min_size} <= {live_hosts} < {size} "
+                        f"— degraded, writes should work"
                     )
-                    self._wait_for_stable_degraded(ct_pod)
-                    self._run_write_io(pod_obj)
+                    # wait a minute to stabilize ceph
+                    log.test_step("Waiting 60s for Ceph to stabilize")
+                    time.sleep(60)
+                    try:
+                        retry(
+                            (CommandFailed, TimeoutExpiredError, TimeoutError),
+                            tries=3,
+                            delay=30,
+                            backoff=1,
+                        )(self._run_write_io)(pod_obj)
+                        log.info("Write succeeded in tier 2")
+                    except (CommandFailed, TimeoutExpiredError, TimeoutError):
+                        log.warning(
+                            f"!!! ALL 3 WRITE ATTEMPTS FAILED in tier 2 "
+                            f"with {live_hosts} hosts "
+                            f"(min_size={min_size}) — proceeding !!!"
+                        )
                     verify_data_integrity(pod_obj, "fio-rand-write", original_md5)
 
                 elif live_hosts >= k:
-                    log.info(
-                        f"--- Tier 3: {k} <= {live_hosts} < {min_size} "
-                        f"— writes may be blocked ---"
+                    log.test_step(
+                        f"Tier 3: {k} <= {live_hosts} < {min_size} "
+                        f"— writes may be blocked"
                     )
                     time.sleep(60)
                     write_ok = self._try_write_io(pod_obj)
@@ -1225,15 +1343,10 @@ class TestECNodeOperations(ManageTest):
                     except (CommandFailed, AssertionError):
                         log.info("Read failed in tier 3 (can happen)")
 
-                log.info(
-                    f"--- Shutdown {i}/{max_shutdowns} complete for " f"{node_name} ---"
-                )
+                log.test_step(f"Shutdown {i}/{max_shutdowns} complete for {node_name}")
 
-            log.info(
-                f"{'=' * 60}\n"
-                f"  RECOVERY: restarting "
-                f"{len(self.stopped_node_objs)} stopped nodes\n"
-                f"{'=' * 60}"
+            self._log_banner(
+                f"RECOVERY: restarting " f"{len(self.stopped_node_objs)} stopped nodes"
             )
             self._log_osd_distribution()
 
@@ -1245,7 +1358,7 @@ class TestECNodeOperations(ManageTest):
             ), "Post-recovery rebalance did not complete"
             self.stopped_node_objs.clear()
 
-            log.info("--- Post-recovery: verifying chunk distribution ---")
+            log.test_step("Post-recovery: verifying chunk distribution")
             ct_pod = get_ceph_tools_pod()
             osd_tree = ct_pod.exec_ceph_cmd("ceph osd tree")
             osd_to_host = {
@@ -1264,7 +1377,7 @@ class TestECNodeOperations(ManageTest):
                         f"{len(hosts)} hosts, need {size}"
                     )
 
-            log.info("--- Post-recovery: data integrity + health check ---")
+            log.test_step("Post-recovery: data integrity + health check")
             verify_data_integrity(pod_obj, "fio-rand-write", original_md5)
             self.sanity_helpers.health_check(tries=90)
 
@@ -1275,6 +1388,7 @@ class TestECNodeOperations(ManageTest):
     @pytest.mark.polarion_id("OCS-YYYY")
     def test_ec_bulk_node_shutdown_data_integrity(
         self,
+        request,
         nodes,
         node_restart_teardown,
         pvc_factory,
@@ -1309,6 +1423,7 @@ class TestECNodeOperations(ManageTest):
             pod_obj, original_md5 = self._create_workload_on_master(
                 pvc_factory, pod_factory
             )
+            self._register_node_restart_finalizer(request)
 
             # Phase 2: Verify baseline PG health
             ceph_cluster = CephCluster()
@@ -1330,48 +1445,40 @@ class TestECNodeOperations(ManageTest):
             )
 
             # Phase 4: Bulk shutdown
-            log.info(
-                f"{'=' * 60}\n"
-                f"  BULK SHUTDOWN: Powering off {m} nodes at once: "
-                f"{targets}\n"
-                f"{'=' * 60}"
+            self._log_banner(
+                f"BULK SHUTDOWN: Powering off {m} nodes at once: " f"{targets}"
             )
             target_node_objs = get_node_objs(targets)
             self.stopped_node_objs.extend(target_node_objs)
             nodes.stop_nodes(target_node_objs)
 
-            log.info("--- Waiting 30s for Ceph to detect OSD failures ---")
+            log.test_step("Waiting 30s for Ceph to detect OSD failures")
             time.sleep(30)
 
-            log.info("--- Cleanup: stale pods/VAs on downed nodes ---")
+            log.test_step("Cleanup stale pods/VAs on downed nodes")
             self._cleanup_stale_pods_on_nodes(targets)
 
             self._unset_noout_if_needed()
 
             # Phase 5: Verify data integrity while degraded
-            log.info(
-                f"{'=' * 60}\n"
-                f"  DEGRADED STATE: {m} nodes down, "
+            self._log_banner(
+                f"DEGRADED STATE: {m} nodes down, "
                 f"{total_hosts - m} hosts remaining — "
-                f"verifying data integrity\n"
-                f"{'=' * 60}"
+                f"verifying data integrity"
             )
-            ct_pod = get_ceph_tools_pod(wait=True)
+            ct_pod = self._get_resilient_ceph_tools_pod()
             self._wait_for_stable_degraded(ct_pod)
             verify_data_integrity(pod_obj, "fio-rand-write", original_md5)
-            log.info("--- Data integrity verified in degraded state ---")
+            log.test_step("Data integrity verified in degraded state")
 
             # Phase 6: Restart all stopped nodes and wait for recovery
-            log.info(
-                f"{'=' * 60}\n"
-                f"  RECOVERY: restarting "
-                f"{len(self.stopped_node_objs)} stopped nodes\n"
-                f"{'=' * 60}"
+            self._log_banner(
+                f"RECOVERY: restarting " f"{len(self.stopped_node_objs)} stopped nodes"
             )
             self._restart_and_recover_nodes(nodes)
 
             # Phase 7: Post-recovery validation
-            log.info("--- Post-recovery: data integrity + health check ---")
+            log.test_step("Post-recovery: data integrity + health check")
             verify_data_integrity(pod_obj, "fio-rand-write", original_md5)
-            log.info("--- Data integrity verified after full recovery ---")
+            log.test_step("Data integrity verified after full recovery")
             self.sanity_helpers.health_check(tries=90)

--- a/tests/functional/z_cluster/nodes/test_nodes_maintenance.py
+++ b/tests/functional/z_cluster/nodes/test_nodes_maintenance.py
@@ -7,8 +7,14 @@ from subprocess import TimeoutExpired
 
 from ocs_ci.ocs.exceptions import (
     CephHealthException,
+    CommandFailed,
     ResourceWrongStatusException,
     ResourceNotFoundError,
+    TimeoutExpiredError,
+)
+from ocs_ci.utility.decorators import (
+    enable_high_recovery_during_rebalance_flag,
+    switch_to_provider_for_function,
 )
 from ocs_ci.utility.retry import retry
 from ocs_ci.utility.utils import ceph_health_check_base, TimeoutSampler
@@ -23,6 +29,8 @@ from ocs_ci.ocs.node import (
     remove_nodes,
     get_osd_running_nodes,
     get_node_objs,
+    get_mon_running_nodes,
+    get_node_mon_ids,
     generate_new_nodes_and_osd_running_nodes_ipi,
 )
 from ocs_ci.ocs.cluster import validate_existence_of_blocking_pdb
@@ -32,6 +40,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_hci_provider,
     skipif_rosa_hcp,
     skipif_compact_mode,
+    runs_on_provider,
 )
 from ocs_ci.framework.testlib import (
     tier1,
@@ -46,8 +55,17 @@ from ocs_ci.framework.testlib import (
     skipif_managed_service,
     skipif_more_than_three_workers,
 )
+from ocs_ci.helpers.ceph_helpers import get_ec_drain_thresholds, get_mon_quorum_count
 from ocs_ci.helpers.sanity_helpers import Sanity, SanityExternalCluster
+from ocs_ci.ocs.cluster import CephCluster, get_pgs_brief_dump, get_specific_pool_pgid
 from ocs_ci.ocs.resources import pod
+from ocs_ci.ocs.resources.pod import (
+    cal_md5sum,
+    verify_data_integrity,
+    get_ceph_tools_pod,
+    wait_for_storage_pods,
+    get_fio_rw_iops,
+)
 from ocs_ci.helpers.helpers import (
     label_worker_node,
     remove_label_from_worker_node,
@@ -610,3 +628,635 @@ class TestNodesMaintenance(ManageTest):
             pvc_factory, pod_factory, bucket_factory, rgw_bucket_factory
         )
         self.sanity_helpers.delete_resources()
+
+
+@brown_squad
+class TestECNodeOperations(ManageTest):
+    """
+    Test node operations on EC-pool clusters, validating Ceph degradation
+    behavior and data integrity at each EC threshold tier.
+
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup(self, request, nodes):
+        """
+        Initialize sanity helpers and register a finalizer to restart
+        any stopped nodes. Skip on client clusters.
+
+        Sets osdMaintenanceTimeout to 0 on the CephCluster CR so Rook's
+        disruption controller releases the noout flag immediately instead
+        of holding it for 30 minutes. Restores the original value in the
+        finalizer.
+
+        """
+        with config.RunWithProviderConfigContextIfAvailable():
+            if config.ENV_DATA.get("cluster_type") not in (None, "provider"):
+                pytest.skip("Test runs only on provider or standalone clusters")
+            if not config.DEPLOYMENT.get("ec_default_pools"):
+                pytest.skip("Test runs only on EC pools")
+
+            self.sanity_helpers = Sanity()
+            self.stopped_node_objs = []
+            self._nodes = nodes
+
+            # Lower osdMaintenanceTimeout so Rook releases the noout
+            # flag immediately after detecting OSDs down, instead of
+            # holding it for the default 30 minutes.
+            ceph_cluster_ocp = ocp.OCP(
+                kind=constants.CEPH_CLUSTER,
+                namespace=config.ENV_DATA["cluster_namespace"],
+                resource_name=constants.CEPH_CLUSTER_NAME,
+            )
+            ceph_cluster_cr = ceph_cluster_ocp.get()
+            dm = ceph_cluster_cr.get("spec", {}).get("disruptionManagement", {})
+            original_timeout = dm.get("osdMaintenanceTimeout")
+            log.info(
+                f"Setting osdMaintenanceTimeout to 0 " f"(was: {original_timeout})"
+            )
+            ceph_cluster_ocp.patch(
+                params='[{"op": "add", "path": '
+                '"/spec/disruptionManagement/osdMaintenanceTimeout", '
+                '"value": 0}]',
+                format_type="json",
+            )
+
+            def finalizer():
+                with config.RunWithProviderConfigContextIfAvailable():
+                    # Restore osdMaintenanceTimeout
+                    if original_timeout is not None:
+                        log.info(
+                            f"Finalizer: restoring osdMaintenanceTimeout "
+                            f"to {original_timeout}"
+                        )
+                        ceph_cluster_ocp.patch(
+                            params='[{"op": "replace", "path": '
+                            '"/spec/disruptionManagement/'
+                            'osdMaintenanceTimeout", '
+                            f'"value": {original_timeout}}}]',
+                            format_type="json",
+                        )
+                    else:
+                        log.info(
+                            "Finalizer: removing osdMaintenanceTimeout " "(was not set)"
+                        )
+                        ceph_cluster_ocp.patch(
+                            params='[{"op": "remove", "path": '
+                            '"/spec/disruptionManagement/'
+                            'osdMaintenanceTimeout"}]',
+                            format_type="json",
+                        )
+
+                    if self.stopped_node_objs:
+                        log.info(
+                            f"Finalizer: restarting "
+                            f"{len(self.stopped_node_objs)} stopped nodes"
+                        )
+                        try:
+                            self._nodes.start_nodes(self.stopped_node_objs)
+                            log.info(
+                                "Finalizer: waiting for storage pods and "
+                                "Ceph recovery after node restart"
+                            )
+                            wait_for_storage_pods(timeout=600)
+                        except (
+                            CommandFailed,
+                            ResourceWrongStatusException,
+                            TimeoutExpiredError,
+                        ) as e:
+                            log.error(f"Finalizer start_nodes failed: {e}")
+
+            request.addfinalizer(finalizer)
+
+    @enable_high_recovery_during_rebalance_flag
+    @switch_to_provider_for_function
+    def _wait_for_clean_pgs(self, timeout=3600, interval=10, stall_timeout=1200):
+        """Wait until all PGs are active+clean (remapped is accepted).
+
+        Gets a fresh ceph tools pod on each iteration so the loop
+        survives tools pod rescheduling after a node shutdown.
+
+        Tracks degraded object count for stall detection — more granular
+        than clean PG count since objects recover within PGs before PGs
+        flip to clean. Logs progress every 60 seconds.
+        """
+        last_progress_log = 0
+        last_degraded = float("inf")
+        last_progress_time = time.time()
+        start_time = time.time()
+
+        while True:
+            elapsed = time.time() - start_time
+            if elapsed > timeout:
+                raise TimeoutExpiredError(
+                    f"_wait_for_clean_pgs timed out after {timeout}s"
+                )
+
+            try:
+                ct_pod = get_ceph_tools_pod()
+                sample = ct_pod.exec_ceph_cmd(ceph_cmd="ceph status")
+            except (CommandFailed, TimeoutExpiredError) as e:
+                # The tools pod may be on a downed node — k8s still
+                # shows it as Running but exec fails. Force-delete it
+                # so the deployment reschedules onto a live node.
+                log.warning(
+                    f"Ceph tools pod unreachable, force-deleting "
+                    f"to trigger reschedule: {e}"
+                )
+                try:
+                    ct_pod.delete(force=True)
+                except (CommandFailed, TimeoutExpiredError):
+                    pass
+                time.sleep(30)
+                continue
+
+            pgmap = sample.get("pgmap", {})
+            pg_states = pgmap.get("pgs_by_state", [])
+            total = pgmap.get("num_pgs", 0)
+            degraded_objects = pgmap.get("degraded_objects", 0)
+            misplaced_objects = pgmap.get("misplaced_objects", 0)
+            recover_bps = pgmap.get("recovering_bytes_per_sec", 0)
+
+            clean_count = sum(
+                s["count"]
+                for s in pg_states
+                if "active" in s["state_name"]
+                and "clean" in s["state_name"]
+                and "degraded" not in s["state_name"]
+                and "backfill" not in s["state_name"]
+                and "recovery" not in s["state_name"]
+                and "peering" not in s["state_name"]
+            )
+            if clean_count == total and total > 0:
+                log.info(f"All {total} PGs in clean state")
+                break
+
+            # Check if remaining non-clean PGs are only topology-limited:
+            # active+undersized+degraded PGs can't recover while a host
+            # is down because CRUSH can't place all EC chunks on the
+            # remaining hosts. These resolve only when the node returns.
+            topology_stuck = sum(
+                s["count"]
+                for s in pg_states
+                if s["state_name"] == "active+undersized+degraded"
+            )
+            recoverable_dirty = total - clean_count - topology_stuck
+            if recoverable_dirty == 0 and clean_count > 0:
+                log.info(
+                    f"Recovery complete: {clean_count}/{total} PGs clean, "
+                    f"{topology_stuck} PG(s) topology-limited "
+                    f"(active+undersized+degraded, will resolve when "
+                    f"node returns)"
+                )
+                break
+
+            # Stall detection: track degraded objects (more granular
+            # than clean PG count — objects recover within PGs before
+            # PGs flip to clean).
+            now = time.time()
+            if degraded_objects < last_degraded or misplaced_objects > 0:
+                last_degraded = degraded_objects
+                last_progress_time = now
+            elif recover_bps > 0:
+                # Recovery IO active even if degraded count unchanged
+                last_progress_time = now
+            elif (now - last_progress_time) > stall_timeout:
+                log.error(
+                    f"Recovery stalled for {stall_timeout}s: "
+                    f"{clean_count}/{total} PGs clean, "
+                    f"{degraded_objects} objects degraded, "
+                    f"recovery rate: 0"
+                )
+                raise TimeoutExpiredError(
+                    f"Recovery stalled at {clean_count}/{total} clean PGs, "
+                    f"{degraded_objects} objects degraded"
+                )
+
+            if (now - last_progress_log) >= 60:
+                recover_mb = recover_bps / 1024 / 1024 if recover_bps else 0
+                log.info(
+                    f"Recovery: {clean_count}/{total} PGs clean, "
+                    f"{degraded_objects} degraded objs, "
+                    f"{recover_mb:.0f} MiB/s"
+                )
+                last_progress_log = now
+
+            time.sleep(interval)
+
+    @switch_to_provider_for_function
+    def _wait_for_stable_degraded(self, ct_pod, timeout=600, checks=3, interval=20):
+        """Wait until PG states stabilize in a degraded condition."""
+        stable_count = 0
+        prev_state = None
+        degraded_keywords = ("degraded", "undersized", "peered")
+        for sample in TimeoutSampler(
+            timeout=timeout,
+            sleep=interval,
+            func=ct_pod.exec_ceph_cmd,
+            ceph_cmd="ceph pg stat",
+        ):
+            state_str = str(sample)
+            is_degraded = any(kw in state_str for kw in degraded_keywords)
+            if not is_degraded:
+                stable_count = 0
+                prev_state = None
+                continue
+            if state_str == prev_state:
+                stable_count += 1
+            else:
+                stable_count = 1
+            prev_state = state_str
+            if stable_count >= checks:
+                log.info(f"PG state stable in degraded condition: {state_str}")
+                break
+
+    @switch_to_provider_for_function
+    def _run_write_io(self, pod_obj):
+        """Run a small FIO write and wait for completion."""
+        pod_obj.run_io(
+            storage_type="fs",
+            size="64M",
+            io_direction="wo",
+            runtime=0,
+            bs="4K",
+            fio_filename="drain_write_test",
+        )
+        get_fio_rw_iops(pod_obj)
+
+    @switch_to_provider_for_function
+    def _try_write_io(self, pod_obj):
+        """Attempt a FIO write, return True if succeeded, False if timed out."""
+        try:
+            pod_obj.run_io(
+                storage_type="fs",
+                size="16M",
+                io_direction="wo",
+                runtime=30,
+                bs="4K",
+                fio_filename="blocked_write",
+                timeout=120,
+            )
+            get_fio_rw_iops(pod_obj)
+            return True
+        except (CommandFailed, TimeoutExpiredError):
+            return False
+
+    @switch_to_provider_for_function
+    def _get_eligible_shutdown_order(self):
+        """Determine worker-only OSD nodes eligible for shutdown, non-mon first.
+
+        Returns:
+            list[str]: Node names in shutdown priority order
+                       (non-mon workers first, then mon workers)
+        """
+        osd_nodes = get_osd_running_nodes()
+        worker_node_objs = get_nodes(node_type=constants.WORKER_MACHINE)
+        worker_names = set()
+        for w_node in worker_node_objs:
+            roles = w_node.ocp.get_resource(resource_name=w_node.name, column="ROLES")
+            if constants.MASTER_MACHINE not in roles:
+                worker_names.add(w_node.name)
+
+        eligible = [n for n in osd_nodes if n in worker_names]
+        assert eligible, "No worker-only OSD nodes available for shutdown"
+        mon_nodes = set(get_mon_running_nodes())
+        return [n for n in eligible if n not in mon_nodes] + [
+            n for n in eligible if n in mon_nodes
+        ]
+
+    @tier4a
+    @runs_on_provider
+    @skipif_managed_service
+    @ignore_leftovers  # Pod/PVC cleanup may hang on degraded EC storage
+    @pytest.mark.polarion_id("OCS-XXXX")
+    def test_ec_gradual_node_shutdown(
+        self,
+        nodes,
+        node_restart_teardown,
+        pvc_factory,
+        pod_factory,
+    ):
+        """
+        Gradually shut down OSD nodes and validate Ceph degradation behavior
+        at each EC threshold tier:
+        - Tier 1: live_hosts >= k+m -> active+clean after rebalance, IO works
+        - Tier 2: min_size <= live_hosts < k+m -> degraded, writes still work
+        - Tier 3: k <= live_hosts < min_size -> writes blocked, reads may work
+
+        """
+        # Phase 0: Pre-conditions
+        with config.RunWithProviderConfigContextIfAvailable():
+            thresholds = get_ec_drain_thresholds()
+            k = thresholds["k"]
+            size, min_size = thresholds["size"], thresholds["min_size"]
+            total_hosts = thresholds["total_osd_hosts"]
+            assert (
+                total_hosts >= size
+            ), f"Not enough OSD hosts ({total_hosts}) for EC pool (need {size})"
+
+            # Phase 1: Create workload on a master node (never shut down)
+            master_nodes = get_nodes(node_type=constants.MASTER_MACHINE)
+            master_node_name = master_nodes[0].name if master_nodes else None
+            # Explicitly use the default RBD SC to avoid picking up
+            # leftover day-2 SCs on HCI platforms (the auto-detection
+            # picks the first SC matching the RBD provisioner).
+            from ocs_ci.ocs.resources.ocs import OCS
+
+            sc_ocp = ocp.OCP(
+                kind="StorageClass",
+                resource_name=constants.DEFAULT_STORAGECLASS_RBD,
+            )
+            sc_obj = OCS(**sc_ocp.get())
+            pvc_obj = pvc_factory(
+                interface=constants.CEPHBLOCKPOOL,
+                size=5,
+                storageclass=sc_obj,
+            )
+            pod_obj = pod_factory(
+                pvc=pvc_obj,
+                interface=constants.CEPHBLOCKPOOL,
+                node_name=master_node_name,
+            )
+            pod_obj.run_io(
+                storage_type="fs", size="256M", io_direction="wo", runtime=0, bs="1M"
+            )
+            get_fio_rw_iops(pod_obj)
+            original_md5 = cal_md5sum(pod_obj, "fio-rand-write")
+
+            # Phase 2: Verify PG health + chunk distribution
+            ceph_cluster = CephCluster()
+            assert ceph_cluster.get_rebalance_status(), "PGs not active+clean at start"
+
+            ct_pod = get_ceph_tools_pod()
+            osd_tree = ct_pod.exec_ceph_cmd("ceph osd tree")
+            osd_to_host = {
+                child_id: entry["name"]
+                for entry in osd_tree["nodes"]
+                if entry["type"] == "host"
+                for child_id in entry.get("children", [])
+            }
+
+            pool_pgids = get_specific_pool_pgid(constants.DEFAULT_CEPHBLOCKPOOL)
+            pgs_dump = get_pgs_brief_dump()
+            for pg in pgs_dump["pg_stats"]:
+                if pg["pgid"] in pool_pgids[:5]:
+                    hosts = {osd_to_host[osd] for osd in pg["acting"]}
+                    assert (
+                        len(hosts) >= size
+                    ), f"PG {pg['pgid']} on {len(hosts)} hosts, need {size}"
+
+            # Phase 3: Determine shutdown order (worker-only OSD nodes, non-mon first)
+            shutdown_order = self._get_eligible_shutdown_order()
+            eligible_count = len(shutdown_order)
+            log.info(
+                f"Eligible worker-only OSD nodes for shutdown: {shutdown_order} "
+                f"({eligible_count} of {total_hosts} total OSD hosts)"
+            )
+
+            # Phase 4: Gradual shutdown loop (Tiers 1-3)
+            # Tier 1 (full rebalance) is only reachable when total_hosts > size,
+            # i.e. there are spare nodes beyond what EC requires.
+            max_shutdowns = min(thresholds["min_drain_io_stops"], eligible_count)
+            spare_hosts = total_hosts - size
+            if spare_hosts > 0:
+                log.info(
+                    f"Tier 1 reachable: {spare_hosts} spare host(s) beyond k+m={size}"
+                )
+            else:
+                log.info(
+                    f"Tier 1 not reachable: total_hosts={total_hosts} == k+m={size}, "
+                    f"starting from Tier 2"
+                )
+
+            for i, node_name in enumerate(shutdown_order[:max_shutdowns], start=1):
+                live_hosts = total_hosts - i
+
+                # Mon quorum safety check
+                quorum_count = get_mon_quorum_count()
+                node_mons = get_node_mon_ids(node_name)
+                if node_mons and (quorum_count - len(node_mons)) < 2:
+                    log.warning(
+                        f"Stopping shutdown sequence: shutting down {node_name} "
+                        f"would lose mon quorum ({quorum_count} mons, "
+                        f"{len(node_mons)} on this node)"
+                    )
+                    break
+
+                # Power off the node. Add to stopped list first so the
+                # finalizer can restart it even if stop_nodes raises partway.
+                shutdown_node_obj = get_node_objs([node_name])[0]
+                self.stopped_node_objs.append(shutdown_node_obj)
+                log.info(
+                    f"Shutting down node {node_name} ({i}/{max_shutdowns}), "
+                    f"{live_hosts} hosts will remain"
+                )
+                nodes.stop_nodes([shutdown_node_obj])
+
+                # Refresh ceph tools pod — it may have been rescheduled
+                # if the previous one lived on a now-stopped node.
+                ct_pod = get_ceph_tools_pod(wait=True)
+
+                # Wait for Ceph to detect OSD failure before tier validation.
+                # OSD heartbeat timeout is ~20s; give extra margin.
+                log.info("Waiting for Ceph to detect OSD failure")
+                time.sleep(30)
+
+                # Tier-based validation
+                if live_hosts >= size:
+                    log.info(f"Tier 1: {live_hosts} live >= {size} (k+m)")
+                    # With EC pools, some PGs stay active+clean+remapped while
+                    # an OSD host is down. Wait for all PGs to be clean
+                    # (accepting remapped), then validate IO + integrity.
+                    self._wait_for_clean_pgs()
+                    self._run_write_io(pod_obj)
+                    verify_data_integrity(pod_obj, "fio-rand-write", original_md5)
+
+                elif live_hosts >= min_size:
+                    log.info(f"Tier 2: {min_size} <= {live_hosts} < {size}")
+                    self._wait_for_stable_degraded(ct_pod)
+                    self._run_write_io(pod_obj)
+                    verify_data_integrity(pod_obj, "fio-rand-write", original_md5)
+
+                elif live_hosts >= k:
+                    log.info(f"Tier 3: {k} <= {live_hosts} < {min_size}")
+                    time.sleep(60)
+                    write_ok = self._try_write_io(pod_obj)
+                    if write_ok:
+                        log.warning(
+                            f"Write succeeded with {live_hosts} hosts "
+                            f"(below min_size={min_size}), may be transient"
+                        )
+                    try:
+                        verify_data_integrity(pod_obj, "fio-rand-write", original_md5)
+                        log.info("Read succeeded in tier 3 (expected: >= k hosts)")
+                    except (CommandFailed, AssertionError):
+                        log.info("Read failed in tier 3 (can happen)")
+
+            # Recovery: start all stopped nodes
+            log.info(f"Starting {len(self.stopped_node_objs)} stopped nodes")
+            nodes.start_nodes(self.stopped_node_objs)
+            wait_for_nodes_status([n.name for n in self.stopped_node_objs], timeout=600)
+            wait_for_storage_pods(timeout=600)
+            assert ceph_cluster.wait_for_rebalance(
+                timeout=3600, repeat=3
+            ), "Post-recovery rebalance did not complete"
+
+            # Clear the list so the finalizer does not re-start them
+            self.stopped_node_objs.clear()
+
+            # Post-recovery: refresh tools pod and verify no chunk co-location
+            ct_pod = get_ceph_tools_pod()
+            osd_tree = ct_pod.exec_ceph_cmd("ceph osd tree")
+            osd_to_host = {
+                child_id: entry["name"]
+                for entry in osd_tree["nodes"]
+                if entry["type"] == "host"
+                for child_id in entry.get("children", [])
+            }
+            pool_pgids = get_specific_pool_pgid(constants.DEFAULT_CEPHBLOCKPOOL)
+            pgs_dump = get_pgs_brief_dump()
+            for pg in pgs_dump["pg_stats"]:
+                if pg["pgid"] in pool_pgids[:5]:
+                    hosts = {osd_to_host[osd] for osd in pg["acting"]}
+                    assert len(hosts) >= size, (
+                        f"Post-recovery co-location: PG {pg['pgid']} on "
+                        f"{len(hosts)} hosts, need {size}"
+                    )
+
+            # Data integrity after full recovery
+            verify_data_integrity(pod_obj, "fio-rand-write", original_md5)
+            self.sanity_helpers.health_check(tries=90)
+
+    @tier4a
+    @runs_on_provider
+    @skipif_managed_service
+    @ignore_leftovers
+    @pytest.mark.polarion_id("OCS-YYYY")
+    def test_ec_bulk_node_shutdown_data_integrity(
+        self,
+        nodes,
+        node_restart_teardown,
+        pvc_factory,
+        pod_factory,
+    ):
+        """
+        Shut down M (coding chunks) worker OSD nodes simultaneously,
+        verify data integrity after restart and full Ceph recovery.
+
+        Unlike test_ec_gradual_node_shutdown which validates tier-by-tier,
+        this test powers off all M nodes at once and only checks that
+        data written before shutdown survives and the cluster recovers.
+
+        """
+        with config.RunWithProviderConfigContextIfAvailable():
+            # Phase 0: Pre-conditions and EC thresholds
+            thresholds = get_ec_drain_thresholds()
+            m = thresholds["m"]
+            size = thresholds["size"]
+            total_hosts = thresholds["total_osd_hosts"]
+            assert (
+                total_hosts >= size
+            ), f"Not enough OSD hosts ({total_hosts}) for EC pool (need {size})"
+
+            shutdown_order = self._get_eligible_shutdown_order()
+            assert len(shutdown_order) >= m, (
+                f"Need at least {m} eligible worker OSD nodes for bulk "
+                f"shutdown, only {len(shutdown_order)} available"
+            )
+
+            # Phase 1: Create workload on a master node (never shut down)
+            master_nodes = get_nodes(node_type=constants.MASTER_MACHINE)
+            master_node_name = master_nodes[0].name if master_nodes else None
+
+            from ocs_ci.ocs.resources.ocs import OCS
+
+            sc_ocp = ocp.OCP(
+                kind="StorageClass",
+                resource_name=constants.DEFAULT_STORAGECLASS_RBD,
+            )
+            sc_obj = OCS(**sc_ocp.get())
+            pvc_obj = pvc_factory(
+                interface=constants.CEPHBLOCKPOOL,
+                size=5,
+                storageclass=sc_obj,
+            )
+            pod_obj = pod_factory(
+                pvc=pvc_obj,
+                interface=constants.CEPHBLOCKPOOL,
+                node_name=master_node_name,
+            )
+            pod_obj.run_io(
+                storage_type="fs",
+                size="256M",
+                io_direction="wo",
+                runtime=0,
+                bs="1M",
+            )
+            get_fio_rw_iops(pod_obj)
+            original_md5 = cal_md5sum(pod_obj, "fio-rand-write")
+            log.info(f"Baseline md5sum captured: {original_md5}")
+
+            # Phase 2: Verify baseline PG health
+            ceph_cluster = CephCluster()
+            assert ceph_cluster.get_rebalance_status(), "PGs not active+clean at start"
+
+            # Phase 3: Select M nodes for bulk shutdown
+            targets = shutdown_order[:m]
+            log.info(f"Bulk shutdown targets ({m} coding chunks): {targets}")
+
+            # Mon quorum safety: count how many mons would go down
+            quorum_count = get_mon_quorum_count()
+            mons_on_targets = 0
+            for node_name in targets:
+                node_mons = get_node_mon_ids(node_name)
+                mons_on_targets += len(node_mons)
+            assert (quorum_count - mons_on_targets) >= 2, (
+                f"Bulk shutdown would break mon quorum: "
+                f"{quorum_count} in quorum, {mons_on_targets} on targets"
+            )
+
+            # Phase 4: Bulk shutdown — power off all M nodes at once
+            target_node_objs = get_node_objs(targets)
+            self.stopped_node_objs.extend(target_node_objs)
+            log.info(f"Powering off {len(target_node_objs)} nodes simultaneously")
+            nodes.stop_nodes(target_node_objs)
+
+            # Wait for Ceph to detect OSD failures
+            log.info("Waiting for Ceph to detect OSD failures")
+            time.sleep(30)
+
+            # osdMaintenanceTimeout on CephCluster is set to 0 in
+            # setup, so Rook clears the noout flag immediately.
+            # Explicitly unset as well in case of any race.
+            ct_pod = get_ceph_tools_pod(wait=True)
+            try:
+                ct_pod.exec_ceph_cmd("ceph osd unset noout")
+                log.info("Unset noout flag to allow recovery")
+            except CommandFailed:
+                log.warning("Failed to unset noout (may not be set)")
+
+            # Phase 5: Verify data integrity while degraded
+            # With M nodes down, k data chunks are still available
+            # so reads should succeed
+            log.info(
+                f"Verifying data integrity with {m} nodes down "
+                f"({total_hosts - m} hosts remaining)"
+            )
+            self._wait_for_stable_degraded(ct_pod)
+            verify_data_integrity(pod_obj, "fio-rand-write", original_md5)
+            log.info("Data integrity verified in degraded state")
+
+            # Phase 6: Restart all stopped nodes
+            log.info(f"Restarting {len(self.stopped_node_objs)} stopped nodes")
+            nodes.start_nodes(self.stopped_node_objs)
+            wait_for_nodes_status([n.name for n in self.stopped_node_objs], timeout=600)
+            wait_for_storage_pods(timeout=600)
+            self._wait_for_clean_pgs()
+
+            # Clear the list so the finalizer does not re-start them
+            self.stopped_node_objs.clear()
+
+            # Phase 7: Post-recovery validation
+            verify_data_integrity(pod_obj, "fio-rand-write", original_md5)
+            log.info("Data integrity verified after full recovery")
+            self.sanity_helpers.health_check(tries=90)


### PR DESCRIPTION
Add get_ec_drain_thresholds() helper and TestECNodeOperations class to validate Ceph degradation behavior when OSD nodes are gradually powered off on erasure-coded clusters.

  The test shuts down worker OSD nodes one at a time and validates at each EC threshold tier:
  - Tier 1 (optional — requires spare nodes): full rebalance to active+clean, IO works
  - Tier 2: degraded state, writes still work
  - Tier 3: writes blocked, reads may still work

  After all shutdowns, nodes are restarted and post-recovery checks verify chunk distribution and data integrity.

  Safety: mon quorum checks before each shutdown, master node exclusion, finalizer-based node restart on failure, node_restart_teardown fixture as backup.

- [x] test on provider baremetal cluster

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an EC-pool drain-threshold helper to calculate tolerated failure tiers (k/m/size/min_size and failure-domain-aware limits).
  * Introduced a tiered “gradual EC node shutdown” maintenance test to validate rebalance behavior and end-to-end write integrity.

* **Bug Fixes**
  * Improved maintenance test robustness by stabilizing degraded-PG checks, using timeout-aware bounded writes, and re-verifying rebalance convergence and checksums after nodes restart.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->