### PR TITLE
Speed up cluster fill in "test_auto_scaling_cli" on vSphere

### DIFF
--- a/ocs_ci/ocs/fill_pool_job.py
+++ b/ocs_ci/ocs/fill_pool_job.py
@@ -41,10 +41,18 @@ class FillPoolJob(object):
         storage="50Gi",
         pvc_base_yaml_path=constants.FILL_POOL_PVC_YAML,
         wait_for_resource=True,
+        direct_io=False,
     ):
         """
         Create a Job that fills up cluster storage by writing data to a PVC.
         Assumes manifest is a Job (pod spec under spec.template.spec).
+
+        Args:
+            direct_io (bool): If True, add oflag=direct to the dd command to
+                bypass the page cache. Useful for callers on backends where
+                page-cache writeback stalls throttle sequential write
+                throughput. Defaults to False (unchanged dd behavior).
+
         """
         self.name = name or create_unique_resource_name("fill-pool", "job")
         sc_name = sc_name or constants.DEFAULT_STORAGECLASS_RBD
@@ -89,9 +97,11 @@ class FillPoolJob(object):
 
         # Ensure the container will run the dd command
         # Insure to handle the case of "No space left on device" error gracefully
+        direct_io_flag = " oflag=direct" if direct_io else ""
         dd_cmd = (
             f'echo "Filling PVC with {fill_mode} data..."; '
-            f"dd if={input_source} of=/mnt/fill/testfile bs=${{BLOCK_SIZE:-{block_size}}} 2>/tmp/dd_err; "
+            f"dd if={input_source} of=/mnt/fill/testfile bs=${{BLOCK_SIZE:-{block_size}}}"
+            f"{direct_io_flag} 2>/tmp/dd_err; "
             f"EXIT_STATUS=$?; "
             f"if [ $EXIT_STATUS -ne 0 ] && grep -q 'No space left on device' /tmp/dd_err; then "
             f"  cat /tmp/dd_err; echo 'Capacity reached. Exiting successfully.'; exit 0; "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12200,6 +12200,7 @@ def fill_job_factory(request):
         pvc_name=None,
         sc_name=constants.DEFAULT_STORAGECLASS_RBD,
         storage="50Gi",
+        direct_io=False,
     ):
         """
         Create a Job that fills up the cluster storage by writing data to a PVC.
@@ -12216,6 +12217,8 @@ def fill_job_factory(request):
             pvc_name (str): Name of the PVC to create and attach to the Pod.
             sc_name (str): StorageClass name for the PVC.
             storage (str): Storage size for the PVC.
+            direct_io (bool): If True, add oflag=direct to the dd command to
+                bypass the page cache.
 
         Returns:
             FillPoolJob: The created FillPoolJob object.
@@ -12236,6 +12239,7 @@ def fill_job_factory(request):
             pvc_name=pvc_name,
             sc_name=sc_name,
             storage=storage,
+            direct_io=direct_io,
         )
 
         return fill_pool_job_obj

--- a/tests/functional/z_cluster/cluster_expansion/test_storage_auto_scaling.py
+++ b/tests/functional/z_cluster/cluster_expansion/test_storage_auto_scaling.py
@@ -201,14 +201,22 @@ class TestStorageAutoscalerBase(ManageTest):
             f"Storage to fill in zero mode: {storage_to_fill_zero_mode}Gi, "
             f"Storage to fill in random mode: {storage_to_fill_random_mode}Gi"
         )
+        # On vSphere, per-volume storage throughput is typically lower, and
+        # page-cache writeback stalls can throttle dd write speed enough to
+        # miss the fill target within the timeout. Use a larger block size
+        # with oflag=direct there to keep fill throughput consistent.
+        is_vsphere = config.ENV_DATA["platform"].lower() == constants.VSPHERE_PLATFORM
+        fill_kwargs = {"block_size": "8M", "direct_io": True} if is_vsphere else {}
         fill_job_obj = self.fill_job_factory(
             fill_mode="zero",
             storage=f"{storage_to_fill_zero_mode}Gi",
+            **fill_kwargs,
         )
         self.fill_job_objs.append(fill_job_obj)
         fill_job_obj = self.fill_job_factory(
             fill_mode="random",
             storage=f"{storage_to_fill_random_mode}Gi",
+            **fill_kwargs,
         )
         self.fill_job_objs.append(fill_job_obj)
 

--- a/tests/functional/z_cluster/cluster_expansion/test_storage_auto_scaling.py
+++ b/tests/functional/z_cluster/cluster_expansion/test_storage_auto_scaling.py
@@ -176,16 +176,19 @@ class TestStorageAutoscalerBase(ManageTest):
 
     def fill_up_cluster(self, target_percentage, is_completed=True):
         """
-        Fill up the cluster to a target percentage of total storage capacity using FIO-based load.
+        Fill up the cluster to a target percentage of total storage
+        capacity using dd-based FillPoolJob objects.
 
-        This method invokes the benchmark operator to prefill the cluster up to a specified
-        usage level. If `fast_fill_up` is enabled, more aggressive FIO settings are applied
-        to increase fill speed, and the `target_percentage` is reduced slightly to compensate
-        for potential overshoot.
+        Storage is split between zero-fill (75%) and random-fill
+        (25%) modes. On vSphere, a larger block size with
+        oflag=direct is used to maintain throughput and avoid
+        page-cache writeback stalls.
 
         Args:
-            target_percentage (int): Desired percentage of used cluster storage to reach.
-            is_completed (bool): Whether to wait until the benchmark workload completes.
+            target_percentage (int): Desired percentage of used
+                cluster storage to reach.
+            is_completed (bool): Whether to wait until the fill
+                jobs complete.
 
         """
         storage_to_fill = get_file_size(


### PR DESCRIPTION
## Summary
  - `test_auto_scaling_cli`'s `fill_up_cluster()` uses `FillPoolJob`, which fills a PVC with `dd bs=1M` buffered
  writes. This was too slow to reliably reach the target used-capacity percentage within the existing timeout,
  observed on a vSphere/VSAN run where used capacity climbed steadily but missed the target by a few minutes while
  Ceph stayed HEALTH_OK throughout.
  - Add an opt-in `direct_io` flag to `FillPoolJob.create()` and `fill_job_factory` (default `False`, no behavior
  change for other callers) that appends `oflag=direct` to the `dd` command to bypass the page cache.
  - `fill_up_cluster()` checks `config.ENV_DATA["platform"]` and only passes `block_size="8M"` and `direct_io=True`
  on vSphere, where per-volume storage throughput is typically lower.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option for fill jobs to enable direct I/O for more consistent write behavior.
  * Cluster scaling tests now apply vSphere-specific fill settings (including direct I/O) for reliability.

* **Documentation**
  * Updated fill job documentation to describe the new direct I/O option and its effect.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->