### PR TITLE
Fix HTTP 504 timeout handling in OCP upgrade graph API

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -645,7 +645,7 @@
         "hashed_secret": "a12337323b638ab044b1166bff4b1a1f83162819",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 857,
+        "line_number": 855,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -653,7 +653,7 @@
         "hashed_secret": "fb947972c92f052c0a08866d182be0075a2b601b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 866,
+        "line_number": 864,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -661,7 +661,7 @@
         "hashed_secret": "03e227627ab8681281fdb8aa3d799b03f782d672",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2077,
+        "line_number": 2060,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -669,7 +669,7 @@
         "hashed_secret": "ef5f3d909f23bd0aa02b4253f98350384f709c86",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2184,
+        "line_number": 2167,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -677,7 +677,7 @@
         "hashed_secret": "cb1ae2b504c4615841d8144267a131231d2bd677",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2185,
+        "line_number": 2168,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -685,7 +685,7 @@
         "hashed_secret": "1a1e70e87dd0452c42f33ce9bf74aa28134dba6b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2186,
+        "line_number": 2169,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -693,7 +693,7 @@
         "hashed_secret": "7b1ba2f04f2f1604dc4e3caffcadf9fcbce7df5b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2187,
+        "line_number": 2170,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -701,7 +701,7 @@
         "hashed_secret": "0fa3b21ced80146d752888f2b60ec80e0d4b8925",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2199,
+        "line_number": 2182,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -709,7 +709,7 @@
         "hashed_secret": "f084f2068494b8d1cd06811dd97d02c3d85f40ee",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2214,
+        "line_number": 2197,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -717,7 +717,7 @@
         "hashed_secret": "adfa401a3b0a733d8f00519ac8c6b3893a2e7e8e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2215,
+        "line_number": 2198,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -725,7 +725,7 @@
         "hashed_secret": "898e46bbadc12f87120548bd445eb4210c8407c8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2223,
+        "line_number": 2206,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -733,7 +733,7 @@
         "hashed_secret": "f57ccec6b8f7b12b635ab53d26c3bf7300247341",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2224,
+        "line_number": 2207,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -741,7 +741,7 @@
         "hashed_secret": "77b044ea736f8cbe568d1954424186d901f89db9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2225,
+        "line_number": 2208,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -749,7 +749,7 @@
         "hashed_secret": "d64368f12ca17c69568c6a132f17d44d56e60660",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2226,
+        "line_number": 2209,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -757,7 +757,7 @@
         "hashed_secret": "8f9ca35156c02cb6ba58c5b51230b9bedc38de4f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2227,
+        "line_number": 2210,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -765,7 +765,7 @@
         "hashed_secret": "9ec53cfd9929c70c3f87c210b6a7b77fb6d79d43",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2824,
+        "line_number": 2807,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -773,7 +773,7 @@
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2990,
+        "line_number": 2972,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -781,7 +781,7 @@
         "hashed_secret": "adc1f5c8707f7d7aba3aabe13c15e5ef1151872e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2991,
+        "line_number": 2973,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -789,7 +789,7 @@
         "hashed_secret": "ee46262b2df945e46ea310b925ad087465dbd3f2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3740,
+        "line_number": 3694,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -797,7 +797,7 @@
         "hashed_secret": "f678cad4ab874d71b559a069d5e34a95fe38a480",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3741,
+        "line_number": 3695,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/ocs_ci/deployment/helpers/lso_helpers.py
+++ b/ocs_ci/deployment/helpers/lso_helpers.py
@@ -21,7 +21,7 @@ from ocs_ci.ocs.node import (
     get_master_nodes,
 )
 from ocs_ci.utility import templating, version
-from ocs_ci.utility.deployment import get_ocp_ga_version
+from ocs_ci.utility.version import get_ocp_ga_version
 from ocs_ci.utility.operators import LocalStorageOperator
 from ocs_ci.utility.localstorage import get_lso_channel
 from ocs_ci.utility.retry import retry

--- a/ocs_ci/deployment/hub_spoke.py
+++ b/ocs_ci/deployment/hub_spoke.py
@@ -75,7 +75,7 @@ from ocs_ci.ocs.resources.storageconsumer import (
 from ocs_ci.ocs.utils import get_pod_name_by_pattern
 from ocs_ci.ocs.version import if_version
 from ocs_ci.utility import templating, version
-from ocs_ci.utility.deployment import get_ocp_ga_version
+from ocs_ci.utility.version import get_ocp_ga_version
 from ocs_ci.utility.json import SetToListJSONEncoder
 from ocs_ci.utility.managedservice import generate_onboarding_token
 from ocs_ci.utility.networking import create_drs_machine_config, create_drs_nad

--- a/ocs_ci/deployment/vmware.py
+++ b/ocs_ci/deployment/vmware.py
@@ -113,7 +113,7 @@ from .helpers.hypershift_base import (
 from .hub_spoke import create_agent_service_config, create_patch_provisioning
 from .mce import set_mirror_registry_configmap
 from ..helpers.helpers import change_default_storageclass
-from ..utility.deployment import get_ocp_ga_version
+from ..utility.version import get_ocp_ga_version
 
 logger = logging.getLogger(__name__)
 

--- a/ocs_ci/utility/deployment.py
+++ b/ocs_ci/utility/deployment.py
@@ -14,8 +14,6 @@ from ocs_ci.utility.retry import retry
 
 import yaml
 
-import requests
-
 from ocs_ci.framework import config
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.exceptions import CommandFailed, ExternalClusterDetailsException
@@ -29,36 +27,6 @@ from ocs_ci.utility.utils import (
 )
 
 logger = logging.getLogger(__name__)
-
-
-# TODO: remove this function and use the one in version.py
-def get_ocp_ga_version(channel):
-    """
-    Retrieve the latest GA version for
-
-    Args:
-        channel (str): the OCP version channel to retrieve GA version for
-
-    Returns:
-        str: latest GA version for the provided channel.
-            An empty string is returned if no version exists.
-
-
-    """
-    logger.debug("Retrieving GA version for channel: %s", channel)
-    url = "https://api.openshift.com/api/upgrades_info/v1/graph"
-    headers = {"Accept": "application/json"}
-    payload = {"channel": f"stable-{channel}"}
-    r = requests.get(url, headers=headers, params=payload, timeout=120)
-    nodes = r.json()["nodes"]
-    if nodes:
-        versions = [node["version"] for node in nodes]
-        versions.sort()
-        ga_version = versions[-1]
-        logger.debug("Found GA version: %s", ga_version)
-        return ga_version
-    logger.debug("No GA version found")
-    return ""
 
 
 def create_external_secret(ocs_version=None, apply=False):

--- a/ocs_ci/utility/localstorage.py
+++ b/ocs_ci/utility/localstorage.py
@@ -17,10 +17,9 @@ from ocs_ci.ocs.node import get_nodes
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.resources import csv
 from ocs_ci.ocs.resources.packagemanifest import PackageManifest
-from ocs_ci.utility.deployment import get_ocp_ga_version
+from ocs_ci.utility.version import get_ocp_ga_version, get_semantic_version
 from ocs_ci.utility.retry import retry
 from ocs_ci.utility.utils import clone_repo, get_ocp_version, run_cmd
-from ocs_ci.utility.version import get_semantic_version
 
 logger = logging.getLogger(__name__)
 

--- a/ocs_ci/utility/version.py
+++ b/ocs_ci/utility/version.py
@@ -16,6 +16,7 @@ from ocs_ci.ocs.exceptions import (
     UnsupportedPlatformVersionError,
 )
 from ocs_ci.ocs import constants
+from ocs_ci.utility.retry import retry
 
 log = logging.getLogger(__name__)
 
@@ -150,25 +151,62 @@ def get_ocp_version(seperator=None):
     return char.join([str(version.major), str(version.minor)])
 
 
+@retry(
+    (requests.exceptions.RequestException, json.JSONDecodeError),
+    tries=6,
+    delay=10,
+    backoff=2,
+)
 def get_ocp_ga_version(channel):
     """
-    Retrieve the latest GA version for
+    Retrieve the latest GA version for the given OCP channel.
+
+    This function queries the Red Hat OpenShift upgrade graph API to find
+    the latest GA version. It includes retry logic to handle transient
+    network issues and API timeouts.
 
     Args:
         channel (str): the OCP version channel to retrieve GA version for
 
     Returns:
         str: latest GA version for the provided channel.
-            An empty string is returned if no version exists.
+            An empty string is returned if no version exists or if all retries fail.
 
-
+    Raises:
+        requests.exceptions.RequestException: if the HTTP request fails after all retries
+        json.JSONDecodeError: if the response is not valid JSON after all retries
     """
     log.debug("Retrieving GA version for channel: %s", channel)
     url = "https://api.openshift.com/api/upgrades_info/v1/graph"
     headers = {"Accept": "application/json"}
     payload = {"channel": f"stable-{channel}"}
-    r = requests.get(url, headers=headers, params=payload, timeout=120)
-    nodes = r.json()["nodes"]
+
+    try:
+        r = requests.get(url, headers=headers, params=payload, timeout=120)
+        r.raise_for_status()
+        nodes = r.json()["nodes"]
+    except requests.exceptions.HTTPError as http_err:
+        log.error(
+            f"HTTP error {r.status_code} when retrieving GA version for channel {channel}: {http_err}"
+        )
+        raise
+    except requests.exceptions.Timeout as timeout_err:
+        log.error(
+            f"Timeout when retrieving GA version for channel {channel}: {timeout_err}"
+        )
+        raise
+    except requests.exceptions.RequestException as req_err:
+        log.error(
+            f"Request error when retrieving GA version for channel {channel}: {req_err}"
+        )
+        raise
+    except json.JSONDecodeError as json_err:
+        log.error(
+            f"Invalid JSON response when retrieving GA version for channel {channel}. "
+            f"Response status: {r.status_code}, Response text: {r.text[:200]}, Error: {json_err}"
+        )
+        raise
+
     if nodes:
         versions = [node["version"] for node in nodes]
         versions.sort()


### PR DESCRIPTION
Add retry logic and proper error handling to get_ocp_ga_version() to handle transient API failures and HTTP 504 Gateway Timeout errors.

The function was calling r.json() unconditionally, which caused JSONDecodeError when the Red Hat OpenShift upgrade graph API returned HTTP 504 with plain text "upstream request timeout" instead of JSON.

This was breaking LSO deployments when the external API was unavailable or experiencing issues.

Changes:
- Add @retry decorator with 6 tries, 10s delay, 2x backoff (~5 min total)
- Add r.raise_for_status() to check HTTP status before parsing JSON
- Add comprehensive exception handling for HTTP errors, timeouts, connection errors, and JSON decode errors
- Consolidate duplicate get_ocp_ga_version() implementations:
  * Enhanced version.py implementation with retry logic
  * Removed duplicate from deployment.py
  * Updated all imports to use version.py

Fixes: https://github.com/red-hat-storage/ocs-ci/issues/15592

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when retrieving OpenShift GA version information by adding automatic retries for transient network issues and response parsing errors.
  * Reduced empty or failed version lookups caused by temporary API or invalid-response conditions.
  * Standardized version lookup behavior across different deployment paths to keep results consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->