### PR TITLE
Fix Sphinx anchor link in code_review.md documentation

### DIFF
--- a/docs/code_review.md
+++ b/docs/code_review.md
@@ -91,7 +91,7 @@ fast and avoiding merge conflicts.
 
 **Prerequisites:**
 Gitleaks must be installed on your system before using pre-commit hooks.
-See [Getting Started - Prerequisites](getting_started.md#prerequisites) for installation instructions.
+See [Getting Started](getting_started.md) (Prerequisites section) for installation instructions.
 
 **Suppressing False Positives:**
 If Gitleaks flags something that isn't a real secret (test data, examples, etc.),


### PR DESCRIPTION
Remove anchor fragment (#prerequisites) from Getting Started link to fix Sphinx documentation build errors. Sphinx cannot resolve the anchor reference, causing docs job to fail in CI.

Changed from:
  [Getting Started - Prerequisites](getting_started.md#prerequisites)

To:
  [Getting Started](getting_started.md) (Prerequisites section)

This maintains user-friendly context while avoiding Sphinx validation errors in cherry-picked branches.