### PR TITLE
improve vsphere-cleanup script for IPI destroy

### DIFF
--- a/ocs_ci/cleanup/vsphere/cleanup.py
+++ b/ocs_ci/cleanup/vsphere/cleanup.py
@@ -87,7 +87,10 @@ def delete_ipi_nodes(vsphere, cluster_name):
     vms_ipi = []
     for vm in vms_dc:
         try:
-            if cluster_name in vm.name and "generated-zone" not in vm.name:
+            if (
+                vm.name.startswith(f"{cluster_name}-")
+                and "generated-zone" not in vm.name
+            ):
                 vms_ipi.append(vm)
                 logger.info(vm.name)
         except vmodl.fault.ManagedObjectNotFound as e:


### PR DESCRIPTION
Signed-off-by: vavuthu [vavuthu@redhat.com](mailto:vavuthu@redhat.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VM cleanup targeting so only cluster-specific VMs are selected for deletion.
  * Reduced the chance of accidentally including unrelated VMs during cleanup while still excluding generated-zone entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->