### PR TITLE
Fix bucket policy UI principal to use ARN format on OCS 4.21+

### DIFF
--- a/ocs_ci/ocs/resources/bucket_policy.py
+++ b/ocs_ci/ocs/resources/bucket_policy.py
@@ -274,9 +274,9 @@ def gen_bucket_policy_ui_compatible(
         # Public access: use direct wildcard
         principals = "*"
     elif isinstance(user_list, str):
-        # Check if it's a NooBaa account (contains @noobaa.io)
-        if "@noobaa.io" in user_list:
-            # NooBaa accounts should not be wrapped in AWS ARN format
+        # Check if it's a NooBaa account (contains @noobaa.io) or already a full ARN
+        if "@noobaa.io" in user_list or user_list.startswith("arn:"):
+            # NooBaa accounts and ARNs should not be wrapped in AWS ARN format
             principals = {"AWS": user_list}
         else:
             # AWS account: wrap in AWS ARN format
@@ -284,8 +284,8 @@ def gen_bucket_policy_ui_compatible(
     elif isinstance(user_list, list) and len(user_list) == 1:
         # Single account passed as list
         account = user_list[0]
-        if "@noobaa.io" in account:
-            # NooBaa account: use directly
+        if "@noobaa.io" in account or account.startswith("arn:"):
+            # NooBaa account or ARN: use directly
             principals = {"AWS": account}
         else:
             # AWS account: wrap in ARN format
@@ -294,8 +294,8 @@ def gen_bucket_policy_ui_compatible(
         # Multiple accounts: handle each appropriately
         formatted_accounts = []
         for account in user_list:
-            if "@noobaa.io" in account:
-                # NooBaa account: use directly
+            if "@noobaa.io" in account or account.startswith("arn:"):
+                # NooBaa account or ARN: use directly
                 formatted_accounts.append(account)
             else:
                 # AWS account: wrap in ARN format

--- a/ocs_ci/ocs/ui/page_objects/bucket_tab_permissions.py
+++ b/ocs_ci/ocs/ui/page_objects/bucket_tab_permissions.py
@@ -116,7 +116,7 @@ class BucketsTabPermissions(ObjectStorage, ConfirmDialog):
             bucket_name (str): Name of the bucket to get account ID for.
 
         Returns:
-            str: Real account ID associated with the bucket.
+            str: Real account ID (or ARN, on OCS >= 4.21) associated with the bucket.
 
         Raises:
             ValueError: If bucket is not found or account ID cannot be retrieved.
@@ -128,8 +128,8 @@ class BucketsTabPermissions(ObjectStorage, ConfirmDialog):
                     continue
 
                 obc_obj = OBC(obc["metadata"]["name"])
-                if hasattr(obc_obj, "obc_account") and obc_obj.obc_account:
-                    return obc_obj.obc_account
+                if obc_obj.id_for_policy_principal:
+                    return obc_obj.id_for_policy_principal
 
                 break
 


### PR DESCRIPTION
- Use OBC.id_for_policy_principal instead of the stale obc_account field when resolving the real account for account-dependent bucket policy tests
- Teach gen_bucket_policy_ui_compatible to recognize already-formatted ARN strings and pass them through instead of re-wrapping them
- Fixes PolicyApplicationError: "Invalid principal in policy" on OCS >= 4.21 for test_set_bucket_policy_ui[policy_config1] and [policy_config3]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bucket policy principal handling so existing identity strings are preserved correctly instead of being converted to a different format.
  * Updated account identification used in bucket permissions to better match current platform behavior, including support for ARN-based values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->