### PR TITLE
[release-4.20] Fix "test_resize_osd" test failures: parse crash, weight lag, and Quay rate limit

### DIFF
--- a/ocs_ci/helpers/osd_resize.py
+++ b/ocs_ci/helpers/osd_resize.py
@@ -1,6 +1,7 @@
 import logging
 import pytest
 
+from ocs_ci.utility.retry import retry
 from ocs_ci.ocs.exceptions import (
     StorageSizeNotReflectedException,
     ResourceWrongStatusException,
@@ -284,7 +285,9 @@ def base_ceph_verification_steps_post_resize_osd(
     logger.info("Check the resources size post resize OSD")
     check_storage_size_is_reflected(expected_storage_size, expected_ceph_capacity)
     logger.info("Check the Ceph state post resize OSD")
-    check_ceph_state_post_resize_osd()
+    retry(CephHealthException, tries=5, delay=30, backoff=1)(
+        check_ceph_state_post_resize_osd
+    )()
     logger.info("All the Ceph verification steps post resize osd finished successfully")
 
 

--- a/ocs_ci/ocs/cluster.py
+++ b/ocs_ci/ocs/cluster.py
@@ -3751,7 +3751,7 @@ def parse_ceph_table_output(raw_output: str) -> pd.DataFrame:
 
     """
     # Known units for sizes (e.g., GiB, TiB, MiB)
-    known_units = ["GiB", "MiB", "KiB", "TiB"]
+    known_units = ["GiB", "MiB", "KiB", "TiB", "B"]
 
     # Step 1: Join size values with their units (e.g., '894 GiB' -> '894GiB')
     for unit in known_units:
@@ -3835,11 +3835,21 @@ def check_ceph_osd_df_tree():
 
     for line in ceph_output_lines:
         osd_id = line["ID"]
+        if osd_id.startswith("-") or osd_id == "TOTAL":
+            continue
+
         weight = float(line["WEIGHT"])
-        # Regular expression to match the numeric part and the unit
         match = re.match(r"([0-9.]+)([a-zA-Z]+)", line["SIZE"])
+        if not match:
+            logger.warning(f"Unable to parse SIZE {line['SIZE']} for OSD ID {osd_id}")
+            return False
+
         size = float(match.group(1))
         units = match.group(2)
+        if units == "B" and size == 0:
+            logger.warning(f"OSD ID {osd_id} reports 0 B — Ceph stats not ready yet")
+            return False
+
         if units.startswith("Ti"):
             storage_size = convert_device_size(storage_size_param, "TB", 1024)
         elif units.startswith("Gi"):
@@ -3856,19 +3866,21 @@ def check_ceph_osd_df_tree():
         diff = size * 0.04
         if not (size - diff <= weight <= size + diff):
             logger.warning(
-                f"OSD weight {weight} (converted) does not match the OSD size {size} "
-                f"for OSD ID {osd_id}. Expected OSD weight within [{size - diff}, {size + diff}]"
+                f"OSD weight {weight} (converted) does not match "
+                f"the OSD size {size} for OSD ID {osd_id}. "
+                f"Expected OSD weight within "
+                f"[{size - diff}, {size + diff}]"
             )
             return False
-        # If it's a regular OSD entry, check if the expected osd size
-        # and the current size are equal ignoring a small diff
+        # Check if the expected osd size and the current size are
+        # equal ignoring a small diff
         diff = size * 0.04
-        if not osd_id.startswith("-") and not (
-            size - diff <= storage_size <= size + diff
-        ):
+        if not (size - diff <= storage_size <= size + diff):
             logger.warning(
-                f"The storage size {storage_size} does not match the OSD size {size} "
-                f"for OSD ID {osd_id}. Expected storage size within [{size - diff}, {size + diff}]"
+                f"The storage size {storage_size} does not match "
+                f"the OSD size {size} for OSD ID {osd_id}. "
+                f"Expected storage size within "
+                f"[{size - diff}, {size + diff}]"
             )
             return False
 

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -2820,6 +2820,7 @@ VOLUMESNAPSHOT = "volumesnapshot"
 LOGICALVOLUME = "logicalvolume"
 
 PERF_IMAGE = "quay.io/ocsci/perf:latest"
+NGINX_FIO_IMAGE = "quay.io/ocsci/nginx:fio"
 
 ROOK_CEPH_CONFIG_VALUES = """
 [global]

--- a/tests/functional/z_cluster/cluster_expansion/test_resize_osd.py
+++ b/tests/functional/z_cluster/cluster_expansion/test_resize_osd.py
@@ -27,7 +27,14 @@ from ocs_ci.framework.testlib import (
     tier4c,
     tier4a,
 )
-from ocs_ci.ocs.constants import VOLUME_MODE_BLOCK, OSD, ROOK_OPERATOR, MON_DAEMON
+from ocs_ci.ocs.constants import (
+    NGINX_FIO_IMAGE,
+    VOLUME_MODE_BLOCK,
+    OSD,
+    ROOK_OPERATOR,
+    MON_DAEMON,
+)
+from ocs_ci.helpers import helpers
 from ocs_ci.helpers.osd_resize import (
     ceph_verification_steps_post_resize_osd,
     check_ceph_health_after_resize_osd,
@@ -169,6 +176,7 @@ class TestResizeOSD(ManageTest):
         Prepare the data before resizing the osd
 
         """
+        helpers.pull_images(NGINX_FIO_IMAGE)
         pvc_size = random.randint(3, 7)
         self.pvcs1, self.pods_for_integrity_check = self.create_pvcs_and_pods(
             pvc_size=pvc_size, num_of_rbd_pvc=6, num_of_cephfs_pvc=6


### PR DESCRIPTION
This is a cherry-pick of https://github.com/red-hat-storage/ocs-ci/pull/15593