### PR TITLE
[release-4.20] deploy-fusion/fdf: allow login to OCP via provided OCP URL and password

### DIFF
--- a/ocs_ci/framework/pytest_customization/ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/ocscilib.py
@@ -31,7 +31,6 @@ from ocs_ci.ocs.constants import (
 )
 from ocs_ci.ocs.exceptions import (
     CommandFailed,
-    ConfigurationError,
     ResourceNotFoundError,
 )
 from ocs_ci.ocs.cluster import check_clusters
@@ -39,7 +38,6 @@ from ocs_ci.ocs.resources.ocs import get_version_info
 from ocs_ci.ocs import utils
 from ocs_ci.utility.utils import (
     dump_config_to_file,
-    exec_cmd,
     get_ceph_version,
     get_cluster_name,
     get_cluster_version,
@@ -48,6 +46,7 @@ from ocs_ci.utility.utils import (
     get_testrun_name,
     load_config_file,
     create_stats_dir,
+    create_kubeconfig,
 )
 
 from ocs_ci.utility.memory import (
@@ -646,39 +645,7 @@ def process_cluster_cli_params(config):
         or get_cli_param(config, "teardown", default=False)
         or get_cli_param(config, "kubeconfig")
     ):
-        if ocsci_config.RUN.get("kubeadmin_password") and ocsci_config.RUN.get(
-            "ocp_url"
-        ):
-            log.info(
-                "Generating kubeconfig file from provided kubeadmin password and OCP URL"
-            )
-            # check and correct OCP URL (change it to API url if console url provided and add port if needed
-            ocp_api_url = ocsci_config.RUN.get("ocp_url").replace(
-                "console-openshift-console.apps", "api"
-            )
-            if ":6443" not in ocp_api_url:
-                ocp_api_url = ocp_api_url.rstrip("/") + ":6443"
-
-            cmd = (
-                f"oc login --username {ocsci_config.RUN['username']} "
-                f"--password {ocsci_config.RUN['kubeadmin_password']} "
-                f"{ocp_api_url} "
-                f"--kubeconfig {kubeconfig_path} "
-                "--insecure-skip-tls-verify=true"
-            )
-            result = exec_cmd(cmd, secrets=(ocsci_config.RUN["kubeadmin_password"],))
-            if result.returncode:
-                log.warning(f"executed command: {cmd}")
-                log.warning(f"returncode: {result.returncode}")
-                log.warning(f"stdout: {result.stdout}")
-                log.warning(f"stderr: {result.stderr}")
-            else:
-                log.warning(f"Kubeconfig file were created: {kubeconfig_path}.")
-        else:
-            raise ConfigurationError(
-                "Kubeconfig doesn't exists and RUN['kubeadmin_password'] and RUN['ocp_url'] "
-                "environment variables were not provided."
-            )
+        create_kubeconfig(kubeconfig_path)
 
     # Importing here cause once the function is invoked we have already config
     # loaded, so this is OK to import once you sure that config is loaded.

--- a/ocs_ci/utility/framework/fusion_fdf_init.py
+++ b/ocs_ci/utility/framework/fusion_fdf_init.py
@@ -22,6 +22,7 @@ from ocs_ci.utility.utils import (
     get_openshift_client,
     get_running_ocp_version,
     run_cmd,
+    create_kubeconfig,
 )
 
 
@@ -200,6 +201,10 @@ class Initializer(object):
         config.RUN["kubeconfig"] = os.path.join(
             config.ENV_DATA["cluster_path"], config.RUN["kubeconfig_location"]
         )
+
+        # create kubeconfig if doesn't exist and OCP url and kubeadmin password is provided
+        create_kubeconfig(config.RUN["kubeconfig"])
+
         setup_bin_dir()
         check_cluster_access(config.RUN["kubeconfig"])
 

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -6486,3 +6486,45 @@ def auto_configure_submariner():
         log.info(
             f"OCP {ocp_version} not in mapping → Submariner: UNRELEASED (safe default)"
         )
+
+
+def create_kubeconfig(kubeconfig_path):
+    """
+    Create kubeconfig if doesn't exist and OCP url and kubeadmin password is provided
+
+    Args:
+        kubeconfig_path (str): kubeconfig file location
+
+    """
+    if not os.path.isfile(kubeconfig_path):
+        if config.RUN.get("kubeadmin_password") and config.RUN.get("ocp_url"):
+            log.info(
+                "Generating kubeconfig file from provided kubeadmin password and OCP URL"
+            )
+            # check and correct OCP URL (change it to API url if console url provided and add port if needed
+            ocp_api_url = config.RUN.get("ocp_url").replace(
+                "console-openshift-console.apps", "api"
+            )
+            if ":6443" not in ocp_api_url:
+                ocp_api_url = ocp_api_url.rstrip("/") + ":6443"
+
+            cmd = (
+                f"oc login --username {config.RUN['username']} "
+                f"--password {config.RUN['kubeadmin_password']} "
+                f"{ocp_api_url} "
+                f"--kubeconfig {kubeconfig_path} "
+                "--insecure-skip-tls-verify=true"
+            )
+            result = exec_cmd(cmd, secrets=(config.RUN["kubeadmin_password"],))
+            if result.returncode:
+                log.warning(f"executed command: {cmd}")
+                log.warning(f"returncode: {result.returncode}")
+                log.warning(f"stdout: {result.stdout}")
+                log.warning(f"stderr: {result.stderr}")
+            else:
+                log.warning(f"Kubeconfig file were created: {kubeconfig_path}.")
+        else:
+            raise ConfigurationError(
+                "Kubeconfig doesn't exists and RUN['kubeadmin_password'] and RUN['ocp_url'] "
+                "environment variables were not provided."
+            )

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -6496,44 +6496,43 @@ def create_kubeconfig(kubeconfig_path):
         kubeconfig_path (str): kubeconfig file location
 
     """
-    if not os.path.isfile(kubeconfig_path):
-        if config.RUN.get("kubeadmin_password") and config.RUN.get("ocp_url"):
-            log.info(
-                "Generating kubeconfig file from provided kubeadmin password and OCP URL"
-            )
-            # check and correct OCP URL (change it to API url if console url provided and add port if needed
-            ocp_api_url = config.RUN.get("ocp_url").replace(
-                "console-openshift-console.apps", "api"
-            )
-            if ":6443" not in ocp_api_url:
-                ocp_api_url = ocp_api_url.rstrip("/") + ":6443"
+    if config.RUN.get("kubeadmin_password") and config.RUN.get("ocp_url"):
+        log.info(
+            "Generating kubeconfig file from provided kubeadmin password and OCP URL"
+        )
+        # check and correct OCP URL (change it to API url if console url provided and add port if needed
+        ocp_api_url = config.RUN.get("ocp_url").replace(
+            "console-openshift-console.apps", "api"
+        )
+        if ":6443" not in ocp_api_url:
+            ocp_api_url = ocp_api_url.rstrip("/") + ":6443"
 
-            cmd = (
-                f"oc login --username {config.RUN['username']} "
-                f"--password {config.RUN['kubeadmin_password']} "
-                f"{ocp_api_url} "
-                f"--kubeconfig {kubeconfig_path} "
-                "--insecure-skip-tls-verify=true"
-            )
-            result = exec_cmd(cmd, secrets=(config.RUN["kubeadmin_password"],))
-            if result.returncode:
-                log.warning(f"executed command: {cmd}")
-                log.warning(f"returncode: {result.returncode}")
-                log.warning(f"stdout: {result.stdout}")
-                log.warning(f"stderr: {result.stderr}")
-            else:
-                log.warning(f"Kubeconfig file were created: {kubeconfig_path}.")
-
-            kubeadmin_password_file = os.path.join(
-                config.ENV_DATA["cluster_path"], config.RUN["password_location"]
-            )
-            if not os.path.isfile(kubeadmin_password_file):
-                with open(kubeadmin_password_file, "w") as fd:
-                    fd.write(config.RUN.get("kubeadmin_password"))
-                log.info("Created kubeadmin-password file")
-
+        cmd = (
+            f"oc login --username {config.RUN['username']} "
+            f"--password {config.RUN['kubeadmin_password']} "
+            f"{ocp_api_url} "
+            f"--kubeconfig {kubeconfig_path} "
+            "--insecure-skip-tls-verify=true"
+        )
+        result = exec_cmd(cmd, secrets=(config.RUN["kubeadmin_password"],))
+        if result.returncode:
+            log.warning(f"executed command: {cmd}")
+            log.warning(f"returncode: {result.returncode}")
+            log.warning(f"stdout: {result.stdout}")
+            log.warning(f"stderr: {result.stderr}")
         else:
-            raise ConfigurationError(
-                "Kubeconfig doesn't exists and RUN['kubeadmin_password'] and RUN['ocp_url'] "
-                "environment variables were not provided."
-            )
+            log.warning(f"Kubeconfig file were created: {kubeconfig_path}.")
+
+        kubeadmin_password_file = os.path.join(
+            config.ENV_DATA["cluster_path"], config.RUN["password_location"]
+        )
+        if not os.path.isfile(kubeadmin_password_file):
+            with open(kubeadmin_password_file, "w") as fd:
+                fd.write(config.RUN.get("kubeadmin_password"))
+            log.info("Created kubeadmin-password file")
+
+    elif not os.path.isfile(kubeconfig_path):
+        raise ConfigurationError(
+            "Kubeconfig doesn't exists and RUN['kubeadmin_password'] and RUN['ocp_url'] "
+            "environment variables were not provided."
+        )

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -6523,6 +6523,15 @@ def create_kubeconfig(kubeconfig_path):
                 log.warning(f"stderr: {result.stderr}")
             else:
                 log.warning(f"Kubeconfig file were created: {kubeconfig_path}.")
+
+            kubeadmin_password_file = os.path.join(
+                config.ENV_DATA["cluster_path"], config.RUN["password_location"]
+            )
+            if not os.path.isfile(kubeadmin_password_file):
+                with open(kubeadmin_password_file, "w") as fd:
+                    fd.write(config.RUN.get("kubeadmin_password"))
+                log.info("Created kubeadmin-password file")
+
         else:
             raise ConfigurationError(
                 "Kubeconfig doesn't exists and RUN['kubeadmin_password'] and RUN['ocp_url'] "


### PR DESCRIPTION
This PR adds the functionality to login to OCP cluster via provided url and kubeadmin password introduced in PR https://github.com/red-hat-storage/ocs-ci/pull/11749 also to the deploy-fusion and deploy-fdf entry points.

This is a backport of https://github.com/red-hat-storage/ocs-ci/pull/14182