### PR TITLE
Fix odf noobaa CLI namespace flag placement for non-openshift-storage namespaces

### DIFF
--- a/ocs_ci/helpers/odf_cli.py
+++ b/ocs_ci/helpers/odf_cli.py
@@ -326,6 +326,8 @@ class ODFCliRunner:
             noobaa_cmd = " ".join(["noobaa"] + command_args)
 
         ns = namespace or config.ENV_DATA["cluster_namespace"]
+        # -n is required on both the odf binary (to avoid defaulting to
+        # openshift-storage) and the noobaa subcommand itself.
         noobaa_cmd += f" -n {ns}"
         full_command = f"{self.binary_name} -n {ns} {noobaa_cmd}"
 

--- a/ocs_ci/helpers/odf_cli.py
+++ b/ocs_ci/helpers/odf_cli.py
@@ -325,14 +325,9 @@ class ODFCliRunner:
         else:
             noobaa_cmd = " ".join(["noobaa"] + command_args)
 
-        # Add namespace if provided (will override the default one in run_command)
-        if namespace:
-            noobaa_cmd += f" -n {namespace}"
-            # Don't let run_command add its default namespace
-            full_command = f"{self.binary_name} {noobaa_cmd}"
-        else:
-            # Let run_command add the default namespace
-            full_command = f"{self.binary_name} -n {config.ENV_DATA['cluster_namespace']} {noobaa_cmd}"
+        ns = namespace or config.ENV_DATA["cluster_namespace"]
+        noobaa_cmd += f" -n {ns}"
+        full_command = f"{self.binary_name} -n {ns} {noobaa_cmd}"
 
         # Execute with appropriate method based on use_yes
         if use_yes:


### PR DESCRIPTION
## Summary

- Fix `-n` flag placement in `ODFCliRunner.run_noobaa()` so the `odf` binary receives the namespace before the `noobaa` subcommand
- Previously the flag was appended after the noobaa args, causing the `odf` binary to default to `openshift-storage`
- On ROSA HCP (namespace `odf-storage`), this broke every NooBaa CLI operation

## Changes

**Before** (broken on ROSA HCP):
```
odf noobaa status -n odf-storage
# odf binary doesn't see -n, defaults to openshift-storage, fails
```

**After** (works on all platforms):
```
odf -n odf-storage noobaa status -n odf-storage
# odf binary sees -n before subcommand, noobaa subcommand also gets -n
```

Closes #15616

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed namespace handling for storage-related CLI executions so the chosen namespace is applied consistently across all command paths.
  * Improved reliability by ensuring the namespace flag is included uniformly, reducing unpredictable behavior when running these operations with or without an explicitly provided namespace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->