### PR TITLE
Adding condition to check the LB starting with kube-<cluster-prefix>

### DIFF
--- a/ocs_ci/deployment/ibmcloud.py
+++ b/ocs_ci/deployment/ibmcloud.py
@@ -1198,7 +1198,10 @@ class IBMCloudIPI(CloudDeploymentBase):
             proc = exec_cmd(cmd)
             load_balancers = json.loads(proc.stdout)
             lb_list = [
-                lb for lb in load_balancers if lb.get("name", "").startswith(prefix)
+                lb
+                for lb in load_balancers
+                if lb.get("name", "").startswith(prefix)
+                or lb.get("name", "").startswith(f"kube-{prefix}")
             ]
             count = len(lb_list)
 


### PR DESCRIPTION
fixes: https://github.com/red-hat-storage/ocs-ci/issues/15669

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved load balancer cleanup by also identifying resources using the `kube-` naming prefix.
  * Prevents eligible load balancers from being unintentionally left behind during deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->