### PR TITLE
Fix cld_mgr secret deletion breaking default backingstore override

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3113,11 +3113,18 @@ def cld_mgr(request):
     cld_mgr = CloudManager()
 
     def finalizer():
-        for client in vars(cld_mgr):
+        for client_name in vars(cld_mgr):
             try:
-                getattr(cld_mgr, client).secret.delete()
+                client_obj = getattr(cld_mgr, client_name)
+                if getattr(client_obj, "keep_secret_post_teardown", False):
+                    log.info(
+                        f"Skipping secret deletion for {client_name} "
+                        "(keep_secret_post_teardown is set)"
+                    )
+                    continue
+                client_obj.secret.delete()
             except AttributeError:
-                log.info(f"{client} secret not found")
+                log.info(f"{client_name} secret not found")
 
     request.addfinalizer(finalizer)
 
@@ -9866,10 +9873,26 @@ def override_default_backingstore_session(
 
 @pytest.fixture(scope="session")
 def override_default_backingstore_session_no_teardown(
+    cld_mgr,
     mcg_obj_session,
     backingstore_factory_session,
     allow_default_backingstore_override,
 ):
+    bs_dict = clone_bs_dict_from_backingstore(constants.DEFAULT_NOOBAA_BACKINGSTORE)
+    cloud_type = next(iter(bs_dict))
+
+    client_map = {
+        "aws": "aws_client",
+        "azure": "azure_client",
+        "gcp": "gcp_client",
+        "ibmcos": "ibmcos_client",
+    }
+    client_attr = client_map.get(cloud_type)
+    if client_attr:
+        client = getattr(cld_mgr, client_attr, None)
+        if client:
+            client.keep_secret_post_teardown = True
+
     return override_default_backingstore_fixture(
         None, mcg_obj_session, backingstore_factory_session
     )


### PR DESCRIPTION
Closes #15657

## Summary

- Fix the `cld_mgr` session finalizer unconditionally deleting cloud client secrets even when a backing store override is still in use on the cluster
- Add a `keep_secret_post_teardown` flag to prevent secret deletion when the no-teardown backingstore override fixture is used

## Problem

The `override_default_backingstore_session_no_teardown` fixture (introduced in #15167) patches the default bucket class to use a test-created backing store and intentionally skips restoring the original - so the override persists across pytest sessions (e.g. through an ODF upgrade).

However, when the session ends, the `cld_mgr` finalizer deletes **all** cloud client secrets - including the one referenced by the still-active backing store. This causes:

1. The backing store enters `Rejected` phase (`MissingSecret`)
2. The default bucket class enters `Rejected` phase (`RejectedBackingStore`)
3. **Every subsequent OBC creation fails** with `BucketClassNotReady`

This was observed in [launch 52491](https://reportportal-ocs4.apps.dno.ocp-hub.prod.psi.redhat.com/ui/#ocs/launches/all/52491) where 44 out of 50 post-upgrade test failures were caused by this single teardown issue.

## Changes

- **`cld_mgr` finalizer**: Before deleting a client's secret, check for a `keep_secret_post_teardown` flag. If set, skip deletion.
- **`override_default_backingstore_session_no_teardown`**: Determine which cloud client's secret will be used by the override (by inspecting the default backing store type) and set `keep_secret_post_teardown = True` on it.