### PR TITLE
[release-4.20] Adding condition to check the LB starting with kube-<cluster-prefix>

### DIFF
--- a/ocs_ci/deployment/ibmcloud.py
+++ b/ocs_ci/deployment/ibmcloud.py
@@ -1197,7 +1197,10 @@ class IBMCloudIPI(CloudDeploymentBase):
             proc = exec_cmd(cmd)
             load_balancers = json.loads(proc.stdout)
             lb_list = [
-                lb for lb in load_balancers if lb.get("name", "").startswith(prefix)
+                lb
+                for lb in load_balancers
+                if lb.get("name", "").startswith(prefix)
+                or lb.get("name", "").startswith(f"kube-{prefix}")
             ]
             count = len(lb_list)
 


### PR DESCRIPTION
Cherry-pick of #15670

Fixes load balancer cleanup by detecting both `{prefix}-*` and `kube-{prefix}-*` naming patterns.

**Original PR:** #15670
**Issue:** #15669

This prevents orphaned load balancers during cluster destroy operations on IBM Cloud.