### PR TITLE
Increase wait_for_nodes_status default timeout to 600s

### DIFF
--- a/ocs_ci/ocs/node.py
+++ b/ocs_ci/ocs/node.py
@@ -328,7 +328,7 @@ def get_all_nodes():
 
 
 def wait_for_nodes_status(
-    node_names=None, status=constants.NODE_READY, timeout=180, sleep=3
+    node_names=None, status=constants.NODE_READY, timeout=600, sleep=3
 ):
     """
     Wait until all nodes are in the given status


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the default timeout for node status checks, giving more time for nodes to reach the requested Kubernetes state before failing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->