### PR TITLE
[z-stream 4.20.14] Enable 62 tests across 26 files for validation

### DIFF
--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -878,3 +878,5 @@ zstream_4_20_14_disaster_recovery = pytest.mark.zstream_4_20_14_disaster_recover
 zstream_4_20_14_mcg = pytest.mark.zstream_4_20_14_mcg
 # z-stream marker
 zstream_4_20_14_upgrade = pytest.mark.zstream_4_20_14_upgrade
+# z-stream marker
+zstream_4_20_14_odf_dr_multicluster_orchestrator = pytest.mark.zstream_4_20_14_odf_dr_multicluster_orchestrator

--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -866,3 +866,5 @@ skipif_lean_deployment = pytest.mark.skipif(
 )
 # z-stream marker
 zstream_4_20_14 = pytest.mark.zstream_4_20_14
+# z-stream marker
+zstream_4_20_14_monitoring = pytest.mark.zstream_4_20_14_monitoring

--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -884,3 +884,5 @@ zstream_4_20_14_odf_dr_multicluster_orchestrator = pytest.mark.zstream_4_20_14_o
 zstream_4_20_14_ocs_operator = pytest.mark.zstream_4_20_14_ocs_operator
 # z-stream marker
 zstream_4_20_14_rook = pytest.mark.zstream_4_20_14_rook
+# z-stream marker
+zstream_4_20_14_odf_console = pytest.mark.zstream_4_20_14_odf_console

--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -874,3 +874,5 @@ zstream_4_20_14_nfs = pytest.mark.zstream_4_20_14_nfs
 zstream_4_20_14_ceph_csi = pytest.mark.zstream_4_20_14_ceph_csi
 # z-stream marker
 zstream_4_20_14_disaster_recovery = pytest.mark.zstream_4_20_14_disaster_recovery
+# z-stream marker
+zstream_4_20_14_mcg = pytest.mark.zstream_4_20_14_mcg

--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -870,3 +870,5 @@ zstream_4_20_14 = pytest.mark.zstream_4_20_14
 zstream_4_20_14_monitoring = pytest.mark.zstream_4_20_14_monitoring
 # z-stream marker
 zstream_4_20_14_nfs = pytest.mark.zstream_4_20_14_nfs
+# z-stream marker
+zstream_4_20_14_ceph_csi = pytest.mark.zstream_4_20_14_ceph_csi

--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -882,3 +882,5 @@ zstream_4_20_14_upgrade = pytest.mark.zstream_4_20_14_upgrade
 zstream_4_20_14_odf_dr_multicluster_orchestrator = pytest.mark.zstream_4_20_14_odf_dr_multicluster_orchestrator
 # z-stream marker
 zstream_4_20_14_ocs_operator = pytest.mark.zstream_4_20_14_ocs_operator
+# z-stream marker
+zstream_4_20_14_rook = pytest.mark.zstream_4_20_14_rook

--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -872,3 +872,5 @@ zstream_4_20_14_monitoring = pytest.mark.zstream_4_20_14_monitoring
 zstream_4_20_14_nfs = pytest.mark.zstream_4_20_14_nfs
 # z-stream marker
 zstream_4_20_14_ceph_csi = pytest.mark.zstream_4_20_14_ceph_csi
+# z-stream marker
+zstream_4_20_14_disaster_recovery = pytest.mark.zstream_4_20_14_disaster_recovery

--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -864,3 +864,5 @@ skipif_lean_deployment = pytest.mark.skipif(
     or not check_cluster_resources_for_nfs(),
     reason="Test cannot run on lean profile or requires higher cluster resources (insufficient CPU/memory)",
 )
+# z-stream marker
+zstream_4_20_14 = pytest.mark.zstream_4_20_14

--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -886,3 +886,5 @@ zstream_4_20_14_ocs_operator = pytest.mark.zstream_4_20_14_ocs_operator
 zstream_4_20_14_rook = pytest.mark.zstream_4_20_14_rook
 # z-stream marker
 zstream_4_20_14_odf_console = pytest.mark.zstream_4_20_14_odf_console
+# z-stream marker
+zstream_4_20_14_odf_cli = pytest.mark.zstream_4_20_14_odf_cli

--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -876,3 +876,5 @@ zstream_4_20_14_ceph_csi = pytest.mark.zstream_4_20_14_ceph_csi
 zstream_4_20_14_disaster_recovery = pytest.mark.zstream_4_20_14_disaster_recovery
 # z-stream marker
 zstream_4_20_14_mcg = pytest.mark.zstream_4_20_14_mcg
+# z-stream marker
+zstream_4_20_14_upgrade = pytest.mark.zstream_4_20_14_upgrade

--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -868,3 +868,5 @@ skipif_lean_deployment = pytest.mark.skipif(
 zstream_4_20_14 = pytest.mark.zstream_4_20_14
 # z-stream marker
 zstream_4_20_14_monitoring = pytest.mark.zstream_4_20_14_monitoring
+# z-stream marker
+zstream_4_20_14_nfs = pytest.mark.zstream_4_20_14_nfs

--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -880,3 +880,5 @@ zstream_4_20_14_mcg = pytest.mark.zstream_4_20_14_mcg
 zstream_4_20_14_upgrade = pytest.mark.zstream_4_20_14_upgrade
 # z-stream marker
 zstream_4_20_14_odf_dr_multicluster_orchestrator = pytest.mark.zstream_4_20_14_odf_dr_multicluster_orchestrator
+# z-stream marker
+zstream_4_20_14_ocs_operator = pytest.mark.zstream_4_20_14_ocs_operator

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 markers =
+    zstream_4_20_14_upgrade: z-stream 4.20.14 upgrade component tests
     zstream_4_20_14_mcg: z-stream 4.20.14 mcg component tests
     zstream_4_20_14_disaster_recovery: z-stream 4.20.14 disaster-recovery component tests
     zstream_4_20_14_ceph_csi: z-stream 4.20.14 ceph-csi component tests

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 markers =
+    zstream_4_20_14_monitoring: z-stream 4.20.14 monitoring component tests
     zstream_4_20_14: z-stream 4.20.14 test enablement
     run_this: testing marker for run this test, useful for development
     acceptance: marker for acceptance tests

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 markers =
+    zstream_4_20_14_rook: z-stream 4.20.14 rook component tests
     zstream_4_20_14_ocs_operator: z-stream 4.20.14 ocs-operator component tests
     zstream_4_20_14_odf_dr_multicluster_orchestrator: z-stream 4.20.14 odf-dr/multicluster-orchestrator component tests
     zstream_4_20_14_upgrade: z-stream 4.20.14 upgrade component tests

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 markers =
+    zstream_4_20_14_disaster_recovery: z-stream 4.20.14 disaster-recovery component tests
     zstream_4_20_14_ceph_csi: z-stream 4.20.14 ceph-csi component tests
     zstream_4_20_14_nfs: z-stream 4.20.14 nfs component tests
     zstream_4_20_14_monitoring: z-stream 4.20.14 monitoring component tests

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 markers =
+    zstream_4_20_14_ocs_operator: z-stream 4.20.14 ocs-operator component tests
     zstream_4_20_14_odf_dr_multicluster_orchestrator: z-stream 4.20.14 odf-dr/multicluster-orchestrator component tests
     zstream_4_20_14_upgrade: z-stream 4.20.14 upgrade component tests
     zstream_4_20_14_mcg: z-stream 4.20.14 mcg component tests

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 markers =
+    zstream_4_20_14_odf_cli: z-stream 4.20.14 odf-cli component tests
     zstream_4_20_14_odf_console: z-stream 4.20.14 odf-console component tests
     zstream_4_20_14_rook: z-stream 4.20.14 rook component tests
     zstream_4_20_14_ocs_operator: z-stream 4.20.14 ocs-operator component tests

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 markers =
+    zstream_4_20_14_odf_console: z-stream 4.20.14 odf-console component tests
     zstream_4_20_14_rook: z-stream 4.20.14 rook component tests
     zstream_4_20_14_ocs_operator: z-stream 4.20.14 ocs-operator component tests
     zstream_4_20_14_odf_dr_multicluster_orchestrator: z-stream 4.20.14 odf-dr/multicluster-orchestrator component tests

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 markers =
+    zstream_4_20_14_ceph_csi: z-stream 4.20.14 ceph-csi component tests
     zstream_4_20_14_nfs: z-stream 4.20.14 nfs component tests
     zstream_4_20_14_monitoring: z-stream 4.20.14 monitoring component tests
     zstream_4_20_14: z-stream 4.20.14 test enablement

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 markers =
+    zstream_4_20_14_odf_dr_multicluster_orchestrator: z-stream 4.20.14 odf-dr/multicluster-orchestrator component tests
     zstream_4_20_14_upgrade: z-stream 4.20.14 upgrade component tests
     zstream_4_20_14_mcg: z-stream 4.20.14 mcg component tests
     zstream_4_20_14_disaster_recovery: z-stream 4.20.14 disaster-recovery component tests

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 markers =
+    zstream_4_20_14_mcg: z-stream 4.20.14 mcg component tests
     zstream_4_20_14_disaster_recovery: z-stream 4.20.14 disaster-recovery component tests
     zstream_4_20_14_ceph_csi: z-stream 4.20.14 ceph-csi component tests
     zstream_4_20_14_nfs: z-stream 4.20.14 nfs component tests

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 markers =
+    zstream_4_20_14_nfs: z-stream 4.20.14 nfs component tests
     zstream_4_20_14_monitoring: z-stream 4.20.14 monitoring component tests
     zstream_4_20_14: z-stream 4.20.14 test enablement
     run_this: testing marker for run this test, useful for development

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 markers =
+    zstream_4_20_14: z-stream 4.20.14 test enablement
     run_this: testing marker for run this test, useful for development
     acceptance: marker for acceptance tests
     tier0: marker for tier0 tests

--- a/tests/cross_functional/ui/test_create_pool_block_pool.py
+++ b/tests/cross_functional/ui/test_create_pool_block_pool.py
@@ -10,6 +10,8 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_disconnected_cluster,
     green_squad,
     jira,
+    zstream_4_20_14,
+    zstream_4_20_14_odf_console,
 )
 from ocs_ci.framework.testlib import skipif_ocs_version, ManageTest, ui
 from ocs_ci.ocs.exceptions import (
@@ -51,6 +53,8 @@ need_to_delete = []
 )
 @skipif_hci_provider_or_client
 @jira("DFBUGS-4385")
+@zstream_4_20_14
+@zstream_4_20_14_odf_console
 class TestPoolUserInterface(ManageTest):
     """
     Test Pool User Interface

--- a/tests/functional/disaster-recovery/metro-dr/test_replace_cluster.py
+++ b/tests/functional/disaster-recovery/metro-dr/test_replace_cluster.py
@@ -4,7 +4,7 @@ import time
 
 from concurrent.futures import ThreadPoolExecutor
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import turquoise_squad, mdr, tier4a
+from ocs_ci.framework.pytest_customization.marks import turquoise_squad, mdr, tier4a, zstream_4_20_14, zstream_4_20_14_disaster_recovery
 from ocs_ci.helpers.dr_helpers import get_active_acm_index
 from ocs_ci.ocs.node import get_node_objs
 from ocs_ci.ocs.dr.dr_workload import validate_data_integrity
@@ -31,6 +31,8 @@ logger = logging.getLogger(__name__)
 @mdr
 @tier4a
 @turquoise_squad
+@zstream_4_20_14
+@zstream_4_20_14_disaster_recovery
 class TestReplaceCluster:
     """
     Test for Recovery of replacement cluster

--- a/tests/functional/disaster-recovery/sc_arbiter/test_device_replacement.py
+++ b/tests/functional/disaster-recovery/sc_arbiter/test_device_replacement.py
@@ -8,6 +8,8 @@ from ocs_ci.framework.pytest_customization.marks import (
     tier4a,
     tier4,
     jira,
+    zstream_4_20_14,
+    zstream_4_20_14_disaster_recovery,
 )
 from ocs_ci.helpers.cnv_helpers import cal_md5sum_vm
 from ocs_ci.helpers.stretchcluster_helper import (
@@ -27,6 +29,8 @@ logger = logging.getLogger(__name__)
 @stretchcluster_required
 @turquoise_squad
 @jira("DFBUGS-1273")
+@zstream_4_20_14
+@zstream_4_20_14_disaster_recovery
 class TestDeviceReplacementInStretchCluster:
 
     @polarion_id("OCS-5047")

--- a/tests/functional/monitoring/prometheus/alerts/test_ceph.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_ceph.py
@@ -23,6 +23,7 @@ from ocs_ci.ocs.fiojob import get_timeout
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.resources.pod import get_osd_pods
 from ocs_ci.utility import prometheus
+from ocs_ci.framework.pytest_customization.marks import zstream_4_20_14, zstream_4_20_14_monitoring
 
 log = logging.getLogger(__name__)
 
@@ -33,6 +34,8 @@ log = logging.getLogger(__name__)
 @pytest.mark.polarion_id("OCS-903")
 @skipif_managed_service
 @runs_on_provider
+@zstream_4_20_14
+@zstream_4_20_14_monitoring
 def test_corrupt_pg_alerts(measure_corrupt_pg, threading_lock):
     """
     Test that there are appropriate alerts when Placement group
@@ -134,6 +137,8 @@ def deprecated_test_ceph_health(
 
 
 @runs_on_provider
+@zstream_4_20_14
+@zstream_4_20_14_monitoring
 class TestCephOSDSlowOps(object):
     @pytest.fixture(scope="function")
     def setup(self, request, pod_factory, multi_pvc_factory):

--- a/tests/functional/monitoring/prometheus/metrics/test_monitoring_defaults.py
+++ b/tests/functional/monitoring/prometheus/metrics/test_monitoring_defaults.py
@@ -18,6 +18,8 @@ from ocs_ci.framework.pytest_customization.marks import (
     provider_client_platform_required,
     provider_mode,
     skipif_external_mode,
+    zstream_4_20_14,
+    zstream_4_20_14_monitoring,
 )
 from ocs_ci.framework.testlib import skipif_ocs_version, tier1
 from ocs_ci.ocs import constants, ocp, defaults
@@ -39,6 +41,8 @@ logger = logging.getLogger(__name__)
 @pytest.mark.polarion_id("OCS-1261")
 @skipif_managed_service
 @runs_on_provider
+@zstream_4_20_14
+@zstream_4_20_14_monitoring
 def test_monitoring_enabled(threading_lock):
     """
     OCS Monitoring is enabled after OCS installation (which is why this test
@@ -90,6 +94,8 @@ def test_monitoring_enabled(threading_lock):
 @pytest.mark.polarion_id("OCS-1265")
 @skipif_managed_service
 @runs_on_provider
+@zstream_4_20_14
+@zstream_4_20_14_monitoring
 def test_ceph_mgr_dashboard_not_deployed():
     """
     Check that `ceph mgr dashboard`_ is not deployed after installation of OCS
@@ -130,6 +136,8 @@ def test_ceph_mgr_dashboard_not_deployed():
 @pytest.mark.polarion_id("OCS-1267")
 @skipif_managed_service
 @runs_on_provider
+@zstream_4_20_14
+@zstream_4_20_14_monitoring
 def test_ceph_rbd_metrics_available(threading_lock):
     """
     Ceph RBD metrics should be provided via OCP Prometheus as well.
@@ -155,6 +163,8 @@ def test_ceph_rbd_metrics_available(threading_lock):
 @pytest.mark.polarion_id("OCS-1268")
 @skipif_managed_service
 @runs_on_provider
+@zstream_4_20_14
+@zstream_4_20_14_monitoring
 def test_ceph_metrics_available(threading_lock):
     """
     Ceph metrics as listed in KNIP-634 should be provided via OCP Prometheus.
@@ -189,6 +199,8 @@ def test_ceph_metrics_available(threading_lock):
 @pytest.mark.polarion_id("OCS-1302")
 @skipif_managed_service
 @runs_on_provider
+@zstream_4_20_14
+@zstream_4_20_14_monitoring
 def test_monitoring_reporting_ok_when_idle(workload_idle, threading_lock):
     """
     When nothing is happening, OCP Prometheus reports OCS status as OK.
@@ -272,6 +284,8 @@ def test_monitoring_reporting_ok_when_idle(workload_idle, threading_lock):
 @runs_on_provider
 @provider_client_platform_required
 @pytest.mark.polarion_id("OCS-5204")
+@zstream_4_20_14
+@zstream_4_20_14_monitoring
 def test_provider_metrics_available(threading_lock):
     """
     Metrics added in provider-client mode should be provided via OCP Prometheus on provider.
@@ -291,6 +305,8 @@ def test_provider_metrics_available(threading_lock):
 @tier1
 @skipif_external_mode
 @pytest.mark.polarion_id("OCS-6796")
+@zstream_4_20_14
+@zstream_4_20_14_monitoring
 def test_monitoring_ip_connectivity(threading_lock):
     """
     Procedure:

--- a/tests/functional/monitoring/prometheus/metrics/test_rgw.py
+++ b/tests/functional/monitoring/prometheus/metrics/test_rgw.py
@@ -9,7 +9,7 @@ import logging
 import pytest
 
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import blue_squad
+from ocs_ci.framework.pytest_customization.marks import blue_squad, zstream_4_20_14, zstream_4_20_14_monitoring
 from ocs_ci.framework.testlib import (
     skipif_managed_service,
     runs_on_provider,
@@ -31,6 +31,8 @@ logger = logging.getLogger(__name__)
 @pytest.mark.polarion_id("OCS-2385")
 @skipif_managed_service
 @runs_on_provider
+@zstream_4_20_14
+@zstream_4_20_14_monitoring
 def test_ceph_rgw_metrics_after_metrics_exporter_respin(
     rgw_deployments, threading_lock
 ):

--- a/tests/functional/nfs_feature/test_nfs_feature_enable_for_ODF_clusters.py
+++ b/tests/functional/nfs_feature/test_nfs_feature_enable_for_ODF_clusters.py
@@ -17,6 +17,8 @@ from ocs_ci.framework.pytest_customization.marks import (
     brown_squad,
     skipif_rosa_hcp,
     skipif_lean_deployment,
+    zstream_4_20_14,
+    zstream_4_20_14_nfs,
 )
 from ocs_ci.framework.testlib import (
     skipif_ocs_version,
@@ -60,6 +62,8 @@ ERRMSG = "Error in command"
 @skip_for_provider_or_client_if_ocs_version("<4.19")
 @skipif_lean_deployment
 @polarion_id("OCS-4270")
+@zstream_4_20_14
+@zstream_4_20_14_nfs
 class TestDefaultNfsDisabled(ManageTest):
     """
     Test nfs feature enable for ODF 4.11

--- a/tests/functional/object/mcg/test_bucket_notifications.py
+++ b/tests/functional/object/mcg/test_bucket_notifications.py
@@ -33,6 +33,7 @@ from ocs_ci.ocs.exceptions import TimeoutExpiredError
 from ocs_ci.ocs.resources.bucket_notifications_manager import BucketNotificationsManager
 from ocs_ci.ocs.resources.mcg_lifecycle_policies import ExpirationRule, LifecyclePolicy
 from ocs_ci.utility.utils import TimeoutSampler
+from ocs_ci.framework.pytest_customization.marks import zstream_4_20_14, zstream_4_20_14_mcg
 
 logger = logging.getLogger(__name__)
 
@@ -44,6 +45,8 @@ logger = logging.getLogger(__name__)
 @skipif_external_mode
 @skipif_proxy_cluster
 @ignore_leftover_label(constants.CUSTOM_MCG_LABEL)
+@zstream_4_20_14
+@zstream_4_20_14_mcg
 class TestBucketNotifications(MCGTest):
     """
     Test the MCG bucket notifications feature

--- a/tests/functional/object/mcg/test_bucketclass.py
+++ b/tests/functional/object/mcg/test_bucketclass.py
@@ -6,6 +6,8 @@ from ocs_ci.framework.pytest_customization.marks import (
     red_squad,
     polarion_id,
     tier2,
+    zstream_4_20_14,
+    zstream_4_20_14_mcg,
 )
 from ocs_ci.framework import config
 from ocs_ci.ocs import constants
@@ -18,6 +20,8 @@ logger = logging.getLogger(__name__)
 
 @mcg
 @red_squad
+@zstream_4_20_14
+@zstream_4_20_14_mcg
 class TestBucketClass:
 
     @tier2

--- a/tests/functional/object/mcg/test_loadbalancer_subnet_config.py
+++ b/tests/functional/object/mcg/test_loadbalancer_subnet_config.py
@@ -12,6 +12,8 @@ from ocs_ci.framework.pytest_customization.marks import (
     polarion_id,
     red_squad,
     tier2,
+    zstream_4_20_14,
+    zstream_4_20_14_mcg,
 )
 from ocs_ci.framework.testlib import MCGTest
 from ocs_ci.ocs.exceptions import CommandFailed
@@ -24,6 +26,8 @@ logger = logging.getLogger(__name__)
 @mcg
 @red_squad
 @aws_platform_required
+@zstream_4_20_14
+@zstream_4_20_14_mcg
 class TestLBSubnetConfig(MCGTest):
 
     @tier2

--- a/tests/functional/object/mcg/test_multi_region.py
+++ b/tests/functional/object/mcg/test_multi_region.py
@@ -14,6 +14,8 @@ from ocs_ci.framework.pytest_customization.marks import (
     runs_on_provider,
     mcg,
     tier2,
+    zstream_4_20_14,
+    zstream_4_20_14_mcg,
 )
 from ocs_ci.framework.testlib import MCGTest
 from ocs_ci.ocs import ocp, constants
@@ -35,6 +37,8 @@ logger = logging.getLogger(__name__)
 @skipif_disconnected_cluster
 @skipif_aws_creds_are_missing
 @runs_on_provider
+@zstream_4_20_14
+@zstream_4_20_14_mcg
 class TestMultiRegion(MCGTest):
     """
     Test the multi region functionality

--- a/tests/functional/odf-cli/test_debug_verbocity_of_ceph_component.py
+++ b/tests/functional/odf-cli/test_debug_verbocity_of_ceph_component.py
@@ -2,7 +2,7 @@ import pytest
 import logging
 
 from ocs_ci.helpers.helpers import get_ceph_log_level
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, zstream_4_20_14, zstream_4_20_14_odf_cli
 from ocs_ci.ocs.exceptions import CommandFailed
 from ocs_ci.framework.testlib import tier2, skipif_kms_deployment, skipif_external_mode
 
@@ -13,6 +13,8 @@ log = logging.getLogger(__name__)
 @tier2
 @skipif_kms_deployment
 @skipif_external_mode
+@zstream_4_20_14
+@zstream_4_20_14_odf_cli
 class TestDebugVerbosityOfCephComponents:
     @pytest.fixture(autouse=True)
     def setup(self, odf_cli_setup):

--- a/tests/functional/pv/pv_services/test_cephfs_fsync_consistency.py
+++ b/tests/functional/pv/pv_services/test_cephfs_fsync_consistency.py
@@ -5,6 +5,7 @@ from ocs_ci.framework.testlib import ManageTest, tier1, green_squad, polarion_id
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.ocp import exec_cmd
 from ocs_ci.ocs.node import get_worker_nodes
+from ocs_ci.framework.pytest_customization.marks import zstream_4_20_14, zstream_4_20_14_ceph_csi
 
 
 logger = logging.getLogger(__name__)
@@ -13,6 +14,8 @@ logger = logging.getLogger(__name__)
 @tier1
 @green_squad
 @polarion_id("OCS-6797")
+@zstream_4_20_14
+@zstream_4_20_14_ceph_csi
 class TestCephfsFsyncConsistency(ManageTest):
     """
     Ensuring File Completeness Post-fsync with Shared CephFS Volume

--- a/tests/functional/pv/pvc_clone/test_pvc_to_pvc_clone.py
+++ b/tests/functional/pv/pvc_clone/test_pvc_to_pvc_clone.py
@@ -7,6 +7,8 @@ from ocs_ci.framework.pytest_customization.marks import (
     jira,
     provider_mode,
     run_on_all_clients_push_missing_configs,
+    zstream_4_20_14,
+    zstream_4_20_14_ceph_csi,
 )
 from ocs_ci.framework.pytest_customization.marks import skipif_hci_provider_and_client
 from ocs_ci.framework.testlib import (
@@ -28,6 +30,8 @@ logger = logging.getLogger(__name__)
 @green_squad
 @skipif_ocs_version("<4.9")
 @skipif_ocp_version("<4.9")
+@zstream_4_20_14
+@zstream_4_20_14_ceph_csi
 class TestClone(ManageTest):
     """
     Tests to verify PVC to PVC clone feature

--- a/tests/functional/storageclass/test_cephfilesystem_creation.py
+++ b/tests/functional/storageclass/test_cephfilesystem_creation.py
@@ -7,11 +7,13 @@ from ocs_ci.helpers.helpers import (
 from ocs_ci.ocs.exceptions import CommandFailed
 import ocs_ci.ocs.resources.pod as pod
 from ocs_ci.framework.testlib import ManageTest
-from ocs_ci.framework.pytest_customization.marks import green_squad
+from ocs_ci.framework.pytest_customization.marks import green_squad, zstream_4_20_14, zstream_4_20_14_ceph_csi
 
 logger = logging.getLogger(__name__)
 
 
+@zstream_4_20_14
+@zstream_4_20_14_ceph_csi
 class TestCephFileSystemCreation(ManageTest):
     """
     Testing Creation of a filesystem and checking its existence.

--- a/tests/functional/storageclass/test_csi_subvolume_group_property.py
+++ b/tests/functional/storageclass/test_csi_subvolume_group_property.py
@@ -2,7 +2,7 @@ import logging
 
 from ocs_ci.framework import config
 from ocs_ci.framework.testlib import ManageTest, tier2, skipif_external_mode
-from ocs_ci.framework.pytest_customization.marks import green_squad, jira, polarion_id
+from ocs_ci.framework.pytest_customization.marks import green_squad, jira, polarion_id, zstream_4_20_14, zstream_4_20_14_ceph_csi
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.ocp import OCP
 
@@ -12,6 +12,8 @@ logger = logging.getLogger(__name__)
 @green_squad
 @skipif_external_mode
 @tier2
+@zstream_4_20_14
+@zstream_4_20_14_ceph_csi
 class TestCSISubvolumeGroup(ManageTest):
     @jira("DFBUGS-2759")
     @polarion_id("OCS-5740")

--- a/tests/functional/upgrade/test_storagecluster_upgrade_params.py
+++ b/tests/functional/upgrade/test_storagecluster_upgrade_params.py
@@ -13,6 +13,7 @@ from ocs_ci.framework.testlib import (
     skipif_external_mode,
     brown_squad,
 )
+from ocs_ci.framework.pytest_customization.marks import zstream_4_20_14, zstream_4_20_14_upgrade
 
 logger = logging.getLogger(__name__)
 
@@ -21,6 +22,8 @@ logger = logging.getLogger(__name__)
 @brown_squad
 @skipif_external_mode
 @pytest.mark.polarion_id("OCS-6225")
+@zstream_4_20_14
+@zstream_4_20_14_upgrade
 class TestStorageclusterUpgradeParams(ManageTest):
     """
     Verify the upgrade storagecluster parameters move to cephcluster

--- a/tests/functional/workloads/cnv/test_cnv_device_replacement.py
+++ b/tests/functional/workloads/cnv/test_cnv_device_replacement.py
@@ -7,6 +7,8 @@ from ocs_ci.framework.pytest_customization.marks import (
     workloads,
     magenta_squad,
     skipif_external_mode,
+    zstream_4_20_14,
+    zstream_4_20_14_odf_dr_multicluster_orchestrator,
 )
 from ocs_ci.helpers.cnv_helpers import cal_md5sum_vm, run_dd_io
 from ocs_ci.ocs import constants
@@ -23,6 +25,8 @@ logger = logging.getLogger(__name__)
 @workloads
 @skipif_external_mode
 @ignore_leftovers
+@zstream_4_20_14
+@zstream_4_20_14_odf_dr_multicluster_orchestrator
 class TestCnvDeviceReplace(E2ETest):
     """
     Test case for Device replacement

--- a/tests/functional/workloads/cnv/test_cnv_node_replacement.py
+++ b/tests/functional/workloads/cnv/test_cnv_node_replacement.py
@@ -9,6 +9,8 @@ from ocs_ci.framework.pytest_customization.marks import (
     ignore_leftovers,
     skipif_external_mode,
     skipif_bm,
+    zstream_4_20_14,
+    zstream_4_20_14_ocs_operator,
 )
 from ocs_ci.helpers.cnv_helpers import cal_md5sum_vm, run_dd_io
 from ocs_ci.ocs import constants
@@ -29,6 +31,8 @@ logger = logging.getLogger(__name__)
 @ignore_leftovers
 @skipif_bm
 @skipif_external_mode
+@zstream_4_20_14
+@zstream_4_20_14_ocs_operator
 class TestCnvNodeReplace(E2ETest):
     """
     Node replacement proactive

--- a/tests/functional/z_cluster/nodes/test_node_replacement_proactive.py
+++ b/tests/functional/z_cluster/nodes/test_node_replacement_proactive.py
@@ -23,6 +23,8 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_hci_client,
     brown_squad,
     skipif_ibm_cloud_managed,
+    zstream_4_20_14,
+    zstream_4_20_14_ocs_operator,
 )
 from ocs_ci.helpers.helpers import (
     verify_storagecluster_nodetopology,
@@ -196,6 +198,8 @@ def delete_and_create_osd_node(osd_node_name):
 @skipif_hci_provider_and_client
 @skipif_bmpsi
 @skipif_external_mode
+@zstream_4_20_14
+@zstream_4_20_14_ocs_operator
 class TestNodeReplacementWithIO(ManageTest):
     """
     Knip-894 Node replacement proactive with IO
@@ -280,6 +284,8 @@ class TestNodeReplacementWithIO(ManageTest):
 @skipif_external_mode
 @skipif_ms_consumer
 @skipif_hci_client
+@zstream_4_20_14
+@zstream_4_20_14_ocs_operator
 class TestNodeReplacement(ManageTest):
     """
     Knip-894 Node replacement proactive
@@ -336,6 +342,8 @@ class TestNodeReplacement(ManageTest):
 @skipif_external_mode
 @skipif_managed_service
 @skipif_hci_provider_and_client
+@zstream_4_20_14
+@zstream_4_20_14_ocs_operator
 class TestNodeReplacementTwice(ManageTest):
     """
     Node replacement twice:

--- a/tests/functional/z_cluster/nodes/test_node_replacement_reactive_aws_ipi.py
+++ b/tests/functional/z_cluster/nodes/test_node_replacement_reactive_aws_ipi.py
@@ -1,7 +1,7 @@
 import logging
 import pytest
 
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, zstream_4_20_14, zstream_4_20_14_ocs_operator
 from ocs_ci.framework.testlib import (
     tier4a,
     ManageTest,
@@ -34,6 +34,8 @@ log = logging.getLogger(__name__)
 @tier4a
 @aws_based_platform_required
 @ipi_deployment_required
+@zstream_4_20_14
+@zstream_4_20_14_ocs_operator
 class TestNodeReplacement(ManageTest):
     """
     Knip-894 Node replacement - AWS-IPI-Reactive

--- a/tests/functional/z_cluster/nodes/test_nodes_restart_hci.py
+++ b/tests/functional/z_cluster/nodes/test_nodes_restart_hci.py
@@ -3,7 +3,7 @@ import pytest
 import random
 
 
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, zstream_4_20_14, zstream_4_20_14_ocs_operator
 from ocs_ci.framework.testlib import (
     tier4a,
     tier4b,
@@ -48,6 +48,8 @@ logger = logging.getLogger(__name__)
 @brown_squad
 @ignore_leftovers
 @provider_client_platform_required
+@zstream_4_20_14
+@zstream_4_20_14_ocs_operator
 class TestNodesRestartHCI(ManageTest):
     """
     Test nodes restart scenarios when using HCI platform

--- a/tests/functional/z_cluster/nodes/test_non_ocs_taint_and_toleration.py
+++ b/tests/functional/z_cluster/nodes/test_non_ocs_taint_and_toleration.py
@@ -41,6 +41,8 @@ from ocs_ci.utility.retry import retry
 from ocs_ci.ocs.resources import storage_cluster
 from ocs_ci.framework.pytest_customization.marks import (
     brown_squad,
+    zstream_4_20_14,
+    zstream_4_20_14_ocs_operator,
 )
 from ocs_ci.helpers.sanity_helpers import Sanity
 from tests.functional.z_cluster.nodes.test_node_replacement_proactive import (
@@ -67,6 +69,8 @@ def verify_pod_count_unchanged(number_of_pods_before):
 @skipif_tainted_nodes
 @skipif_managed_service
 @skipif_hci_provider_and_client
+@zstream_4_20_14
+@zstream_4_20_14_ocs_operator
 class TestNonOCSTaintAndTolerations(E2ETest):
     """
     Test to test non ocs taints on ocs nodes

--- a/tests/functional/z_cluster/test_add_mds_to_cluster.py
+++ b/tests/functional/z_cluster/test_add_mds_to_cluster.py
@@ -8,7 +8,7 @@ import pytest
 
 from ocs_ci.ocs import constants, defaults, ocp
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, zstream_4_20_14, zstream_4_20_14_rook
 from ocs_ci.framework.testlib import ManageTest
 from ocs_ci.ocs.resources.ocs import OCS
 from ocs_ci.utility.utils import TimeoutSampler
@@ -76,6 +76,8 @@ def get_mds_active_count():
 # @tier1
 # Test case is disabled, as per requirement not to support this scenario
 @brown_squad
+@zstream_4_20_14
+@zstream_4_20_14_rook
 class TestCephFilesystemCreation(ManageTest):
     """
     Testing creation of Ceph FileSystem

--- a/tests/functional/z_cluster/test_mon_healthcheck_passthrough.py
+++ b/tests/functional/z_cluster/test_mon_healthcheck_passthrough.py
@@ -11,6 +11,7 @@ from ocs_ci.framework.testlib import (
 )
 from ocs_ci.ocs import constants, ocp
 from ocs_ci.utility.utils import TimeoutSampler
+from ocs_ci.framework.pytest_customization.marks import zstream_4_20_14, zstream_4_20_14_ocs_operator
 
 logger = logging.getLogger(__name__)
 
@@ -85,6 +86,8 @@ def _healthcheck_matches(actual, desired):
 @brown_squad
 @skipif_external_mode
 @pytest.mark.polarion_id("OCS-7403")
+@zstream_4_20_14
+@zstream_4_20_14_ocs_operator
 class TestMonHealthcheckPassthrough(ManageTest):
     """
     Verify StorageCluster.spec.managedResources.cephCluster.healthCheck.daemonHealth.mon

--- a/tests/functional/z_cluster/test_multiple_mds.py
+++ b/tests/functional/z_cluster/test_multiple_mds.py
@@ -12,6 +12,8 @@ from ocs_ci.framework.pytest_customization.marks import (
     tier4c,
     skipif_external_mode,
     skipif_hci_client,
+    zstream_4_20_14,
+    zstream_4_20_14_rook,
 )
 from ocs_ci.framework import config
 from ocs_ci.helpers import helpers
@@ -52,6 +54,8 @@ def verify_active_and_standby_mds_count(target_count):
 @tier4c
 @skipif_external_mode
 @skipif_hci_client
+@zstream_4_20_14
+@zstream_4_20_14_rook
 class TestMultipleMds:
     """
     Tests for support multiple mds


### PR DESCRIPTION
# Z-Stream Test Enablement: ODF 4.20.14

## Summary

This PR enables automated testing for ODF z-stream release **4.20.14**, validating 21 backported fixes and improvements across multiple components including MCG/NooBaa, Ceph CSI, OCS Operator, Rook, Disaster Recovery, and ODF Console.

## Test Coverage

- **Tests Enabled**: 62 test functions
- **Components Covered**: MCG, Ceph CSI, OCS Operator, Rook, Disaster Recovery, Must-Gather, ODF Console, ODF CLI
- **Primary Test Areas**: 
  - NFS feature enablement and exports (15 tests)
  - Monitoring and metrics validation
  - Disaster recovery and metro-DR scenarios
  - CephFS consistency and performance
  - Alert validation

## Changes Validated

### MCG/NooBaa (6 fixes)
| ID | Summary |
|----|---------|
| [DFBUGS-7079](https://redhat.atlassian.net/browse/DFBUGS-7079) | NooBaa upgrade failure due to remove_mongo_pool.js error |
| [DFBUGS-6846](https://redhat.atlassian.net/browse/DFBUGS-6846) | Intermittent S3 upload failures (HTTP 500) via JFrog Artifactory |
| [DFBUGS-6872](https://redhat.atlassian.net/browse/DFBUGS-6872) | INVALID_SCHEMA_REPLY SERVER after upgrading ODF to 4.21 |
| [DFBUGS-7045](https://redhat.atlassian.net/browse/DFBUGS-7045) | Update nodejs from v22.11.0 to v24.13.0 |
| [DFBUGS-6740](https://redhat.atlassian.net/browse/DFBUGS-6740) | NooBaa-endpoint crashes with AbortError from @azure/storage-blob |
| [DFBUGS-6176](https://redhat.atlassian.net/browse/DFBUGS-6176) | NooBaa POD failing with IBM KeyProtect clusterwide encryption |

### OCS Operator (4 fixes)
| ID | Summary |
|----|---------|
| [DFBUGS-6533](https://redhat.atlassian.net/browse/DFBUGS-6533) | Missing default tolerations |
| [DFBUGS-6541](https://redhat.atlassian.net/browse/DFBUGS-6541) | Provider Server sub channel delivery timing issue |
| [DFBUGS-6531](https://redhat.atlassian.net/browse/DFBUGS-6531) | Missing toleration for node.ocs.openshift.io/storage in rbd-mirror |
| [DFBUGS-5746](https://redhat.atlassian.net/browse/DFBUGS-5746) | Ceph PVC provisioning/mounting issues after v4.20 upgrade |

### Rook (3 fixes)
| ID | Summary |
|----|---------|
| [DFBUGS-7066](https://redhat.atlassian.net/browse/DFBUGS-7066) | RHODF 4.20.14 release |
| [DFBUGS-7016](https://redhat.atlassian.net/browse/DFBUGS-7016) | Upgrade ceph version to RHCEPH-8.1z6 |
| [DFBUGS-6705](https://redhat.atlassian.net/browse/DFBUGS-6705) | Unnecessary OSD redeployments on 4.19.z upgrade for encrypted OSDs |

### ODF Console (2 fixes)
| ID | Summary |
|----|---------|
| [DFBUGS-7104](https://redhat.atlassian.net/browse/DFBUGS-7104) | ODF Console breaking issue |
| [DFBUGS-6953](https://redhat.atlassian.net/browse/DFBUGS-6953) | Security: Upgrade on-headers and undici (CVE-2025-7339, CVE-2026-22036) |

### Disaster Recovery (2 fixes)
| ID | Summary |
|----|---------|
| [DFBUGS-6460](https://redhat.atlassian.net/browse/DFBUGS-6460) | Partial s3StoreProfile missing after hub upgrade 4.17→4.18 |
| PR-401 | Remove GenerationChangedPredicate from S3 controller for OBC status changes |

### Security Fixes (2 fixes)
| ID | Summary |
|----|---------|
| [DFBUGS-6098](https://redhat.atlassian.net/browse/DFBUGS-6098) | CVE-2026-33186: gRPC-Go authorization bypass |
| [DFBUGS-6953](https://redhat.atlassian.net/browse/DFBUGS-6953) | CVE-2025-7339, CVE-2026-22036: on-headers and undici vulnerabilities |

### Other Components
| ID | Component | Summary |
|----|-----------|---------|
| [DFBUGS-6487](https://redhat.atlassian.net/browse/DFBUGS-6487) | must-gather | Rook-ceph-exporter log causes huge must-gather size |
| [DFBUGS-6673](https://redhat.atlassian.net/browse/DFBUGS-6673) | ceph-csi | Random pod delete causes csi-addons container restart |
| PR-297 | odf-cli | Update gRPC and networking dependencies |

## Top Test Coverage

High-priority tests enabled include:
- **NFS Feature Validation**: 15 tests covering default state, enablement, in-cluster/out-cluster exports, multi-mount scenarios, and resiliency
- **Monitoring & Metrics**: IP connectivity validation, corrupt PG alerts, slow OSD operations
- **Disaster Recovery**: Metro-DR cluster replacement, stretch cluster device replacement
- **CephFS**: Fsync consistency validation

## Verification

All 62 tests have been marked for execution against the 4.20.14 z-stream builds to ensure regression-free delivery of these critical fixes.