### PR TITLE
fix test_health_score_changes_based_on_alert_severity

### DIFF
--- a/ocs_ci/templates/health_overview_alerts/custom-odf-latency-rule.yaml
+++ b/ocs_ci/templates/health_overview_alerts/custom-odf-latency-rule.yaml
@@ -14,7 +14,7 @@ spec:
       annotations:
         description: Node {{ $labels.instance }} has max ICMP RTT latency > 5ms over the last 1min. This may impact Ceph performance.
         runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/ODFNodeLatencyHighOnOSDNodes.md
-        summary: High ICMP latency (>1ms) detected on ODF OSD node(s)
+        summary: High ICMP latency (>5ms) detected on ODF OSD node(s)
       expr: |
         count(
              max_over_time(

--- a/ocs_ci/templates/health_overview_alerts/custom-odf-latency-rule.yaml
+++ b/ocs_ci/templates/health_overview_alerts/custom-odf-latency-rule.yaml
@@ -12,7 +12,7 @@ spec:
     rules:
     - alert: ODFNodeLatencyHighOnOSDNodes   # SAME NAME
       annotations:
-        description: Node {{ $labels.instance }} has max ICMP RTT latency > 1ms over the last 1min. This may impact Ceph performance.
+        description: Node {{ $labels.instance }} has max ICMP RTT latency > 5ms over the last 1min. This may impact Ceph performance.
         runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/ODFNodeLatencyHighOnOSDNodes.md
         summary: High ICMP latency (>1ms) detected on ODF OSD node(s)
       expr: |

--- a/ocs_ci/templates/health_overview_alerts/custom-odf-latency-rule.yaml
+++ b/ocs_ci/templates/health_overview_alerts/custom-odf-latency-rule.yaml
@@ -16,12 +16,19 @@ spec:
         runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/ODFNodeLatencyHighOnOSDNodes.md
         summary: High ICMP latency (>1ms) detected on ODF OSD node(s)
       expr: |
-        max_over_time(
-        probe_icmp_duration_seconds{
-          phase="rtt",
-          job="odf-blackbox-exporter",
-          daemon_type="osd"}[24h: ]
-        ) > 0.005
+        count(
+             max_over_time(
+               probe_icmp_duration_seconds{phase="rtt",
+               job=~"probe/.*/odf-blackbox-exporter",
+               daemon_type="osd"
+               }[24h:]
+             ) > 0.005
+             and on(instance, job, daemon_type, namespace)
+             probe_success{
+               job=~"probe/.*/odf-blackbox-exporter",
+               daemon_type="osd"
+             } == 1
+            ) > 0
       for: 1m
       labels:
         component: odf

--- a/ocs_ci/templates/health_overview_alerts/custom-odf-node-latency-high-non-osd.yaml
+++ b/ocs_ci/templates/health_overview_alerts/custom-odf-node-latency-high-non-osd.yaml
@@ -9,13 +9,19 @@ spec:
       rules:
         - alert: ODFNodeLatencyHighOnNonOSDNodes
           expr: |
-            max_over_time(
-              probe_icmp_duration_seconds{
-                phase="rtt",
-                job="odf-blackbox-exporter",
-                daemon_type="mon"
-              }[24h:]
-            ) > 0.005
+            count(
+             max_over_time(
+               probe_icmp_duration_seconds{phase="rtt",
+               job=~"probe/.*/odf-blackbox-exporter",
+               daemon_type="mon"
+               }[24h:]
+             ) > 0.005
+             and on(instance, job, daemon_type, namespace)
+             probe_success{
+               job=~"probe/.*/odf-blackbox-exporter",
+               daemon_type="mon"
+             } == 1
+            ) > 0
           for: 1m
           labels:
             component: odf

--- a/tests/functional/ui/test_health_overview.py
+++ b/tests/functional/ui/test_health_overview.py
@@ -615,9 +615,7 @@ class TestHealthOverview(ManageTest):
             api = PrometheusAPI(threading_lock=threading_lock)
             api.refresh_connection()
             alerts = api.wait_for_alert(name=alert_name, state="firing", sleep=60)
-            assert (
-                len(alerts) > 0
-            ), f"Alert {alert_name} is not in firing state after unsilencing"
+            assert len(alerts) > 0, f"Alert {alert_name} is not in firing state"
             logger.info(f"Alert {alert_name} confirmed in firing state")
         self.update_alert_map(threading_lock)
         logger.info("Silence all pre-existing alerts")

--- a/tests/functional/ui/test_health_overview.py
+++ b/tests/functional/ui/test_health_overview.py
@@ -612,6 +612,13 @@ class TestHealthOverview(ManageTest):
             self.restart_pod()
             logger.info("Waiting for 120 sec for pod to restart")
             time.sleep(120)
+            api = PrometheusAPI(threading_lock=threading_lock)
+            api.refresh_connection()
+            alerts = api.wait_for_alert(name=alert_name, state="firing", sleep=60)
+            assert (
+                len(alerts) > 0
+            ), f"Alert {alert_name} is not in firing state after unsilencing"
+            logger.info(f"Alert {alert_name} confirmed in firing state")
         self.update_alert_map(threading_lock)
         logger.info("Silence all pre-existing alerts")
         df_overview = PageNavigator().nav_storage_data_foundation_overview_page()
@@ -657,7 +664,9 @@ class TestHealthOverview(ManageTest):
             api = PrometheusAPI(threading_lock=threading_lock)
             api.refresh_connection()
             alerts = api.wait_for_alert(name=alert_name, state="firing", sleep=60)
-            logger.info(f"Alert {alerts} triggered")
+            assert (
+                len(alerts) > 0
+            ), f"Alert {alert_name} was not triggered after applying mock alert rule"
             PageNavigator().take_screenshot(f"triggered_alert_{alert_name}")
             logger.info(
                 "Waiting for 120 sec to update health score after alert is triggered"


### PR DESCRIPTION
add check to verify mock alerts are triggered 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced the health overview scenario to validate the target alert directly in Prometheus, waiting for it to enter a firing state before continuing.
  * Added stricter assertions so the test fails immediately if no firing alerts are observed.

* **Alerting / Health Overview**
  * Updated ODF node latency alerting (OSD and non-OSD) to use improved PromQL logic, including successful probe gating and broader probe matching.
  * Adjusted the ODF node latency threshold messaging and evaluation to reflect the new >5ms target.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->