### PR TITLE
Handle PV deletion race during VM teardown

### DIFF
--- a/ocs_ci/ocs/cnv/virtual_machine.py
+++ b/ocs_ci/ocs/cnv/virtual_machine.py
@@ -736,6 +736,26 @@ chpasswd:
         """
         return self.get().get("status").get("printableStatus")
 
+    def _cleanup_backing_pv(self, pv_obj):
+        """
+        Clean up the backing PV.
+
+        Handles the case where the PV was already deleted due to the
+        Delete reclaim policy before VM teardown reaches it.
+        """
+        try:
+            pv_obj.reload()
+        except CommandFailed as ex:
+            if "not found" in str(ex).lower():
+                logger.info(
+                    "PV %s already deleted. Skipping PV cleanup.",
+                    pv_obj.name,
+                )
+            else:
+                raise
+        else:
+            delete_pv_with_force_and_finalizers(pv_obj, timeout=600)
+
     def delete(self):
         """
         Delete the VirtualMachine
@@ -762,21 +782,8 @@ chpasswd:
                     resource_name=self.pvc_obj.name, timeout=180
                 )
                 # Clean up backing PV (handles Retain policy Released PVs)
-                # PV may already be deleted by PVC (Delete reclaim policy).
-                # Reload the PV and gracefully handle the race if it no longer exists.
+                self._cleanup_backing_pv(self.pv_obj)
 
-                try:
-                    self.pv_obj.reload()
-                except CommandFailed as ex:
-                    if "not found" in str(ex).lower():
-                        logger.info(
-                            "PV %s already deleted. Skipping PV cleanup.",
-                            self.pv_obj.name,
-                        )
-                    else:
-                        raise
-                else:
-                    delete_pv_with_force_and_finalizers(self.pv_obj, timeout=600)
             if self.volumeimportsource_obj:
                 self.volumeimportsource_obj.delete()
         elif self.volume_interface == constants.VM_VOLUME_DV:
@@ -794,20 +801,7 @@ chpasswd:
                     resource_name=self.dv_obj.name, timeout=300
                 )
                 # Clean up backing PV (handles Retain policy Released PVs)
-                # PV may already be deleted by PVC (Delete reclaim policy).
-                # Reload the PV and gracefully handle the race if it no longer exists.
-                try:
-                    self.dv_pv.reload()
-                except CommandFailed as ex:
-                    if "not found" in str(ex).lower():
-                        logger.info(
-                            "PV %s already deleted. Skipping PV cleanup.",
-                            self.dv_pv.name,
-                        )
-                    else:
-                        raise
-                else:
-                    delete_pv_with_force_and_finalizers(self.dv_pv, timeout=600)
+                self._cleanup_backing_pv(self.dv_pv)
         if self.ns_obj:
             self.ns_obj.delete_project(project_name=self.namespace)
 

--- a/ocs_ci/ocs/cnv/virtual_machine.py
+++ b/ocs_ci/ocs/cnv/virtual_machine.py
@@ -767,8 +767,18 @@ chpasswd:
                     self.pv_obj.ocp.get(resource_name=self.pv_obj.name, dont_raise=True)
                     is not None
                 ):
-                    self.pv_obj.reload()
-                    delete_pv_with_force_and_finalizers(self.pv_obj, timeout=600)
+                    try:
+                        self.pv_obj.reload()
+                    except CommandFailed as ex:
+                        if "not found" in str(ex).lower():
+                            logger.info(
+                                "PV %s already deleted. Skipping PV cleanup.",
+                                self.pv_obj.name,
+                            )
+                        else:
+                            raise
+                    else:
+                        delete_pv_with_force_and_finalizers(self.pv_obj, timeout=600)
             if self.volumeimportsource_obj:
                 self.volumeimportsource_obj.delete()
         elif self.volume_interface == constants.VM_VOLUME_DV:

--- a/ocs_ci/ocs/cnv/virtual_machine.py
+++ b/ocs_ci/ocs/cnv/virtual_machine.py
@@ -979,9 +979,7 @@ class VMCloner(VirtualMachine):
             self.pvc_obj.ocp.wait_for_delete(
                 resource_name=self.pvc_obj.name, timeout=180
             )
-            # PV may already be deleted (Delete reclaim policy) - check first
-            if pv_obj.ocp.get(resource_name=pv_obj.name, dont_raise=True) is not None:
-                delete_pv_with_force_and_finalizers(pv_obj, timeout=600)
+            self._cleanup_backing_pv(pv_obj)
         elif self.volume_interface == constants.VM_VOLUME_DV:
             dv_pvc_name = self.dv_obj.get().get("status").get("claimName")
             data = dict()
@@ -992,9 +990,7 @@ class VMCloner(VirtualMachine):
             dv_pv = dv_pvc.backed_pv_obj
             self.dv_obj.delete()
             self.dv_obj.ocp.wait_for_delete(resource_name=self.dv_obj.name, timeout=180)
-            # PV may already be deleted (Delete reclaim policy) - check first
-            if dv_pv.ocp.get(resource_name=dv_pv.name, dont_raise=True) is not None:
-                delete_pv_with_force_and_finalizers(dv_pv, timeout=600)
+            self._cleanup_backing_pv(dv_pv)
         elif self.volume_interface == constants.VM_VOLUME_DVT:
             self.dv_rb_data_obj.delete()
             self.dv_cr_data_obj.delete()

--- a/ocs_ci/ocs/cnv/virtual_machine.py
+++ b/ocs_ci/ocs/cnv/virtual_machine.py
@@ -742,6 +742,9 @@ chpasswd:
 
         Handles the case where the PV was already deleted due to the
         Delete reclaim policy before VM teardown reaches it.
+
+        Args:
+            pv_obj (PV): PersistentVolume object associated with the VM.
         """
         try:
             pv_obj.reload()

--- a/ocs_ci/ocs/cnv/virtual_machine.py
+++ b/ocs_ci/ocs/cnv/virtual_machine.py
@@ -763,22 +763,19 @@ chpasswd:
                 )
                 # Clean up backing PV (handles Retain policy Released PVs)
                 # PV may already be deleted by PVC (Delete reclaim policy) - check first
-                if (
-                    self.pv_obj.ocp.get(resource_name=self.pv_obj.name, dont_raise=True)
-                    is not None
-                ):
-                    try:
-                        self.pv_obj.reload()
-                    except CommandFailed as ex:
-                        if "not found" in str(ex).lower():
-                            logger.info(
-                                "PV %s already deleted. Skipping PV cleanup.",
-                                self.pv_obj.name,
-                            )
-                        else:
-                            raise
+
+                try:
+                    self.pv_obj.reload()
+                except CommandFailed as ex:
+                    if "not found" in str(ex).lower():
+                        logger.info(
+                            "PV %s already deleted. Skipping PV cleanup.",
+                            self.pv_obj.name,
+                        )
                     else:
-                        delete_pv_with_force_and_finalizers(self.pv_obj, timeout=600)
+                        raise
+                else:
+                    delete_pv_with_force_and_finalizers(self.pv_obj, timeout=600)
             if self.volumeimportsource_obj:
                 self.volumeimportsource_obj.delete()
         elif self.volume_interface == constants.VM_VOLUME_DV:

--- a/ocs_ci/ocs/cnv/virtual_machine.py
+++ b/ocs_ci/ocs/cnv/virtual_machine.py
@@ -762,7 +762,8 @@ chpasswd:
                     resource_name=self.pvc_obj.name, timeout=180
                 )
                 # Clean up backing PV (handles Retain policy Released PVs)
-                # PV may already be deleted by PVC (Delete reclaim policy) - check first
+                # PV may already be deleted by PVC (Delete reclaim policy).
+                # Reload the PV and gracefully handle the race if it no longer exists.
 
                 try:
                     self.pv_obj.reload()
@@ -793,11 +794,19 @@ chpasswd:
                     resource_name=self.dv_obj.name, timeout=300
                 )
                 # Clean up backing PV (handles Retain policy Released PVs)
-                # PV may already be deleted (Delete reclaim policy) - check first
-                if (
-                    self.dv_pv.ocp.get(resource_name=self.dv_pv.name, dont_raise=True)
-                    is not None
-                ):
+                # PV may already be deleted by PVC (Delete reclaim policy).
+                # Reload the PV and gracefully handle the race if it no longer exists.
+                try:
+                    self.dv_pv.reload()
+                except CommandFailed as ex:
+                    if "not found" in str(ex).lower():
+                        logger.info(
+                            "PV %s already deleted. Skipping PV cleanup.",
+                            self.dv_pv.name,
+                        )
+                    else:
+                        raise
+                else:
                     delete_pv_with_force_and_finalizers(self.dv_pv, timeout=600)
         if self.ns_obj:
             self.ns_obj.delete_project(project_name=self.namespace)


### PR DESCRIPTION
Fixes: #15702 
## Description

Handle a race condition during VM teardown where the backing PersistentVolume
may be deleted after the existence check but before `reload()` is called.

Instead of failing teardown with a `CommandFailed` exception when the PV is
already deleted, log the condition and skip PV cleanup. Unexpected
`CommandFailed` exceptions continue to be raised.

## Verification

Verified by rerunning:

tests/functional/workloads/cnv

The teardown completed successfully without the previous
`PersistentVolume ... not found` failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved virtual machine and cloner teardown to reliably clean up backing persistent volumes, even when resources are removed concurrently.
  * Added more resilient handling for “not found” scenarios during storage cleanup, reducing teardown failures and allowing deletion to proceed smoothly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->