### PR TITLE
Fix "test_resize_osd" test failures: parse crash, weight lag, and Quay rate limit

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -646,7 +646,6 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 857,
-        "line_number": 855,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -655,7 +654,6 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 866,
-        "line_number": 864,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -664,8 +662,6 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 2077,
-        "line_number": 2075,
-        "line_number": 2060,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -674,8 +670,6 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 2184,
-        "line_number": 2182,
-        "line_number": 2167,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -684,8 +678,6 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 2185,
-        "line_number": 2183,
-        "line_number": 2168,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -694,8 +686,6 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 2186,
-        "line_number": 2184,
-        "line_number": 2169,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -704,8 +694,6 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 2187,
-        "line_number": 2185,
-        "line_number": 2170,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -714,8 +702,6 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 2199,
-        "line_number": 2197,
-        "line_number": 2182,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -724,8 +710,6 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 2214,
-        "line_number": 2212,
-        "line_number": 2197,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -734,8 +718,6 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 2215,
-        "line_number": 2213,
-        "line_number": 2198,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -744,8 +726,6 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 2223,
-        "line_number": 2221,
-        "line_number": 2206,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -754,8 +734,6 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 2224,
-        "line_number": 2222,
-        "line_number": 2207,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -764,8 +742,6 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 2225,
-        "line_number": 2223,
-        "line_number": 2208,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -774,8 +750,6 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 2226,
-        "line_number": 2224,
-        "line_number": 2209,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -784,8 +758,6 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 2227,
-        "line_number": 2225,
-        "line_number": 2210,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -794,8 +766,6 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 2824,
-        "line_number": 2822,
-        "line_number": 2807,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -804,8 +774,6 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 2990,
-        "line_number": 2988,
-        "line_number": 2972,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -814,8 +782,6 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 2991,
-        "line_number": 2989,
-        "line_number": 2973,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -823,9 +789,7 @@
         "hashed_secret": "ee46262b2df945e46ea310b925ad087465dbd3f2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3713,
-        "line_number": 3737,
-        "line_number": 3694,
+        "line_number": 3740,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -833,9 +797,7 @@
         "hashed_secret": "f678cad4ab874d71b559a069d5e34a95fe38a480",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3714,
-        "line_number": 3738,
-        "line_number": 3695,
+        "line_number": 3741,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/ocs_ci/helpers/osd_resize.py
+++ b/ocs_ci/helpers/osd_resize.py
@@ -1,6 +1,7 @@
 import logging
 import pytest
 
+from ocs_ci.utility.retry import retry
 from ocs_ci.ocs.exceptions import (
     StorageSizeNotReflectedException,
     ResourceWrongStatusException,
@@ -284,7 +285,9 @@ def base_ceph_verification_steps_post_resize_osd(
     logger.info("Check the resources size post resize OSD")
     check_storage_size_is_reflected(expected_storage_size, expected_ceph_capacity)
     logger.info("Check the Ceph state post resize OSD")
-    check_ceph_state_post_resize_osd()
+    retry(CephHealthException, tries=5, delay=30, backoff=1)(
+        check_ceph_state_post_resize_osd
+    )()
     logger.info("All the Ceph verification steps post resize osd finished successfully")
 
 

--- a/ocs_ci/ocs/cluster.py
+++ b/ocs_ci/ocs/cluster.py
@@ -4059,17 +4059,13 @@ def check_ceph_osd_df_tree():
         weight = float(line["WEIGHT"])
         match = re.match(r"([0-9.]+)([a-zA-Z]+)", line["SIZE"])
         if not match:
-            logger.warning(
-                f"Unable to parse SIZE {line['SIZE']} " f"for OSD ID {osd_id}"
-            )
+            logger.warning(f"Unable to parse SIZE {line['SIZE']} for OSD ID {osd_id}")
             return False
 
         size = float(match.group(1))
         units = match.group(2)
         if units == "B" and size == 0:
-            logger.warning(
-                f"OSD ID {osd_id} reports 0 B " f"— Ceph stats not ready yet"
-            )
+            logger.warning(f"OSD ID {osd_id} reports 0 B — Ceph stats not ready yet")
             return False
 
         if units.startswith("Ti"):

--- a/ocs_ci/ocs/cluster.py
+++ b/ocs_ci/ocs/cluster.py
@@ -4060,9 +4060,7 @@ def check_ceph_osd_df_tree():
         match = re.match(r"([0-9.]+)([a-zA-Z]+)", line["SIZE"])
         if not match:
             logger.warning(
-                "Unable to parse SIZE %s for OSD ID %s",
-                line["SIZE"],
-                osd_id,
+                f"Unable to parse SIZE {line['SIZE']} " f"for OSD ID {osd_id}"
             )
             return False
 
@@ -4070,8 +4068,7 @@ def check_ceph_osd_df_tree():
         units = match.group(2)
         if units == "B" and size == 0:
             logger.warning(
-                "OSD ID %s reports 0 B — Ceph stats not ready yet",
-                osd_id,
+                f"OSD ID {osd_id} reports 0 B " f"— Ceph stats not ready yet"
             )
             return False
 

--- a/ocs_ci/ocs/cluster.py
+++ b/ocs_ci/ocs/cluster.py
@@ -3969,7 +3969,7 @@ def parse_ceph_table_output(raw_output: str) -> pd.DataFrame:
 
     """
     # Known units for sizes (e.g., GiB, TiB, MiB)
-    known_units = ["GiB", "MiB", "KiB", "TiB"]
+    known_units = ["GiB", "MiB", "KiB", "TiB", "B"]
 
     # Step 1: Join size values with their units (e.g., '894 GiB' -> '894GiB')
     for unit in known_units:
@@ -4053,11 +4053,28 @@ def check_ceph_osd_df_tree():
 
     for line in ceph_output_lines:
         osd_id = line["ID"]
+        if osd_id.startswith("-") or osd_id == "TOTAL":
+            continue
+
         weight = float(line["WEIGHT"])
-        # Regular expression to match the numeric part and the unit
         match = re.match(r"([0-9.]+)([a-zA-Z]+)", line["SIZE"])
+        if not match:
+            logger.warning(
+                "Unable to parse SIZE %s for OSD ID %s",
+                line["SIZE"],
+                osd_id,
+            )
+            return False
+
         size = float(match.group(1))
         units = match.group(2)
+        if units == "B" and size == 0:
+            logger.warning(
+                "OSD ID %s reports 0 B — Ceph stats not ready yet",
+                osd_id,
+            )
+            return False
+
         if units.startswith("Ti"):
             storage_size = convert_device_size(storage_size_param, "TB", 1024)
         elif units.startswith("Gi"):
@@ -4074,19 +4091,21 @@ def check_ceph_osd_df_tree():
         diff = size * 0.04
         if not (size - diff <= weight <= size + diff):
             logger.warning(
-                f"OSD weight {weight} (converted) does not match the OSD size {size} "
-                f"for OSD ID {osd_id}. Expected OSD weight within [{size - diff}, {size + diff}]"
+                f"OSD weight {weight} (converted) does not match "
+                f"the OSD size {size} for OSD ID {osd_id}. "
+                f"Expected OSD weight within "
+                f"[{size - diff}, {size + diff}]"
             )
             return False
-        # If it's a regular OSD entry, check if the expected osd size
-        # and the current size are equal ignoring a small diff
+        # Check if the expected osd size and the current size are
+        # equal ignoring a small diff
         diff = size * 0.04
-        if not osd_id.startswith("-") and not (
-            size - diff <= storage_size <= size + diff
-        ):
+        if not (size - diff <= storage_size <= size + diff):
             logger.warning(
-                f"The storage size {storage_size} does not match the OSD size {size} "
-                f"for OSD ID {osd_id}. Expected storage size within [{size - diff}, {size + diff}]"
+                f"The storage size {storage_size} does not match "
+                f"the OSD size {size} for OSD ID {osd_id}. "
+                f"Expected storage size within "
+                f"[{size - diff}, {size + diff}]"
             )
             return False
 

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -3000,6 +3000,7 @@ VOLUMESNAPSHOT = "volumesnapshot"
 LOGICALVOLUME = "logicalvolume"
 
 PERF_IMAGE = "quay.io/ocsci/perf:latest"
+NGINX_FIO_IMAGE = "quay.io/ocsci/nginx:fio"
 
 ROOK_CEPH_CONFIG_VALUES = """
 [global]

--- a/tests/functional/z_cluster/cluster_expansion/test_resize_osd.py
+++ b/tests/functional/z_cluster/cluster_expansion/test_resize_osd.py
@@ -27,7 +27,13 @@ from ocs_ci.framework.testlib import (
     tier4c,
     tier4a,
 )
-from ocs_ci.ocs.constants import OSD, ROOK_OPERATOR, MON_DAEMON
+from ocs_ci.ocs.constants import (
+    NGINX_FIO_IMAGE,
+    OSD,
+    ROOK_OPERATOR,
+    MON_DAEMON,
+)
+from ocs_ci.helpers import helpers
 from ocs_ci.helpers.osd_resize import (
     ceph_verification_steps_post_resize_osd,
     check_ceph_health_after_resize_osd,
@@ -142,6 +148,7 @@ class TestResizeOSD(ManageTest):
         Prepare the data before resizing the osd
 
         """
+        helpers.pull_images(NGINX_FIO_IMAGE)
         pvc_size = random.randint(3, 7)
         self.pvcs1, self.pods_for_integrity_check = self.create_pvcs_and_pods(
             pvc_size=pvc_size, num_of_rbd_pvc=6, num_of_cephfs_pvc=6


### PR DESCRIPTION
## Summary
  - Add `"B"` to `known_units` in `parse_ceph_table_output()` so transient `0 B` values from `ceph osd df tree` are
  parsed correctly instead of crashing with `AttributeError`
  - Skip hierarchy rows (negative ID) and `TOTAL` row in `check_ceph_osd_df_tree()`, and add a null guard on the SIZE
  regex match
  - Wrap `check_ceph_state_post_resize_osd()` with `retry(CephHealthException)` to tolerate ~30s crush weight lag after
  OSD resize
  - Pre-pull `quay.io/ocsci/nginx:fio` on worker nodes before creating workload pods to avoid Quay rate limiting on
  batch pod creation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for an additional Ceph storage size unit when normalizing reported values.
  * Introduced a new container image reference used during resize validation workflows.
* **Bug Fixes**
  * Improved OSD resize verification by automatically retrying post-resize health checks when Ceph health is temporarily unstable.
  * Enhanced OSD tree validation to ignore non-OSD entries and fail clearly when size parsing fails or when reported sizes indicate Ceph stats aren’t ready, with improved warning context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->