### PR TITLE
OCSQE-5134: Fix environment_check non-ODF PV/PVC leftover false positives

### DIFF
--- a/ocs_ci/utility/environment_check.py
+++ b/ocs_ci/utility/environment_check.py
@@ -13,6 +13,41 @@ from ocs_ci.ocs import ocp, defaults, constants, exceptions
 log = logging.getLogger(__name__)
 
 
+def _pv_or_pvc_storage_provisioner(item):
+    """
+    Extract the CSI provisioner driver name from a PV or PVC item.
+
+    Args:
+        item (dict): Kubernetes resource dictionary (PV or PVC)
+
+    Returns:
+        str: The provisioner driver name, or None if not detected
+    """
+    kind = item.get("kind")
+    if kind == constants.PV:
+        driver = (
+            item.get("spec", {}).get("csi", {}).get("driver")
+        )
+        if driver:
+            return driver
+        return (
+            item.get("metadata", {})
+            .get("annotations", {})
+            .get("pv.kubernetes.io/provisioned-by")
+        )
+    if kind == constants.PVC:
+        annotations = item.get("metadata", {}).get("annotations", {})
+        provisioner = annotations.get(
+            "volume.kubernetes.io/storage-provisioner"
+        )
+        if provisioner:
+            return provisioner
+        return annotations.get(
+            "volume.beta.kubernetes.io/storage-provisioner"
+        )
+    return None
+
+
 def compare_dicts(before, after):
     """
     Comparing 2 dicts and providing diff list of [added items, removed items]
@@ -100,6 +135,24 @@ def assign_get_values(
         ):
             log.debug("ignoring item in %s namespace: %s", ns, item)
             continue
+        if item.get("kind") in (constants.PV, constants.PVC):
+            provisioner = _pv_or_pvc_storage_provisioner(item)
+            if provisioner and provisioner not in constants.OCS_PROVISIONERS:
+                log.debug(
+                    "ignoring non-ODF %s provisioned by %s: %s",
+                    item.get("kind"),
+                    provisioner,
+                    item.get("metadata", {}).get("name"),
+                )
+                continue
+        if item.get("kind") == constants.STORAGECLASS:
+            owner_refs = item.get("metadata", {}).get("ownerReferences", [])
+            if any(ref.get("kind") == "StorageClient" for ref in owner_refs):
+                log.debug(
+                    "ignoring StorageClient-owned StorageClass: %s",
+                    item.get("metadata", {}).get("name"),
+                )
+                continue
         if item.get("kind") == constants.POD:
             name = item.get("metadata", {}).get("name", "")
             if name.endswith("-debug") or "-debug-" in name:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1368,6 +1368,57 @@ def storageclass_factory_fixture(
         instances.append(sc_obj)
         return sc_obj
 
+    def _strip_storageclient_owner_refs(instance):
+        """
+        Remove StorageClient ownerReferences from a StorageClass so that
+        the finalizer delete is not blocked by the ownership chain.
+
+        Only StorageClient entries are removed; other ownerReferences are
+        preserved.
+
+        Args:
+            instance: OCS StorageClass instance with .ocp and .name attrs
+        """
+        try:
+            sc_data = instance.ocp.get(resource_name=instance.name)
+        except CommandFailed as ex:
+            if "NotFound" in str(ex):
+                log.debug(
+                    f"StorageClass {instance.name} already removed, "
+                    "skipping ownerRef strip"
+                )
+                return
+            raise
+        owner_refs = (
+            sc_data.get("metadata", {}).get("ownerReferences") or []
+        )
+        sc_client_refs = [
+            ref for ref in owner_refs if ref.get("kind") == "StorageClient"
+        ]
+        if not sc_client_refs:
+            return
+        filtered_refs = [
+            ref for ref in owner_refs if ref.get("kind") != "StorageClient"
+        ]
+        patch_data = json.dumps(
+            {"metadata": {"ownerReferences": filtered_refs or None}}
+        )
+        try:
+            instance.ocp.patch(
+                resource_name=instance.name,
+                params=patch_data,
+                format_type="merge",
+            )
+            log.info(
+                f"Stripped StorageClient ownerReferences from "
+                f"StorageClass {instance.name}"
+            )
+        except CommandFailed as ex:
+            log.warning(
+                f"Failed to strip StorageClient ownerReferences from "
+                f"StorageClass {instance.name}: {ex}"
+            )
+
     def finalizer():
         """
         Delete the storageclass by deregistering from StorageConsumer first
@@ -1379,10 +1430,20 @@ def storageclass_factory_fixture(
         teardown_errors = []
         for instance in instances:
             try:
+                _strip_storageclient_owner_refs(instance)
                 delete_storageclass_and_deregister(
                     sc_name=instance.name,
                     sc_ocp=instance.ocp,
                 )
+            except CommandFailed as ex:
+                if "NotFound" in str(ex):
+                    log.info(
+                        f"StorageClass {instance.name} not found, "
+                        "skipping deletion"
+                    )
+                    continue
+                log.error(f"Failed to delete storageclass {instance.name}: {ex}")
+                teardown_errors.append((instance.name, ex))
             except Exception as e:
                 log.error(f"Failed to delete storageclass {instance.name}: {e}")
                 teardown_errors.append((instance.name, e))


### PR DESCRIPTION
## Summary

Fix false-positive `ResourceLeftoversException` errors in interop environments where
non-ODF PersistentVolumes (e.g. from Quay, CNV, ACM) trigger teardown failures.

### Changes

**`ocs_ci/utility/environment_check.py`**
- Add `_pv_or_pvc_storage_provisioner(item)` helper to extract the CSI provisioner
  from PV (`spec.csi.driver` / annotation fallback) or PVC (both
  `[volume.kubernetes.io/storage-provisioner](http://volume.kubernetes.io/storage-provisioner)` and beta annotation fallback)
- In `assign_get_values()`, skip PV/PVCs whose provisioner is not in
  `constants.OCS_PROVISIONERS` (filters out [ebs.csi.aws.com](http://ebs.csi.aws.com/),
  [csi.vsphere.vmware.com](http://csi.vsphere.vmware.com/), etc.)
- Skip StorageClass objects owned by a StorageClient controller

**`tests/conftest.py`**
- Add `_strip_storageclient_owner_refs()` to remove only StorageClient
  ownerReferences before deletion (preserves other ownerRefs)
- Add NotFound tolerance to finalizer exception handling

### References

- Fixes: #15158
- Related Jira: [OCSQE-5134](https://redhat.atlassian.net/browse/OCSQE-5134) (AWS EBS variant), [OCSQE-4715](https://redhat.atlassian.net/browse/OCSQE-4715) (vSphere variant)
- Supersedes: #15157 (closed, not merged)
- Incorporates CodeRabbit review feedback from #15157:
  1. Added beta annotation fallback for PVC provisioner detection
  2. Strip only StorageClient ownerReferences, not all ownerReferences