### PR TITLE
Deployment timeouts for vSphere

### DIFF
--- a/ocs_ci/deployment/terraform.py
+++ b/ocs_ci/deployment/terraform.py
@@ -89,7 +89,7 @@ class Terraform(object):
             cmd = f"{self.terraform_installer} init {self.path}"
         else:
             cmd = f"{self.terraform_installer} -chdir={self.path} init"
-        run_cmd(cmd, timeout=1200)
+        run_cmd(cmd, timeout=2400)
 
     def apply(self, tfvars, bootstrap_complete=False, module=None, refresh=True):
         """
@@ -121,7 +121,7 @@ class Terraform(object):
             f" -auto-approve {bootstrap_complete_param} {dir_path}"
         )
 
-        run_cmd(cmd, timeout=1500)
+        run_cmd(cmd, timeout=3000)
 
     def destroy(self, tfvars, refresh=True):
         """
@@ -143,7 +143,7 @@ class Terraform(object):
             f"{self.terraform_installer} {chdir_param} destroy {refresh_param}"
             f" {self.state_file_param} '-var-file={tfvars}' -auto-approve {dir_path}"
         )
-        run_cmd(cmd, timeout=1200)
+        run_cmd(cmd, timeout=2400)
 
     def output(self, tfstate, module, json_format=True):
         """
@@ -187,7 +187,7 @@ class Terraform(object):
             f"{self.terraform_installer} {chdir_param} destroy -auto-approve "
             f" -target={module} {self.state_file_param} '-var-file={tfvars}' {dir_path}"
         )
-        run_cmd(cmd, timeout=1200)
+        run_cmd(cmd, timeout=2400)
 
     def change_statefile(self, module, vm_index):
         """

--- a/ocs_ci/deployment/vmware.py
+++ b/ocs_ci/deployment/vmware.py
@@ -275,7 +275,7 @@ class VSPHEREBASE(Deployment):
         time.sleep(self.wait_time)
 
         # wait for nodes to be in READY state
-        wait_for_nodes_status(timeout=300)
+        wait_for_nodes_status(timeout=600)
 
     def delete_disks(self):
         """
@@ -1283,9 +1283,7 @@ class VSPHEREUPI(VSPHEREBASE):
                 time.sleep(600)
                 logger.info("waiting for bootstrap to complete")
                 try:
-                    bootstrap_timeout = (
-                        7200 if config.DEPLOYMENT.get("dual_stack") else 3600
-                    )
+                    bootstrap_timeout = 7200
                     run_cmd(
                         f"{self.installer} wait-for bootstrap-complete "
                         f"--dir {self.cluster_path} "
@@ -1351,7 +1349,7 @@ class VSPHEREUPI(VSPHEREBASE):
                 # multus deployment need more time to generate CSRs
                 is_multus_enabled = config.ENV_DATA.get("is_multus_enabled")
                 csr_timeout = (
-                    4800 if is_multus_enabled else (2400 if num_nodes >= 6 else 1500)
+                    4800 if is_multus_enabled else (2400 if num_nodes >= 6 else 2400)
                 )
                 wait_for_all_nodes_csr_and_approve(timeout=csr_timeout, sleep=10)
 
@@ -1364,7 +1362,7 @@ class VSPHEREUPI(VSPHEREBASE):
 
                 # wait for install to complete
                 logger.info("waiting for install to complete")
-                install_timeout = 7200 if config.DEPLOYMENT.get("dual_stack") else 3600
+                install_timeout = 7200
                 run_cmd(
                     f"{self.installer} wait-for install-complete "
                     f"--dir {self.cluster_path} "


### PR DESCRIPTION
It seems like IPV6 OCP deployments get timeout and I'm sure because of the migration there are some other issues in timeouts.

Terraform and OCP deployment operations on vSphere can be slow, especially with VSAN storage. Increase timeouts across the board:

- terraform init: 1200s -> 2400s
- terraform apply: 1500s -> 3000s
- terraform destroy: 1200s -> 2400s
- terraform destroy_module: 1200s -> 2400s
- wait_for_nodes_status: 300s -> 600s
- bootstrap-complete: 3600s -> 7200s (was conditional on dual_stack)
- install-complete: 3600s -> 7200s (was conditional on dual_stack)
- CSR approval base: 1500s -> 2400s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased several deployment wait times to reduce timeouts during Terraform operations, vSphere scaling, and cluster installation.
  * Added more generous readiness and approval waits for large or slower environments, improving deployment reliability.
  * Standardized some install timeout behavior so long-running steps have more consistent completion windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->