### PR TITLE
Add KEDA autoscaling test for NooBaa endpoints

### DIFF
--- a/tests/functional/object/mcg/test_noobaa_endpoint_keda.py
+++ b/tests/functional/object/mcg/test_noobaa_endpoint_keda.py
@@ -93,7 +93,6 @@ class TestNooBaaEndpointKeda(MCGTest):
                 )
             except CommandFailed:
                 logger.warning("Failed to restore StorageCluster config")
-                return
 
             # Wait for the ScaledObject to be deleted before keda_class
             # teardown uninstalls KEDA. Otherwise the KEDA finalizer on
@@ -155,6 +154,17 @@ class TestNooBaaEndpointKeda(MCGTest):
                     break
         except TimeoutExpiredError:
             raise TimeoutExpiredError("ScaledObject was not created")
+
+        so_spec = so_ocp.get(resource_name="noobaa")["spec"]
+        assert so_spec.get("maxReplicaCount") == self.MAX_ENDPOINT_COUNT, (
+            f"ScaledObject maxReplicaCount is {so_spec.get('maxReplicaCount')}, "
+            f"expected {self.MAX_ENDPOINT_COUNT}"
+        )
+        assert so_spec.get("scaleTargetRef", {}).get("name") == "noobaa-endpoint", (
+            f"ScaledObject scaleTargetRef is "
+            f"{so_spec.get('scaleTargetRef', {}).get('name')}, "
+            f"expected noobaa-endpoint"
+        )
 
         hpa_ocp = OCP(kind="HorizontalPodAutoscaler", namespace=namespace)
         hpa_ocp.wait_for_delete(resource_name="noobaa-hpav2", timeout=60)

--- a/tests/functional/object/mcg/test_noobaa_endpoint_keda.py
+++ b/tests/functional/object/mcg/test_noobaa_endpoint_keda.py
@@ -51,7 +51,6 @@ class TestNooBaaEndpointKeda(MCGTest):
 
         1. Set endpoint min/max counts and autoscalerType=keda via StorageCluster
         2. Wait for the noobaa-operator to create a ScaledObject and delete the HPA
-        3. Wait for endpoints to stabilize at minCount
         """
         namespace = config.ENV_DATA["cluster_namespace"]
         sc_ocp = OCP(kind=constants.STORAGECLUSTER, namespace=namespace)
@@ -109,13 +108,6 @@ class TestNooBaaEndpointKeda(MCGTest):
 
         request.addfinalizer(finalizer)
 
-        get_endpoint_pods = partial(
-            get_pods_having_label,
-            label=constants.NOOBAA_ENDPOINT_POD_LABEL,
-            namespace=namespace,
-            statuses=[constants.STATUS_RUNNING],
-        )
-
         # 1. Patch StorageCluster with endpoint counts and KEDA autoscaler
         logger.test_step(
             f"Configure StorageCluster: endpoints min={self.MIN_ENDPOINT_COUNT}, "
@@ -169,24 +161,6 @@ class TestNooBaaEndpointKeda(MCGTest):
         hpa_ocp = OCP(kind="HorizontalPodAutoscaler", namespace=namespace)
         hpa_ocp.wait_for_delete(resource_name="noobaa-hpav2", timeout=60)
         logger.info("HPA deleted by noobaa-operator")
-
-        # 3. Wait for endpoints to stabilize at minCount
-        logger.test_step(
-            f"Wait for endpoints to stabilize at {self.MIN_ENDPOINT_COUNT}"
-        )
-        try:
-            for endpoint_pods in TimeoutSampler(
-                timeout=300, sleep=30, func=get_endpoint_pods
-            ):
-                count = len(endpoint_pods)
-                logger.debug(f"Endpoint pod count: {count}")
-                if count == self.MIN_ENDPOINT_COUNT:
-                    logger.info(f"Endpoints stabilized at {self.MIN_ENDPOINT_COUNT}")
-                    break
-        except TimeoutExpiredError:
-            raise TimeoutExpiredError(
-                f"Endpoints did not stabilize at {self.MIN_ENDPOINT_COUNT}"
-            )
 
     @pytest.fixture(scope="class")
     def warp_workload_runner(self, request):

--- a/tests/functional/object/mcg/test_noobaa_endpoint_keda.py
+++ b/tests/functional/object/mcg/test_noobaa_endpoint_keda.py
@@ -1,0 +1,235 @@
+import logging
+
+import pytest
+
+from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import (
+    mcg,
+    red_squad,
+    skipif_disconnected_cluster,
+    skipif_external_mode,
+    skipif_managed_service,
+)
+from ocs_ci.framework.testlib import MCGTest, tier2
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.exceptions import CommandFailed, TimeoutExpiredError
+from ocs_ci.ocs.ocp import OCP
+from ocs_ci.ocs.resources.objectbucket import OBC
+from ocs_ci.ocs.resources.pod import get_pods_having_label
+from ocs_ci.ocs.warp import WarpWorkloadRunner
+from ocs_ci.utility.utils import TimeoutSampler
+
+logger = logging.getLogger(__name__)
+
+
+@mcg
+@red_squad
+@skipif_disconnected_cluster
+@skipif_external_mode
+@skipif_managed_service
+@tier2
+class TestNooBaaEndpointKeda(MCGTest):
+    """
+    Test NooBaa endpoint autoscaling with KEDA.
+
+    Setting spec.multiCloudGateway.autoscaler.autoscalerType=keda on
+    the StorageCluster makes the ocs-operator propagate it to the
+    NooBaa CR, which in turn makes the noobaa-operator create a
+    ScaledObject with a CPU utilization trigger, replacing the
+    default HPA.
+    """
+
+    MIN_ENDPOINT_COUNT = 1
+    MAX_ENDPOINT_COUNT = 2
+
+    @pytest.fixture(scope="class")
+    def setup_keda_autoscaling(self, request, keda_class):
+        """
+        Configure KEDA-based autoscaling for NooBaa endpoints.
+
+        1. Set endpoint min/max counts and autoscalerType=keda via StorageCluster
+        2. Wait for the noobaa-operator to create a ScaledObject and delete the HPA
+        3. Wait for endpoints to stabilize at minCount
+        """
+        namespace = config.ENV_DATA["cluster_namespace"]
+        sc_ocp = OCP(kind=constants.STORAGECLUSTER, namespace=namespace)
+        sc_resource = sc_ocp.get()["items"][0]
+        sc_name = sc_resource["metadata"]["name"]
+
+        # Save original values for restoration
+        mcg_spec = sc_resource.get("spec", {}).get("multiCloudGateway", {})
+        endpoints_spec = mcg_spec.get("endpoints", {})
+        original_min = endpoints_spec.get("minCount", 1)
+        original_max = endpoints_spec.get("maxCount", 2)
+        original_autoscaler_type = mcg_spec.get("autoscaler", {}).get(
+            "autoscalerType", "hpav2"
+        )
+
+        def finalizer():
+            logger.info(
+                f"Restoring endpoint counts to min={original_min}, "
+                f"max={original_max} and autoscaler to {original_autoscaler_type}"
+            )
+            try:
+                sc_ocp.patch(
+                    resource_name=sc_name,
+                    params=(
+                        f'{{"spec":{{"multiCloudGateway":{{'
+                        f'"endpoints":{{"minCount":{original_min},"maxCount":{original_max}}},'
+                        f'"autoscaler":{{"autoscalerType":"{original_autoscaler_type}"}}'
+                        f"}}}}}}"
+                    ),
+                    format_type="merge",
+                )
+            except CommandFailed:
+                logger.warning("Failed to restore StorageCluster config")
+
+        request.addfinalizer(finalizer)
+
+        # 1. Patch StorageCluster with endpoint counts and KEDA autoscaler
+        logger.info(
+            f"Configuring StorageCluster: endpoints min={self.MIN_ENDPOINT_COUNT}, "
+            f"max={self.MAX_ENDPOINT_COUNT}, autoscalerType=keda"
+        )
+        sc_ocp.patch(
+            resource_name=sc_name,
+            params=(
+                f'{{"spec":{{"multiCloudGateway":{{'
+                f'"endpoints":{{"minCount":{self.MIN_ENDPOINT_COUNT},"maxCount":{self.MAX_ENDPOINT_COUNT}}},'
+                f'"autoscaler":{{"autoscalerType":"keda"}}'
+                f"}}}}}}"
+            ),
+            format_type="merge",
+        )
+
+        # 2. Wait for ScaledObject creation and HPA deletion
+        scaled_object_ocp = OCP(kind=constants.SCALED_OBJECT, namespace=namespace)
+
+        def _scaled_object_exists():
+            try:
+                scaled_object_ocp.get(resource_name="noobaa")
+                return True
+            except CommandFailed:
+                return False
+
+        logger.info("Waiting for ScaledObject 'noobaa' to be created")
+        try:
+            for exists in TimeoutSampler(120, 10, _scaled_object_exists):
+                if exists:
+                    logger.info("ScaledObject created by noobaa-operator")
+                    break
+        except TimeoutExpiredError:
+            raise TimeoutExpiredError("ScaledObject was not created")
+
+        hpa_ocp = OCP(kind="HorizontalPodAutoscaler", namespace=namespace)
+
+        def _hpa_deleted():
+            try:
+                hpa_ocp.get(resource_name="noobaa-hpav2")
+                return False
+            except CommandFailed:
+                return True
+
+        logger.info("Waiting for HPA 'noobaa-hpav2' to be deleted")
+        try:
+            for deleted in TimeoutSampler(60, 10, _hpa_deleted):
+                if deleted:
+                    logger.info("HPA deleted by noobaa-operator")
+                    break
+        except TimeoutExpiredError:
+            logger.warning("HPA was not deleted, continuing anyway")
+
+        # 3. Wait for endpoints to stabilize at minCount
+        logger.info(f"Waiting for endpoints to stabilize at {self.MIN_ENDPOINT_COUNT}")
+        try:
+            for endpoint_pods in TimeoutSampler(
+                timeout=300,
+                sleep=30,
+                func=get_pods_having_label,
+                label=constants.NOOBAA_ENDPOINT_POD_LABEL,
+                namespace=namespace,
+            ):
+                count = len(endpoint_pods)
+                logger.info(f"Endpoint pod count: {count}")
+                if count == self.MIN_ENDPOINT_COUNT:
+                    break
+        except TimeoutExpiredError:
+            raise TimeoutExpiredError(
+                f"Endpoints did not stabilize at {self.MIN_ENDPOINT_COUNT}"
+            )
+
+    @pytest.fixture(scope="class")
+    def warp_workload_runner(self, request):
+        """Create a WarpWorkloadRunner targeting the NooBaa S3 endpoint."""
+        namespace = config.ENV_DATA["cluster_namespace"]
+        host = f"s3.{namespace}.svc:443"
+        return WarpWorkloadRunner(request, host)
+
+    def test_noobaa_endpoint_keda_autoscaling(
+        self,
+        setup_keda_autoscaling,
+        bucket_factory,
+        warp_workload_runner,
+    ):
+        """
+        Test KEDA-based autoscaling of NooBaa endpoint pods.
+
+        1. Create an OBC and start S3 load via Warp
+        2. Wait for endpoint pods to scale up
+        3. Stop the workload
+        4. Wait for endpoint pods to scale back down to minCount
+        """
+        namespace = config.ENV_DATA["cluster_namespace"]
+
+        # 1. Create an OBC and start S3 load
+        bucket = bucket_factory(amount=1, interface="OC")[0]
+        obc_obj = OBC(bucket.name)
+        warp_workload_runner.start(
+            access_key=obc_obj.access_key_id,
+            secret_key=obc_obj.access_key,
+            bucket_name=bucket.name,
+            workload_type="mixed",
+            concurrent=32,
+            obj_size="1MiB",
+            duration="30s",
+        )
+
+        # 2. Wait for scale-up
+        try:
+            for endpoint_pods in TimeoutSampler(
+                timeout=300,
+                sleep=30,
+                func=get_pods_having_label,
+                label=constants.NOOBAA_ENDPOINT_POD_LABEL,
+                namespace=namespace,
+            ):
+                count = len(endpoint_pods)
+                pod_names = ", ".join(p["metadata"]["name"] for p in endpoint_pods)
+                logger.info(f"Endpoint pods ({count}): {pod_names}")
+                if count > self.MIN_ENDPOINT_COUNT:
+                    logger.info("Endpoints scaled up")
+                    break
+        except TimeoutExpiredError:
+            logger.error("Endpoints did not scale up")
+            raise
+        finally:
+            # 3. Stop the workload
+            warp_workload_runner.stop()
+
+        # 4. Wait for scale-down
+        try:
+            for endpoint_pods in TimeoutSampler(
+                timeout=900,
+                sleep=30,
+                func=get_pods_having_label,
+                label=constants.NOOBAA_ENDPOINT_POD_LABEL,
+                namespace=namespace,
+            ):
+                count = len(endpoint_pods)
+                logger.info(f"Endpoint pod count: {count}")
+                if count == self.MIN_ENDPOINT_COUNT:
+                    logger.info("Endpoints scaled down")
+                    break
+        except TimeoutExpiredError:
+            logger.error("Endpoints did not scale down")
+            raise

--- a/tests/functional/object/mcg/test_noobaa_endpoint_keda.py
+++ b/tests/functional/object/mcg/test_noobaa_endpoint_keda.py
@@ -1,6 +1,5 @@
 import json
 import logging
-from functools import partial
 
 import pytest
 
@@ -185,8 +184,7 @@ class TestNooBaaEndpointKeda(MCGTest):
         4. Wait for endpoint pods to scale back down to minCount
         """
         namespace = config.ENV_DATA["cluster_namespace"]
-        get_endpoint_pods = partial(
-            get_pods_having_label,
+        endpoint_pods_kwargs = dict(
             label=constants.NOOBAA_ENDPOINT_POD_LABEL,
             namespace=namespace,
             statuses=[constants.STATUS_RUNNING],
@@ -212,7 +210,10 @@ class TestNooBaaEndpointKeda(MCGTest):
         )
         try:
             for endpoint_pods in TimeoutSampler(
-                timeout=300, sleep=30, func=get_endpoint_pods
+                timeout=300,
+                sleep=30,
+                func=get_pods_having_label,
+                **endpoint_pods_kwargs,
             ):
                 count = len(endpoint_pods)
                 pod_names = ", ".join(p["metadata"]["name"] for p in endpoint_pods)
@@ -238,7 +239,10 @@ class TestNooBaaEndpointKeda(MCGTest):
         )
         try:
             for endpoint_pods in TimeoutSampler(
-                timeout=1200, sleep=30, func=get_endpoint_pods
+                timeout=1200,
+                sleep=30,
+                func=get_pods_having_label,
+                **endpoint_pods_kwargs,
             ):
                 count = len(endpoint_pods)
                 logger.debug(f"Endpoint pod count: {count}")

--- a/tests/functional/object/mcg/test_noobaa_endpoint_keda.py
+++ b/tests/functional/object/mcg/test_noobaa_endpoint_keda.py
@@ -1,4 +1,6 @@
+import json
 import logging
+from functools import partial
 
 import pytest
 
@@ -66,55 +68,88 @@ class TestNooBaaEndpointKeda(MCGTest):
         )
 
         def finalizer():
-            logger.info(
-                f"Restoring endpoint counts to min={original_min}, "
-                f"max={original_max} and autoscaler to {original_autoscaler_type}"
+            logger.test_step(
+                f"Restore StorageCluster config: min={original_min}, "
+                f"max={original_max}, autoscaler={original_autoscaler_type}"
+            )
+            restore_patch = json.dumps(
+                {
+                    "spec": {
+                        "multiCloudGateway": {
+                            "endpoints": {
+                                "minCount": original_min,
+                                "maxCount": original_max,
+                            },
+                            "autoscaler": {"autoscalerType": original_autoscaler_type},
+                        }
+                    }
+                }
             )
             try:
                 sc_ocp.patch(
                     resource_name=sc_name,
-                    params=(
-                        f'{{"spec":{{"multiCloudGateway":{{'
-                        f'"endpoints":{{"minCount":{original_min},"maxCount":{original_max}}},'
-                        f'"autoscaler":{{"autoscalerType":"{original_autoscaler_type}"}}'
-                        f"}}}}}}"
-                    ),
+                    params=restore_patch,
                     format_type="merge",
                 )
             except CommandFailed:
                 logger.warning("Failed to restore StorageCluster config")
+                return
+
+            # Wait for the ScaledObject to be deleted before keda_class
+            # teardown uninstalls KEDA. Otherwise the KEDA finalizer on
+            # the ScaledObject gets stuck with no operator to process it.
+            so_ocp = OCP(kind=constants.SCALED_OBJECT, namespace=namespace)
+            try:
+                so_ocp.wait_for_delete(resource_name="noobaa", timeout=120)
+                logger.info("ScaledObject deleted during teardown")
+            except (CommandFailed, TimeoutError):
+                logger.warning(
+                    "ScaledObject not deleted in time, "
+                    "may leave a stuck finalizer after KEDA uninstall"
+                )
 
         request.addfinalizer(finalizer)
 
+        get_endpoint_pods = partial(
+            get_pods_having_label,
+            label=constants.NOOBAA_ENDPOINT_POD_LABEL,
+            namespace=namespace,
+            statuses=[constants.STATUS_RUNNING],
+        )
+
         # 1. Patch StorageCluster with endpoint counts and KEDA autoscaler
-        logger.info(
-            f"Configuring StorageCluster: endpoints min={self.MIN_ENDPOINT_COUNT}, "
+        logger.test_step(
+            f"Configure StorageCluster: endpoints min={self.MIN_ENDPOINT_COUNT}, "
             f"max={self.MAX_ENDPOINT_COUNT}, autoscalerType=keda"
         )
-        sc_ocp.patch(
+        setup_patch = json.dumps(
+            {
+                "spec": {
+                    "multiCloudGateway": {
+                        "endpoints": {
+                            "minCount": self.MIN_ENDPOINT_COUNT,
+                            "maxCount": self.MAX_ENDPOINT_COUNT,
+                        },
+                        "autoscaler": {"autoscalerType": "keda"},
+                    }
+                }
+            }
+        )
+        patched = sc_ocp.patch(
             resource_name=sc_name,
-            params=(
-                f'{{"spec":{{"multiCloudGateway":{{'
-                f'"endpoints":{{"minCount":{self.MIN_ENDPOINT_COUNT},"maxCount":{self.MAX_ENDPOINT_COUNT}}},'
-                f'"autoscaler":{{"autoscalerType":"keda"}}'
-                f"}}}}}}"
-            ),
+            params=setup_patch,
             format_type="merge",
         )
+        logger.assertion(f"StorageCluster patch applied: {patched}")
+        assert patched, "Failed to patch StorageCluster with KEDA autoscaler config"
 
         # 2. Wait for ScaledObject creation and HPA deletion
-        scaled_object_ocp = OCP(kind=constants.SCALED_OBJECT, namespace=namespace)
-
-        def _scaled_object_exists():
-            try:
-                scaled_object_ocp.get(resource_name="noobaa")
-                return True
-            except CommandFailed:
-                return False
-
-        logger.info("Waiting for ScaledObject 'noobaa' to be created")
+        logger.test_step("Wait for ScaledObject creation and HPA deletion")
+        so_ocp = OCP(kind=constants.SCALED_OBJECT, namespace=namespace)
         try:
-            for exists in TimeoutSampler(120, 10, _scaled_object_exists):
+            for exists in TimeoutSampler(
+                120, 10, so_ocp.is_exist, resource_name="noobaa"
+            ):
                 if exists:
                     logger.info("ScaledObject created by noobaa-operator")
                     break
@@ -122,36 +157,21 @@ class TestNooBaaEndpointKeda(MCGTest):
             raise TimeoutExpiredError("ScaledObject was not created")
 
         hpa_ocp = OCP(kind="HorizontalPodAutoscaler", namespace=namespace)
-
-        def _hpa_deleted():
-            try:
-                hpa_ocp.get(resource_name="noobaa-hpav2")
-                return False
-            except CommandFailed:
-                return True
-
-        logger.info("Waiting for HPA 'noobaa-hpav2' to be deleted")
-        try:
-            for deleted in TimeoutSampler(60, 10, _hpa_deleted):
-                if deleted:
-                    logger.info("HPA deleted by noobaa-operator")
-                    break
-        except TimeoutExpiredError:
-            logger.warning("HPA was not deleted, continuing anyway")
+        hpa_ocp.wait_for_delete(resource_name="noobaa-hpav2", timeout=60)
+        logger.info("HPA deleted by noobaa-operator")
 
         # 3. Wait for endpoints to stabilize at minCount
-        logger.info(f"Waiting for endpoints to stabilize at {self.MIN_ENDPOINT_COUNT}")
+        logger.test_step(
+            f"Wait for endpoints to stabilize at {self.MIN_ENDPOINT_COUNT}"
+        )
         try:
             for endpoint_pods in TimeoutSampler(
-                timeout=300,
-                sleep=30,
-                func=get_pods_having_label,
-                label=constants.NOOBAA_ENDPOINT_POD_LABEL,
-                namespace=namespace,
+                timeout=300, sleep=30, func=get_endpoint_pods
             ):
                 count = len(endpoint_pods)
-                logger.info(f"Endpoint pod count: {count}")
+                logger.debug(f"Endpoint pod count: {count}")
                 if count == self.MIN_ENDPOINT_COUNT:
+                    logger.info(f"Endpoints stabilized at {self.MIN_ENDPOINT_COUNT}")
                     break
         except TimeoutExpiredError:
             raise TimeoutExpiredError(
@@ -180,8 +200,15 @@ class TestNooBaaEndpointKeda(MCGTest):
         4. Wait for endpoint pods to scale back down to minCount
         """
         namespace = config.ENV_DATA["cluster_namespace"]
+        get_endpoint_pods = partial(
+            get_pods_having_label,
+            label=constants.NOOBAA_ENDPOINT_POD_LABEL,
+            namespace=namespace,
+            statuses=[constants.STATUS_RUNNING],
+        )
 
         # 1. Create an OBC and start S3 load
+        logger.test_step("Create an OBC and start S3 load via Warp")
         bucket = bucket_factory(amount=1, interface="OC")[0]
         obc_obj = OBC(bucket.name)
         warp_workload_runner.start(
@@ -195,41 +222,47 @@ class TestNooBaaEndpointKeda(MCGTest):
         )
 
         # 2. Wait for scale-up
+        logger.test_step(
+            f"Wait for endpoint pods to scale up to {self.MAX_ENDPOINT_COUNT}"
+        )
         try:
             for endpoint_pods in TimeoutSampler(
-                timeout=300,
-                sleep=30,
-                func=get_pods_having_label,
-                label=constants.NOOBAA_ENDPOINT_POD_LABEL,
-                namespace=namespace,
+                timeout=300, sleep=30, func=get_endpoint_pods
             ):
                 count = len(endpoint_pods)
                 pod_names = ", ".join(p["metadata"]["name"] for p in endpoint_pods)
-                logger.info(f"Endpoint pods ({count}): {pod_names}")
-                if count > self.MIN_ENDPOINT_COUNT:
-                    logger.info("Endpoints scaled up")
+                logger.debug(f"Endpoint pods ({count}): {pod_names}")
+                assert count <= self.MAX_ENDPOINT_COUNT, (
+                    f"Endpoint count {count} exceeds configured max "
+                    f"{self.MAX_ENDPOINT_COUNT}"
+                )
+                if count == self.MAX_ENDPOINT_COUNT:
+                    logger.info("Endpoints scaled up to max")
                     break
         except TimeoutExpiredError:
             logger.error("Endpoints did not scale up")
             raise
         finally:
             # 3. Stop the workload
+            logger.test_step("Stop the Warp workload")
             warp_workload_runner.stop()
 
         # 4. Wait for scale-down
+        logger.test_step(
+            f"Wait for endpoint pods to scale down to {self.MIN_ENDPOINT_COUNT}"
+        )
         try:
             for endpoint_pods in TimeoutSampler(
-                timeout=900,
-                sleep=30,
-                func=get_pods_having_label,
-                label=constants.NOOBAA_ENDPOINT_POD_LABEL,
-                namespace=namespace,
+                timeout=1200, sleep=30, func=get_endpoint_pods
             ):
                 count = len(endpoint_pods)
-                logger.info(f"Endpoint pod count: {count}")
+                logger.debug(f"Endpoint pod count: {count}")
                 if count == self.MIN_ENDPOINT_COUNT:
-                    logger.info("Endpoints scaled down")
+                    logger.info("Endpoints scaled down to min")
                     break
         except TimeoutExpiredError:
-            logger.error("Endpoints did not scale down")
+            logger.error(
+                f"Endpoints did not scale down to {self.MIN_ENDPOINT_COUNT} "
+                f"within 1200s"
+            )
             raise

--- a/tests/functional/object/mcg/test_noobaa_endpoint_keda.py
+++ b/tests/functional/object/mcg/test_noobaa_endpoint_keda.py
@@ -195,6 +195,7 @@ class TestNooBaaEndpointKeda(MCGTest):
         host = f"s3.{namespace}.svc:443"
         return WarpWorkloadRunner(request, host)
 
+    @pytest.mark.polarion_id("OCS-8062")
     def test_noobaa_endpoint_keda_autoscaling(
         self,
         setup_keda_autoscaling,

--- a/tests/functional/object/mcg/test_noobaa_endpoint_keda.py
+++ b/tests/functional/object/mcg/test_noobaa_endpoint_keda.py
@@ -6,12 +6,13 @@ import pytest
 from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import (
     mcg,
+    tier2,
     red_squad,
     skipif_disconnected_cluster,
     skipif_external_mode,
     skipif_managed_service,
 )
-from ocs_ci.framework.testlib import MCGTest, tier2
+from ocs_ci.framework.testlib import MCGTest
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.exceptions import CommandFailed, TimeoutExpiredError
 from ocs_ci.ocs.ocp import OCP


### PR DESCRIPTION
## Summary

- Add a tier2 test that validates KEDA-based autoscaling for NooBaa endpoint pods
- Uses the StorageCluster `spec.multiCloudGateway.autoscaler.autoscalerType` API (introduced in [ocs-operator PR #3911](https://github.com/red-hat-storage/ocs-operator/pull/3911)) to configure KEDA, replacing the previous workaround of pausing ocs-operator and patching the NooBaa CR directly

## Changes

- New test `test_noobaa_endpoint_keda_autoscaling` that:
  1. Installs KEDA via Helm (using existing `keda_class` fixture)
  2. Patches the StorageCluster to set endpoint min/max counts and `autoscalerType: keda`
  3. Verifies the noobaa-operator creates a ScaledObject and deletes the default HPA
  4. Runs a Warp S3 workload and waits for endpoint upscaling
  5. Stops the workload and waits for downscaling back to minCount
  6. Restores original StorageCluster config in teardown

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added functional coverage for KEDA-driven autoscaling of NooBaa MultiCloudGateway endpoint pods under a sustained S3 workload.
  * Validates that the created autoscaling resource targets the expected endpoint and applies the correct min/max replica limits.
  * Confirms legacy autoscaling resources are removed.
  * Verifies endpoint pods scale up to (and never beyond) the maximum during load, then scale back down to the minimum after the workload stops, with cleanup safeguards to prevent stuck autoscalers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->