### PR TITLE
rosa hcp tag quota issue. improve removal

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1005,7 +1005,7 @@
         "hashed_secret": "6eae3a5b062c6d0d79f070c26e6d62486b40cb46",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 687,
+        "line_number": 777,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/ocs_ci/deployment/rosa.py
+++ b/ocs_ci/deployment/rosa.py
@@ -166,7 +166,10 @@ class ROSAOCP(BaseOCPDeployment):
                     )
                     return
                 raise
-            subnet_ids = aws.get_cluster_subnet_ids(cluster_name=self.cluster_name)
+            if rosa_hcp:
+                subnet_ids = rosa.get_rosa_hcp_subnet_ids()
+            else:
+                subnet_ids = aws.get_cluster_subnet_ids(cluster_name=self.cluster_name)
             oidc_endpoint_url = None
             if rosa_hcp:
                 try:
@@ -217,6 +220,11 @@ class ROSAOCP(BaseOCPDeployment):
                 f"{constants.ACCOUNT_ROLE_PREFIX_ROSA_HCP}-{self.cluster_name}"
             )
             delete_account_roles(account_roles_prefix)
+            if rosa_hcp and subnet_ids:
+                try:
+                    rosa.clean_stale_subnet_tags(subnet_ids)
+                except Exception as e:
+                    logger.warning(f"Stale subnet tag cleanup failed: {e}")
             logger.info(
                 f"Cluster {self.cluster_name} and associated resources deleted successfully"
             )

--- a/ocs_ci/utility/rosa.py
+++ b/ocs_ci/utility/rosa.py
@@ -61,6 +61,84 @@ def login():
     logger.info("Successfully logged in to ROSA")
 
 
+def get_rosa_hcp_subnet_ids():
+    """
+    Resolve the ROSA HCP subnet IDs from config.
+
+    Returns the same subnet IDs that create_cluster() uses, read from
+    config.ENV_DATA rather than querying AWS by Name tag (which doesn't
+    work for shared BYO VPC subnets).
+
+    Returns:
+        list: Subnet ID strings [public_subnet, private_subnet]
+
+    """
+    if config.ENV_DATA.get("subnet_ids", ""):
+        return config.ENV_DATA["subnet_ids"].split(",")
+    region = config.ENV_DATA.get("region", "us-west-2")
+    hcp_subnets = config.ENV_DATA.get("rosahcp_subnet_ids_per_region_default", {})
+    region_subnets = hcp_subnets.get(region, {})
+    public = region_subnets.get("public_subnet", "").split(",")[0]
+    private = region_subnets.get("private_subnet", "").split(",")[0]
+    return [s for s in [public, private] if s]
+
+
+def clean_stale_subnet_tags(subnet_ids):
+    """
+    Remove stale kubernetes.io/cluster/* tags from subnets.
+
+    AWS limits subnets to 50 tags. ROSA adds a kubernetes.io/cluster/<id>
+    tag on cluster creation. If destroy fails to clean up, tags accumulate
+    until the limit is reached, blocking new deployments.
+
+    This function removes tags for clusters that no longer exist in OCM.
+
+    Args:
+        subnet_ids (list): Subnet IDs to clean
+
+    Returns:
+        int: Number of stale tags removed
+
+    """
+    aws = AWSUtil()
+    removed = 0
+    active_clusters = set()
+    try:
+        out = utils.exec_cmd(
+            "ocm get /api/clusters_mgmt/v1/clusters --parameter size=200",
+            timeout=120,
+        )
+        clusters_data = json.loads(out.stdout.decode())
+        active_clusters = {c["id"] for c in clusters_data.get("items", [])}
+        logger.info(f"Found {len(active_clusters)} active clusters in OCM")
+    except Exception as e:
+        logger.warning(f"Could not fetch active cluster list: {e}")
+
+    for subnet_id in subnet_ids:
+        response = aws.ec2_client.describe_tags(
+            Filters=[{"Name": "resource-id", "Values": [subnet_id]}]
+        )
+        stale_keys = []
+        for tag in response.get("Tags", []):
+            key = tag.get("Key", "")
+            if not key.startswith("kubernetes.io/cluster/"):
+                continue
+            cluster_id = key.replace("kubernetes.io/cluster/", "")
+            if cluster_id not in active_clusters:
+                stale_keys.append(key)
+
+        if stale_keys:
+            logger.info(
+                f"Removing {len(stale_keys)} stale cluster tags from {subnet_id}"
+            )
+            aws.ec2_client.delete_tags(
+                Resources=[subnet_id],
+                Tags=[{"Key": k} for k in stale_keys],
+            )
+            removed += len(stale_keys)
+    return removed
+
+
 def create_cluster(cluster_name, version_str, region):
     """
     Create OCP cluster.
@@ -179,7 +257,19 @@ def create_cluster(cluster_name, version_str, region):
         cmd += " --hosted-cp "
 
     log_step("Running create rosa cluster command")
-    utils.run_cmd(cmd, timeout=create_timeout)
+    try:
+        utils.run_cmd(cmd, timeout=create_timeout)
+    except CommandFailed as e:
+        if "tag quota" in str(e).lower() and rosa_hcp:
+            logger.warning(
+                "Subnet tag quota exceeded. Cleaning stale cluster tags and retrying."
+            )
+            cleanup_subnet_ids = subnet_ids.split(",")
+            removed = clean_stale_subnet_tags(cleanup_subnet_ids)
+            logger.info(f"Removed {removed} stale tags. Retrying cluster creation.")
+            utils.run_cmd(cmd, timeout=create_timeout)
+        else:
+            raise
     if rosa_mode != "auto" and not rosa_hcp:
         logger.info(
             "Waiting for ROSA cluster status changed to waiting or pending state"


### PR DESCRIPTION
Subnets subnet-06de2b94c676e2e1b / subnet-08d4ad834dec518c0 are shared BYO VPC subnets reused by every ROSA HCP deployment. ROSA adds a kubernetes.io/cluster/{id}=shared tag on creation. The destroy() cleanup was silently failing because get_cluster_subnet_ids() searches by tag:Name matching {cluster_name}* — but shared subnets aren't named after the cluster, so the query always returned [] and the cleanup was skipped via if subnet_ids.

1. New retry logic on deployment
2. Improved removal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ROSA HCP cluster creation reliability by detecting AWS tag quota failures, cleaning stale Kubernetes cluster subnet tags, and retrying the operation.
  * Updated ROSA HCP teardown to use the correct ROSA HCP subnet IDs and to remove any stale `kubernetes.io/cluster/*` subnet tags when applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->