### PR TITLE
Fix MCE deployment picking wrong CSV in multicluster-engine namespace

### DIFF
--- a/ocs_ci/deployment/mce.py
+++ b/ocs_ci/deployment/mce.py
@@ -393,17 +393,32 @@ class MCEInstaller(object):
     def mce_installed(self):
         """
         Check if MCE is already installed.
+        Verifies both the operator resource and the subscription exist.
 
         Returns:
              bool: True if MCE is installed, False otherwise
         """
         ocp_obj = OCP(kind=constants.ROOK_OPERATOR)
         # unlike other k8s resources, operators are OLM manager resources that identified by merged name.namespace
-        return ocp_obj.check_resource_existence(
+        operator_exists = ocp_obj.check_resource_existence(
             timeout=12,
             should_exist=True,
             resource_name=constants.MCE_OPERATOR_OPERATOR_NAME_WITH_NS,
         )
+        if not operator_exists:
+            return False
+        sub_exists = self.subs.check_resource_existence(
+            timeout=12,
+            should_exist=True,
+            resource_name=constants.MCE_OPERATOR,
+        )
+        if not sub_exists:
+            logger.warning(
+                "MCE operator resource exists but subscription is missing. "
+                "Likely leftover from partial cleanup."
+            )
+            return False
+        return True
 
     def mce_exists(self):
         """
@@ -646,11 +661,21 @@ class MCEInstaller(object):
             TimeoutExpiredError: If the CSV is not in the 'Succeeded' state within the timeout
 
         """
-        csv_ocp_obj = OCP(
-            kind=constants.CLUSTER_SERVICE_VERSION,
-            namespace=self.mce_namespace,
+        sampler = TimeoutSampler(
+            timeout=300,
+            sleep=10,
+            func=self.get_mce_csv_name,
         )
-        csv_name = csv_ocp_obj.get(resource_name="")["items"][0]["metadata"]["name"]
+        csv_name = ""
+        try:
+            for csv_name in sampler:
+                if csv_name:
+                    logger.info(f"Found MCE CSV: {csv_name}")
+                    break
+        except TimeoutExpiredError:
+            raise MultiClusterEngineNotDeployedException(
+                "MCE CSV not found in namespace %s" % self.mce_namespace
+            )
         csv_obj = CSV(
             resource_name=csv_name,
             namespace=self.mce_namespace,


### PR DESCRIPTION
wait_csv_upgraded() was taking the first CSV in the namespace (["items"][0]), which could be ingress-node-firewall instead of the MCE operator CSV. Replaced with get_mce_csv_name() which filters by the multicluster-engine prefix, and added retry logic to handle the CSV not existing yet right after subscription creation.   

to fix the problem 
```
2026-07-08 17:07:05  10:07:05 - MainThread - ocs_ci.ocs.ocp - INFO  - Resource ingress-node-firewall.v4.22.0-202607010254 is in phase: Succeeded!
2026-07-08 17:07:05  10:07:05 - MainThread - ocs_ci.ocs.ocp - INFO  - Check if resource: multiclusterengine exists.
2026-07-08 17:07:05  10:07:05 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig -n multicluster-engine get MultiClusterEngine multiclusterengine -n multicluster-engine -o yaml
2026-07-08 17:07:06  10:07:06 - MainThread - ocs_ci.ocs.ocp - INFO  - Resource: 'multiclusterengine', selector: 'None' was not found.
2026-07-08 17:07:06  10:07:06 - MainThread - ocs_ci.ocs.resources.ocs - INFO  - Adding MultiClusterEngine with name multiclusterengine
2026-07-08 17:07:06  10:07:06 - MainThread - ocs_ci.utility.templating - INFO  - apiVersion: multicluster.openshift.io/v1
2026-07-08 17:07:06  kind: MultiClusterEngine
2026-07-08 17:07:06  metadata:
2026-07-08 17:07:06    name: multiclusterengine
2026-07-08 17:07:06  spec:
2026-07-08 17:07:06    availabilityConfig: High
2026-07-08 17:07:06    overrides:
2026-07-08 17:07:06      components:
2026-07-08 17:07:06      - enabled: true
2026-07-08 17:07:06        name: local-cluster
2026-07-08 17:07:06  
2026-07-08 17:07:06  10:07:06 - MainThread - ocs_ci.utility.utils - INFO  - Executing command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig create -f /tmp/MultiClusterEngineejnjuicw -o yaml
2026-07-08 17:07:06  10:07:06 - MainThread - ocs_ci.utility.utils - WARNING  - Command stderr: Error from server (InternalError): error when creating "/tmp/MultiClusterEngineejnjuicw": Internal error occurred: failed calling webhook "multiclusterengines.multicluster.openshift.io": failed to call webhook: Post "[https://multicluster-engine-operator-webhook-service.multicluster-engine.svc:443/validate-multicluster-openshift-io-v1-multiclusterengine?timeout=10s](https://multicluster-engine-operator-webhook-service.multicluster-engine.svc/validate-multicluster-openshift-io-v1-multiclusterengine?timeout=10s)": no endpoints available for service "multicluster-engine-operator-webhook-service"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened MCE installation validation by confirming both the MCE operator and its corresponding subscription are present (with a warning if the operator exists but the subscription does not).
  * Improved upgrade handling by waiting for the MCE ClusterServiceVersion name to be discovered before checking upgrade status.
  * Added a clearer failure message when the MCE CSV can’t be found in the namespace during upgrade checks, reducing timing-related false negatives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->