### PR TITLE
Fix revert_noobaa_endpoint_scc for Provider Client clusters

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7205,6 +7205,7 @@ def revert_noobaa_endpoint_scc_class(request):
     return revert_noobaa_endpoint_scc_fixture(request)
 
 
+@config.run_with_provider_context_if_available
 def revert_noobaa_endpoint_scc_fixture(request):
     """
     This fixture reverts the noobaa-endpoint SCC back to the way it was before ODF 4.12.
@@ -7223,6 +7224,7 @@ def revert_noobaa_endpoint_scc_fixture(request):
     if scc_dict["seLinuxContext"]["type"] == "MustRunAs" or scc_dict["users"]:
         return
 
+    @config.run_with_provider_context_if_available
     def revert_endpoint_scc_implementation():
         """
         1. Modify the noobaa-endpoint scc via oc patch
@@ -7250,6 +7252,7 @@ def revert_noobaa_endpoint_scc_fixture(request):
             constants.NOOBAA_ENDPOINT_SERVICE_ACCOUNT in scc_dict["users"]
         ), "The noobaa-endpoint SA wasn't added to the noobaa-endpoint SCC"
 
+    @config.run_with_provider_context_if_available
     def finalizer():
         """
         1. Restore the noobaa-endpoint SCC back to its default values


### PR DESCRIPTION
## Summary
- Fix `revert_noobaa_endpoint_scc_fixture` failing on Provider Client clusters
  because the `noobaa-endpoint` SCC doesn't exist on the client cluster.

## Changes
- Add `@config.run_with_provider_context_if_available` to
  `revert_noobaa_endpoint_scc_fixture` so the initial SCC lookup runs
  against the provider cluster.
- Add the same decorator to the inner `revert_endpoint_scc_implementation`
  and `finalizer` functions so SCC patching and teardown also target the
  provider cluster (the finalizer decorator is critical since pytest calls
  it outside the outer function's context).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated test fixture behavior so SCC patching and restoration execute within the correct provider execution context when available.
  * Improved teardown finalization to ensure settings are consistently reverted during cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->