### PR TITLE
Skip submariner MG if current phase is import clusters as submariner wouldn't be present

### DIFF
--- a/ocs_ci/ocs/utils.py
+++ b/ocs_ci/ocs/utils.py
@@ -1380,9 +1380,7 @@ def _collect_ocs_logs(
                 )
 
             # We want to skip submariner log collection if it's in import clusters phase
-            if not cluster_config.ENV_DATA.get(
-                "import_clusters_to_acm", False
-            ) or cluster_config.ENV_DATA.get("submariner_source", ""):
+            if not cluster_config.ENV_DATA.get("import_clusters_to_acm", False):
                 subctl_available = True
                 with subctl_lock:
                     try:


### PR DESCRIPTION
Due to https://github.com/red-hat-storage/ocs-ci/blob/master/ocs_ci/utility/utils.py#L7696 , submariner_source will always be true and hence it forced submariner mustgather everytime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostic log collection for Submariner: logs are now gathered whenever cluster import to ACM is disabled, even if a Submariner source is configured.
  * Log collection is skipped only when cluster import to ACM is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->