### PR TITLE
Skip test_ceph_osd_slow_ops_alert on compact mode deployments

### DIFF
--- a/tests/functional/monitoring/prometheus/alerts/test_ceph.py
+++ b/tests/functional/monitoring/prometheus/alerts/test_ceph.py
@@ -11,6 +11,7 @@ from ocs_ci.framework.testlib import (
     runs_on_provider,
     blue_squad,
     provider_mode,
+    skipif_compact_mode,
 )
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.cluster import (
@@ -211,6 +212,7 @@ class TestCephOSDSlowOps(object):
     @tier3
     @pytest.mark.polarion_id("OCS-5158")
     @blue_squad
+    @skipif_compact_mode
     def test_ceph_osd_slow_ops_alert(self, setup, threading_lock):
         """
         Test to verify bz #1966139, more info about Prometheus alert - #1885441


### PR DESCRIPTION
## Summary

- Skip `test_ceph_osd_slow_ops_alert` on compact mode (3M/0W) deployments to prevent cascading cluster failures that invalidate the entire tier3 run

## Changes

- Add `@skipif_compact_mode` marker to `test_ceph_osd_slow_ops_alert` in `tests/functional/monitoring/prometheus/alerts/test_ceph.py`
- Import `skipif_compact_mode` from `ocs_ci.framework.testlib`

Closes #15634

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated a Prometheus alert test to skip the Ceph slow-ops scenario when running in compact mode, avoiding unsupported test execution in that environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->