### PR TITLE
fix(ibm_hci): recover missing rackIP from backups and verify BMC conn…

### DIFF
--- a/docs/usecases/ibm_hci_manual_node_operations.md
+++ b/docs/usecases/ibm_hci_manual_node_operations.md
@@ -54,35 +54,12 @@ Backups are also kept at:
 ## Step 1a — Generating the Rack Details File
 
 The file is generated automatically when ocs-ci first initialises `IBMHCI`.
-If it is missing entirely (first run, or the file was deleted), there are
-two options.
+If it is missing entirely (first run, or the file was deleted), build it
+manually using the steps below.
 
-### Option A — Generate via ocs-ci (preferred, requires cluster API)
+### Build manually (cluster API required)
 
-Run the helper function from a Python shell inside the ocs-ci environment:
-
-```bash
-cd <ocs-ci-root>
-python3 - <<'EOF'
-from ocs_ci.utility.utils import genereate_cred_file_rack
-genereate_cred_file_rack()
-EOF
-```
-
-This connects to the cluster API, reads all `kickstart-*` ConfigMaps from
-the `ibm-spectrum-fusion-ns` namespace, fetches BMC credentials from the
-node secrets, and writes the JSON to
-`<DATA_DIR>/rack_details/<cluster_name>.json`.
-
-> **Note:** `rackIP` is fetched from a GitHub rack-config URL configured in
-> `auth.yaml` under `ibm_hci.rack_config_url`.  If that fetch fails,
-> `rackIP` will be absent — add it manually as shown in Option B.
-
----
-
-### Option B — Build manually (cluster API not required)
-
-Use this when the cluster API is unreachable (e.g. all nodes are off).
+Use this when the cluster is accessible.
 
 **1. Collect BMC IPs from the kickstart ConfigMaps**
 

--- a/docs/usecases/ibm_hci_manual_node_operations.md
+++ b/docs/usecases/ibm_hci_manual_node_operations.md
@@ -1,0 +1,497 @@
+# IBM HCI Manual Node Power Operations
+
+This guide explains how to perform node power operations on an IBM HCI
+(Hardware Converged Infrastructure) cluster **manually** — without running
+ocs-ci — using SSH, IPMI, and Redfish directly.
+
+Use this when:
+- ocs-ci is unavailable or you want to verify a node outside of a test run
+- The cluster API is unreachable and you need to recover nodes
+- You want to debug power management issues independently
+
+---
+
+## Architecture Overview
+
+```
+Test runner / you
+      │
+      │  SSH (rack_ssh_username / rack_ssh_password)
+      ▼
+  MGem / Rack host  (rackIP from rack-details JSON)
+      │
+      │  IPMI (Lenovo)  or  Redfish/curl (Dell)
+      ▼
+  Node BMC  (ipv4 / ipv6 from rack-details JSON)
+```
+
+All IPMI and Redfish commands are executed **on the MGem**, not from your
+local machine.  The node BMC IPs are only routable from the MGem.
+
+---
+
+## Step 1 — Find Your Rack Details
+
+The rack-details JSON is saved at:
+
+```
+<DATA_DIR>/rack_details/<cluster_name>.json
+```
+
+`DATA_DIR` defaults to `<ocs-ci-root>/data` but can be overridden with the
+`OCSCI_DATA_DIR` environment variable.
+
+Backups are also kept at:
+- `<DATA_DIR>/rack_details/<cluster_name>_backup_<timestamp>.json`
+- `~/<cluster_name>_rack_backup_<timestamp>.json`
+
+> **If the file does not exist**, see
+> [Step 1a — Generating the Rack Details File](#step-1a--generating-the-rack-details-file)
+> before continuing.
+
+---
+
+## Step 1a — Generating the Rack Details File
+
+The file is generated automatically when ocs-ci first initialises `IBMHCI`.
+If it is missing entirely (first run, or the file was deleted), there are
+two options.
+
+### Option A — Generate via ocs-ci (preferred, requires cluster API)
+
+Run the helper function from a Python shell inside the ocs-ci environment:
+
+```bash
+cd <ocs-ci-root>
+python3 - <<'EOF'
+from ocs_ci.utility.utils import genereate_cred_file_rack
+genereate_cred_file_rack()
+EOF
+```
+
+This connects to the cluster API, reads all `kickstart-*` ConfigMaps from
+the `ibm-spectrum-fusion-ns` namespace, fetches BMC credentials from the
+node secrets, and writes the JSON to
+`<DATA_DIR>/rack_details/<cluster_name>.json`.
+
+> **Note:** `rackIP` is fetched from a GitHub rack-config URL configured in
+> `auth.yaml` under `ibm_hci.rack_config_url`.  If that fetch fails,
+> `rackIP` will be absent — add it manually as shown in Option B.
+
+---
+
+### Option B — Build manually (cluster API not required)
+
+Use this when the cluster API is unreachable (e.g. all nodes are off).
+
+**1. Collect BMC IPs from the kickstart ConfigMaps**
+
+If the cluster is still partially accessible, extract the data directly:
+
+```bash
+# List all kickstart configmaps
+oc get configmap -n ibm-spectrum-fusion-ns | grep kickstart-
+
+# Dump one configmap (replace kickstart-<rack_serial> with your rack serial)
+oc get configmap kickstart-<rack_serial> -n ibm-spectrum-fusion-ns -o jsonpath='{.data}' | python3 -m json.tool
+```
+
+The JSON value inside the configmap contains a
+`computeNodeIntegratedManagementModules` array with each node's `OCPRole`,
+`ipv4`, `ipv6`, `manufacturer`, and `secretName`.
+
+**2. Fetch BMC credentials from node secrets**
+
+```bash
+# Get the secret for a node (secretName comes from the configmap above)
+oc get secret <secretName> -n ibm-spectrum-fusion-ns \
+  -o jsonpath='{.data.isfmgmtUserName}' | base64 -d && echo
+oc get secret <secretName> -n ibm-spectrum-fusion-ns \
+  -o jsonpath='{.data.isfmgmtUserPasswrd}' | base64 -d && echo
+```
+
+**3. Find the rackIP (MGem IP)**
+
+The `rackIP` is not stored in the cluster — it lives in an external GitHub
+rack-config file.  Ask your team/infrastructure owner for the MGem IP for
+each rack serial.  It is the IP address you SSH into in Step 2.
+
+Alternatively, check any existing backup file:
+
+```bash
+ls -lt ~/<cluster_name>_rack_backup_*.json 2>/dev/null | head -3
+cat ~/<cluster_name>_rack_backup_<timestamp>.json | python3 -m json.tool \
+  | grep -A2 rackIP
+```
+
+**4. Write the JSON file**
+
+Create the directory and write the file manually:
+
+```bash
+mkdir -p <DATA_DIR>/rack_details
+
+cat > <DATA_DIR>/rack_details/<cluster_name>.json <<'EOF'
+{
+  "<rack_serial>": {
+    "nodes": {
+      "<node_role>": {
+        "ipv4": "<bmc_ipv4>",
+        "ipv6": null,
+        "manufacturer": "Lenovo",
+        "role": "master",
+        "username": "<bmc_username>",
+        "password": "<bmc_password>"
+      }
+    },
+    "rackInfo": {
+      "ibmSerialNumber": "<rack_serial_upper>",
+      "ibmMTM": "9155-R42",
+      "rackGen": 2,
+      "storageType": "fdf",
+      "isfModel": "9155",
+      "ipStack": "v4",
+      "rackIP": "<mgem_ip>"
+    }
+  }
+}
+EOF
+
+# Restrict permissions (file contains BMC passwords)
+chmod 600 <DATA_DIR>/rack_details/<cluster_name>.json
+```
+
+**5. Verify the file is valid JSON**
+
+```bash
+python3 -m json.tool <DATA_DIR>/rack_details/<cluster_name>.json > /dev/null \
+  && echo "JSON OK" || echo "JSON INVALID"
+```
+
+**6. Verify BMC reachability from the MGem**
+
+SSH into the MGem and ping each BMC IP:
+
+```bash
+ssh <rack_ssh_username>@<rackIP>
+ping -c 1 -W 5 <bmc_ipv4>
+```
+
+Once the file exists and the pings succeed, proceed from Step 2.
+
+---
+
+**Example config (multi-AZ cluster):**
+
+```json
+{
+  "<rack_serial_1>": {
+    "nodes": {
+      "<node_role_1>": {
+        "ipv4": "<bmc_ipv4_1>",
+        "ipv6": null,
+        "manufacturer": "Lenovo",
+        "role": "master",
+        "username": "<bmc_username>",
+        "password": "<bmc_password>"
+      },
+      "<node_role_2>": {
+        "ipv4": "<bmc_ipv4_2>",
+        "ipv6": null,
+        "manufacturer": "Lenovo",
+        "role": "worker",
+        "username": "<bmc_username>",
+        "password": "<bmc_password>"
+      }
+    },
+    "rackInfo": {
+      "rackIP": "<mgem_ip_1>"
+    }
+  },
+  "<rack_serial_2>": {
+    "nodes": {
+      "<node_role_1>": {
+        "ipv4": "<bmc_ipv4_3>",
+        "ipv6": null,
+        "manufacturer": "Lenovo",
+        "role": "master",
+        "username": "<bmc_username>",
+        "password": "<bmc_password>"
+      }
+    },
+    "rackInfo": {
+      "rackIP": "<mgem_ip_2>"
+    }
+  }
+}
+```
+
+Key fields used in every operation:
+
+| Field | Description |
+|---|---|
+| `rackIP` | IP of the MGem — the SSH hop host |
+| `ipv4` / `ipv6` | BMC IP of the node (reachable only from MGem) |
+| `username` / `password` | BMC credentials (IPMI or Redfish) |
+| `manufacturer` | `Lenovo` → use IPMI; `Dell` → use Redfish |
+
+---
+
+## Step 2 — SSH into the MGem
+
+```bash
+ssh <rack_ssh_username>@<mgem_ip>
+```
+
+All commands in Steps 3–6 are run **inside this SSH session**.
+
+---
+
+## Step 3 — Verify BMC Reachability (Ping)
+
+Before running any power command, confirm the node BMC is reachable from
+the MGem.
+
+**IPv4:**
+```bash
+ping -c 1 -W 5 <bmc_ipv4>
+```
+
+**IPv6:**
+```bash
+ping6 -c 1 -W 5 <bmc_ipv6>
+```
+
+A successful ping (`0% packet loss`) confirms the network path is healthy.
+If ping fails, try another rack's MGem (see [Multi-AZ fallback](#multi-az-mgem-fallback)).
+
+---
+
+## Step 4 — Lenovo Nodes (IPMI)
+
+All Lenovo operations use `ipmitool` via `lanplus`.
+
+### Install ipmitool (if not present)
+
+```bash
+which ipmitool || yum install -y ipmitool || dnf install -y ipmitool
+```
+
+### Power status
+
+```bash
+ipmitool -I lanplus -H <bmc_ipv4> -U <bmc_username> -P '<bmc_password>' power status
+# Expected output: "Chassis Power is on"  or  "Chassis Power is off"
+```
+
+**IPv6:**
+```bash
+ipmitool -I lanplus -H "<bmc_ipv6>" -U <bmc_username> -P '<bmc_password>' power status
+```
+> Note: IPv6 addresses must be **quoted** for ipmitool.
+
+### Power on
+
+```bash
+ipmitool -I lanplus -H <bmc_ipv4> -U <bmc_username> -P '<bmc_password>' power on
+```
+
+### Power off (graceful)
+
+```bash
+ipmitool -I lanplus -H <bmc_ipv4> -U <bmc_username> -P '<bmc_password>' power soft
+```
+
+### Power off (force)
+
+```bash
+ipmitool -I lanplus -H <bmc_ipv4> -U <bmc_username> -P '<bmc_password>' power off
+```
+
+### Power cycle
+
+```bash
+ipmitool -I lanplus -H <bmc_ipv4> -U <bmc_username> -P '<bmc_password>' power cycle
+```
+
+### Power reset
+
+```bash
+ipmitool -I lanplus -H <bmc_ipv4> -U <bmc_username> -P '<bmc_password>' power reset
+```
+
+---
+
+## Step 5 — Dell Nodes (Redfish)
+
+All Dell operations use `curl` against the Redfish REST API.
+
+> IPv6 addresses must be wrapped in `[brackets]` in URLs.
+
+### Discover the Systems URI
+
+```bash
+curl -k -sS -f \
+  -u <bmc_username>:'<bmc_password>' \
+  https://<bmc_ipv4>/redfish/v1/Systems
+```
+
+From the JSON response, note the `@odata.id` of the first member, e.g.
+`/redfish/v1/Systems/System.Embedded.1`.  Use this as `<SYSTEM_URI>` below.
+
+### Power status
+
+```bash
+curl -k -sS -f \
+  -u <bmc_username>:'<bmc_password>' \
+  https://<bmc_ipv4><SYSTEM_URI> | grep -i powerstate
+# Expected: "PowerState": "On"  or  "PowerState": "Off"
+```
+
+### Power on
+
+```bash
+curl -k -sS -f \
+  -u <bmc_username>:'<bmc_password>' -X POST \
+  https://<bmc_ipv4><SYSTEM_URI>/Actions/ComputerSystem.Reset \
+  -H 'Content-Type: application/json' \
+  -d '{"ResetType": "On"}'
+```
+
+### Power off (graceful)
+
+```bash
+curl -k -sS -f \
+  -u <bmc_username>:'<bmc_password>' -X POST \
+  https://<bmc_ipv4><SYSTEM_URI>/Actions/ComputerSystem.Reset \
+  -H 'Content-Type: application/json' \
+  -d '{"ResetType": "GracefulShutdown"}'
+```
+
+### Power off (force)
+
+```bash
+curl -k -sS -f \
+  -u <bmc_username>:'<bmc_password>' -X POST \
+  https://<bmc_ipv4><SYSTEM_URI>/Actions/ComputerSystem.Reset \
+  -H 'Content-Type: application/json' \
+  -d '{"ResetType": "ForceOff"}'
+```
+
+### Power cycle
+
+```bash
+curl -k -sS -f \
+  -u <bmc_username>:'<bmc_password>' -X POST \
+  https://<bmc_ipv4><SYSTEM_URI>/Actions/ComputerSystem.Reset \
+  -H 'Content-Type: application/json' \
+  -d '{"ResetType": "PowerCycle"}'
+```
+
+### Power reset (graceful)
+
+```bash
+curl -k -sS -f \
+  -u <bmc_username>:'<bmc_password>' -X POST \
+  https://<bmc_ipv4><SYSTEM_URI>/Actions/ComputerSystem.Reset \
+  -H 'Content-Type: application/json' \
+  -d '{"ResetType": "GracefulRestart"}'
+```
+
+### Power reset (force)
+
+```bash
+curl -k -sS -f \
+  -u <bmc_username>:'<bmc_password>' -X POST \
+  https://<bmc_ipv4><SYSTEM_URI>/Actions/ComputerSystem.Reset \
+  -H 'Content-Type: application/json' \
+  -d '{"ResetType": "ForceRestart"}'
+```
+
+---
+
+## Step 6 — Power on All Nodes (Recovery)
+
+When the cluster API is unreachable and all nodes are off, power them all
+on from the MGem without any ocs-ci involvement.
+
+Repeat the following for each rack in your cluster, substituting the
+rack's MGem IP and each node's BMC IP from the rack-details JSON:
+
+```bash
+ssh <rack_ssh_username>@<mgem_ip>
+
+# Power on each node in this rack (one BMC IP per node)
+for BMC_IP in <bmc_ipv4_1> <bmc_ipv4_2> <bmc_ipv4_3>; do
+  echo "Powering on $BMC_IP"
+  ipmitool -I lanplus -H $BMC_IP -U <bmc_username> -P '<bmc_password>' power on
+done
+```
+
+Wait ~5 minutes then verify each node booted:
+
+```bash
+ipmitool -I lanplus -H <bmc_ipv4> -U <bmc_username> -P '<bmc_password>' power status
+```
+
+---
+
+## Multi-AZ MGem Fallback
+
+In a multi-AZ cluster each rack has its own MGem (`rackIP`).  If a node's
+BMC is not reachable from its own rack's MGem, try another rack's MGem.
+
+Look up the `rackIP` values for all racks from the rack-details JSON, then:
+
+```bash
+# BMC not reachable from its own rack's MGem?
+# SSH into another rack's MGem and try from there:
+ssh <rack_ssh_username>@<other_mgem_ip>
+ping -c 1 -W 5 <bmc_ipv4>
+ipmitool -I lanplus -H <bmc_ipv4> -U <bmc_username> -P '<bmc_password>' power status
+```
+
+---
+
+## Quick Reference
+
+| Operation | Lenovo (IPMI) | Dell (Redfish ResetType) |
+|---|---|---|
+| Status | `power status` | GET `<SYSTEM_URI>` → `PowerState` |
+| Power on | `power on` | `On` |
+| Power off graceful | `power soft` | `GracefulShutdown` |
+| Power off force | `power off` | `ForceOff` |
+| Power cycle | `power cycle` | `PowerCycle` |
+| Reset graceful | `power reset` | `GracefulRestart` |
+| Reset force | `power reset` (with force) | `ForceRestart` |
+
+---
+
+## Troubleshooting
+
+**`ipmitool: command not found`**
+```bash
+yum install -y ipmitool   # RHEL/CentOS
+dnf install -y ipmitool   # Fedora/newer RHEL
+```
+
+**`Error in open session response message : insufficient resources for session`**
+Too many open IPMI sessions on the BMC.  Close them:
+```bash
+ipmitool -I lanplus -H <bmc_ipv4> -U <bmc_username> -P '<bmc_password>' session info all
+ipmitool -I lanplus -H <bmc_ipv4> -U <bmc_username> -P '<bmc_password>' session deactivate <session-id>
+```
+
+**`curl: (22) The requested URL returned error: 401`**
+Wrong Redfish credentials.  Verify `username`/`password` from the rack-details JSON.
+
+**Ping succeeds but IPMI/Redfish fails**
+- Check credentials in the rack-details JSON (`username`, `password` fields).
+- Verify ipmitool is installed on the MGem.
+- For Dell nodes, ensure the Systems URI is correct by re-running the
+  discovery curl command.
+
+**Node BMC not pingable from own MGem**
+- Try another rack's MGem (see [Multi-AZ MGem Fallback](#multi-az-mgem-fallback)).
+- If no MGem can reach the BMC, there is a network-level issue that must
+  be resolved before power operations are possible.

--- a/ocs_ci/ocs/exceptions.py
+++ b/ocs_ci/ocs/exceptions.py
@@ -842,3 +842,13 @@ class UnexpectedCatalogBuildException(Exception):
     """
 
     pass
+
+
+class NodeBMCUnreachableError(Exception):
+    """
+    Raised when a node's BMC is unreachable from any MGem during IBMHCI init.
+    Indicates that neither IPv6 nor IPv4 responded to ping from any available
+    rack management host (MGem / rackIP) for the given node.
+    """
+
+    pass

--- a/ocs_ci/ocs/platform_nodes.py
+++ b/ocs_ci/ocs/platform_nodes.py
@@ -4109,11 +4109,12 @@ class IBMHCINode(object):
 
     def restart_nodes_by_stop_and_start_teardown(self):
         """
-        Teardown method to ensure all nodes are powered on and cluster is accessible
+        Teardown method to ensure all nodes are powered on and cluster is accessible.
 
-        This method is designed to recover the cluster even when the API is down.
-        It powers on all nodes directly via IPMI/Redfish and waits for cluster recovery.
-        Includes automatic re-login if authentication is lost.
+        First checks whether the cluster API is reachable and all nodes are Ready.
+        If so, there is nothing to do (nodes were never stopped).
+        Only falls back to powering on all nodes via IPMI/Redfish when the API is
+        unreachable, which indicates the nodes were actually powered off.
         """
         from ocs_ci.helpers.helpers import refresh_oc_login_connection
 
@@ -4122,7 +4123,25 @@ class IBMHCINode(object):
         )
 
         try:
-            # Power on all nodes (works even if API is down)
+            # Re-authenticate first so the API check uses a fresh token.
+            try:
+                refresh_oc_login_connection()
+                logger.info("Successfully re-authenticated to cluster")
+            except Exception as login_error:
+                logger.warning(f"Could not re-authenticate: {login_error}")
+
+            # Check whether all nodes are already Ready.
+            try:
+                wait_for_nodes_status(timeout=60, status=constants.NODE_READY)
+                logger.info("All nodes are already Ready - no power-on action needed")
+                return
+            except Exception as check_error:
+                logger.warning(
+                    f"Node status check failed ({check_error}); "
+                    "assuming nodes are down - proceeding with power-on"
+                )
+
+            # Nodes appear to be down: power them all on via IPMI/Redfish.
             powered_on_nodes = self.power_on_all_nodes()
             logger.info(f"Powered on {len(powered_on_nodes)} nodes")
 
@@ -4130,54 +4149,38 @@ class IBMHCINode(object):
             logger.info("Waiting 30 seconds for nodes to start booting...")
             time.sleep(30)
 
-            # Try to verify nodes are ready (may fail if API still down)
+            # Wait for nodes to become Ready, retrying if the API is still coming up.
             max_retries = 5
             for attempt in range(max_retries):
+                logger.info(
+                    f"Attempting to verify node status via API "
+                    f"(attempt {attempt + 1}/{max_retries})..."
+                )
                 try:
-                    logger.info(
-                        f"Attempting to verify node status via API (attempt {attempt + 1}/{max_retries})..."
-                    )
-
-                    # Try to re-login if we lost authentication
                     try:
                         refresh_oc_login_connection()
                         logger.info("Successfully re-authenticated to cluster")
                     except Exception as login_error:
-                        if self._is_api_unavailable_error(login_error):
-                            logger.warning(
-                                f"API unavailable (attempt {attempt + 1}): {str(login_error)[:100]}"
-                            )
-                        else:
-                            logger.warning(
-                                f"Could not re-authenticate (attempt {attempt + 1}): {login_error}"
-                            )
+                        logger.warning(
+                            f"Could not re-authenticate (attempt {attempt + 1}): {login_error}"
+                        )
                         if attempt < max_retries - 1:
                             logger.info("Waiting 30 seconds before retry...")
                             time.sleep(30)
                             continue
 
-                    # Try to check node status
                     wait_for_nodes_status(timeout=900, status=constants.NODE_READY)
                     logger.info("All nodes are ready - cluster is accessible")
-                    break
+                    return
 
                 except Exception as e:
-                    if self._is_api_unavailable_error(e):
-                        logger.warning(
-                            f"API unavailable (attempt {attempt + 1}): {str(e)[:100]}"
-                        )
-                    else:
-                        logger.warning(
-                            f"Could not verify node status (attempt {attempt + 1}): {e}"
-                        )
+                    logger.warning(
+                        f"Could not verify node status (attempt {attempt + 1}): {e}"
+                    )
                     if attempt < max_retries - 1:
                         logger.info("Waiting 30 seconds before retry...")
                         time.sleep(30)
                     else:
-                        logger.error(
-                            "Could not verify cluster status via API after all retries. "
-                            "Nodes have been powered on but cluster may not be fully recovered."
-                        )
                         raise RuntimeError(
                             f"Failed to verify cluster status after {max_retries} attempts. "
                             "Nodes are powered on but API verification failed."
@@ -4185,7 +4188,6 @@ class IBMHCINode(object):
 
         except Exception as e:
             logger.error(f"Critical error during teardown: {e}")
-            # Re-raise to propagate failure to test harness
             raise
 
     def create_and_attach_nodes_to_cluster(self, node_conf, node_type, num_nodes):

--- a/ocs_ci/utility/ibm_hci.py
+++ b/ocs_ci/utility/ibm_hci.py
@@ -1,9 +1,11 @@
 import json
 import logging
+import os
 from pathlib import Path
 from paramiko import SSHClient, AutoAddPolicy
 
 from ocs_ci.ocs import constants
+from ocs_ci.ocs.exceptions import NodeBMCUnreachableError
 from ocs_ci.utility.utils import genereate_cred_file_rack
 from ocs_ci.ocs.ocp import OCP
 
@@ -40,6 +42,20 @@ class IBMHCI(object):
         # Load rack details
         self.rack_details = self._load_rack_details()
 
+        # Backfill any missing rackIP entries from previously saved backups.
+        # This is needed when the cached file was generated while the GitHub
+        # rack-IP fetch failed (e.g. token missing at generation time).
+        if self._any_rack_missing_ip():
+            log.warning(
+                "One or more racks are missing rackIP in cached file. "
+                "Attempting to recover from backup files..."
+            )
+            self._patch_rack_ips()
+
+        # Verify BMC connectivity for every node from the MGem.
+        # Raises NodeBMCUnreachableError if any node has no reachable IP.
+        self._verify_bmc_connectivity()
+
     def _load_rack_details(self):
         """
         Load rack details from cluster-specific JSON file
@@ -61,6 +77,276 @@ class IBMHCI(object):
         except Exception as e:
             log.error(f"Failed to load rack details: {e}")
             return {}
+
+    def _any_rack_missing_ip(self):
+        """Return True if any rack in rack_details is missing a rackIP."""
+        for rack_data in self.rack_details.values():
+            if not rack_data.get("rackInfo", {}).get("rackIP"):
+                return True
+        return False
+
+    def _patch_rack_ips(self):
+        """
+        Backfill missing rackIP values in self.rack_details by scanning
+        previously saved backup files (newest first).
+
+        genereate_cred_file_rack() writes two backup locations on every run:
+          - IBM_HCI_RACK_DIR/<cluster_name>_backup_<timestamp>.json
+          - ~/<cluster_name>_rack_backup_<timestamp>.json
+
+        A backup from a run where the GitHub fetch succeeded will contain
+        rackIP.  We scan both locations, pick the most-recent file that has
+        rackIP for each missing rack, and patch self.rack_details in memory.
+        The primary file is then updated so future runs don't need this step.
+        """
+        from ocs_ci.framework import config
+
+        cluster_name = config.ENV_DATA.get("cluster_name", "")
+
+        # Collect all candidate backup files from both locations, newest first
+        candidates = []
+
+        rack_dir = Path(constants.IBM_HCI_RACK_DIR)
+        for p in rack_dir.glob(f"{cluster_name}_backup_*.json"):
+            candidates.append(p)
+
+        home_dir = Path.home()
+        for p in home_dir.glob(f"{cluster_name}_rack_backup_*.json"):
+            candidates.append(p)
+
+        # Sort newest-first by modification time
+        candidates.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+
+        if not candidates:
+            log.warning(
+                "No backup files found to recover rackIP from. "
+                "Rack IP backfill skipped."
+            )
+            return
+
+        patched = False
+        for backup_path in candidates:
+            try:
+                with open(backup_path, "r") as f:
+                    backup_data = json.load(f)
+            except Exception as e:
+                log.warning(f"Could not read backup {backup_path}: {e}")
+                continue
+
+            for rack_serial, rack_data in self.rack_details.items():
+                rack_info = rack_data.setdefault("rackInfo", {})
+                if rack_info.get("rackIP"):
+                    continue  # already have it
+
+                backup_rack = backup_data.get(rack_serial, {})
+                ip = backup_rack.get("rackInfo", {}).get("rackIP")
+                if ip:
+                    rack_info["rackIP"] = ip
+                    log.info(
+                        f"Recovered rackIP {ip} for rack {rack_serial} "
+                        f"from backup {backup_path.name}"
+                    )
+                    patched = True
+
+            # Stop scanning once every rack has an IP
+            if not self._any_rack_missing_ip():
+                break
+
+        if patched:
+            # Persist so future runs don't need to scan backups again
+            fd = os.open(
+                self.rack_file_path,
+                os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+                0o600,
+            )
+            with os.fdopen(fd, "w") as f:
+                json.dump(self.rack_details, f, indent=2)
+            log.info(
+                f"Updated primary rack file with recovered rackIP(s): "
+                f"{self.rack_file_path}"
+            )
+        else:
+            log.error(
+                "Could not recover rackIP for one or more racks from any "
+                "backup file. Power operations may fail."
+            )
+
+    def _ping_from_mgem(self, rack_ip, node_ip):
+        """
+        Ping a BMC IP from the MGem (rack SSH host) to verify reachability.
+
+        Args:
+            rack_ip (str): IP of the MGem / rack SSH host
+            node_ip (str): BMC IP to ping (IPv4 or IPv6); None is treated as
+                           unreachable and returns False immediately.
+
+        Returns:
+            bool: True if the ping succeeds, False otherwise
+        """
+        if not node_ip:
+            log.debug("_ping_from_mgem called with empty node_ip, skipping")
+            return False
+
+        # -c 1  — single packet, -W 5  — 5-second timeout
+        if ":" in node_ip:
+            # IPv6
+            cmd = f"ping6 -c 1 -W 5 {node_ip}"
+        else:
+            cmd = f"ping -c 1 -W 5 {node_ip}"
+
+        try:
+            _, _, exit_code = self._execute_ssh_command(
+                rack_ip, self.rack_ssh_username, self.rack_ssh_password, cmd
+            )
+            reachable = exit_code == 0
+            if reachable:
+                log.debug(f"BMC {node_ip} is reachable from MGem {rack_ip}")
+            else:
+                log.debug(f"BMC {node_ip} is NOT reachable from MGem {rack_ip}")
+            return reachable
+        except Exception as e:
+            log.debug(f"Ping from MGem to {node_ip} failed with exception: {e}")
+            return False
+
+    def _verify_bmc_connectivity(self):
+        """
+        Ping every node's BMC IPs (IPv6 then IPv4) from the MGem.
+
+        Multi-AZ clusters have one MGem (rackIP) per rack (2 for 2-AZ,
+        3 for 3-AZ).  A node's BMC may not be reachable from its own rack's
+        MGem but may be reachable from another AZ's MGem (e.g. during a
+        partial network fault).  The algorithm is:
+
+          1. Try the node's own rack's rackIP first.
+          2. If that fails, try every other rack's rackIP.
+          3. If any MGem reaches the BMC, record that MGem IP as the working
+             rackIP for this rack and propagate it to every other rack entry
+             that shared the same (broken) rackIP — so power operations on
+             all affected nodes will use the known-good MGem going forward.
+          4. If no MGem reaches the BMC, add it to the unreachable list.
+          5. After all nodes are checked, raise NodeBMCUnreachableError if
+             anything remains unreachable.
+
+        Raises:
+            NodeBMCUnreachableError: When a node has no reachable BMC IP.
+        """
+        # Collect all distinct rackIP values available in the loaded details
+        all_rack_ips = {
+            serial: data.get("rackInfo", {}).get("rackIP")
+            for serial, data in self.rack_details.items()
+            if data.get("rackInfo", {}).get("rackIP")
+        }
+
+        unreachable = []
+        # Tracks rackIP corrections: broken_ip -> working_ip
+        rackip_fixes = {}
+
+        for rack_serial, rack_data in self.rack_details.items():
+            rack_ip = rack_data.get("rackInfo", {}).get("rackIP")
+            if not rack_ip:
+                # rackIP still missing — already warned in _patch_rack_ips
+                continue
+
+            for node_role, node_info in rack_data.get("nodes", {}).items():
+                ipv6 = node_info.get("ipv6")
+                ipv4 = node_info.get("ipv4")
+                node_label = f"{node_role}.{rack_serial}"
+
+                if not ipv6 and not ipv4:
+                    log.warning(f"No BMC IP configured for {node_label}, skipping ping")
+                    continue
+
+                if not ipv6 and ipv4:
+                    log.info(f"IPv6 not present for {node_label}, using IPv4 ({ipv4})")
+
+                # Build ordered list of BMC IPs to try (IPv6 first, then IPv4)
+                bmc_ips = [
+                    (ip_type, ip)
+                    for ip_type, ip in [("IPv6", ipv6), ("IPv4", ipv4)]
+                    if ip
+                ]
+
+                # Build ordered list of MGem IPs to try:
+                # own rack's MGem first, then all other racks' MGems
+                mgem_candidates = [rack_ip] + [
+                    ip
+                    for serial, ip in all_rack_ips.items()
+                    if serial != rack_serial and ip != rack_ip
+                ]
+
+                log.info(
+                    f"Verifying BMC connectivity for {node_label} "
+                    f"(trying {len(mgem_candidates)} MGem(s))"
+                )
+
+                node_reachable = False
+                working_mgem = None
+
+                for mgem_ip in mgem_candidates:
+                    for ip_type, bmc_ip in bmc_ips:
+                        log.info(
+                            f"Pinging BMC {ip_type} ({bmc_ip}) for {node_label} "
+                            f"from MGem {mgem_ip}"
+                        )
+                        if self._ping_from_mgem(mgem_ip, bmc_ip):
+                            log.info(
+                                f"BMC {ip_type} ({bmc_ip}) reachable for {node_label} "
+                                f"via MGem {mgem_ip}"
+                            )
+                            node_reachable = True
+                            working_mgem = mgem_ip
+                            break
+                        else:
+                            log.warning(
+                                f"BMC {ip_type} ({bmc_ip}) not reachable for "
+                                f"{node_label} from MGem {mgem_ip}"
+                            )
+
+                    if node_reachable:
+                        break
+
+                if not node_reachable:
+                    unreachable.append(node_label)
+                    continue
+
+                # If a different MGem reached this node, the rack's own rackIP
+                # is broken — record the fix.
+                if working_mgem and working_mgem != rack_ip:
+                    log.warning(
+                        f"rack {rack_serial} rackIP {rack_ip} could not reach "
+                        f"{node_label}; updating to working MGem {working_mgem}"
+                    )
+                    rackip_fixes[rack_ip] = working_mgem
+
+        # Apply rackIP fixes: update every rack that carries a broken rackIP
+        # with the working one found above.
+        if rackip_fixes:
+            for serial, rack_data in self.rack_details.items():
+                current_ip = rack_data.get("rackInfo", {}).get("rackIP")
+                if current_ip in rackip_fixes:
+                    new_ip = rackip_fixes[current_ip]
+                    rack_data["rackInfo"]["rackIP"] = new_ip
+                    log.info(
+                        f"Updated rackIP for rack {serial}: {current_ip} -> {new_ip}"
+                    )
+
+            # Persist the corrected details so future runs use the good IP
+            fd = os.open(
+                self.rack_file_path,
+                os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+                0o600,
+            )
+            with os.fdopen(fd, "w") as f:
+                json.dump(self.rack_details, f, indent=2)
+            log.info(f"Persisted rackIP corrections to {self.rack_file_path}")
+
+        if unreachable:
+            raise NodeBMCUnreachableError(
+                f"BMC unreachable for the following nodes (tried all MGems, "
+                f"no IPv6 or IPv4 responded to ping): {unreachable}"
+            )
+
+        log.info("BMC connectivity verified for all nodes")
 
     def _get_node_details_by_name(self, node_name):
         """

--- a/ocs_ci/utility/ibm_hci.py
+++ b/ocs_ci/utility/ibm_hci.py
@@ -1,3 +1,4 @@
+import ipaddress
 import json
 import logging
 import os
@@ -103,6 +104,13 @@ class IBMHCI(object):
 
         cluster_name = config.ENV_DATA.get("cluster_name", "")
 
+        if not cluster_name:
+            log.warning(
+                "cluster_name is empty; cannot construct backup glob patterns. "
+                "Rack IP backfill skipped."
+            )
+            return
+
         # Collect all candidate backup files from both locations, newest first
         candidates = []
 
@@ -125,12 +133,20 @@ class IBMHCI(object):
             return
 
         patched = False
+        still_missing = []
         for backup_path in candidates:
             try:
                 with open(backup_path, "r") as f:
                     backup_data = json.load(f)
             except Exception as e:
                 log.warning(f"Could not read backup {backup_path}: {e}")
+                continue
+
+            if not isinstance(backup_data, dict):
+                log.warning(
+                    f"Backup {backup_path.name} contains unexpected JSON type "
+                    f"({type(backup_data).__name__}); skipping"
+                )
                 continue
 
             for rack_serial, rack_data in self.rack_details.items():
@@ -152,6 +168,12 @@ class IBMHCI(object):
             if not self._any_rack_missing_ip():
                 break
 
+        still_missing = [
+            serial
+            for serial, data in self.rack_details.items()
+            if not data.get("rackInfo", {}).get("rackIP")
+        ]
+
         if patched:
             # Persist so future runs don't need to scan backups again
             fd = os.open(
@@ -161,14 +183,21 @@ class IBMHCI(object):
             )
             with os.fdopen(fd, "w") as f:
                 json.dump(self.rack_details, f, indent=2)
+            os.chmod(self.rack_file_path, 0o600)
             log.info(
                 f"Updated primary rack file with recovered rackIP(s): "
                 f"{self.rack_file_path}"
             )
+            if still_missing:
+                log.warning(
+                    f"Recovery partial — rackIP still missing for racks: "
+                    f"{still_missing}"
+                )
         else:
             log.error(
-                "Could not recover rackIP for one or more racks from any "
-                "backup file. Power operations may fail."
+                f"Could not recover rackIP for any rack from backup files. "
+                f"Racks still missing rackIP: {still_missing}. "
+                f"Power operations may fail."
             )
 
     def _ping_from_mgem(self, rack_ip, node_ip):
@@ -187,10 +216,16 @@ class IBMHCI(object):
             log.debug("_ping_from_mgem called with empty node_ip, skipping")
             return False
 
+        try:
+            addr = ipaddress.ip_address(node_ip)
+        except ValueError:
+            log.debug(f"_ping_from_mgem: invalid IP address '{node_ip}', skipping")
+            return False
+
         # -c 1  — single packet, -W 5  — 5-second timeout
-        if ":" in node_ip:
-            # IPv6
-            cmd = f"ping6 -c 1 -W 5 {node_ip}"
+        if addr.version == 6:
+            # Use portable ping -6 (ping6 is not available on all distros)
+            cmd = f"ping -6 -c 1 -W 5 {node_ip}"
         else:
             cmd = f"ping -c 1 -W 5 {node_ip}"
 
@@ -238,7 +273,6 @@ class IBMHCI(object):
         }
 
         unreachable = []
-        # Tracks rackIP corrections: broken_ip -> working_ip
         rackip_fixes = {}
 
         for rack_serial, rack_data in self.rack_details.items():
@@ -259,15 +293,11 @@ class IBMHCI(object):
                 if not ipv6 and ipv4:
                     log.info(f"IPv6 not present for {node_label}, using IPv4 ({ipv4})")
 
-                # Build ordered list of BMC IPs to try (IPv6 first, then IPv4)
                 bmc_ips = [
                     (ip_type, ip)
                     for ip_type, ip in [("IPv6", ipv6), ("IPv4", ipv4)]
                     if ip
                 ]
-
-                # Build ordered list of MGem IPs to try:
-                # own rack's MGem first, then all other racks' MGems
                 mgem_candidates = [rack_ip] + [
                     ip
                     for serial, ip in all_rack_ips.items()
@@ -279,66 +309,22 @@ class IBMHCI(object):
                     f"(trying {len(mgem_candidates)} MGem(s))"
                 )
 
-                node_reachable = False
-                working_mgem = None
+                working_mgem = self._find_reachable_mgem(
+                    node_label, bmc_ips, mgem_candidates
+                )
 
-                for mgem_ip in mgem_candidates:
-                    for ip_type, bmc_ip in bmc_ips:
-                        log.info(
-                            f"Pinging BMC {ip_type} ({bmc_ip}) for {node_label} "
-                            f"from MGem {mgem_ip}"
-                        )
-                        if self._ping_from_mgem(mgem_ip, bmc_ip):
-                            log.info(
-                                f"BMC {ip_type} ({bmc_ip}) reachable for {node_label} "
-                                f"via MGem {mgem_ip}"
-                            )
-                            node_reachable = True
-                            working_mgem = mgem_ip
-                            break
-                        else:
-                            log.warning(
-                                f"BMC {ip_type} ({bmc_ip}) not reachable for "
-                                f"{node_label} from MGem {mgem_ip}"
-                            )
-
-                    if node_reachable:
-                        break
-
-                if not node_reachable:
+                if working_mgem is None:
                     unreachable.append(node_label)
                     continue
 
-                # If a different MGem reached this node, the rack's own rackIP
-                # is broken — record the fix.
-                if working_mgem and working_mgem != rack_ip:
+                if working_mgem != rack_ip:
                     log.warning(
                         f"rack {rack_serial} rackIP {rack_ip} could not reach "
                         f"{node_label}; updating to working MGem {working_mgem}"
                     )
                     rackip_fixes[rack_ip] = working_mgem
 
-        # Apply rackIP fixes: update every rack that carries a broken rackIP
-        # with the working one found above.
-        if rackip_fixes:
-            for serial, rack_data in self.rack_details.items():
-                current_ip = rack_data.get("rackInfo", {}).get("rackIP")
-                if current_ip in rackip_fixes:
-                    new_ip = rackip_fixes[current_ip]
-                    rack_data["rackInfo"]["rackIP"] = new_ip
-                    log.info(
-                        f"Updated rackIP for rack {serial}: {current_ip} -> {new_ip}"
-                    )
-
-            # Persist the corrected details so future runs use the good IP
-            fd = os.open(
-                self.rack_file_path,
-                os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
-                0o600,
-            )
-            with os.fdopen(fd, "w") as f:
-                json.dump(self.rack_details, f, indent=2)
-            log.info(f"Persisted rackIP corrections to {self.rack_file_path}")
+        self._apply_rackip_fixes(rackip_fixes)
 
         if unreachable:
             raise NodeBMCUnreachableError(
@@ -347,6 +333,68 @@ class IBMHCI(object):
             )
 
         log.info("BMC connectivity verified for all nodes")
+
+    def _find_reachable_mgem(self, node_label, bmc_ips, mgem_candidates):
+        """
+        Search for the first MGem that can reach any of the node's BMC IPs.
+
+        Args:
+            node_label (str): Display label for logging (e.g. "control-1-ru2.l001")
+            bmc_ips (list): Ordered [(ip_type, ip), ...] — IPv6 first, IPv4 second
+            mgem_candidates (list): Ordered MGem IPs — own rack first, others after
+
+        Returns:
+            str: The working MGem IP, or None if no MGem reached the BMC
+        """
+        for mgem_ip in mgem_candidates:
+            for ip_type, bmc_ip in bmc_ips:
+                log.info(
+                    f"Pinging BMC {ip_type} ({bmc_ip}) for {node_label} "
+                    f"from MGem {mgem_ip}"
+                )
+                if self._ping_from_mgem(mgem_ip, bmc_ip):
+                    log.info(
+                        f"BMC {ip_type} ({bmc_ip}) reachable for {node_label} "
+                        f"via MGem {mgem_ip}"
+                    )
+                    return mgem_ip
+                else:
+                    log.warning(
+                        f"BMC {ip_type} ({bmc_ip}) not reachable for "
+                        f"{node_label} from MGem {mgem_ip}"
+                    )
+        return None
+
+    def _apply_rackip_fixes(self, rackip_fixes):
+        """
+        Apply rackIP corrections to self.rack_details and persist to disk.
+
+        For every rack whose current rackIP appears in rackip_fixes, replace it
+        with the working IP found by _verify_bmc_connectivity and write the
+        updated rack_details back to the primary JSON file.
+
+        Args:
+            rackip_fixes (dict): Mapping of broken_rackIP -> working_rackIP
+        """
+        if not rackip_fixes:
+            return
+
+        for serial, rack_data in self.rack_details.items():
+            current_ip = rack_data.get("rackInfo", {}).get("rackIP")
+            if current_ip in rackip_fixes:
+                new_ip = rackip_fixes[current_ip]
+                rack_data["rackInfo"]["rackIP"] = new_ip
+                log.info(f"Updated rackIP for rack {serial}: {current_ip} -> {new_ip}")
+
+        fd = os.open(
+            self.rack_file_path,
+            os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+            0o600,
+        )
+        with os.fdopen(fd, "w") as f:
+            json.dump(self.rack_details, f, indent=2)
+        os.chmod(self.rack_file_path, 0o600)
+        log.info(f"Persisted rackIP corrections to {self.rack_file_path}")
 
     def _get_node_details_by_name(self, node_name):
         """

--- a/ocs_ci/utility/ibm_hci.py
+++ b/ocs_ci/utility/ibm_hci.py
@@ -2,6 +2,7 @@ import ipaddress
 import json
 import logging
 import os
+import shlex
 from pathlib import Path
 from paramiko import SSHClient, AutoAddPolicy
 
@@ -615,7 +616,12 @@ class IBMHCI(object):
             return False
 
         ipmi_cmd = ipmi_ops[operation]
-        command = f"ipmitool -I lanplus -H {formatted_ip} -U {node_username} -P {node_password} {ipmi_cmd}"
+        command = (
+            f"ipmitool -I lanplus -H {formatted_ip} "
+            f"-U {shlex.quote(node_username)} "
+            f"-P {shlex.quote(node_password)} "
+            f"{ipmi_cmd}"
+        )
 
         log.info(f"Executing IPMI command via SSH for {operation} on node {node_ip}")
         log.info(
@@ -708,7 +714,11 @@ class IBMHCI(object):
 
         # First, discover the Systems URI
         log.info(f"Discovering Redfish Systems URI for node {node_ip}")
-        discover_cmd = f"curl -k -sS -f -u {node_username}:{node_password} https://{formatted_ip}/redfish/v1/Systems"
+        discover_cmd = (
+            f"curl -k -sS -f -u "
+            f"{shlex.quote(node_username)}:{shlex.quote(node_password)} "
+            f"https://{formatted_ip}/redfish/v1/Systems"
+        )
         log.info(
             f"Redfish Discovery Command: curl -k -sS -f -u <REDACTED>:<REDACTED> "
             f"https://{formatted_ip}/redfish/v1/Systems"
@@ -750,7 +760,8 @@ class IBMHCI(object):
             if operation == "status":
                 # Get power status
                 command = (
-                    f"curl -k -sS -f -u {node_username}:{node_password} "
+                    f"curl -k -sS -f "
+                    f"-u {shlex.quote(node_username)}:{shlex.quote(node_password)} "
                     f"https://{formatted_ip}{system_uri} | grep -i powerstate"
                 )
                 redacted_command = (
@@ -760,7 +771,9 @@ class IBMHCI(object):
             else:
                 reset_type = redfish_ops[operation]
                 command = (
-                    f"curl -k -sS -f -u {node_username}:{node_password} -X POST "
+                    f"curl -k -sS -f "
+                    f"-u {shlex.quote(node_username)}:{shlex.quote(node_password)} "
+                    f"-X POST "
                     f"https://{formatted_ip}{system_uri}/Actions/ComputerSystem.Reset "
                     f"-H 'Content-Type: application/json' "
                     f'-d \'{{"ResetType": "{reset_type}"}}\''

--- a/ocs_ci/utility/ibm_hci.py
+++ b/ocs_ci/utility/ibm_hci.py
@@ -54,8 +54,14 @@ class IBMHCI(object):
             )
             self._patch_rack_ips()
 
-        # Verify BMC connectivity for every node from the MGem.
-        # Raises NodeBMCUnreachableError if any node has no reachable IP.
+        # Nodes whose BMC could not be reached during init (missing rackIP or
+        # no ping response from any MGem).  Stored as "role.rack_serial" labels.
+        # Power operations on these nodes raise NodeBMCUnreachableError instead
+        # of attempting a doomed connection.
+        self._unreachable_nodes: set = set()
+
+        # Verify BMC connectivity for every node from the MGem.  Unreachable
+        # nodes are recorded in self._unreachable_nodes; construction continues.
         self._verify_bmc_connectivity()
 
     def _load_rack_details(self):

--- a/ocs_ci/utility/ibm_hci.py
+++ b/ocs_ci/utility/ibm_hci.py
@@ -1,4 +1,3 @@
-import ipaddress
 import json
 import logging
 import os
@@ -7,7 +6,6 @@ from pathlib import Path
 from paramiko import SSHClient, AutoAddPolicy
 
 from ocs_ci.ocs import constants
-from ocs_ci.ocs.exceptions import NodeBMCUnreachableError
 from ocs_ci.utility.utils import genereate_cred_file_rack
 from ocs_ci.ocs.ocp import OCP
 
@@ -53,16 +51,6 @@ class IBMHCI(object):
                 "Attempting to recover from backup files..."
             )
             self._patch_rack_ips()
-
-        # Nodes whose BMC could not be reached during init (missing rackIP or
-        # no ping response from any MGem).  Stored as "role.rack_serial" labels.
-        # Power operations on these nodes raise NodeBMCUnreachableError instead
-        # of attempting a doomed connection.
-        self._unreachable_nodes: set = set()
-
-        # Verify BMC connectivity for every node from the MGem.  Unreachable
-        # nodes are recorded in self._unreachable_nodes; construction continues.
-        self._verify_bmc_connectivity()
 
     def _load_rack_details(self):
         """
@@ -206,171 +194,6 @@ class IBMHCI(object):
                 f"Racks still missing rackIP: {still_missing}. "
                 f"Power operations may fail."
             )
-
-    def _ping_from_mgem(self, rack_ip, node_ip):
-        """
-        Ping a BMC IP from the MGem (rack SSH host) to verify reachability.
-
-        Args:
-            rack_ip (str): IP of the MGem / rack SSH host
-            node_ip (str): BMC IP to ping (IPv4 or IPv6); None is treated as
-                           unreachable and returns False immediately.
-
-        Returns:
-            bool: True if the ping succeeds, False otherwise
-        """
-        if not node_ip:
-            log.debug("_ping_from_mgem called with empty node_ip, skipping")
-            return False
-
-        try:
-            addr = ipaddress.ip_address(node_ip)
-        except ValueError:
-            log.debug(f"_ping_from_mgem: invalid IP address '{node_ip}', skipping")
-            return False
-
-        # -c 1  — single packet, -W 5  — 5-second timeout
-        if addr.version == 6:
-            # Use portable ping -6 (ping6 is not available on all distros)
-            cmd = f"ping -6 -c 1 -W 5 {node_ip}"
-        else:
-            cmd = f"ping -c 1 -W 5 {node_ip}"
-
-        try:
-            _, _, exit_code = self._execute_ssh_command(
-                rack_ip, self.rack_ssh_username, self.rack_ssh_password, cmd
-            )
-            reachable = exit_code == 0
-            if reachable:
-                log.debug(f"BMC {node_ip} is reachable from MGem {rack_ip}")
-            else:
-                log.debug(f"BMC {node_ip} is NOT reachable from MGem {rack_ip}")
-            return reachable
-        except Exception as e:
-            log.debug(f"Ping from MGem to {node_ip} failed with exception: {e}")
-            return False
-
-    def _verify_bmc_connectivity(self):
-        """
-        Ping every node's BMC IPs (IPv6 then IPv4) from the MGem.
-
-        Multi-AZ clusters have one MGem (rackIP) per rack (2 for 2-AZ,
-        3 for 3-AZ).  A node's BMC may not be reachable from its own rack's
-        MGem but may be reachable from another AZ's MGem (e.g. during a
-        partial network fault).  The algorithm is:
-
-          1. Try the node's own rack's rackIP first.
-          2. If that fails, try every other rack's rackIP.
-          3. If any MGem reaches the BMC, record that MGem IP as the working
-             rackIP for this rack and propagate it to every other rack entry
-             that shared the same (broken) rackIP — so power operations on
-             all affected nodes will use the known-good MGem going forward.
-          4. If no MGem reaches the BMC, add it to the unreachable list.
-          5. After all nodes are checked, raise NodeBMCUnreachableError if
-             anything remains unreachable.
-
-        Raises:
-            NodeBMCUnreachableError: When a node has no reachable BMC IP.
-        """
-        # Collect all distinct rackIP values available in the loaded details
-        all_rack_ips = {
-            serial: data.get("rackInfo", {}).get("rackIP")
-            for serial, data in self.rack_details.items()
-            if data.get("rackInfo", {}).get("rackIP")
-        }
-
-        unreachable = []
-        rackip_fixes = {}
-
-        for rack_serial, rack_data in self.rack_details.items():
-            rack_ip = rack_data.get("rackInfo", {}).get("rackIP")
-            if not rack_ip:
-                # rackIP still missing — already warned in _patch_rack_ips
-                continue
-
-            for node_role, node_info in rack_data.get("nodes", {}).items():
-                ipv6 = node_info.get("ipv6")
-                ipv4 = node_info.get("ipv4")
-                node_label = f"{node_role}.{rack_serial}"
-
-                if not ipv6 and not ipv4:
-                    log.warning(f"No BMC IP configured for {node_label}, skipping ping")
-                    continue
-
-                if not ipv6 and ipv4:
-                    log.info(f"IPv6 not present for {node_label}, using IPv4 ({ipv4})")
-
-                bmc_ips = [
-                    (ip_type, ip)
-                    for ip_type, ip in [("IPv6", ipv6), ("IPv4", ipv4)]
-                    if ip
-                ]
-                mgem_candidates = [rack_ip] + [
-                    ip
-                    for serial, ip in all_rack_ips.items()
-                    if serial != rack_serial and ip != rack_ip
-                ]
-
-                log.info(
-                    f"Verifying BMC connectivity for {node_label} "
-                    f"(trying {len(mgem_candidates)} MGem(s))"
-                )
-
-                working_mgem = self._find_reachable_mgem(
-                    node_label, bmc_ips, mgem_candidates
-                )
-
-                if working_mgem is None:
-                    unreachable.append(node_label)
-                    continue
-
-                if working_mgem != rack_ip:
-                    log.warning(
-                        f"rack {rack_serial} rackIP {rack_ip} could not reach "
-                        f"{node_label}; updating to working MGem {working_mgem}"
-                    )
-                    rackip_fixes[rack_ip] = working_mgem
-
-        self._apply_rackip_fixes(rackip_fixes)
-
-        if unreachable:
-            raise NodeBMCUnreachableError(
-                f"BMC unreachable for the following nodes (tried all MGems, "
-                f"no IPv6 or IPv4 responded to ping): {unreachable}"
-            )
-
-        log.info("BMC connectivity verified for all nodes")
-
-    def _find_reachable_mgem(self, node_label, bmc_ips, mgem_candidates):
-        """
-        Search for the first MGem that can reach any of the node's BMC IPs.
-
-        Args:
-            node_label (str): Display label for logging (e.g. "control-1-ru2.l001")
-            bmc_ips (list): Ordered [(ip_type, ip), ...] — IPv6 first, IPv4 second
-            mgem_candidates (list): Ordered MGem IPs — own rack first, others after
-
-        Returns:
-            str: The working MGem IP, or None if no MGem reached the BMC
-        """
-        for mgem_ip in mgem_candidates:
-            for ip_type, bmc_ip in bmc_ips:
-                log.info(
-                    f"Pinging BMC {ip_type} ({bmc_ip}) for {node_label} "
-                    f"from MGem {mgem_ip}"
-                )
-                if self._ping_from_mgem(mgem_ip, bmc_ip):
-                    log.info(
-                        f"BMC {ip_type} ({bmc_ip}) reachable for {node_label} "
-                        f"via MGem {mgem_ip}"
-                    )
-                    return mgem_ip
-                else:
-                    log.warning(
-                        f"BMC {ip_type} ({bmc_ip}) not reachable for "
-                        f"{node_label} from MGem {mgem_ip}"
-                    )
-        return None
 
     def _apply_rackip_fixes(self, rackip_fixes):
         """

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -7632,7 +7632,17 @@ def genereate_cred_file_rack():
         json.dump(rack_dict, f, indent=2)
     log.info(f"Rack details saved to {file_path} with restrictive permissions (0o600)")
 
-    # Also save a timestamped backup copy in home directory
+    # Verify BMC connectivity for every node via ping from the MGem.
+    # Any rackIP corrections discovered are applied to rack_dict and persisted
+    # back to the primary JSON file before the backup is written, so the backup
+    # always reflects the final corrected rackIP values.
+    rack_dict = _verify_bmc_connectivity_rack(
+        rack_dict=rack_dict,
+        file_path=str(file_path),
+    )
+
+    # Save a timestamped backup copy in home directory — written after ping
+    # verification so the backup contains any corrected rackIP values.
     try:
         home_dir = Path.home()
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
@@ -7658,6 +7668,158 @@ def genereate_cred_file_rack():
         f"File location: {file_path}"
     )
 
+    return rack_dict
+
+
+def _verify_bmc_connectivity_rack(rack_dict, file_path):
+    """
+    Ping every node BMC IP (IPv6 then IPv4) from its rack's MGem (SSH hop host)
+    and verify reachability.  Any rackIP corrections are applied in-place and
+    persisted back to ``file_path``.
+
+    Multi-AZ clusters have one MGem (rackIP) per rack.  If a node's BMC is not
+    reachable from its own rack's MGem, every other rack's MGem is tried.  The
+    first MGem that responds is recorded as the working rackIP for that rack
+    (and propagated to every other rack that shared the same broken rackIP).
+
+    Args:
+        rack_dict (dict): Rack details as returned by genereate_cred_file_rack.
+        file_path (str): Path to the JSON file — rackIP corrections are written
+            back here so the on-disk file stays consistent.
+
+    Returns:
+        dict: rack_dict with any rackIP corrections applied.
+
+    Raises:
+        NodeBMCUnreachableError: If any node has no reachable BMC IP from any MGem.
+    """
+    import ipaddress
+    from paramiko import SSHClient, AutoAddPolicy
+    from ocs_ci.framework import config
+
+    rack_ssh_username = config.AUTH.get("ibm_hci", {}).get("rack_ssh_username")
+    rack_ssh_password = config.AUTH.get("ibm_hci", {}).get("rack_ssh_password")
+
+    def _ssh_ping(rack_ip, node_ip):
+        """Return True if node_ip responds to a ping executed on rack_ip via SSH."""
+        if not node_ip:
+            return False
+        try:
+            addr = ipaddress.ip_address(node_ip)
+        except ValueError:
+            log.debug(f"_ssh_ping: invalid IP '{node_ip}', skipping")
+            return False
+        cmd = (
+            f"ping -6 -c 1 -W 5 {node_ip}"
+            if addr.version == 6
+            else f"ping -c 1 -W 5 {node_ip}"
+        )
+        ssh = SSHClient()
+        ssh.set_missing_host_key_policy(AutoAddPolicy())
+        try:
+            ssh.connect(
+                rack_ip,
+                username=rack_ssh_username,
+                password=rack_ssh_password,
+                timeout=30,
+            )
+            _, stdout, _ = ssh.exec_command(cmd)
+            return stdout.channel.recv_exit_status() == 0
+        except Exception as e:
+            log.debug(f"SSH ping from MGem {rack_ip} to {node_ip} failed: {e}")
+            return False
+        finally:
+            ssh.close()
+
+    # Collect all rackIP values available across all racks
+    all_rack_ips = {
+        serial: data.get("rackInfo", {}).get("rackIP")
+        for serial, data in rack_dict.items()
+        if data.get("rackInfo", {}).get("rackIP")
+    }
+
+    unreachable = []
+    rackip_fixes = {}
+
+    for rack_serial, rack_data in rack_dict.items():
+        rack_ip = rack_data.get("rackInfo", {}).get("rackIP")
+        if not rack_ip:
+            log.warning(f"Rack {rack_serial} has no rackIP, skipping BMC ping check")
+            continue
+
+        for node_role, node_info in rack_data.get("nodes", {}).items():
+            ipv6 = node_info.get("ipv6")
+            ipv4 = node_info.get("ipv4")
+            node_label = f"{node_role}.{rack_serial}"
+
+            if not ipv6 and not ipv4:
+                log.warning(f"No BMC IP configured for {node_label}, skipping ping")
+                continue
+
+            bmc_ips = [(t, ip) for t, ip in [("IPv6", ipv6), ("IPv4", ipv4)] if ip]
+            mgem_candidates = [rack_ip] + [
+                ip
+                for s, ip in all_rack_ips.items()
+                if s != rack_serial and ip != rack_ip
+            ]
+
+            log.info(
+                f"Verifying BMC connectivity for {node_label} "
+                f"(trying {len(mgem_candidates)} MGem(s))"
+            )
+
+            working_mgem = None
+            for mgem_ip in mgem_candidates:
+                for ip_type, bmc_ip in bmc_ips:
+                    log.info(
+                        f"Pinging BMC {ip_type} ({bmc_ip}) for {node_label} from MGem {mgem_ip}"
+                    )
+                    if _ssh_ping(mgem_ip, bmc_ip):
+                        log.info(
+                            f"BMC {ip_type} ({bmc_ip}) reachable for {node_label} via MGem {mgem_ip}"
+                        )
+                        working_mgem = mgem_ip
+                        break
+                    else:
+                        log.warning(
+                            f"BMC {ip_type} ({bmc_ip}) not reachable for {node_label} from MGem {mgem_ip}"
+                        )
+                if working_mgem:
+                    break
+
+            if working_mgem is None:
+                unreachable.append(node_label)
+                continue
+
+            if working_mgem != rack_ip:
+                log.warning(
+                    f"rack {rack_serial} rackIP {rack_ip} could not reach "
+                    f"{node_label}; updating to working MGem {working_mgem}"
+                )
+                rackip_fixes[rack_ip] = working_mgem
+
+    # Apply rackIP corrections and persist to disk
+    if rackip_fixes:
+        for serial, rack_data in rack_dict.items():
+            current_ip = rack_data.get("rackInfo", {}).get("rackIP")
+            if current_ip in rackip_fixes:
+                new_ip = rackip_fixes[current_ip]
+                rack_data["rackInfo"]["rackIP"] = new_ip
+                log.info(f"Updated rackIP for rack {serial}: {current_ip} -> {new_ip}")
+        fd = os.open(file_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, "w") as f:
+            json.dump(rack_dict, f, indent=2)
+        log.info(f"Persisted rackIP corrections to {file_path}")
+
+    if unreachable:
+        from ocs_ci.ocs.exceptions import NodeBMCUnreachableError
+
+        raise NodeBMCUnreachableError(
+            f"BMC unreachable for the following nodes (tried all MGems, "
+            f"no IPv6 or IPv4 responded to ping): {unreachable}"
+        )
+
+    log.info("BMC connectivity verified for all nodes")
     return rack_dict
 
 

--- a/tests/libtest/test_ibm_hci_nodes.py
+++ b/tests/libtest/test_ibm_hci_nodes.py
@@ -10,7 +10,6 @@ from ocs_ci.ocs.node import (
     wait_for_nodes_status,
 )
 from ocs_ci.ocs.platform_nodes import IBMHCINode
-from ocs_ci.utility.ibm_hci import IBMHCI
 
 logger = logging.getLogger(__name__)
 
@@ -316,19 +315,16 @@ class TestIBMHCINodeOperations:
         """
         logger.info("Test: Verify power_status_direct for all nodes after BMC ping")
 
-        # Instantiating IBMHCI runs _verify_bmc_connectivity internally —
-        # if BMC ping fails for any node, the constructor raises
-        # NodeBMCUnreachableError and the test fails here with a clear message.
-        ibm_hci_obj = IBMHCI()
-
-        # Derive domain suffix from IBMHCINode (reuses existing helper)
+        # IBMHCINode instantiates IBMHCI (which runs _verify_bmc_connectivity)
+        # and exposes it as .ibm_hci; reuse that instance instead of creating
+        # a separate IBMHCI().
         ibm_hci_node = IBMHCINode()
         domain_suffix = ibm_hci_node.domain_suffix
 
         failed_nodes = []
         checked_count = 0
 
-        for rack_serial, rack_data in ibm_hci_obj.rack_details.items():
+        for rack_serial, rack_data in ibm_hci_node.ibm_hci.rack_details.items():
             rack_ip = rack_data.get("rackInfo", {}).get("rackIP")
             if not rack_ip:
                 logger.warning(f"Skipping rack {rack_serial}: no rackIP available")
@@ -341,7 +337,7 @@ class TestIBMHCINodeOperations:
                 checked_count += 1
 
                 try:
-                    status = ibm_hci_obj.power_status_direct(node_name)
+                    status = ibm_hci_node.ibm_hci.power_status_direct(node_name)
                 except RuntimeError as e:
                     logger.error(
                         f"power_status_direct raised RuntimeError for "

--- a/tests/libtest/test_ibm_hci_nodes.py
+++ b/tests/libtest/test_ibm_hci_nodes.py
@@ -326,6 +326,7 @@ class TestIBMHCINodeOperations:
         domain_suffix = ibm_hci_node.domain_suffix
 
         failed_nodes = []
+        checked_count = 0
 
         for rack_serial, rack_data in ibm_hci_obj.rack_details.items():
             rack_ip = rack_data.get("rackInfo", {}).get("rackIP")
@@ -337,8 +338,18 @@ class TestIBMHCINodeOperations:
             for node_role in nodes_dict:
                 node_name = f"{node_role}.{rack_serial}.{domain_suffix}"
                 logger.info(f"Checking power status (direct) for: {node_name}")
+                checked_count += 1
 
-                status = ibm_hci_obj.power_status_direct(node_name)
+                try:
+                    status = ibm_hci_obj.power_status_direct(node_name)
+                except RuntimeError as e:
+                    logger.error(
+                        f"power_status_direct raised RuntimeError for "
+                        f"{node_name}: {e}"
+                    )
+                    failed_nodes.append((node_name, str(e)))
+                    continue
+
                 logger.info(f"  {node_name} -> {status}")
 
                 if status not in ("on", "off"):
@@ -348,11 +359,18 @@ class TestIBMHCINodeOperations:
                     )
                     failed_nodes.append((node_name, status))
 
+        assert checked_count > 0, (
+            "No nodes were checked — rack_details is empty or all racks "
+            "are missing rackIP. Verify the rack-details JSON is populated."
+        )
         assert not failed_nodes, (
             "power_status_direct failed or returned unexpected status for "
             f"the following nodes: {failed_nodes}"
         )
-        logger.info("power_status_direct verified successfully for all nodes")
+        logger.info(
+            f"power_status_direct verified successfully for all "
+            f"{checked_count} node(s)"
+        )
 
 
 # Made with Bob

--- a/tests/libtest/test_ibm_hci_nodes.py
+++ b/tests/libtest/test_ibm_hci_nodes.py
@@ -10,6 +10,7 @@ from ocs_ci.ocs.node import (
     wait_for_nodes_status,
 )
 from ocs_ci.ocs.platform_nodes import IBMHCINode
+from ocs_ci.utility.ibm_hci import IBMHCI
 
 logger = logging.getLogger(__name__)
 
@@ -294,6 +295,64 @@ class TestIBMHCINodeOperations:
         logger.info("Checking Ceph cluster health after node restart")
         ceph_health_check(tries=30, delay=60)
         logger.info("Ceph cluster health is OK")
+
+    def test_power_status_direct_after_bmc_ping(self):
+        """
+        Verify power_status_direct works for every node after BMC ping succeeds.
+
+        IBMHCI.__init__ runs _verify_bmc_connectivity which confirms each
+        node's BMC is reachable from the MGem via ping.  This test goes one
+        step further: it calls power_status_direct on every node in rack_details
+        and asserts that a valid power state ("on" or "off") is returned,
+        proving the full IPMI/Redfish path works end-to-end without relying
+        on the Kubernetes API.
+
+        Steps:
+        1. Instantiate IBMHCI (triggers BMC ping validation at init).
+        2. Iterate every rack and every node in rack_details.
+        3. Construct the full node FQDN from rack serial + domain suffix.
+        4. Call power_status_direct for each node.
+        5. Assert the result is "on" or "off" (not None / not an error).
+        """
+        logger.info("Test: Verify power_status_direct for all nodes after BMC ping")
+
+        # Instantiating IBMHCI runs _verify_bmc_connectivity internally —
+        # if BMC ping fails for any node, the constructor raises
+        # NodeBMCUnreachableError and the test fails here with a clear message.
+        ibm_hci_obj = IBMHCI()
+
+        # Derive domain suffix from IBMHCINode (reuses existing helper)
+        ibm_hci_node = IBMHCINode()
+        domain_suffix = ibm_hci_node.domain_suffix
+
+        failed_nodes = []
+
+        for rack_serial, rack_data in ibm_hci_obj.rack_details.items():
+            rack_ip = rack_data.get("rackInfo", {}).get("rackIP")
+            if not rack_ip:
+                logger.warning(f"Skipping rack {rack_serial}: no rackIP available")
+                continue
+
+            nodes_dict = rack_data.get("nodes", {})
+            for node_role in nodes_dict:
+                node_name = f"{node_role}.{rack_serial}.{domain_suffix}"
+                logger.info(f"Checking power status (direct) for: {node_name}")
+
+                status = ibm_hci_obj.power_status_direct(node_name)
+                logger.info(f"  {node_name} -> {status}")
+
+                if status not in ("on", "off"):
+                    logger.error(
+                        f"power_status_direct returned unexpected value "
+                        f"'{status}' for {node_name}"
+                    )
+                    failed_nodes.append((node_name, status))
+
+        assert not failed_nodes, (
+            "power_status_direct failed or returned unexpected status for "
+            f"the following nodes: {failed_nodes}"
+        )
+        logger.info("power_status_direct verified successfully for all nodes")
 
 
 # Made with Bob


### PR DESCRIPTION
…ectivity at init

The cached rack-details JSON file can be written without rackIP when the GitHub rack-config fetch fails during genereate_cred_file_rack() (e.g. missing token).  Because IBMHCI.__init__ skips regeneration if the file already exists, every subsequent power operation silently failed with 'Missing rack IP for node ...'.

Changes:
- IBMHCI.__init__: after loading rack details, check if any rack is missing rackIP (_any_rack_missing_ip) and if so scan previously saved backup files — both IBM_HCI_RACK_DIR/<cluster>_backup_*.json and ~/<cluster>_rack_backup_*.json — newest-first to recover the missing IP without requiring cluster API access (_patch_rack_ips). Persists the patched data back to the primary file.

- IBMHCI.__init__: after rack details are settled, ping every node's BMC IP (IPv6 first, IPv4 fallback) from the MGem via SSH to verify reachability before any test runs (_verify_bmc_connectivity, _ping_from_mgem).

- Multi-AZ support in _verify_bmc_connectivity: for 2-AZ/3-AZ clusters each rack has its own MGem (rackIP). If a node's BMC is unreachable from its own rack's MGem, all other racks' MGems are tried in order. If a cross-AZ MGem succeeds, the broken rackIP is replaced with the working one for all affected racks and persisted to the file.

- _ping_from_mgem guards against None node_ip to prevent AttributeError if a null IPv6 somehow bypasses the bmc_ips filter.

- NodeBMCUnreachableError moved from ibm_hci.py local definition to ocs_ci/ocs/exceptions.py to follow project conventions.

Fixes: power_on_all_nodes always powering on 0 nodes in teardown when rackIP was absent from the cached rack-details file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Restores missing rack management IPs from the newest backup data and persists repaired rack configuration.
  - Adds initialization-time verification of node BMC reachability by attempting ping from available management hosts (IPv6 then IPv4), then applies discovered working connectivity to affected rack entries.
- **Bug Fixes**
  - Introduces a dedicated initialization error when any node BMC remains unreachable.
  - Improves safety of rack-executed credential command construction for IPMI/Redfish operations.
- **Tests**
  - Verifies direct power status queries run after BMC connectivity checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->