### PR TITLE
Avoid NooBaa pod collisions in degraded-state node-stop tests

### DIFF
--- a/ocs_ci/helpers/sanity_helpers.py
+++ b/ocs_ci/helpers/sanity_helpers.py
@@ -131,7 +131,13 @@ class Sanity:
             )
 
             if not is_hci_client_cluster():
-                self.ceph_cluster.wait_for_noobaa_health_ok()
+                # Give the health check the same order-of-magnitude grace
+                # period as bucket_creation_timeout, without regressing the
+                # default budget for callers that don't extend it.
+                noobaa_health_check_tries = max(120, bucket_creation_timeout // 5)
+                self.ceph_cluster.wait_for_noobaa_health_ok(
+                    tries=noobaa_health_check_tries
+                )
 
     def delete_resources(self):
         """

--- a/tests/functional/z_cluster/nodes/test_nodes_restart.py
+++ b/tests/functional/z_cluster/nodes/test_nodes_restart.py
@@ -15,7 +15,12 @@ from ocs_ci.framework.testlib import (
     skipif_hci_provider_and_client,
 )
 from ocs_ci.ocs import constants
-from ocs_ci.ocs.node import get_node_objs, get_nodes, wait_for_nodes_status
+from ocs_ci.ocs.node import (
+    get_app_pod_running_nodes,
+    get_node_objs,
+    get_nodes,
+    wait_for_nodes_status,
+)
 from ocs_ci.ocs.resources import pod
 from ocs_ci.helpers.sanity_helpers import Sanity, SanityExternalCluster
 from ocs_ci.helpers.helpers import (
@@ -26,7 +31,7 @@ from ocs_ci.helpers.helpers import (
 )
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.exceptions import ServiceUnavailable
-from ocs_ci.ocs.exceptions import CommandFailed
+from ocs_ci.ocs.exceptions import CommandFailed, NotFoundError
 from ocs_ci.utility.utils import retry
 from ocs_ci.ocs.cluster import is_vsphere_ipi_cluster
 
@@ -205,24 +210,39 @@ class TestNodesRestart(ManageTest):
             provisioner_pods = pod.get_cephfsplugin_provisioner_pods()
         provisioner_pod = provisioner_pods[0]
 
-        # Making sure that the node is not running the rook operator pod:
-        provisioner_node = pod.get_pod_node(provisioner_pod)
+        # Avoid rook operator's node, and NooBaa's node (may miss bucket_creation_timeout)
         rook_operator_pod = pod.get_operator_pods()[0]
         operator_node = pod.get_pod_node(rook_operator_pod)
-        if operator_node.get().get("metadata").get(
-            "name"
-        ) == provisioner_node.get().get("metadata").get("name"):
+        unsafe_nodes = {operator_node.name}
+        if operation == "create_resources":
+            try:
+                unsafe_nodes.update(get_app_pod_running_nodes(pod.get_noobaa_pods()))
+            except (CommandFailed, NotFoundError) as ex:
+                logger.warning(f"Could not determine NooBaa pod nodes: {ex}")
+
+        provisioner_node = pod.get_pod_node(provisioner_pod)
+        if provisioner_node.name in unsafe_nodes:
             provisioner_pod = provisioner_pods[1]
+            provisioner_node = pod.get_pod_node(provisioner_pod)
 
         provisioner_pod_name = provisioner_pod.name
         logger.info(f"{interface} provisioner pod found: {provisioner_pod_name}")
 
-        # Get the node name that has the provisioner pod running on
-        provisioner_node = pod.get_pod_node(provisioner_pod)
-        provisioner_node_name = provisioner_node.get().get("metadata").get("name")
+        provisioner_node_name = provisioner_node.name
         logger.info(
             f"{interface} provisioner pod is running on node {provisioner_node_name}"
         )
+
+        # Only 2 provisioner pods exist; extend timeout if both are unsafe
+        bucket_creation_timeout = 180  # same as sanity_helpers default
+        if operation == "create_resources" and provisioner_node_name in unsafe_nodes:
+            bucket_creation_timeout = 800
+            logger.info(
+                f"Node {provisioner_node_name} running the {interface} provisioner "
+                "pod could not be swapped away from a node also running a NooBaa "
+                f"pod; extending bucket_creation_timeout to {bucket_creation_timeout} "
+                "seconds"
+            )
 
         # Stopping the nodes
         nodes.stop_nodes(nodes=[provisioner_node])
@@ -260,7 +280,11 @@ class TestNodesRestart(ManageTest):
         if operation == "create_resources":
             # Cluster validation (resources creation and IO running)
             self.sanity_helpers.create_resources(
-                pvc_factory, pod_factory, bucket_factory, rgw_bucket_factory
+                pvc_factory,
+                pod_factory,
+                bucket_factory,
+                rgw_bucket_factory,
+                bucket_creation_timeout=bucket_creation_timeout,
             )
         elif operation == "delete_resources":
             # Cluster validation (resources creation and IO running)
@@ -329,10 +353,26 @@ class TestNodesRestart(ManageTest):
 
         # Get the node name that has the rook operator pod running on
         operator_node = pod.get_pod_node(rook_operator_pod)
-        operator_node_name = operator_node.get().get("metadata").get("name")
+        operator_node_name = operator_node.name
         logger.info(
             f"{rook_operator_pod_name} pod is running on node {operator_node_name}"
         )
+
+        # No alternate pod exists here; extend timeout if this node is unsafe
+        bucket_creation_timeout = 180  # same as sanity_helpers default
+        if operation == "create_resources":
+            try:
+                noobaa_nodes = get_app_pod_running_nodes(pod.get_noobaa_pods())
+            except (CommandFailed, NotFoundError) as ex:
+                logger.warning(f"Could not determine NooBaa pod nodes: {ex}")
+                noobaa_nodes = []
+            if operator_node_name in noobaa_nodes:
+                bucket_creation_timeout = 800
+                logger.info(
+                    f"Node {operator_node_name} running the rook operator pod is "
+                    "also running a NooBaa pod; extending bucket_creation_timeout "
+                    f"to {bucket_creation_timeout} seconds"
+                )
 
         # Stopping the node
         nodes.stop_nodes(nodes=[operator_node])
@@ -370,7 +410,11 @@ class TestNodesRestart(ManageTest):
             # Cluster validation (resources creation and IO running)
 
             self.sanity_helpers.create_resources(
-                pvc_factory, pod_factory, bucket_factory, rgw_bucket_factory
+                pvc_factory,
+                pod_factory,
+                bucket_factory,
+                rgw_bucket_factory,
+                bucket_creation_timeout=bucket_creation_timeout,
             )
         elif operation == "delete_resources":
             # Cluster validation (resources creation and IO running)


### PR DESCRIPTION
test_pv_provisioning_under_degraded_state_stop_provisioner_pod_node (OCS-1138, [OCS-1139](https://redhat.atlassian.net/browse/OCS-1139)) and test_pv_provisioning_under_degraded_state_stop_rook_operator_pod_node (OCS-2016) intermittently fail with UnhealthyBucket when the node they stop also happens to host a NooBaa pod (core, db, endpoint, or operator) — the new default bucket created right after can miss the 180s bucket_creation_timeout waiting for that pod to reschedule.

- Widen the existing rook-operator node-avoidance check in the provisioner test to also avoid nodes running any NooBaa pod when creating resources
- Extend bucket_creation_timeout to 800s when avoidance isn't structurally possible: the rook-operator test has no alternate pod to swap to, and the provisioner test has a residual case where both candidate pods are unsafe
- Guard the new NooBaa pod lookups against transient scheduling states, mirroring the existing get_node_pods() exception handling pattern
- Scale the NooBaa health check that runs right after bucket creation with the same timeout: it previously used a fixed ~600s retry budget independent of bucket_creation_timeout, so it could still fail with NoobaaHealthException even after the timeout above was extended

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of storage provisioning validation during degraded cluster scenarios.
  * More robust selection of provisioner and rook-operator pods to avoid unstable node placement.
  * Adjust bucket creation health-check timing and retry behavior when unsafe scheduling conditions are detected.

* **Tests**
  * Enhanced running-NooBaa node detection and broadened error handling for missing/unavailable pods.
  * Added configurable bucket-creation timeout handling for degraded-state create-resources flows, including safer pod fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
