### PR TITLE
Fix test_secondary_db_ro_queries

### DIFF
--- a/tests/functional/object/mcg/test_secondary_db_optimization.py
+++ b/tests/functional/object/mcg/test_secondary_db_optimization.py
@@ -146,7 +146,7 @@ class TestSecondaryDbOptimization(MCGTest):
                 pod_name=db_pod.name,
                 namespace=config.ENV_DATA["cluster_namespace"],
                 since="5m",
-                grep="nbcore.*statement.*SELECT",
+                grep="nbcore.*(statement|execute).*SELECT",
                 regex=True,
                 first_match_only=False,
             ).split("\n")


### PR DESCRIPTION
## Summary
- Fix `test_secondary_db_ro_queries` step 4 grep pattern to also match parameterized SQL queries logged by PostgreSQL as `execute` (not just `statement`)

## Changes
- `tests/functional/object/mcg/test_secondary_db_optimization.py`: change grep from `nbcore.*statement.*SELECT` to `nbcore.*(statement|execute).*SELECT`

The DB cleaner's `find_deleted_blocks` query uses parameterized SQL (`$1` placeholders), which PostgreSQL logs as `execute <unnamed>: SELECT ...` rather than `statement: SELECT ...`. The old grep pattern only matched `statement`, causing the test to miss the `datablocks` query and fail with `"secondary DB pod logs do not contain the expected query for: DB Cleaner"` even though the query was present in the pod logs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated automated coverage for secondary database read-only queries so it accepts SELECT activity logged in either of two logging formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->