### PR TITLE
Reduce TimeoutSampler per-iteration log noise

### DIFF
--- a/ocs_ci/utility/tests/test_utils_timeout_sampler.py
+++ b/ocs_ci/utility/tests/test_utils_timeout_sampler.py
@@ -54,6 +54,8 @@ def test_ts_simple_logging(caplog, capsys):
     sleep_msg = f"Going to sleep for {sleep_time} seconds before next iteration"
     for rec in caplog.records:
         assert rec.getMessage() == sleep_msg
+        # iteration-level details belong to DEBUG (see docs/logging_guide.md)
+        assert rec.levelno == logging.DEBUG
     assert len(caplog.records) == timeout
 
 
@@ -352,3 +354,60 @@ def test_ts_wait_for_value_negative_never_succeeded(caplog):
     assert "last sampled value: <no successful sample>" in log_msg
     # the terminal ERROR log still surfaces the last failure reason
     assert "last attempt raised ValueError: always fails" in log_msg
+
+
+def test_ts_progress_heartbeat(caplog):
+    """
+    Long-running samplers log a rate-limited INFO-level progress heartbeat
+    (at most once per progress_log_interval seconds), regardless of how many
+    sampling iterations happen within that window.
+    """
+    func = lambda: 1  # noqa: E731
+    # sleep (0.25s) is much shorter than the heartbeat interval (1s), so many
+    # iterations happen per interval -- this exercises the rate-limit ceiling
+    # (a per-iteration log would produce ~8 heartbeats, not <= 2).
+    ts = TimeoutSampler(2, 0.25, func)
+    ts.progress_log_interval = 1
+    caplog.set_level(logging.INFO)
+    iterations = 0
+    with pytest.raises(TimeoutExpiredError):
+        for _ in ts:
+            iterations += 1
+    heartbeats = [
+        r for r in caplog.records if "Still waiting for results of" in r.getMessage()
+    ]
+    # far more iterations than heartbeats proves the heartbeat is rate-limited
+    # rather than logged on every iteration
+    assert iterations >= 4
+    assert 1 <= len(heartbeats) <= 2
+    for rec in heartbeats:
+        assert rec.levelno == logging.INFO
+        assert "Still waiting for results of <lambda>" in rec.getMessage()
+        assert "of 2s timeout" in rec.getMessage()
+
+
+def test_ts_no_progress_heartbeat_for_short_wait(caplog):
+    """
+    Samplers which time out sooner than progress_log_interval do not log any
+    progress messages (so short waits stay quiet on the INFO level).
+    """
+    caplog.set_level(logging.DEBUG)
+    with pytest.raises(TimeoutExpiredError):
+        for _ in TimeoutSampler(2, 1, lambda: 1):
+            pass
+    assert not [r for r in caplog.records if "Still waiting" in r.getMessage()]
+
+
+def test_ts_float_sleep_logged_correctly(caplog):
+    """
+    Float sleep intervals are rendered correctly in the sleep log message
+    (%d used to truncate 0.5 to 0).
+    """
+    caplog.set_level(logging.DEBUG)
+    with pytest.raises(TimeoutExpiredError):
+        for _ in TimeoutSampler(1, 0.5, lambda: 1):
+            pass
+    sleep_records = [r for r in caplog.records if "Going to sleep" in r.getMessage()]
+    assert sleep_records
+    for rec in sleep_records:
+        assert "0.5 seconds" in rec.getMessage()

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -2248,6 +2248,9 @@ class TimeoutSampler(object):
         func_kwargs: Keyword arguments for the function
     """
 
+    # How often (seconds, at most) to log the INFO-level progress heartbeat
+    progress_log_interval = 60
+
     def __init__(self, timeout, sleep, func, *func_args, **func_kwargs):
         self.timeout = timeout
         self.sleep = sleep
@@ -2282,6 +2285,8 @@ class TimeoutSampler(object):
         # distinguishable from "func never succeeded"
         self._has_result = False
         self.last_exception = None
+        # Timestamp of the last INFO-level progress log (for rate limiting)
+        self.last_progress_log_time = None
         # The exception to raise
         self.timeout_exc_cls = TimeoutExpiredError
         # Arguments that will be passed to the exception
@@ -2362,6 +2367,27 @@ class TimeoutSampler(object):
         all_args_string = ", ".join(args + kwargs)
         return f"{self._get_func_name()}({all_args_string})"
 
+    def _log_progress(self):
+        """
+        Log an INFO-level progress message at most once per
+        `progress_log_interval` seconds, so that long-running samplers show
+        a heartbeat without logging every iteration.
+        """
+        now = time.time()
+        if self.last_progress_log_time is None:
+            self.last_progress_log_time = self.start_time
+        if (now - self.last_progress_log_time) < self.progress_log_interval:
+            return
+        log.info(
+            "Still waiting for results of %s: elapsed %ss of %ss timeout, "
+            "sleeping %ss between samples",
+            self._get_func_name(),
+            int(now - self.start_time),
+            self.timeout,
+            self.sleep,
+        )
+        self.last_progress_log_time = now
+
     def __iter__(self):
         if self.start_time is None:
             self.start_time = time.time()
@@ -2400,7 +2426,8 @@ class TimeoutSampler(object):
                 )
             if self.timeout <= (time.time() - self.start_time):
                 self._raise_timeout()
-            log.info("Going to sleep for %d seconds before next iteration", self.sleep)
+            self._log_progress()
+            log.debug("Going to sleep for %s seconds before next iteration", self.sleep)
             time.sleep(self.sleep)
 
     def wait_for_func_value(self, value):


### PR DESCRIPTION
Long-running TimeoutSampler waits (e.g. hours with a short sleep) flood the Jenkins console with an identical INFO line on every single iteration.

- Demote the per-iteration "Going to sleep" message from INFO to DEBUG
- Add a rate-limited INFO progress heartbeat (default once per 60s, tunable) so long waits still show progress
- Fix sleep interval formatting so float sleep values aren't truncated to 0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Long-running sampling now emits periodic INFO-level "still waiting" progress messages, capped by a configurable interval, so ongoing work is visibly tracked.
  * "Going to sleep…" timing logs now support clearer fractional sleep durations (for example, `0.5 seconds`).

* **Tests**
  * Expanded coverage for progress heartbeat emission, rate limiting behavior, correct logging levels, and sleep message formatting (including cases where timeout happens before the interval).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->