### PR TITLE
Improve TimeoutSampler failure diagnostics

### DIFF
--- a/ocs_ci/utility/tests/test_utils_timeout_sampler.py
+++ b/ocs_ci/utility/tests/test_utils_timeout_sampler.py
@@ -1,5 +1,6 @@
 # -*- coding: utf8 -*-
 
+import functools
 import logging
 import time
 
@@ -138,7 +139,12 @@ def test_ts_func_exception(caplog):
     ]
     assert len(info_exception_records) >= 1
     for rec in info_exception_records:
-        assert "for function 'func' failed" in rec.getMessage()
+        msg = rec.getMessage()
+        assert "for function 'func' failed" in msg
+        # the rate-limited INFO message names the exception type but not its
+        # (possibly sensitive) message text, which stays at DEBUG level
+        assert "failed with Exception" in msg
+        assert "oh no" not in msg
 
 
 def test_ti_func_values():
@@ -212,3 +218,137 @@ def test_ts_wait_for_value_negative(caplog):
         assert "function <lambda> failed" in log_msg
         assert "failed to return expected value 2" in log_msg
         assert "during 3 second timeout" in log_msg
+        assert "last sampled value: 1" in log_msg
+
+
+def test_ts_func_without_name():
+    """
+    Check that TimeoutSampler handles func objects without __name__ attribute
+    (e.g. functools.partial): the timeout message is still assembled and
+    failing attempts are logged instead of crashing with AttributeError
+    inside the exception handler.
+    """
+
+    def func(a):
+        raise ValueError("nope")
+
+    ts = TimeoutSampler(1, 1, functools.partial(func, 1))
+    # the call string (and so the timeout message) was built despite the
+    # missing __name__ attribute
+    assert len(ts.timeout_exc_args) == 2
+    with pytest.raises(TimeoutExpiredError):
+        for _ in ts:
+            pass
+
+
+def test_ts_timeout_chained_to_last_exception():
+    """
+    When sampling times out and the most recent attempt raised an exception,
+    the TimeoutExpiredError is chained to it (__cause__), so the root cause
+    shows up directly in the resulting traceback.
+    """
+
+    def func():
+        raise ValueError("persistent failure")
+
+    with pytest.raises(TimeoutExpiredError) as excinfo:
+        for _ in TimeoutSampler(1, 1, func):
+            pass
+    assert isinstance(excinfo.value.__cause__, ValueError)
+    assert str(excinfo.value.__cause__) == "persistent failure"
+
+
+def test_ts_timeout_not_chained_without_func_exception():
+    """
+    When func never raised, the TimeoutExpiredError has no __cause__.
+    """
+    func = lambda: 1  # noqa: E731
+    with pytest.raises(TimeoutExpiredError) as excinfo:
+        for _ in TimeoutSampler(1, 1, func):
+            pass
+    assert excinfo.value.__cause__ is None
+
+
+def test_ts_post_mortem_attributes_last_attempt_ok():
+    """
+    attempt/last_result/last_exception attributes are available for
+    post-mortem inspection: when the most recent attempt succeeded,
+    last_exception is None and last_result holds its return value.
+    """
+    func_state = []
+
+    def func():
+        func_state.append(0)
+        if len(func_state) == 1:
+            raise ValueError("transient")
+        return len(func_state)
+
+    ts = TimeoutSampler(2, 1, func)
+    with pytest.raises(TimeoutExpiredError):
+        for _ in ts:
+            pass
+    assert ts.attempt == 2
+    assert ts.last_result == 2
+    assert ts.last_exception is None
+
+
+def test_ts_post_mortem_attributes_last_attempt_failed():
+    """
+    When the most recent attempt raised, last_exception holds the exception
+    while last_result still holds the value of the last successful attempt,
+    and the timeout exception is chained to last_exception.
+    """
+    outcomes = [1, ValueError("boom")]
+
+    def func():
+        outcome = outcomes.pop(0)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+    ts = TimeoutSampler(2, 1, func)
+    with pytest.raises(TimeoutExpiredError) as excinfo:
+        for _ in ts:
+            pass
+    assert ts.attempt == 2
+    assert ts.last_result == 1
+    assert isinstance(ts.last_exception, ValueError)
+    assert excinfo.value.__cause__ is ts.last_exception
+
+
+def test_ts_wait_for_value_negative_complex_value(caplog):
+    """
+    Complex sampled values (e.g. dicts) are reported in the error log only by
+    their type, so large or potentially sensitive content is not dumped into
+    the log.
+    """
+    func = lambda: {"password": "secret123"}  # noqa: E731  # pragma: allowlist secret
+    ts = TimeoutSampler(1, 1, func)
+    caplog.set_level(logging.ERROR)
+    with pytest.raises(TimeoutExpiredError):
+        ts.wait_for_func_value(True)
+    assert len(caplog.records) == 1
+    log_msg = caplog.records[0].getMessage()
+    assert "last sampled value: <dict>" in log_msg
+    assert "secret123" not in log_msg
+
+
+def test_ts_wait_for_value_negative_never_succeeded(caplog):
+    """
+    When func never returns a value (every attempt raises), the error log
+    reports "<no successful sample>" instead of the ambiguous "None", so a
+    func that never ran to completion is distinguishable from one that
+    genuinely returned None.
+    """
+
+    def func():
+        raise ValueError("always fails")
+
+    ts = TimeoutSampler(1, 1, func)
+    caplog.set_level(logging.ERROR)
+    with pytest.raises(TimeoutExpiredError):
+        ts.wait_for_func_value(1)
+    log_msg = caplog.records[0].getMessage()
+    assert "last sampled value: <no successful sample>" in log_msg
+    # the terminal ERROR log still surfaces the last failure reason
+    assert "last attempt raised ValueError: always fails" in log_msg

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -2235,6 +2235,10 @@ class TimeoutSampler(object):
 
     Feel free to set the instance variables.
 
+    Once iteration starts, the following attributes are available for
+    inspection: `attempt` (number of samples so far), `last_result` (most
+    recent value returned by func) and `last_exception` (the exception raised
+    by the most recent sample, None if that sample succeeded).
 
     Args:
         timeout (int): Timeout in seconds
@@ -2268,6 +2272,16 @@ class TimeoutSampler(object):
         self.last_sample_time = None
         # Timestamp of the last INFO-level exception log (for rate limiting)
         self.last_exception_info_log_time = None
+        # Number of sampling attempts made so far
+        self.attempt = 0
+        # Outcome of recent sampling attempts: the value func
+        # returned last time it succeeded, and the exception it raised on the
+        # most recent attempt (None if that attempt succeeded)
+        self.last_result = None
+        # Whether func has returned at least once, so a genuine None result is
+        # distinguishable from "func never succeeded"
+        self._has_result = False
+        self.last_exception = None
         # The exception to raise
         self.timeout_exc_cls = TimeoutExpiredError
         # Arguments that will be passed to the exception
@@ -2277,9 +2291,65 @@ class TimeoutSampler(object):
                 f"Timed out after {timeout}s running {self._build_call_string()}"
             )
         except Exception:
-            log.exception(
-                "Failed to assemble call string. Not necessarily a test failure."
+            log.debug(
+                "Failed to assemble call string. Not necessarily a test failure.",
+                exc_info=True,
             )
+
+    def _get_func_name(self):
+        """
+        Returns:
+            str: Name of the sampled function, or its repr when it has no
+                __name__ attribute (e.g. functools.partial objects)
+
+        """
+        return getattr(self.func, "__name__", repr(self.func))
+
+    @staticmethod
+    def _describe_exception(exc):
+        """
+        Args:
+            exc (Exception): Exception to summarize
+
+        Returns:
+            str: One-line summary of the exception: its type and the first
+                line of its message, truncated to keep log entries short
+
+        """
+        try:
+            message_lines = str(exc).splitlines()
+            first_line = message_lines[0] if message_lines else ""
+        except Exception:
+            first_line = "<unprintable exception>"
+        return f"{type(exc).__name__}: {first_line[:150]}"
+
+    def _describe_last_result(self):
+        """
+        Render last_result for logging: simple scalar values are shown
+        verbatim, other objects only as their type, to keep error logs short
+        and avoid dumping potentially sensitive content into them.
+
+        Returns:
+            str: Safe short representation of the last sampled value
+
+        """
+        if not self._has_result:
+            return "<no successful sample>"
+        if isinstance(self.last_result, (bool, int, float, type(None))):
+            return repr(self.last_result)
+        if isinstance(self.last_result, str) and len(self.last_result) <= 80:
+            return repr(self.last_result)
+        return f"<{type(self.last_result).__name__}>"
+
+    def _raise_timeout(self):
+        """
+        Raise the configured timeout exception. When func raised an exception
+        on the most recent attempt, chain to it so the root cause is visible
+        directly in the resulting traceback.
+        """
+        if self.last_exception is not None:
+            raise self.timeout_exc_cls(*self.timeout_exc_args) from self.last_exception
+        raise self.timeout_exc_cls(*self.timeout_exc_args)
 
     def _build_call_string(self):
         def stringify(value):
@@ -2290,37 +2360,46 @@ class TimeoutSampler(object):
         args = list(map(stringify, self.func_args))
         kwargs = [f"{stringify(k)}={stringify(v)}" for k, v in self.func_kwargs.items()]
         all_args_string = ", ".join(args + kwargs)
-        return f"{self.func.__name__}({all_args_string})"
+        return f"{self._get_func_name()}({all_args_string})"
 
     def __iter__(self):
         if self.start_time is None:
             self.start_time = time.time()
-        attempt = 0
         while True:
             self.last_sample_time = time.time()
             if self.timeout <= (self.last_sample_time - self.start_time):
-                raise self.timeout_exc_cls(*self.timeout_exc_args)
-            attempt += 1
+                self._raise_timeout()
+            self.attempt += 1
             try:
-                yield self.func(*self.func_args, **self.func_kwargs)
-            except Exception:
+                result = self.func(*self.func_args, **self.func_kwargs)
+                self.last_result = result
+                self._has_result = True
+                self.last_exception = None
+                yield result
+            except Exception as exc:
+                self.last_exception = exc
                 # Rate-limit INFO logging to once per minute to reduce log noise
                 current_time = time.time()
                 if (
                     self.last_exception_info_log_time is None
                     or (current_time - self.last_exception_info_log_time) >= 60
                 ):
+                    # Surface only the exception type here: this line is
+                    # emitted at INFO, so keep it free of the (possibly
+                    # sensitive) exception message. The full message and
+                    # traceback are logged at DEBUG below.
                     log.info(
-                        f"TimeoutSampler attempt {attempt} for function '{self.func.__name__}' failed, "
-                        "see debug level logs for details"
+                        f"TimeoutSampler attempt {self.attempt} for function "
+                        f"'{self._get_func_name()}' failed with "
+                        f"{type(exc).__name__}, see debug level logs for details"
                     )
                     self.last_exception_info_log_time = current_time
                 log.debug(
-                    f"Exception raised during iteration attempt {attempt}:",
+                    f"Exception raised during iteration attempt {self.attempt}:",
                     exc_info=True,
                 )
             if self.timeout <= (time.time() - self.start_time):
-                raise self.timeout_exc_cls(*self.timeout_exc_args)
+                self._raise_timeout()
             log.info("Going to sleep for %d seconds before next iteration", self.sleep)
             time.sleep(self.sleep)
 
@@ -2337,12 +2416,19 @@ class TimeoutSampler(object):
                 if i_value == value:
                     break
         except self.timeout_exc_cls:
+            last_attempt_info = f"last sampled value: {self._describe_last_result()}"
+            if self.last_exception is not None:
+                last_attempt_info += (
+                    ", last attempt raised "
+                    f"{self._describe_exception(self.last_exception)}"
+                )
             log.error(
                 "function %s failed to return expected value %s "
-                "after multiple retries during %d second timeout",
-                self.func.__name__,
+                "after multiple retries during %d second timeout (%s)",
+                self._get_func_name(),
                 value,
                 self.timeout,
+                last_attempt_info,
             )
             raise
 


### PR DESCRIPTION
When a TimeoutSampler wait times out, the failure reason is hard to find - wait_for_func_status() swallows the exception entirely, and the raised TimeoutExpiredError carries no link back to what actually failed.

- Chain TimeoutExpiredError to the last exception raised by the sampled function so the root cause shows up in the failure traceback
- Expose attempt, last_result and last_exception attributes for post-mortem inspection after a timeout
- Include the failure reason (exception type only) in the rate-limited INFO log, keeping full messages at DEBUG to avoid leaking sensitive text
- Report the last sampled value in the wait_for_func_value timeout error, sanitized for safe logging
- Fix a crash when sampling callables without __name__ (e.g. functools.partial)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeout and retry handling with better tracking of the latest attempt, result, and exception.
  * Timeout errors now preserve the original failure as the cause when applicable.
  * Logging was tightened to avoid exposing full exception messages or large sampled values, while still showing useful summaries.
  * `wait_for_func_value()` now reports clearer diagnostics when a value never succeeds or times out after transient failures.

* **Tests**
  * Added coverage for timeout chaining, logging behavior, and post-timeout state across several retry scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->