### PR TITLE
attach LSO disks to vsphere masters

### DIFF
--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -104,7 +104,6 @@ from ocs_ci.ocs.node import (
     label_nodes,
     get_all_nodes,
     get_node_objs,
-    get_nodes,
 )
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.resources import machineconfig
@@ -2263,6 +2262,23 @@ class Deployment(object):
         ):
             image = prepare_disconnected_ocs_deployment()
 
+        # Mark masters schedulable and label all nodes as storage nodes
+        # when required by the deployment configuration:
+        # - ODF provider mode with schedulable masters
+        # - EC with schedulable masters (needs all nodes as OSD hosts)
+        needs_schedulable_masters = config.ENV_DATA.get(
+            "mark_masters_schedulable", False
+        ) and (
+            config.ENV_DATA.get("odf_provider_mode_deployment", False)
+            or config.DEPLOYMENT.get("ec_default_pools", False)
+        )
+        if needs_schedulable_masters:
+            mark_masters_schedulable()
+            logger.info("Labeling all nodes as storage nodes")
+            nodes = get_all_nodes()
+            node_objs = get_node_objs(nodes)
+            label_nodes(nodes=node_objs, label=constants.OPERATOR_NODE_LABEL)
+
         if (
             config.ENV_DATA.get("odf_provider_mode_deployment", False)
             and not config.ENV_DATA["skip_ocs_deployment"]
@@ -2275,19 +2291,6 @@ class Deployment(object):
                 + f"default --type json -p '{params}'"
             )
             OCP().exec_oc_cmd(command=patch_cmd)
-
-            # Mark master nodes schedulable if mark_masters_schedulable: True
-            if config.ENV_DATA.get("mark_masters_schedulable", True):
-                mark_masters_schedulable()
-                # Allow ODF to be deployed on all nodes
-                logger.info("labeling all nodes as storage nodes")
-                nodes = get_all_nodes()
-                node_objs = get_node_objs(nodes)
-                label_nodes(nodes=node_objs, label=constants.OPERATOR_NODE_LABEL)
-            else:
-                logger.info("labeling worker nodes as storage nodes")
-                worker_node_objs = get_nodes(node_type=constants.WORKER_MACHINE)
-                label_nodes(nodes=worker_node_objs, label=constants.OPERATOR_NODE_LABEL)
 
         if config.DEPLOYMENT["external_mode"]:
             self.deploy_with_external_mode(image)

--- a/ocs_ci/deployment/helpers/lso_helpers.py
+++ b/ocs_ci/deployment/helpers/lso_helpers.py
@@ -48,10 +48,24 @@ def setup_local_storage(storageclass, add_new_disks=True):
         add_new_disks (bool): whether to add new disks to nodes after LSO installation
 
     """
-    # Get the worker nodes
+    # Get the storage node names -- workers plus masters when EC with
+    # schedulable masters or provider mode requires all nodes as OSD hosts.
     workers = get_nodes(node_type="worker")
     worker_names = [worker.name for worker in workers]
     logger.debug("Workers: %s", worker_names)
+
+    include_masters = config.ENV_DATA.get("mark_masters_schedulable", False) and (
+        config.ENV_DATA.get("odf_provider_mode_deployment", False)
+        or config.DEPLOYMENT.get("ec_default_pools", False)
+    )
+    storage_node_names = get_compute_node_names(no_replace=True)
+    if include_masters:
+        master_names = get_master_nodes()
+        existing = set(storage_node_names)
+        for name in master_names:
+            if name not in existing:
+                storage_node_names.append(name)
+    logger.info("Storage node names for LSO: %s", storage_node_names)
 
     ocp_version = version.get_semantic_ocp_version_from_config()
     ocs_version = version.get_semantic_ocs_version_from_config()
@@ -72,16 +86,9 @@ def setup_local_storage(storageclass, add_new_disks=True):
         # Set local-volume-discovery namespace
         lvd_data["metadata"]["namespace"] = lso_operator.namespace
 
-        storage_node_names = get_compute_node_names(no_replace=True)
-
-        if config.ENV_DATA.get(
-            "odf_provider_mode_deployment", False
-        ) and config.ENV_DATA.get("mark_masters_schedulable", True):
-            storage_node_names.extend(get_master_nodes())
-
-        # Update local volume discovery data with Worker node Names
+        # Update local volume discovery data with storage node names
         logger.info(
-            "Updating LocalVolumeDiscovery CR data with worker nodes Name: %s",
+            "Updating LocalVolumeDiscovery CR data with storage nodes: %s",
             storage_node_names,
         )
         lvd_data["spec"]["nodeSelector"]["nodeSelectorTerms"][0]["matchExpressions"][0][
@@ -155,7 +162,7 @@ def setup_local_storage(storageclass, add_new_disks=True):
         storage_class_device_count = config.ENV_DATA.get("extra_disks", 1)
         if config.DEPLOYMENT.get("deploy_multiple_device_classes"):
             storage_class_device_count *= 2
-    expected_pvs = len(worker_names) * storage_class_device_count
+    expected_pvs = len(storage_node_names) * storage_class_device_count
     if platform in [constants.BAREMETAL_PLATFORM, constants.HCI_BAREMETAL]:
         verify_pvs_created(expected_pvs, storageclass, False)
         if config.DEPLOYMENT.get("partitioned_disk_on_workers", False):

--- a/ocs_ci/deployment/vmware.py
+++ b/ocs_ci/deployment/vmware.py
@@ -170,6 +170,7 @@ class VSPHEREBASE(Deployment):
         disk_type=constants.VM_DISK_TYPE,
         ssd=False,
         include_masters=False,
+        target_node_names=None,
     ):
         """
         Add a new disk to worker nodes (and optionally master nodes).
@@ -182,6 +183,9 @@ class VSPHEREBASE(Deployment):
             size (int): Size of disk in GB (default: 100)
             ssd (bool): if True, mark disk as SSD
             include_masters (bool): if True, also add disks to control-plane VMs
+            target_node_names (list): if provided, only attach disks to VMs
+                whose name is in this list. This avoids unnecessarily
+                power-cycling nodes that don't need storage disks.
 
         """
         vms = self.vsphere.get_all_vms_in_pool(
@@ -189,9 +193,33 @@ class VSPHEREBASE(Deployment):
         )
         extra_disks = config.ENV_DATA.get("extra_disks", 1)
 
-        worker_vms = [vm for vm in vms if "compute" in vm.name]
-        master_vms = (
-            [vm for vm in vms if "control-plane" in vm.name] if include_masters else []
+        if target_node_names:
+            target_set = set(target_node_names)
+            worker_vms = [
+                vm for vm in vms if "compute" in vm.name and vm.name in target_set
+            ]
+            master_vms = (
+                [
+                    vm
+                    for vm in vms
+                    if "control-plane" in vm.name and vm.name in target_set
+                ]
+                if include_masters
+                else []
+            )
+        else:
+            worker_vms = [vm for vm in vms if "compute" in vm.name]
+            master_vms = (
+                [vm for vm in vms if "control-plane" in vm.name]
+                if include_masters
+                else []
+            )
+
+        logger.info(
+            "Attaching disks to %d worker VM(s)%s: %s",
+            len(worker_vms),
+            f" and {len(master_vms)} control-plane VM(s)" if master_vms else "",
+            [vm.name for vm in worker_vms + master_vms],
         )
 
         for vm in worker_vms:
@@ -412,15 +440,16 @@ class VSPHEREBASE(Deployment):
 
     def add_vmdk_disks(self):
         """
-        Attach VMDK disks to all worker nodes (and master nodes when EC with
-        schedulable masters is configured), skipping if sufficient disks
-        already exist (idempotent).
+        Attach VMDK disks to OCS-labeled worker nodes (and master nodes when
+        EC with schedulable masters is configured), skipping if sufficient
+        disks already exist (idempotent).
 
-        Reads device_size, provision_type, extra_disks, hdd_disks, and
-        deploy_multiple_device_classes from config. Checks existing non-boot
-        disks via disks_available_to_cleanup before attaching to avoid
-        duplicates on re-runs.
+        Only nodes with the OCS storage label are targeted, avoiding
+        unnecessary power-cycles on nodes that don't need storage disks.
         """
+        from ocs_ci.deployment.baremetal import disks_available_to_cleanup
+        from ocs_ci.ocs.machine import get_labeled_nodes
+
         ssd_disk = True
         if config.ENV_DATA.get("hdd_disks"):
             ssd_disk = False
@@ -433,19 +462,37 @@ class VSPHEREBASE(Deployment):
             "ec_default_pools"
         ) and config.ENV_DATA.get("mark_masters_schedulable", True)
 
-        # Importing here to avoid circular dependency (baremetal imports lso_helpers)
-        from ocs_ci.deployment.baremetal import disks_available_to_cleanup
-
-        target_nodes = get_nodes(node_type=constants.WORKER_MACHINE)
+        ocs_labeled_names = set(get_labeled_nodes(constants.OPERATOR_NODE_LABEL))
+        all_workers = get_nodes(node_type=constants.WORKER_MACHINE)
+        all_masters = (
+            get_nodes(node_type=constants.MASTER_MACHINE) if include_masters else []
+        )
+        target_nodes = [n for n in all_workers if n.name in ocs_labeled_names]
         if include_masters:
-            target_nodes += get_nodes(node_type=constants.MASTER_MACHINE)
+            target_nodes += [n for n in all_masters if n.name in ocs_labeled_names]
+
+        if not target_nodes:
+            logger.warning(
+                "No nodes found with OCS label %s, falling back to all " "worker nodes",
+                constants.OPERATOR_NODE_LABEL,
+            )
+            target_nodes = all_workers
+            if include_masters:
+                target_nodes += all_masters
+
+        target_node_names = [n.name for n in target_nodes]
+        logger.info(
+            "OCS-labeled target nodes for disk attachment: %s",
+            target_node_names,
+        )
+
         extra_disks = config.ENV_DATA.get("extra_disks", 1)
         total_available_disks = sum(
             len(disks_available_to_cleanup(n)) for n in target_nodes
         )
         logger.info(
-            "Total available (non-boot) disks across %s nodes: %s",
-            "all" if include_masters else constants.WORKER_MACHINE,
+            "Total available (non-boot) disks across %d target nodes: %s",
+            len(target_nodes),
             total_available_disks,
         )
 
@@ -456,6 +503,7 @@ class VSPHEREBASE(Deployment):
                 provision_type,
                 ssd=ssd_disk,
                 include_masters=include_masters,
+                target_node_names=target_node_names,
             )
         else:
             logger.info(
@@ -475,6 +523,7 @@ class VSPHEREBASE(Deployment):
                     provision_type,
                     ssd=ssd_disk,
                     include_masters=include_masters,
+                    target_node_names=target_node_names,
                 )
             else:
                 logger.info(

--- a/ocs_ci/deployment/vmware.py
+++ b/ocs_ci/deployment/vmware.py
@@ -174,6 +174,10 @@ class VSPHEREBASE(Deployment):
         """
         Add a new disk to worker nodes (and optionally master nodes).
 
+        When include_masters is True, control-plane nodes are processed one
+        at a time with stabilization waits between restarts to prevent etcd
+        quorum loss. Worker nodes are always processed first.
+
         Args:
             size (int): Size of disk in GB (default: 100)
             ssd (bool): if True, mark disk as SSD
@@ -183,10 +187,30 @@ class VSPHEREBASE(Deployment):
         vms = self.vsphere.get_all_vms_in_pool(
             config.ENV_DATA.get("cluster_name"), self.datacenter, self.cluster
         )
-        for vm in vms:
-            if "compute" in vm.name or (include_masters and "control-plane" in vm.name):
+        extra_disks = config.ENV_DATA.get("extra_disks", 1)
+
+        worker_vms = [vm for vm in vms if "compute" in vm.name]
+        master_vms = (
+            [vm for vm in vms if "control-plane" in vm.name] if include_masters else []
+        )
+
+        for vm in worker_vms:
+            self.vsphere.add_disks_with_same_size(extra_disks, vm, size, disk_type, ssd)
+
+        if master_vms:
+            logger.info(
+                "Processing %d control-plane node(s) sequentially with "
+                "stabilization waits to preserve etcd quorum",
+                len(master_vms),
+            )
+            for vm in master_vms:
                 self.vsphere.add_disks_with_same_size(
-                    config.ENV_DATA.get("extra_disks", 1), vm, size, disk_type, ssd
+                    extra_disks,
+                    vm,
+                    size,
+                    disk_type,
+                    ssd,
+                    is_control_plane=True,
                 )
 
     def add_nodes(self):

--- a/ocs_ci/ocs/cluster.py
+++ b/ocs_ci/ocs/cluster.py
@@ -1434,6 +1434,24 @@ def validate_pdb_creation():
             pdb_count = constants.PDB_COUNT_ARBITER_VSPHERE
             pdb_required.append(constants.RGW_PDB)
 
+    # EC with host failure domain: Rook creates per-host OSD PDBs
+    # (rook-ceph-osd-host-<node>) instead of a single rook-ceph-osd PDB.
+    # Discover them from the cluster to get the correct count and names.
+    ec_host_fd = (
+        config.DEPLOYMENT.get("ec_default_pools")
+        and config.DEPLOYMENT.get("ec_failure_domain", "host") == "host"
+    )
+    if ec_host_fd:
+        osd_pdb_names = [
+            item["metadata"]["name"]
+            for item in item_list
+            if item["metadata"]["name"].startswith("rook-ceph-osd-host-")
+        ]
+        if osd_pdb_names:
+            pdb_required.remove(constants.OSD_PDB)
+            pdb_required.extend(osd_pdb_names)
+            pdb_count += len(osd_pdb_names) - 1
+
     if odf_running_version >= version.VERSION_4_19 and not config.COMPONENTS.get(
         "disable_noobaa", False
     ):

--- a/ocs_ci/utility/vsphere.py
+++ b/ocs_ci/utility/vsphere.py
@@ -401,7 +401,13 @@ class VSPHERE(object):
             self.start_vms(vms=[vm])
 
     def add_disks_with_same_size(
-        self, num_disks, vm, size, disk_type="thin", ssd=False
+        self,
+        num_disks,
+        vm,
+        size,
+        disk_type="thin",
+        ssd=False,
+        is_control_plane=False,
     ):
         """
         Adds multiple disks to the VM with the same size
@@ -412,12 +418,17 @@ class VSPHERE(object):
             size (int) : size of disk in GB
             disk_type (str) : disk type
             ssd (bool): if True, mark disk as SSD
+            is_control_plane (bool): if True, this VM is a control-plane node
+                and extra stabilization waits are applied after restart to
+                ensure etcd quorum is preserved
 
         """
         disk_sizes = [size] * num_disks
-        self.add_disks(vm, disk_sizes, disk_type, ssd)
+        self.add_disks(vm, disk_sizes, disk_type, ssd, is_control_plane)
 
-    def add_disks(self, vm, disk_sizes, disk_type="thin", ssd=False):
+    def add_disks(
+        self, vm, disk_sizes, disk_type="thin", ssd=False, is_control_plane=False
+    ):
         """
         Adds multiple disks to the VM
 
@@ -426,6 +437,9 @@ class VSPHERE(object):
             disk_sizes (list) : List of the disk sizes in GB
             disk_type (str) : disk type
             ssd (bool): if True, mark disk as SSD
+            is_control_plane (bool): if True, this VM is a control-plane node
+                and extra stabilization waits are applied after restart to
+                ensure etcd quorum is preserved
 
         """
         if ssd:
@@ -436,20 +450,108 @@ class VSPHERE(object):
 
         if ssd:
             self.start_vms(vms=[vm])
-        # Importing here to avoid circular dependencies
+
         from ocs_ci.ocs.node import get_compute_node_names, wait_for_nodes_status
 
-        compute_nodes = get_compute_node_names()
+        if is_control_plane:
+            self._wait_for_control_plane_stable(vm.name)
+        else:
+            compute_nodes = get_compute_node_names()
+            try:
+                wait_for_nodes_status(compute_nodes, NODE_READY)
+            except ResourceWrongStatusException as ex:
+                logger.warning(
+                    f"At least one of the compute node is not in READY state: {ex}"
+                )
+                logger.warning(f"Trying to restart the node vm {vm.name} once again.")
+                self.stop_vms(vms=[vm])
+                self.start_vms(vms=[vm])
+                wait_for_nodes_status(compute_nodes, NODE_READY)
+
+    def _wait_for_control_plane_stable(self, vm_name, timeout=600):
+        """
+        Wait for a control-plane node to fully rejoin the cluster after
+        a restart. Verifies the node reaches Ready status and then waits
+        for the API server to be responsive, ensuring etcd quorum is
+        restored before the next control-plane node can be restarted.
+
+        Handles transient API server timeouts gracefully -- the API may be
+        temporarily unavailable while the restarted etcd member rejoins.
+
+        Args:
+            vm_name (str): Name of the control-plane VM that was restarted
+            timeout (int): Maximum seconds to wait for stabilization
+
+        Raises:
+            ResourceWrongStatusException: If the node does not reach Ready
+                within the timeout
+
+        """
+        from ocs_ci.ocs.exceptions import TimeoutExpiredError
+
+        logger.info(
+            "Waiting for control-plane node %s to reach Ready status "
+            "and etcd to stabilize (timeout=%ds)",
+            vm_name,
+            timeout,
+        )
+
         try:
-            wait_for_nodes_status(compute_nodes, NODE_READY)
-        except ResourceWrongStatusException as ex:
-            logger.warning(
-                f"At least one of the compute node is not in  READY state: {ex}"
+            for attempt in TimeoutSampler(timeout, 15, self._is_node_ready, vm_name):
+                if attempt:
+                    logger.info(
+                        "Control-plane node %s is Ready",
+                        vm_name,
+                    )
+                    break
+        except TimeoutExpiredError:
+            raise ResourceWrongStatusException(
+                f"Control-plane node {vm_name} did not reach Ready status "
+                f"within {timeout}s after disk attachment"
             )
-            logger.warning(f"Trying to restart the node vm {vm.name} once again.")
-            self.stop_vms(vms=[vm])
-            self.start_vms(vms=[vm])
-            wait_for_nodes_status(compute_nodes, NODE_READY)
+
+        grace = 30
+        logger.info(
+            "Allowing %ds grace period for etcd cluster stabilization "
+            "after %s rejoined",
+            grace,
+            vm_name,
+        )
+        time.sleep(grace)
+
+    @staticmethod
+    def _is_node_ready(node_name):
+        """
+        Check whether a single node has reached Ready status.
+
+        Returns True if the node is Ready, False otherwise. Catches API
+        errors (timeouts, connection issues) and returns False so the
+        caller can retry.
+
+        Args:
+            node_name (str): The node name to check
+
+        Returns:
+            bool: True if the node is Ready
+
+        """
+        from ocs_ci.ocs.node import wait_for_nodes_status
+        from ocs_ci.ocs.exceptions import CommandFailed
+
+        try:
+            wait_for_nodes_status(
+                node_names=[node_name],
+                status=NODE_READY,
+                timeout=10,
+            )
+            return True
+        except (ResourceWrongStatusException, CommandFailed) as ex:
+            logger.debug(
+                "Node %s not yet Ready or API unavailable: %s",
+                node_name,
+                ex,
+            )
+            return False
 
     def add_rdm_disk(self, vm, device_name, disk_mode=None, compatibility_mode=None):
         """

--- a/ocs_ci/utility/vsphere.py
+++ b/ocs_ci/utility/vsphere.py
@@ -17,6 +17,7 @@ from pyVim.connect import Disconnect, SmartStubAdapter, VimSessionOrientedStub
 from ocs_ci.ocs.exceptions import (
     ResourceWrongStatusException,
     ResourcePoolNotFound,
+    TimeoutExpiredError,
     VMMaxDisksReachedException,
     VSLMNotFoundException,
 )
@@ -449,7 +450,7 @@ class VSPHERE(object):
             self._configure_disk_for_vm(vm, size, disk_type, ssd)
 
         if ssd:
-            self.start_vms(vms=[vm])
+            self._start_vm_with_retry(vm)
 
         from ocs_ci.ocs.node import get_compute_node_names, wait_for_nodes_status
 
@@ -465,8 +466,47 @@ class VSPHERE(object):
                 )
                 logger.warning(f"Trying to restart the node vm {vm.name} once again.")
                 self.stop_vms(vms=[vm])
-                self.start_vms(vms=[vm])
+                self._start_vm_with_retry(vm)
                 wait_for_nodes_status(compute_nodes, NODE_READY)
+
+    def _start_vm_with_retry(self, vm, max_retries=2):
+        """
+        Start a VM and wait for it to obtain an IP address. If the VM
+        fails to get an IP within the timeout, power-cycle it and retry.
+
+        This handles transient vSphere networking issues where a VM boots
+        but never obtains network connectivity.
+
+        Args:
+            vm (vim.VirtualMachine): VM to start
+            max_retries (int): Maximum number of power-cycle retries
+
+        Raises:
+            TimeoutExpiredError: If the VM fails to obtain an IP after
+                all retries are exhausted
+
+        """
+        for attempt in range(1, max_retries + 1):
+            try:
+                self.start_vms(vms=[vm])
+                return
+            except TimeoutExpiredError:
+                if attempt >= max_retries:
+                    logger.error(
+                        "VM %s failed to obtain an IP after %d attempt(s). "
+                        "Giving up.",
+                        vm.name,
+                        max_retries,
+                    )
+                    raise
+                logger.warning(
+                    "VM %s did not obtain an IP within the timeout "
+                    "(attempt %d/%d). Retrying power cycle.",
+                    vm.name,
+                    attempt,
+                    max_retries,
+                )
+                self.stop_vms(vms=[vm])
 
     def _wait_for_control_plane_stable(self, vm_name, timeout=600):
         """
@@ -487,8 +527,6 @@ class VSPHERE(object):
                 within the timeout
 
         """
-        from ocs_ci.ocs.exceptions import TimeoutExpiredError
-
         logger.info(
             "Waiting for control-plane node %s to reach Ready status "
             "and etcd to stabilize (timeout=%ds)",
@@ -545,7 +583,12 @@ class VSPHERE(object):
                 timeout=10,
             )
             return True
-        except (ResourceWrongStatusException, CommandFailed) as ex:
+        except (
+            ResourceWrongStatusException,
+            CommandFailed,
+            TimeoutExpiredError,
+            AssertionError,
+        ) as ex:
             logger.debug(
                 "Node %s not yet Ready or API unavailable: %s",
                 node_name,

--- a/tests/libtest/test_vsphere_disk_attach_helpers.py
+++ b/tests/libtest/test_vsphere_disk_attach_helpers.py
@@ -1,0 +1,216 @@
+import logging
+
+import pytest
+
+from ocs_ci.framework import config
+from ocs_ci.framework.testlib import (
+    ManageTest,
+    libtest,
+    brown_squad,
+    ignore_leftovers,
+    skipif_no_lso,
+    vsphere_platform_required,
+)
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.constants import NODE_READY, VM_POWERED_ON
+from ocs_ci.ocs.node import get_nodes, wait_for_nodes_status
+from ocs_ci.utility.vsphere import VSPHERE
+
+log = logging.getLogger(__name__)
+
+
+@brown_squad
+@libtest
+@ignore_leftovers
+@skipif_no_lso
+@vsphere_platform_required
+class TestVsphereDiskAttachHelpers(ManageTest):
+    """
+    Exercise the vSphere disk-attachment helper methods that were fixed
+    to prevent etcd quorum loss (control-plane stabilization) and to
+    retry VM power-on when a VM fails to obtain an IP address.
+
+    Prerequisites:
+      - vSphere UPI cluster with LSO installed (not necessarily provisioned)
+      - At least one compute and one control-plane VM in the resource pool
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup_vsphere(self):
+        """Set up the VSPHERE connection and discover VMs."""
+        self.vsphere = VSPHERE(
+            config.ENV_DATA["vsphere_server"],
+            config.ENV_DATA["vsphere_user"],
+            config.ENV_DATA["vsphere_password"],
+        )
+        self.cluster_name = config.ENV_DATA["cluster_name"]
+        self.datacenter = config.ENV_DATA["vsphere_datacenter"]
+        self.cluster = config.ENV_DATA["vsphere_cluster"]
+
+        vms = self.vsphere.get_all_vms_in_pool(
+            self.cluster_name,
+            self.datacenter,
+            self.cluster,
+        )
+        self.worker_vms = [vm for vm in vms if "compute" in vm.name]
+        self.master_vms = [vm for vm in vms if "control-plane" in vm.name]
+        log.info(
+            "Discovered %d worker VM(s) and %d control-plane VM(s)",
+            len(self.worker_vms),
+            len(self.master_vms),
+        )
+        assert self.worker_vms, "No compute VMs found in resource pool"
+        assert self.master_vms, "No control-plane VMs found in resource pool"
+
+    def test_is_node_ready_worker(self):
+        """
+        Verify _is_node_ready returns True for all running worker nodes.
+        """
+        for vm in self.worker_vms:
+            status = self.vsphere.get_vm_power_status(vm)
+            if status != VM_POWERED_ON:
+                log.info("Skipping VM %s (status=%s)", vm.name, status)
+                continue
+            result = self.vsphere._is_node_ready(vm.name)
+            log.info("_is_node_ready(%s) = %s", vm.name, result)
+            assert result, (
+                f"Worker node {vm.name} is powered on but _is_node_ready "
+                f"returned False"
+            )
+
+    def test_is_node_ready_control_plane(self):
+        """
+        Verify _is_node_ready returns True for all running control-plane nodes.
+        """
+        for vm in self.master_vms:
+            status = self.vsphere.get_vm_power_status(vm)
+            if status != VM_POWERED_ON:
+                log.info("Skipping VM %s (status=%s)", vm.name, status)
+                continue
+            result = self.vsphere._is_node_ready(vm.name)
+            log.info("_is_node_ready(%s) = %s", vm.name, result)
+            assert result, (
+                f"Control-plane node {vm.name} is powered on but "
+                f"_is_node_ready returned False"
+            )
+
+    def test_is_node_ready_catches_api_errors(self):
+        """
+        Verify _is_node_ready returns False (not raises) for a non-existent
+        node name. This simulates the API-unavailable / node-not-found
+        scenario that the method must handle gracefully.
+        """
+        result = self.vsphere._is_node_ready("nonexistent-node-xyz")
+        log.info("_is_node_ready('nonexistent-node-xyz') = %s", result)
+        assert result is False, (
+            "_is_node_ready should return False for a nonexistent node, "
+            "not raise an exception"
+        )
+
+    def test_start_vm_with_retry_worker(self):
+        """
+        Power-cycle a single worker VM using _start_vm_with_retry and
+        confirm the VM comes back up with an IP and reaches Ready status.
+        """
+
+        vm = self.worker_vms[0]
+        log.info(
+            "Testing _start_vm_with_retry on worker VM %s",
+            vm.name,
+        )
+
+        self.vsphere.stop_vms(vms=[vm])
+        self.vsphere._start_vm_with_retry(vm)
+
+        status = self.vsphere.get_vm_power_status(vm)
+        assert status == VM_POWERED_ON, (
+            f"VM {vm.name} should be powered on after _start_vm_with_retry, "
+            f"got {status}"
+        )
+
+        log.info("Waiting for node %s to reach Ready status", vm.name)
+        wait_for_nodes_status(
+            node_names=[vm.name],
+            status=NODE_READY,
+            timeout=300,
+        )
+        log.info(
+            "Worker VM %s successfully restarted via _start_vm_with_retry", vm.name
+        )
+
+    def test_wait_for_control_plane_stable(self):
+        """
+        Power-cycle a single control-plane VM and use
+        _wait_for_control_plane_stable to verify it rejoins with proper
+        etcd stabilization wait. This is the core fix that prevents etcd
+        quorum loss when processing control-plane nodes sequentially.
+        """
+        vm = self.master_vms[0]
+        log.info(
+            "Testing _wait_for_control_plane_stable on control-plane VM %s",
+            vm.name,
+        )
+
+        self.vsphere.stop_vms(vms=[vm])
+        self.vsphere._start_vm_with_retry(vm)
+        self.vsphere._wait_for_control_plane_stable(vm.name)
+
+        assert self.vsphere._is_node_ready(vm.name), (
+            f"Control-plane node {vm.name} should be Ready after "
+            f"_wait_for_control_plane_stable"
+        )
+        log.info(
+            "Control-plane VM %s stabilized successfully",
+            vm.name,
+        )
+
+    def test_sequential_control_plane_restart(self):
+        """
+        Power-cycle each control-plane VM one at a time with
+        _wait_for_control_plane_stable between each restart.
+        This validates that sequential processing preserves etcd quorum
+        by ensuring a previously restarted node is fully stabilized
+        before the next one is power-cycled.
+        """
+        for i, vm in enumerate(self.master_vms):
+            log.info(
+                "Sequential control-plane restart: VM %s (%d/%d)",
+                vm.name,
+                i + 1,
+                len(self.master_vms),
+            )
+            self.vsphere.stop_vms(vms=[vm])
+            self.vsphere._start_vm_with_retry(vm)
+            self.vsphere._wait_for_control_plane_stable(vm.name)
+
+            assert self.vsphere._is_node_ready(vm.name), (
+                f"Control-plane node {vm.name} not Ready after "
+                f"stabilization (step {i + 1}/{len(self.master_vms)})"
+            )
+            log.info(
+                "Control-plane VM %s stabilized (%d/%d)",
+                vm.name,
+                i + 1,
+                len(self.master_vms),
+            )
+
+        log.info(
+            "All %d control-plane VMs restarted sequentially with "
+            "etcd stabilization — no quorum loss",
+            len(self.master_vms),
+        )
+
+    def test_all_nodes_ready_after_operations(self):
+        """
+        Final sanity check: verify all worker and control-plane nodes
+        are in Ready status.
+        """
+        from ocs_ci.ocs.node import wait_for_nodes_status
+
+        worker_names = [n.name for n in get_nodes(constants.WORKER_MACHINE)]
+        master_names = [n.name for n in get_nodes(constants.MASTER_MACHINE)]
+        all_names = worker_names + master_names
+
+        log.info("Verifying all nodes are Ready: %s", all_names)
+        wait_for_nodes_status(all_names, NODE_READY, timeout=120)
+        log.info("All %d nodes confirmed Ready", len(all_names))


### PR DESCRIPTION
PR is to resolve the problem with sequential Master nodes shut down:

```
2026-07-12 17:43:35  10:43:32 - MainThread - ocs_ci.framework.pytest_customization.reports - INFO  - duration reported by tests/functional/deployment/test_deployment.py::test_deployment immediately after test execution: 1166.9
2026-07-12 17:43:35  ERROR
2026-07-12 17:43:35  ______________________ ERROR at setup of test_deployment _______________________
2026-07-12 17:43:35  
2026-07-12 17:43:35  request = <SubRequest 'cluster' for <Function test_deployment>>
2026-07-12 17:43:35  log_cli_level = 'INFO'
2026-07-12 17:43:35  record_testsuite_property = <bound method LogXML.add_global_property of <_pytest.junitxml.LogXML object at 0x7f02553dbfd0>>
2026-07-12 17:43:35  set_live_must_gather_images = None
2026-07-12 17:43:35  
2026-07-12 17:43:35      @pytest.fixture(scope="session", autouse=True)
2026-07-12 17:43:35      def cluster(
2026-07-12 17:43:35          request, log_cli_level, record_testsuite_property, set_live_must_gather_images
2026-07-12 17:43:35      ):
2026-07-12 17:43:35          """
2026-07-12 17:43:35          This fixture initiates deployment for both OCP and OCS clusters.
2026-07-12 17:43:35          Specific platform deployment classes will handle the fine details
2026-07-12 17:43:35          of action
2026-07-12 17:43:35          """
2026-07-12 17:43:35          log.info(f"All logs located at {ocsci_log_path()}")
2026-07-12 17:43:35      
2026-07-12 17:43:35          teardown = ocsci_config.RUN["cli_params"]["teardown"]
2026-07-12 17:43:35          deploy = ocsci_config.RUN["cli_params"]["deploy"]
2026-07-12 17:43:35          if teardown or deploy:
2026-07-12 17:43:35              for index in range(ocsci_config.nclusters):
2026-07-12 17:43:35                  with config.RunWithConfigContext(index):
2026-07-12 17:43:35                      # Let get initiated deployer for each cluster here to be sure all necesary
2026-07-12 17:43:35                      # values are propagated to all clusters configs
2026-07-12 17:43:35                      DEPLOYERS[config.ENV_DATA["cluster_name"]] = (
2026-07-12 17:43:35                          dep_factory.DeploymentFactory().get_deployment()
2026-07-12 17:43:35                      )
2026-07-12 17:43:35              deployer = DEPLOYERS[config.ENV_DATA["cluster_name"]]
2026-07-12 17:43:35      
2026-07-12 17:43:35          # Add a finalizer to teardown the cluster after test execution is finished
2026-07-12 17:43:35          if teardown:
2026-07-12 17:43:35      
2026-07-12 17:43:35              def cluster_teardown_finalizer():
2026-07-12 17:43:35                  # If KMS is configured, clean up the backend resources
2026-07-12 17:43:35                  # we are doing it before OCP cleanup
2026-07-12 17:43:35                  if ocsci_config.DEPLOYMENT.get("kms_deployment"):
2026-07-12 17:43:35                      try:
2026-07-12 17:43:35                          kms = KMS.get_kms_deployment()
2026-07-12 17:43:35                          kms.cleanup()
2026-07-12 17:43:35                      except Exception as ex:
2026-07-12 17:43:35                          log.error(f"Failed to cleanup KMS. Exception is: {ex}")
2026-07-12 17:43:35                  if ocsci_config.MULTICLUSTER.get("acm_cluster"):
2026-07-12 17:43:35                      try:
2026-07-12 17:43:35                          from ocs_ci.utility.aws import AWS
2026-07-12 17:43:35      
2026-07-12 17:43:35                          thanos_bucket_name = (
2026-07-12 17:43:35                              f"dr-thanos-bucket-{config.ENV_DATA['cluster_name']}"
2026-07-12 17:43:35                          )
2026-07-12 17:43:35                          AWS().delete_bucket(thanos_bucket_name)
2026-07-12 17:43:35                      except Exception as ex:
2026-07-12 17:43:35                          log.error(
2026-07-12 17:43:35                              f"Either failed to delete bucket or bucket doesn't exist {ex}"
2026-07-12 17:43:35                          )
2026-07-12 17:43:35                  if ocsci_config.ENV_DATA.get("iscsi_setup", False):
2026-07-12 17:43:35                      try:
2026-07-12 17:43:35                          iscsi_teardown()
2026-07-12 17:43:35                      except Exception as ex:
2026-07-12 17:43:35                          log.error(f"Failed to teardown iSCSI: {ex}")
2026-07-12 17:43:35                  # Destroy AWS HCP hosted clusters before the management cluster.
2026-07-12 17:43:35                  # This terminates EC2 worker instances, cleans up VPCs, IAM roles,
2026-07-12 17:43:35                  # peering connections, and HostedCluster CRs.
2026-07-12 17:43:35                  try:
2026-07-12 17:43:35                      if ocsci_config.ENV_DATA["cluster_type"] == constants.HCI_PROVIDER:
2026-07-12 17:43:35                          if not destroy_aws_hcp_clusters():
2026-07-12 17:43:35                              log.error(
2026-07-12 17:43:35                                  "!!!!! Cluster teardown failed. Delete manually !!!!!"
2026-07-12 17:43:35                              )
2026-07-12 17:43:35                  except Exception as ex:
2026-07-12 17:43:35                      log.error(f"Failed to destroy AWS HCP clusters: {ex}")
2026-07-12 17:43:35                  deployer.destroy_cluster(log_cli_level)
2026-07-12 17:43:35      
2026-07-12 17:43:35              request.addfinalizer(cluster_teardown_finalizer)
2026-07-12 17:43:35              log.info("Will teardown cluster because --teardown was provided")
2026-07-12 17:43:35      
2026-07-12 17:43:35          # Download client
2026-07-12 17:43:35          if ocsci_config.DEPLOYMENT["skip_download_client"]:
2026-07-12 17:43:35              log.info("Skipping client download")
2026-07-12 17:43:35          else:
2026-07-12 17:43:35              force_download = (
2026-07-12 17:43:35                  ocsci_config.RUN["cli_params"].get("deploy")
2026-07-12 17:43:35                  and ocsci_config.DEPLOYMENT["force_download_client"]
2026-07-12 17:43:35              )
2026-07-12 17:43:35              get_openshift_client(force_download=force_download)
2026-07-12 17:43:35      
2026-07-12 17:43:35          multi_arch = ocsci_config.ENV_DATA.get("multi_arch")
2026-07-12 17:43:35          if ocsci_config.ENV_DATA.get("early_testing") or multi_arch:
2026-07-12 17:43:35              release_img = ocsci_config.ENV_DATA.get("release_img")
2026-07-12 17:43:35              if not release_img and ocsci_config.ENV_DATA.get("multi_arch"):
2026-07-12 17:43:35                  release_img = get_latest_ocp_multi_image()
2026-07-12 17:43:35              if not release_img:
2026-07-12 17:43:35                  raise ValueError(
2026-07-12 17:43:35                      "No release_img provided in config under ENV_DATA section!"
2026-07-12 17:43:35                  )
2026-07-12 17:43:35              log.info(
2026-07-12 17:43:35                  f"Running early testing of RHCOS or multi-arch testing with release image: {release_img}"
2026-07-12 17:43:35              )
2026-07-12 17:43:35              # set environment variables for early testing of RHCOS or multi-arch
2026-07-12 17:43:35              os.environ["RELEASE_IMG"] = release_img
2026-07-12 17:43:35              os.environ["OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE"] = release_img
2026-07-12 17:43:35      
2026-07-12 17:43:35          if deploy:
2026-07-12 17:43:35              # Deploy cluster
2026-07-12 17:43:35  >           deployer.deploy_cluster(log_cli_level)
2026-07-12 17:43:35  
2026-07-12 17:43:35  tests/conftest.py:2501: 
2026-07-12 17:43:35  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2026-07-12 17:43:35  ocs_ci/deployment/deployment.py:990: in deploy_cluster
2026-07-12 17:43:35      self.do_deploy_ocs()
2026-07-12 17:43:35  ocs_ci/deployment/deployment.py:523: in do_deploy_ocs
2026-07-12 17:43:35      self.deploy_ocs()
2026-07-12 17:43:35  ocs_ci/deployment/deployment.py:2295: in deploy_ocs
2026-07-12 17:43:35      self.deploy_ocs_via_operator(image)
2026-07-12 17:43:35  ocs_ci/deployment/deployment.py:1494: in deploy_ocs_via_operator
2026-07-12 17:43:35      setup_local_storage(
2026-07-12 17:43:35  ocs_ci/deployment/helpers/lso_helpers.py:66: in setup_local_storage
2026-07-12 17:43:35      add_disks_lso()
2026-07-12 17:43:35  ocs_ci/deployment/helpers/lso_helpers.py:173: in add_disks_lso
2026-07-12 17:43:35      add_disk_for_vsphere_platform()
2026-07-12 17:43:35  ocs_ci/deployment/helpers/lso_helpers.py:455: in add_disk_for_vsphere_platform
2026-07-12 17:43:35      vsphere_base.add_vmdk_disks()
2026-07-12 17:43:35  ocs_ci/deployment/vmware.py:430: in add_vmdk_disks
2026-07-12 17:43:35      self.attach_disk(
2026-07-12 17:43:35  ocs_ci/deployment/vmware.py:188: in attach_disk
2026-07-12 17:43:35      self.vsphere.add_disks_with_same_size(
2026-07-12 17:43:35  ocs_ci/utility/vsphere.py:418: in add_disks_with_same_size
2026-07-12 17:43:35      self.add_disks(vm, disk_sizes, disk_type, ssd)
2026-07-12 17:43:35  ocs_ci/utility/vsphere.py:442: in add_disks
2026-07-12 17:43:35      compute_nodes = get_compute_node_names()
2026-07-12 17:43:35  ocs_ci/ocs/node.py:1040: in get_compute_node_names
2026-07-12 17:43:35      compute_node_objs = get_nodes()
2026-07-12 17:43:35  ocs_ci/ocs/node.py:280: in get_nodes
2026-07-12 17:43:35      for node in get_node_objs()
2026-07-12 17:43:35  ocs_ci/ocs/node.py:230: in get_node_objs
2026-07-12 17:43:35      node_dicts = nodes_obj.get()["items"]
2026-07-12 17:43:35  ocs_ci/ocs/ocp.py:358: in get
2026-07-12 17:43:35      return self.exec_oc_cmd(
2026-07-12 17:43:35  ocs_ci/ocs/ocp.py:216: in exec_oc_cmd
2026-07-12 17:43:35      out = run_cmd(
2026-07-12 17:43:35  ocs_ci/utility/utils.py:632: in run_cmd
2026-07-12 17:43:35      completed_process = exec_cmd(
2026-07-12 17:43:35  ocs_ci/utility/retry.py:79: in f_retry
2026-07-12 17:43:35      return f(*args, **kwargs)
2026-07-12 17:43:35  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2026-07-12 17:43:35  
2026-07-12 17:43:35  cmd = ['oc', '--kubeconfig', '/home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig', 'get', 'node', '-o', ...]
2026-07-12 17:43:35  secrets = None, timeout = 600, ignore_error = False, threading_lock = None
2026-07-12 17:43:35  silent = False
2026-07-12 17:43:35  cluster_config = <ocs_ci.framework.MultiClusterConfig object at 0x7f027abdd610>
2026-07-12 17:43:35  lock_timeout = 7200, output_file = None, kwargs = {}
2026-07-12 17:43:35  _env = {'ANTHROPIC_VERTEX_PROJECT_ID': 'itpc-gcp-core-pe-eng-claude', 'AUTOMATICALLY_RE_TRIGGER_FAILED_TESTS': 'false', 'BASH... --read-alias --read-functions --show-tilde --show-dot $@\n}', 'BUILD_DISPLAY_NAME': '#70289 - dosypenk-127v2eco', ...}
2026-07-12 17:43:35  kubeconfig_path = '/home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig'
2026-07-12 17:43:35  
2026-07-12 17:43:35      @retry(
2026-07-12 17:43:35          CommandFailed,
2026-07-12 17:43:35          tries=6,
2026-07-12 17:43:35          delay=10,
2026-07-12 17:43:35          backoff=1,
2026-07-12 17:43:35          text_in_exception="client connection lost",
2026-07-12 17:43:35      )
2026-07-12 17:43:35      def exec_cmd(
2026-07-12 17:43:35          cmd,
2026-07-12 17:43:35          secrets=None,
2026-07-12 17:43:35          timeout=600,
2026-07-12 17:43:35          ignore_error=False,
2026-07-12 17:43:35          threading_lock=None,
2026-07-12 17:43:35          silent=False,
2026-07-12 17:43:35          cluster_config=None,
2026-07-12 17:43:35          lock_timeout=7200,
2026-07-12 17:43:35          output_file=None,
2026-07-12 17:43:35          **kwargs,
2026-07-12 17:43:35      ):
2026-07-12 17:43:35          """
2026-07-12 17:43:35          Run an arbitrary command locally
2026-07-12 17:43:35      
2026-07-12 17:43:35          If the command is grep and matching pattern is not found, then this function
2026-07-12 17:43:35          returns "command terminated with exit code 1" in stderr.
2026-07-12 17:43:35      
2026-07-12 17:43:35          Args:
2026-07-12 17:43:35              cmd (str): command to run
2026-07-12 17:43:35              secrets (list): A list of secrets to be masked with asterisks
2026-07-12 17:43:35                  This kwarg is popped in order to not interfere with
2026-07-12 17:43:35                  subprocess.run(``**kwargs``)
2026-07-12 17:43:35              timeout (int): Timeout for the command, defaults to 600 seconds.
2026-07-12 17:43:35              ignore_error (bool): True if ignore non zero return code and do not
2026-07-12 17:43:35                  raise the exception.
2026-07-12 17:43:35              threading_lock (threading.RLock): threading.RLock object that is used
2026-07-12 17:43:35                  for handling concurrent oc commands
2026-07-12 17:43:35              silent (bool): If True will silent errors from the server, default false
2026-07-12 17:43:35              cluster_config (MultiClusterConfig): In case of multicluster environment this object
2026-07-12 17:43:35                      will be non-null
2026-07-12 17:43:35              lock_timeout (int): maximum timeout to wait for lock to prevent deadlocks (default 2 hours)
2026-07-12 17:43:35              output_file (str): path where to write output of stderr from command - apply only when silent mode is True
2026-07-12 17:43:35      
2026-07-12 17:43:35          Raises:
2026-07-12 17:43:35              CommandFailed: In case the command execution fails
2026-07-12 17:43:35      
2026-07-12 17:43:35          Returns:
2026-07-12 17:43:35              (CompletedProcess) A CompletedProcess object of the command that was executed
2026-07-12 17:43:35              CompletedProcess attributes:
2026-07-12 17:43:35              args: The list or str args passed to run().
2026-07-12 17:43:35              returncode (str): The exit code of the process, negative for signals.
2026-07-12 17:43:35              stdout     (str): The standard output (None if not captured).
2026-07-12 17:43:35              stderr     (str): The standard error (None if not captured).
2026-07-12 17:43:35      
2026-07-12 17:43:35          """
2026-07-12 17:43:35          _env = kwargs.pop("env", os.environ.copy())
2026-07-12 17:43:35          kubeconfig_path = config.RUN.get("kubeconfig")
2026-07-12 17:43:35          if kubeconfig_path:
2026-07-12 17:43:35              _env["KUBECONFIG"] = kubeconfig_path
2026-07-12 17:43:35          if cluster_config:
2026-07-12 17:43:35              kubeconfig_path = cluster_config.RUN.get("kubeconfig")
2026-07-12 17:43:35              if kubeconfig_path:
2026-07-12 17:43:35                  _env["KUBECONFIG"] = cluster_config.RUN.get("kubeconfig")
2026-07-12 17:43:35          if isinstance(cmd, str) and not kwargs.get("shell"):
2026-07-12 17:43:35              cmd = shlex.split(cmd)
2026-07-12 17:43:35          if (
2026-07-12 17:43:35              kubeconfig_path
2026-07-12 17:43:35              and cmd[0] == "oc"
2026-07-12 17:43:35              and "--kubeconfig" not in cmd
2026-07-12 17:43:35              and "mirror" not in cmd
2026-07-12 17:43:35          ):
2026-07-12 17:43:35              kube_index = 1
2026-07-12 17:43:35              # check if we have an oc plugin in the command
2026-07-12 17:43:35              global _oc_plugin_list_cache
2026-07-12 17:43:35              if _oc_plugin_list_cache is None:
2026-07-12 17:43:35                  cp = subprocess.run(
2026-07-12 17:43:35                      shlex.split("oc plugin list"),
2026-07-12 17:43:35                      stdout=subprocess.PIPE,
2026-07-12 17:43:35                      stderr=subprocess.PIPE,
2026-07-12 17:43:35                  )
2026-07-12 17:43:35                  if cp.returncode == 0:
2026-07-12 17:43:35                      _oc_plugin_list_cache = cp.stdout.decode().splitlines()
2026-07-12 17:43:35      
2026-07-12 17:43:35              subcmd = cmd[1].split("-")
2026-07-12 17:43:35              if len(subcmd) > 1:
2026-07-12 17:43:35                  subcmd = "_".join(subcmd)
2026-07-12 17:43:35              if not isinstance(subcmd, str) and isinstance(subcmd, list):
2026-07-12 17:43:35                  subcmd = str(subcmd[0])
2026-07-12 17:43:35      
2026-07-12 17:43:35              plugin_lines = _oc_plugin_list_cache or []
2026-07-12 17:43:35              for l in plugin_lines:
2026-07-12 17:43:35                  if subcmd in l:
2026-07-12 17:43:35                      kube_index = 2
2026-07-12 17:43:35                      log.info(f"Found oc plugin {subcmd}")
2026-07-12 17:43:35              cmd = list_insert_at_position(cmd, kube_index, ["--kubeconfig"])
2026-07-12 17:43:35              cmd = list_insert_at_position(cmd, kube_index + 1, [kubeconfig_path])
2026-07-12 17:43:35          try:
2026-07-12 17:43:35              if kwargs.get("shell"):
2026-07-12 17:43:35                  masked_cmd = mask_secrets(cmd, secrets)
2026-07-12 17:43:35              else:
2026-07-12 17:43:35                  masked_cmd = shlex.join(mask_secrets(cmd, secrets))
2026-07-12 17:43:35              log.info(f"Executing command: {masked_cmd}")
2026-07-12 17:43:35              if threading_lock and cmd[0] == "oc":
2026-07-12 17:43:35                  threading_lock.acquire(timeout=lock_timeout)
2026-07-12 17:43:35              run_kw = {
2026-07-12 17:43:35                  "stdout": subprocess.PIPE,
2026-07-12 17:43:35                  "stderr": subprocess.PIPE,
2026-07-12 17:43:35                  "timeout": timeout,
2026-07-12 17:43:35                  "env": _env,
2026-07-12 17:43:35              }
2026-07-12 17:43:35              # subprocess.run forbids stdin= and input= together; when callers pass input,
2026-07-12 17:43:35              # stdin is managed internally. Do not inject stdin=PIPE if the caller set stdin.
2026-07-12 17:43:35              if "input" not in kwargs and "stdin" not in kwargs:
2026-07-12 17:43:35                  run_kw["stdin"] = subprocess.PIPE
2026-07-12 17:43:35              completed_process = subprocess.run(cmd, **run_kw, **kwargs)
2026-07-12 17:43:35          finally:
2026-07-12 17:43:35              if threading_lock and cmd[0] == "oc":
2026-07-12 17:43:35                  threading_lock.release()
2026-07-12 17:43:35          masked_stdout = mask_secrets(completed_process.stdout.decode(), secrets)
2026-07-12 17:43:35          truncated_stdout = truncate_long_lines(masked_stdout)
2026-07-12 17:43:35          if len(completed_process.stdout) > 0:
2026-07-12 17:43:35              truncated_stdout = truncate_large_base64(truncated_stdout)
2026-07-12 17:43:35              log.debug(f"Command stdout: {truncated_stdout}")
2026-07-12 17:43:35          else:
2026-07-12 17:43:35              log.debug("Command stdout is empty")
2026-07-12 17:43:35      
2026-07-12 17:43:35          masked_stderr = mask_secrets(completed_process.stderr.decode(), secrets)
2026-07-12 17:43:35          if len(completed_process.stderr) > 0:
2026-07-12 17:43:35              if not silent:
2026-07-12 17:43:35                  truncated_stderr = truncate_large_base64(masked_stderr)
2026-07-12 17:43:35                  log.warning(f"Command stderr: {truncated_stderr}")
2026-07-12 17:43:35              else:
2026-07-12 17:43:35                  if output_file:
2026-07-12 17:43:35                      with open(output_file, "a") as out_fd:
2026-07-12 17:43:35                          out_fd.write(masked_stderr)
2026-07-12 17:43:35          else:
2026-07-12 17:43:35              if not silent:
2026-07-12 17:43:35                  log.debug("Command stderr is empty")
2026-07-12 17:43:35          log.debug(f"Command return code: {completed_process.returncode}")
2026-07-12 17:43:35          if completed_process.returncode and not ignore_error:
2026-07-12 17:43:35              masked_stderr = bin_xml_escape(filter_out_emojis(masked_stderr))
2026-07-12 17:43:35              if (
2026-07-12 17:43:35                  "grep" in masked_cmd
2026-07-12 17:43:35                  and b"command terminated with exit code 1" in completed_process.stderr
2026-07-12 17:43:35              ):
2026-07-12 17:43:35                  log.info(f"No results found for grep command: {masked_cmd}")
2026-07-12 17:43:35              else:
2026-07-12 17:43:35  >               raise CommandFailed(
2026-07-12 17:43:35                      f"Error during execution of command: {masked_cmd}."
2026-07-12 17:43:35                      f"\nError is {masked_stderr}"
2026-07-12 17:43:35                  )
2026-07-12 17:43:35  E               ocs_ci.ocs.exceptions.CommandFailed: Error during execution of command: oc --kubeconfig /home/jenkins/current-cluster-dir/openshift-cluster-dir/auth/kubeconfig get node -o yaml.
2026-07-12 17:43:35  E               Error is Error from server (Timeout): the server was unable to return a response in the time allotted, but may still be processing the request (get nodes)
2026-07-12 17:43:35  
2026-07-12 17:43:35  ocs_ci/utility/utils.py:885: CommandFailed
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VMware disk attachment by targeting OCS-labeled nodes (with fallback) and attaching to compute VMs first; when including masters, control-plane VMs are restarted sequentially with added stabilization to reduce readiness/quorum disruption.
  * Enhanced readiness handling with control-plane vs worker-specific probes, retryable checks, and a restart helper that power-cycles and retries when start times out.
* **Tests**
  * Added a vSphere disk-attachment helper test suite covering node readiness probing, retryable VM starts, control-plane stabilization, sequential control-plane restarts, and final cluster readiness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->