### PR TITLE
[Fusion access]Creation of external system,lungroups,fs via UI

### DIFF
--- a/conf/deployment/fusion_access/fusion_access.yaml
+++ b/conf/deployment/fusion_access/fusion_access.yaml
@@ -1,0 +1,3 @@
+---
+DEPLOYMENT:
+    fusion_access: true

--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -568,6 +568,11 @@ external_mode_required = pytest.mark.skipif(
     reason="Test will run on External Mode cluster only",
 )
 
+fusion_access_required = pytest.mark.skipif(
+    config.DEPLOYMENT.get("fusion_access") is not True,
+    reason="Test will run on Fusion Access cluster only",
+)
+
 skipif_aws_i3 = pytest.mark.skipif(
     config.ENV_DATA["platform"].lower() == "aws"
     and config.DEPLOYMENT.get("local_storage") is True,

--- a/ocs_ci/ocs/ui/page_objects/fusion_access_ui.py
+++ b/ocs_ci/ocs/ui/page_objects/fusion_access_ui.py
@@ -1,5 +1,7 @@
 import logging
 
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
 from ocs_ci.ocs.ui.base_ui import BaseUI, wait_for_element_to_be_clickable
 from ocs_ci.ocs.ui.page_objects.page_navigator import PageNavigator
 from ocs_ci.ocs.ui.views import FDF_SAN_LOCATORS, SCALE_DASHBOARD_LOCATORS
@@ -18,14 +20,13 @@ class FusionAccessUI(PageNavigator, BaseUI):
 
     def __init__(self):
         super().__init__()
-        self.base_ui = BaseUI()
 
     def click_connect_external_systems(self):
         """
         Click on 'Connect external systems' button.
 
         """
-        self.base_ui.do_click(FDF_SAN_LOCATORS["connect_external_storage_button"])
+        self.do_click(FDF_SAN_LOCATORS["connect_external_storage_button"])
         logger.info("Clicked on Connect external systems button")
 
     def select_storage_area_network(self):
@@ -37,7 +38,7 @@ class FusionAccessUI(PageNavigator, BaseUI):
         wait_for_element_to_be_clickable(
             locator=FDF_SAN_LOCATORS["san_radio_button"], timeout=60
         )
-        self.base_ui.do_click(FDF_SAN_LOCATORS["san_radio_button"])
+        self.do_click(FDF_SAN_LOCATORS["san_radio_button"])
         logger.info("Selected Storage Area Network option")
 
     def click_next_button(self):
@@ -45,7 +46,7 @@ class FusionAccessUI(PageNavigator, BaseUI):
         Click the Next button to proceed.
 
         """
-        self.base_ui.do_click(FDF_SAN_LOCATORS["next_button"])
+        self.do_click(FDF_SAN_LOCATORS["next_button"])
         logger.info("Clicked Next button")
 
     def enter_image_registry_url(self, image_registry_url):
@@ -56,7 +57,7 @@ class FusionAccessUI(PageNavigator, BaseUI):
             image_registry_url (str): URL of the image registry e.g. quay.io
 
         """
-        self.base_ui.do_send_keys(
+        self.do_send_keys(
             FDF_SAN_LOCATORS["image_registry_url_input"], image_registry_url
         )
         logger.info(f"Entered Image registry URL: {image_registry_url}")
@@ -69,7 +70,7 @@ class FusionAccessUI(PageNavigator, BaseUI):
             image_repository_name (str): Name of the image repository
 
         """
-        self.base_ui.do_send_keys(
+        self.do_send_keys(
             FDF_SAN_LOCATORS["image_repository_name_input"], image_repository_name
         )
         logger.info(f"Entered Image repository name: {image_repository_name}")
@@ -82,30 +83,25 @@ class FusionAccessUI(PageNavigator, BaseUI):
             TimeoutExpiredError: If the dropdown or its options are not found
 
         """
-        from selenium.webdriver.support.ui import WebDriverWait
-        from selenium.webdriver.support import expected_conditions as EC
-
         # Open the dropdown
-        self.base_ui.do_click(FDF_SAN_LOCATORS["secret_key_dropdown"])
+        self.do_click(FDF_SAN_LOCATORS["secret_key_dropdown"])
         logger.info("Opened Secret key dropdown")
 
-        # Wait for dropdown options to appear in the DOM (up to 15 seconds)
-        wait_path, wait_by = FDF_SAN_LOCATORS["secret_key_dropdown_wait"]
+        # Wait for dropdown options to appear in the DOM (up to 15 seconds).
+        opt_path, opt_by = FDF_SAN_LOCATORS["secret_key_dropdown_options"]
         logger.info("Waiting for Secret key dropdown options to appear...")
         try:
-            WebDriverWait(self.base_ui.driver, 15).until(
-                EC.presence_of_element_located((wait_by, wait_path))
+            WebDriverWait(self.driver, 15).until(
+                EC.presence_of_element_located((opt_by, opt_path))
             )
-        except Exception:
-            self.base_ui.take_screenshot("secret_dropdown_no_options")
+        except Exception as err:
+            self.take_screenshot("secret_dropdown_no_options")
             raise TimeoutExpiredError(
                 "Secret key dropdown options did not appear after 15 seconds"
-            )
+            ) from err
 
         # Get all enabled options
-        options = self.base_ui.get_elements(
-            FDF_SAN_LOCATORS["secret_key_dropdown_options"]
-        )
+        options = self.get_elements(FDF_SAN_LOCATORS["secret_key_dropdown_options"])
         if not options:
             raise TimeoutExpiredError("No options found in Secret key dropdown")
 
@@ -121,7 +117,7 @@ class FusionAccessUI(PageNavigator, BaseUI):
 
         """
 
-        elements = self.base_ui.get_elements(FDF_SAN_LOCATORS["all_nodes_radio"])
+        elements = self.get_elements(FDF_SAN_LOCATORS["all_nodes_radio"])
 
         if not elements:
             raise TimeoutExpiredError("AllNodes radio button not found")
@@ -130,9 +126,7 @@ class FusionAccessUI(PageNavigator, BaseUI):
 
         if not san_element.is_selected():
             logger.info("Selecting All Nodes option")
-            self.base_ui.do_click(
-                FDF_SAN_LOCATORS["all_nodes_radio"], enable_screenshot=True
-            )
+            self.do_click(FDF_SAN_LOCATORS["all_nodes_radio"], enable_screenshot=True)
         else:
             logger.info("All Nodes (Default) option already selected")
 
@@ -144,9 +138,7 @@ class FusionAccessUI(PageNavigator, BaseUI):
             lun_group_name (str): Name for the LUN group
 
         """
-        self.base_ui.do_send_keys(
-            FDF_SAN_LOCATORS["lun_group_name_input"], lun_group_name
-        )
+        self.do_send_keys(FDF_SAN_LOCATORS["lun_group_name_input"], lun_group_name)
         logger.info(f"Entered LUN group name: {lun_group_name}")
 
     def select_luns_from_table(self, num_luns=1):
@@ -167,10 +159,10 @@ class FusionAccessUI(PageNavigator, BaseUI):
         row_id_path, row_id_by = FDF_SAN_LOCATORS["lun_table_row_id"]
         for i in range(1, num_luns + 1):
             lun_checkbox_locator = (checkbox_path.format(i=i), checkbox_by)
-            self.base_ui.do_click(lun_checkbox_locator)
+            self.do_click(lun_checkbox_locator)
 
             lun_id_locator = (row_id_path.format(i=i), row_id_by)
-            lun_id = self.base_ui.get_element_text(lun_id_locator)
+            lun_id = self.get_element_text(lun_id_locator)
             selected_luns.append(lun_id)
             logger.info(f"Selected LUN: {lun_id}")
 
@@ -181,7 +173,7 @@ class FusionAccessUI(PageNavigator, BaseUI):
         Click the 'Connect and Create' button.
 
         """
-        self.base_ui.do_click(
+        self.do_click(
             FDF_SAN_LOCATORS["connect_and_create_button"], enable_screenshot=True
         )
 
@@ -190,9 +182,7 @@ class FusionAccessUI(PageNavigator, BaseUI):
         Navigate to san_storage tab under external systems page
 
         """
-        self.base_ui.do_click(
-            FDF_SAN_LOCATORS["san_storage_link"], enable_screenshot=True
-        )
+        self.do_click(FDF_SAN_LOCATORS["san_storage_link"], enable_screenshot=True)
         logger.info("Navigated to storage san dashboard")
 
     @retry((AssertionError, TimeoutExpiredError), tries=40, delay=30, backoff=1)
@@ -209,7 +199,7 @@ class FusionAccessUI(PageNavigator, BaseUI):
         """
         # 1. Check Connection (Standard Swap)
         path, strategy = SCALE_DASHBOARD_LOCATORS["scale_connection_green"]
-        assert self.base_ui.check_element_presence(
+        assert self.check_element_presence(
             (strategy, path), timeout=20
         ), "Scale dashboard connection is not green"
         logger.info("Scale dashboard connection is green")
@@ -218,21 +208,18 @@ class FusionAccessUI(PageNavigator, BaseUI):
         path_row, strategy_row = SCALE_DASHBOARD_LOCATORS["lun_group_row_by_name"]
         specific_row_xpath = f"{path_row}[contains(., '{lun_group_name}')]"
 
-        assert self.base_ui.check_element_presence(
+        assert self.check_element_presence(
             (strategy_row, specific_row_xpath), timeout=20
         ), f"LUN group '{lun_group_name}' not found in the table"
         logger.info(f"LUN group {lun_group_name} found in the table")
 
         # 3. Check that the SPECIFIC LUN group has an OK/Healthy/Connected status.
-        _, strategy_ok = SCALE_DASHBOARD_LOCATORS["lun_group_status_ok_by_name"]
-        specific_ok_xpath = (
-            f"//tr[contains(td[1], '{lun_group_name}')]"
-            f"//td[@data-label='Status' or position()=2]"
-            f"[text()='Healthy' or text()='OK' or text()='Connected'"
-            f" or .//*[text()='Healthy' or text()='OK' or text()='Connected']]"
-        )
+        status_path, strategy_ok = SCALE_DASHBOARD_LOCATORS[
+            "lun_group_status_ok_by_name"
+        ]
+        specific_ok_xpath = status_path.format(lun_group_name=lun_group_name)
 
-        assert self.base_ui.check_element_presence(
-            (strategy_ok, specific_ok_xpath), timeout=20
+        assert self.check_element_presence(
+            (strategy_ok, specific_ok_xpath), timeout=25
         ), f"LUN group '{lun_group_name}' is not in Healthy/OK/Connected state"
         logger.info(f"LUN group {lun_group_name} health status is OK/Healthy/Connected")

--- a/ocs_ci/ocs/ui/page_objects/fusion_access_ui.py
+++ b/ocs_ci/ocs/ui/page_objects/fusion_access_ui.py
@@ -1,0 +1,248 @@
+import logging
+
+from selenium.webdriver.common.by import By
+from ocs_ci.ocs.ui.base_ui import BaseUI, wait_for_element_to_be_clickable
+from ocs_ci.ocs.ui.page_objects.page_navigator import PageNavigator
+from ocs_ci.ocs.ui.views import FDF_SAN_LOCATORS, SCALE_DASHBOARD_LOCATORS
+from ocs_ci.utility.retry import retry
+from ocs_ci.ocs.exceptions import TimeoutExpiredError
+
+
+logger = logging.getLogger(__name__)
+
+
+class FusionAccessUI(PageNavigator, BaseUI):
+    """
+    FusionAccessUI class implements san connection and lun group management
+
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.base_ui = BaseUI()
+
+    def click_connect_external_systems(self):
+        """
+        Click on 'Connect external systems' button.
+
+        """
+        self.base_ui.do_click(FDF_SAN_LOCATORS["connect_external_storage_button"])
+        logger.info("Clicked on Connect external systems button")
+
+    def select_storage_area_network(self):
+        """
+        Select Storage Area Network radio button.
+
+        """
+
+        wait_for_element_to_be_clickable(
+            locator=FDF_SAN_LOCATORS["san_radio_button"], timeout=60
+        )
+        self.base_ui.do_click(FDF_SAN_LOCATORS["san_radio_button"])
+        logger.info("Selected Storage Area Network option")
+
+    def click_next_button(self):
+        """
+        Click the Next button to proceed.
+
+        """
+        self.base_ui.do_click(FDF_SAN_LOCATORS["next_button"])
+        logger.info("Clicked Next button")
+
+    def enter_image_registry_url(self, image_registry_url):
+        """
+        Enter the Image registry URL in the text field.
+
+        Args:
+            image_registry_url (str): URL of the image registry e.g. quay.io
+
+        """
+        self.base_ui.do_send_keys(
+            FDF_SAN_LOCATORS["image_registry_url_input"], image_registry_url
+        )
+        logger.info(f"Entered Image registry URL: {image_registry_url}")
+
+    def enter_image_repository_name(self, image_repository_name):
+        """
+        Enter the Image repository name in the text field.
+
+        Args:
+            image_repository_name (str): Name of the image repository
+
+        """
+        self.base_ui.do_send_keys(
+            FDF_SAN_LOCATORS["image_repository_name_input"], image_repository_name
+        )
+        logger.info(f"Entered Image repository name: {image_repository_name}")
+
+    def select_secret_key(self):
+        """
+        Select the last option from the Secret key dropdown.
+
+        Raises:
+            TimeoutExpiredError: If the dropdown or its options are not found
+
+        """
+        from selenium.webdriver.support.ui import WebDriverWait
+        from selenium.webdriver.support import expected_conditions as EC
+        from selenium.webdriver.common.by import By
+
+        # Open the dropdown
+        self.base_ui.do_click(FDF_SAN_LOCATORS["secret_key_dropdown"])
+        logger.info("Opened Secret key dropdown")
+
+        # Wait for dropdown options to appear in the DOM (up to 15 seconds)
+        options_xpath = "//ul[contains(@class,'pf-v6-c-menu__list')]//li//button"
+        logger.info("Waiting for Secret key dropdown options to appear...")
+        try:
+            WebDriverWait(self.base_ui.driver, 15).until(
+                EC.presence_of_element_located((By.XPATH, options_xpath))
+            )
+        except Exception:
+            self.base_ui.take_screenshot("secret_dropdown_no_options")
+            raise TimeoutExpiredError(
+                "Secret key dropdown options did not appear after 15 seconds"
+            )
+
+        # Get all available options
+        options = self.base_ui.get_elements(
+            FDF_SAN_LOCATORS["secret_key_dropdown_options"]
+        )
+        if not options:
+            raise TimeoutExpiredError("No options found in Secret key dropdown")
+
+        # Click the last option
+        last_option = options[-1]
+        last_option_text = last_option.text
+        last_option.click()
+        logger.info(f"Selected last Secret key option: '{last_option_text}'")
+
+    def select_all_nodes_option(self):
+        """
+        Select AllNodes (Default) radio button.
+
+        """
+
+        elements = self.base_ui.get_elements(FDF_SAN_LOCATORS["all_nodes_radio"])
+
+        if not elements:
+            raise TimeoutExpiredError("AllNodes radio button not found")
+
+        san_element = elements[0]
+
+        if not san_element.is_selected():
+            logger.info("Selecting All Nodes option")
+            self.base_ui.do_click(
+                FDF_SAN_LOCATORS["all_nodes_radio"], enable_screenshot=True
+            )
+        else:
+            logger.info("All Nodes (Default) option already selected")
+
+    def enter_lun_group_name(self, lun_group_name):
+        """
+        Enter LUN group name in the Name text field.
+
+        Args:
+            lun_group_name (str): Name for the LUN group
+
+        """
+        self.base_ui.do_send_keys(
+            FDF_SAN_LOCATORS["lun_group_name_input"], lun_group_name
+        )
+        logger.info(f"Entered LUN group name: {lun_group_name}")
+
+    def select_luns_from_table(self, num_luns=1):
+        """
+        Select a subset of LUNs from the available LUNs table.
+
+        Args:
+            num_luns (int): Number of LUNs to select (default: 1)
+
+        Returns:
+            list: List of selected LUN identifiers
+
+        Raises:
+            TimeoutExpiredError: If LUN table is not found
+        """
+        selected_luns = []
+        for i in range(1, num_luns + 1):
+            # XPath for checkbox in row i
+            lun_checkbox_xpath = (
+                f"//table[@aria-label='LUNs table' or contains(@class, 'pf-v5-c-table')]"
+                f"//tbody//tr[{i}]//input[@type='checkbox']"
+            )
+            lun_checkbox_locator = (lun_checkbox_xpath, By.XPATH)
+            self.base_ui.do_click(lun_checkbox_locator)
+
+            # XPath for LUN identifier in column 2 of row i
+            lun_id_xpath = (
+                f"//table[@aria-label='LUNs table' or contains(@class, 'pf-v5-c-table__text')]"
+                f"//tbody//tr[{i}]//td[2]"
+            )
+            lun_id_locator = (lun_id_xpath, By.XPATH)
+            lun_id = self.base_ui.get_element_text(lun_id_locator)
+            selected_luns.append(lun_id)
+            logger.info(f"Selected LUN: {lun_id}")
+
+        return selected_luns
+
+    def click_connect_and_create(self):
+        """
+        Click the 'Connect and Create' button.
+
+        """
+        self.base_ui.do_click(
+            FDF_SAN_LOCATORS["connect_and_create_button"], enable_screenshot=True
+        )
+
+    def navigate_to_san_storage_tab(self):
+        """
+        Navigate to san_storage tab under external systems page
+
+        """
+        self.base_ui.do_click(
+            FDF_SAN_LOCATORS["san_storage_link"], enable_screenshot=True
+        )
+        logger.info("Navigated to storage san dashboard")
+
+    @retry((AssertionError, TimeoutExpiredError), tries=40, delay=30, backoff=1)
+    def wait_for_filesystem_and_verify_connection(self, lun_group_name):
+        """
+        Wait for filesystem and verify connection.
+
+        Retries every 30 seconds for up to 20 minutes (40 x 30s) waiting for
+        the LUN group to reach a healthy/connected state on the UI.
+
+        Args:
+            lun_group_name (str): Name for the LUN group
+
+        """
+        # 1. Check Connection (Standard Swap)
+        path, strategy = SCALE_DASHBOARD_LOCATORS["scale_connection_green"]
+        assert self.base_ui.check_element_presence(
+            (strategy, path), timeout=20
+        ), "Scale dashboard connection is not green"
+        logger.info("Scale dashboard connection is green")
+
+        # 2. Check for the SPECIFIC LUN group row
+        path_row, strategy_row = SCALE_DASHBOARD_LOCATORS["lun_group_row_by_name"]
+        specific_row_xpath = f"{path_row}[contains(., '{lun_group_name}')]"
+
+        assert self.base_ui.check_element_presence(
+            (strategy_row, specific_row_xpath), timeout=20
+        ), f"LUN group '{lun_group_name}' not found in the table"
+        logger.info(f"LUN group {lun_group_name} found in the table")
+
+        # 3. Check that the SPECIFIC LUN group has an OK/Healthy/Connected status.
+        _, strategy_ok = SCALE_DASHBOARD_LOCATORS["lun_group_status_ok_by_name"]
+        specific_ok_xpath = (
+            f"//tr[contains(td[1], '{lun_group_name}')]"
+            f"//td[@data-label='Status' or position()=2]"
+            f"[text()='Healthy' or text()='OK' or text()='Connected'"
+            f" or .//*[text()='Healthy' or text()='OK' or text()='Connected']]"
+        )
+
+        assert self.base_ui.check_element_presence(
+            (strategy_ok, specific_ok_xpath), timeout=20
+        ), f"LUN group '{lun_group_name}' is not in Healthy/OK/Connected state"
+        logger.info(f"LUN group {lun_group_name} health status is OK/Healthy/Connected")

--- a/ocs_ci/ocs/ui/page_objects/fusion_access_ui.py
+++ b/ocs_ci/ocs/ui/page_objects/fusion_access_ui.py
@@ -1,6 +1,5 @@
 import logging
 
-from selenium.webdriver.common.by import By
 from ocs_ci.ocs.ui.base_ui import BaseUI, wait_for_element_to_be_clickable
 from ocs_ci.ocs.ui.page_objects.page_navigator import PageNavigator
 from ocs_ci.ocs.ui.views import FDF_SAN_LOCATORS, SCALE_DASHBOARD_LOCATORS
@@ -85,18 +84,17 @@ class FusionAccessUI(PageNavigator, BaseUI):
         """
         from selenium.webdriver.support.ui import WebDriverWait
         from selenium.webdriver.support import expected_conditions as EC
-        from selenium.webdriver.common.by import By
 
         # Open the dropdown
         self.base_ui.do_click(FDF_SAN_LOCATORS["secret_key_dropdown"])
         logger.info("Opened Secret key dropdown")
 
         # Wait for dropdown options to appear in the DOM (up to 15 seconds)
-        options_xpath = "//ul[contains(@class,'pf-v6-c-menu__list')]//li//button"
+        wait_path, wait_by = FDF_SAN_LOCATORS["secret_key_dropdown_wait"]
         logger.info("Waiting for Secret key dropdown options to appear...")
         try:
             WebDriverWait(self.base_ui.driver, 15).until(
-                EC.presence_of_element_located((By.XPATH, options_xpath))
+                EC.presence_of_element_located((wait_by, wait_path))
             )
         except Exception:
             self.base_ui.take_screenshot("secret_dropdown_no_options")
@@ -104,7 +102,7 @@ class FusionAccessUI(PageNavigator, BaseUI):
                 "Secret key dropdown options did not appear after 15 seconds"
             )
 
-        # Get all available options
+        # Get all enabled options
         options = self.base_ui.get_elements(
             FDF_SAN_LOCATORS["secret_key_dropdown_options"]
         )
@@ -165,21 +163,13 @@ class FusionAccessUI(PageNavigator, BaseUI):
             TimeoutExpiredError: If LUN table is not found
         """
         selected_luns = []
+        checkbox_path, checkbox_by = FDF_SAN_LOCATORS["lun_table_checkbox"]
+        row_id_path, row_id_by = FDF_SAN_LOCATORS["lun_table_row_id"]
         for i in range(1, num_luns + 1):
-            # XPath for checkbox in row i
-            lun_checkbox_xpath = (
-                f"//table[@aria-label='LUNs table' or contains(@class, 'pf-v5-c-table')]"
-                f"//tbody//tr[{i}]//input[@type='checkbox']"
-            )
-            lun_checkbox_locator = (lun_checkbox_xpath, By.XPATH)
+            lun_checkbox_locator = (checkbox_path.format(i=i), checkbox_by)
             self.base_ui.do_click(lun_checkbox_locator)
 
-            # XPath for LUN identifier in column 2 of row i
-            lun_id_xpath = (
-                f"//table[@aria-label='LUNs table' or contains(@class, 'pf-v5-c-table__text')]"
-                f"//tbody//tr[{i}]//td[2]"
-            )
-            lun_id_locator = (lun_id_xpath, By.XPATH)
+            lun_id_locator = (row_id_path.format(i=i), row_id_by)
             lun_id = self.base_ui.get_element_text(lun_id_locator)
             selected_luns.append(lun_id)
             logger.info(f"Selected LUN: {lun_id}")

--- a/ocs_ci/ocs/ui/page_objects/fusion_access_ui.py
+++ b/ocs_ci/ocs/ui/page_objects/fusion_access_ui.py
@@ -3,6 +3,7 @@ import logging
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from ocs_ci.ocs.ui.base_ui import BaseUI, wait_for_element_to_be_clickable
+from ocs_ci.ocs.ui.helpers_ui import format_locator
 from ocs_ci.ocs.ui.page_objects.page_navigator import PageNavigator
 from ocs_ci.ocs.ui.views import FDF_SAN_LOCATORS, SCALE_DASHBOARD_LOCATORS
 from ocs_ci.utility.retry import retry
@@ -204,22 +205,27 @@ class FusionAccessUI(PageNavigator, BaseUI):
         ), "Scale dashboard connection is not green"
         logger.info("Scale dashboard connection is green")
 
-        # 2. Check for the SPECIFIC LUN group row
-        path_row, strategy_row = SCALE_DASHBOARD_LOCATORS["lun_group_row_by_name"]
-        specific_row_xpath = f"{path_row}[contains(., '{lun_group_name}')]"
-
+        # 2. Check for the SPECIFIC LUN group row.
+        row_xpath, row_by = format_locator(
+            SCALE_DASHBOARD_LOCATORS["lun_group_row_by_name"],
+            lun_group_name=lun_group_name,
+        )
         assert self.check_element_presence(
-            (strategy_row, specific_row_xpath), timeout=20
+            (row_by, row_xpath), timeout=20
         ), f"LUN group '{lun_group_name}' not found in the table"
         logger.info(f"LUN group {lun_group_name} found in the table")
 
         # 3. Check that the SPECIFIC LUN group has an OK/Healthy/Connected status.
-        status_path, strategy_ok = SCALE_DASHBOARD_LOCATORS[
-            "lun_group_status_ok_by_name"
-        ]
-        specific_ok_xpath = status_path.format(lun_group_name=lun_group_name)
-
-        assert self.check_element_presence(
-            (strategy_ok, specific_ok_xpath), timeout=25
-        ), f"LUN group '{lun_group_name}' is not in Healthy/OK/Connected state"
+        status_xpath, status_by = format_locator(
+            SCALE_DASHBOARD_LOCATORS["lun_group_status_ok_by_name"],
+            lun_group_name=lun_group_name,
+        )
+        try:
+            WebDriverWait(self.driver, 25).until(
+                EC.presence_of_element_located((status_by, status_xpath))
+            )
+        except Exception:
+            assert (
+                False
+            ), f"LUN group '{lun_group_name}' is not in Healthy/OK/Connected state"
         logger.info(f"LUN group {lun_group_name} health status is OK/Healthy/Connected")

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -1032,6 +1032,85 @@ page_nav_4_20 = {
     "external_systems_page": ("External systems", By.LINK_TEXT),
 }
 
+# FDF SAN UI Locators
+FDF_SAN_LOCATORS = {
+    # Connect to external storage button on External Systems page
+    "connect_external_storage_button": (
+        "//button[@data-test='configure-external-systems' or contains(text(), 'Connect external systems')]",
+        By.XPATH,
+    ),
+    # Storage Area Network card clickable button (radio input is hidden behind the card)
+    "san_radio_button": ("//button[@id='san-storage']", By.XPATH),
+    # Next button in wizard
+    "next_button": (
+        "//button[contains(text(), 'Next') or .//span[contains(text(), 'Next')]]",
+        By.XPATH,
+    ),
+    # Image registry URL input field
+    "image_registry_url_input": (
+        "//input["
+        "@id='imageRegistryURL' or @name='imageRegistryURL'"
+        " or @aria-label='Image registry URL'"
+        " or @data-test='image-registry-url']",
+        By.XPATH,
+    ),
+    # Image repository name input field
+    "image_repository_name_input": (
+        "//input["
+        "@id='imageRepositoryName' or @name='imageRepositoryName'"
+        " or @aria-label='Image repository name'"
+        " or @data-test='image-repository-name']",
+        By.XPATH,
+    ),
+    # Secret key dropdown toggle button (PF6 MenuToggle)
+    "secret_key_dropdown": (
+        "//button[@data-test='secret-key-dropdown']",
+        By.XPATH,
+    ),
+    # All options inside the Secret key dropdown (PF6 Menu list)
+    "secret_key_dropdown_options": (
+        "//ul[contains(@class,'pf-v6-c-menu__list')]"
+        "//li[not(contains(@class,'pf-v6-c-menu__list-item--disabled'))]"
+        "//button",
+        By.XPATH,
+    ),
+    # All nodes radio button
+    "all_nodes_radio": ("//input[@id='use-all-nodes']", By.XPATH),
+    # LUN group name input field
+    "lun_group_name_input": (
+        "//input[@id='lunGroupName' or @name='lunGroupName' or @placeholder='Enter LUN group name']",
+        By.XPATH,
+    ),
+    # Connect and create button
+    "connect_and_create_button": (
+        "//button[@data-test='connect-and-create-san-system' "
+        "or contains(text(), 'Connect and create') "
+        "or contains(text(), 'Connect and Create')]",
+        By.XPATH,
+    ),
+    # SAN storage page
+    "san_storage_link": (
+        "//a[normalize-space(text())='SAN_Storage' "
+        "and contains(@href, '/odf/external-systems/scale.spectrum.ibm.com')]",
+        By.XPATH,
+    ),
+}
+
+SCALE_DASHBOARD_LOCATORS = {
+    "scale_connection_green": (
+        "//*[@data-test='Connection-health-item-icon']//*[@data-test='success-icon']",
+        By.XPATH,
+    ),
+    "lun_group_row_by_name": (
+        "//table//tbody//tr",
+        By.XPATH,
+    ),
+    "lun_group_status_ok_by_name": (
+        "//table//tbody//tr//*[text()='OK' or text()='Healthy' or text()='Connected']",
+        By.XPATH,
+    ),
+}
+
 acm_page_nav = {
     "Home": ("//button[text()='Home']", By.XPATH),
     "Welcome_page": ("Welcome", By.LINK_TEXT),

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -1111,9 +1111,9 @@ SCALE_DASHBOARD_LOCATORS = {
         "//*[@data-test='Connection-health-item-icon']//*[@data-test='success-icon']",
         By.XPATH,
     ),
-    # Base XPath for a table row — caller appends a name filter via .format()
+    # Row locator for a specific LUN group — anchored on td[1] (name column)
     "lun_group_row_by_name": (
-        "//table//tbody//tr",
+        "//table//tbody//tr[contains(td[1], '{lun_group_name}')]",
         By.XPATH,
     ),
     # Status cell locator for a specific LUN group row.

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -1067,16 +1067,7 @@ FDF_SAN_LOCATORS = {
         "//button[@data-test='secret-key-dropdown']",
         By.XPATH,
     ),
-    # Wait anchor: any button inside a <li> inside the dropdown <ul>
-    # Intentionally avoids PF version-specific class names so it works
-    # across PatternFly versions.
-    "secret_key_dropdown_wait": (
-        "//ul[@role='listbox' or @role='menu']//li//button",
-        By.XPATH,
-    ),
     # All enabled options inside the Secret key dropdown.
-    # Uses aria-disabled rather than a PF-version class so the locator
-    # remains stable across PatternFly upgrades.
     "secret_key_dropdown_options": (
         "//ul[@role='listbox' or @role='menu']"
         "//li[not(@aria-disabled='true')]"
@@ -1086,7 +1077,6 @@ FDF_SAN_LOCATORS = {
     # All nodes radio button
     "all_nodes_radio": ("//input[@id='use-all-nodes']", By.XPATH),
     # LUN table checkbox for row i — use @aria-label to anchor the table,
-    # avoids PF version-specific class names.
     "lun_table_checkbox": (
         "//table[@aria-label='LUNs table']//tbody//tr[{i}]//input[@type='checkbox']",
         By.XPATH,
@@ -1121,12 +1111,17 @@ SCALE_DASHBOARD_LOCATORS = {
         "//*[@data-test='Connection-health-item-icon']//*[@data-test='success-icon']",
         By.XPATH,
     ),
+    # Base XPath for a table row — caller appends a name filter via .format()
     "lun_group_row_by_name": (
         "//table//tbody//tr",
         By.XPATH,
     ),
+    # Status cell locator for a specific LUN group row.
     "lun_group_status_ok_by_name": (
-        "//table//tbody//tr//*[text()='OK' or text()='Healthy' or text()='Connected']",
+        "//tr[contains(td[1], '{lun_group_name}')]"
+        "//td[@data-label='Status' or position()=2]"
+        "[text()='Healthy' or text()='OK' or text()='Connected'"
+        " or .//*[text()='Healthy' or text()='OK' or text()='Connected']]",
         By.XPATH,
     ),
 }

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -1062,20 +1062,40 @@ FDF_SAN_LOCATORS = {
         " or @data-test='image-repository-name']",
         By.XPATH,
     ),
-    # Secret key dropdown toggle button (PF6 MenuToggle)
+    # Secret key dropdown toggle button
     "secret_key_dropdown": (
         "//button[@data-test='secret-key-dropdown']",
         By.XPATH,
     ),
-    # All options inside the Secret key dropdown (PF6 Menu list)
+    # Wait anchor: any button inside a <li> inside the dropdown <ul>
+    # Intentionally avoids PF version-specific class names so it works
+    # across PatternFly versions.
+    "secret_key_dropdown_wait": (
+        "//ul[@role='listbox' or @role='menu']//li//button",
+        By.XPATH,
+    ),
+    # All enabled options inside the Secret key dropdown.
+    # Uses aria-disabled rather than a PF-version class so the locator
+    # remains stable across PatternFly upgrades.
     "secret_key_dropdown_options": (
-        "//ul[contains(@class,'pf-v6-c-menu__list')]"
-        "//li[not(contains(@class,'pf-v6-c-menu__list-item--disabled'))]"
+        "//ul[@role='listbox' or @role='menu']"
+        "//li[not(@aria-disabled='true')]"
         "//button",
         By.XPATH,
     ),
     # All nodes radio button
     "all_nodes_radio": ("//input[@id='use-all-nodes']", By.XPATH),
+    # LUN table checkbox for row i — use @aria-label to anchor the table,
+    # avoids PF version-specific class names.
+    "lun_table_checkbox": (
+        "//table[@aria-label='LUNs table']//tbody//tr[{i}]//input[@type='checkbox']",
+        By.XPATH,
+    ),
+    # LUN table second column (WWID) for row i
+    "lun_table_row_id": (
+        "//table[@aria-label='LUNs table']//tbody//tr[{i}]//td[2]",
+        By.XPATH,
+    ),
     # LUN group name input field
     "lun_group_name_input": (
         "//input[@id='lunGroupName' or @name='lunGroupName' or @placeholder='Enter LUN group name']",

--- a/tests/cross_functional/ui/fusion_access/test_create_filesystem.py
+++ b/tests/cross_functional/ui/fusion_access/test_create_filesystem.py
@@ -5,12 +5,10 @@ from time import sleep
 
 from ocs_ci.ocs.ui.page_objects.fusion_access_ui import FusionAccessUI
 from ocs_ci.framework.testlib import (
-    tier1,
     ui,
     ManageTest,
 )
 from ocs_ci.framework.pytest_customization.marks import (
-    green_squad,
     fusion_access_required,
     ignore_leftovers,
 )
@@ -24,7 +22,6 @@ logger = logging.getLogger(__name__)
 
 
 @ui
-@green_squad
 @fusion_access_required
 @ignore_leftovers
 class TestFDFSANConnection(ManageTest):
@@ -87,7 +84,6 @@ class TestFDFSANConnection(ManageTest):
         """
         self.setup_ui_class_factory = setup_ui_class_factory
 
-    @tier1
     @pytest.mark.polarion_id("OCS-5500")
     def test_connect_san_storage_and_create_filesystem(
         self,

--- a/tests/cross_functional/ui/fusion_access/test_create_filesystem.py
+++ b/tests/cross_functional/ui/fusion_access/test_create_filesystem.py
@@ -1,0 +1,233 @@
+import logging
+import pytest
+from time import sleep
+
+from ocs_ci.ocs.ui.page_objects.fusion_access_ui import FusionAccessUI
+from ocs_ci.framework.testlib import (
+    tier1,
+    ui,
+    ManageTest,
+)
+from ocs_ci.framework.pytest_customization.marks import (
+    green_squad,
+    fusion_access_required,
+    ignore_leftovers,
+)
+from ocs_ci.ocs.ui.page_objects.page_navigator import PageNavigator
+from ocs_ci.ocs.ui.base_ui import BaseUI
+from ocs_ci.framework import config
+from ocs_ci.ocs import ocp
+from ocs_ci.helpers.helpers import (
+    create_unique_resource_name,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@ui
+@green_squad
+@fusion_access_required
+@ignore_leftovers
+class TestFDFSANConnection(ManageTest):
+    """
+    Test class for FDF SAN (Storage Area Network) connection UI automation.
+
+    This class contains test cases for:
+    1. Connecting to external SAN storage
+    2. Creating LUN groups
+    3. Verifying file system creation
+    4. Validating connectivity
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup_lun_discovery(self):
+        """
+        Run LUN discovery on all worker nodes before test execution.
+
+        Discovers and logs in to the iSCSI target on every worker node so that
+        the LUNs are visible on the UI when the test runs.
+
+        Reads the following keys from ENV_DATA (set in your private cluster config):
+            san_iscsi_ip:  IP of the iSCSI target portal, e.g. "192.168.1.100"
+            san_iscsi_iqn: IQN of the iSCSI target, e.g. "iqn.2023-01.com.example:storage"
+        """
+        iscsi_ip = config.ENV_DATA.get("san_iscsi_ip")
+        iscsi_iqn = config.ENV_DATA.get("san_iscsi_iqn")
+        logger.info(
+            f"Starting LUN discovery on all worker nodes "
+            f"(portal: {iscsi_ip}, iqn: {iscsi_iqn})"
+        )
+        ocp_obj = ocp.OCP()
+        ocp_obj.exec_oc_cmd(
+            f"get nodes -l node-role.kubernetes.io/worker --no-headers -o name "
+            f"| xargs -I {{}} -- oc debug {{}} -- bash -c "
+            f"'chroot /host iscsiadm -m discovery -t st -p {iscsi_ip}; "
+            f"chroot /host iscsiadm --mode node --target {iscsi_iqn} "
+            f"--portal {iscsi_ip} -l' 2> /dev/null",
+            shell=True,
+        )
+        logger.info("LUN discovery completed on all worker nodes")
+        logger.info("Waiting 2 minute for LUNs to become visible on the UI...")
+        sleep(120)
+
+    @pytest.fixture(autouse=True)
+    def setup_ui(self, setup_ui_class_factory):
+        """
+        Setup UI session for the test class.
+
+        Args:
+            setup_ui_class_factory: Factory fixture to setup UI session
+        """
+        setup_ui_class_factory()
+        self.page_nav = PageNavigator()
+        self.base_ui = BaseUI()
+        self.fusion_access = FusionAccessUI()
+
+    @tier1
+    @pytest.mark.polarion_id("OCS-5500")
+    def test_connect_san_storage_and_create_filesystem(
+        self,
+    ):
+        """
+        Test to connect SAN storage and create file system via UI.
+
+        Test Steps:
+        1. Log into the OpenShift console and navigate to Storage > External systems
+        2. On the External systems page, Click on "Create External System" Button
+        3. On the Connect to external storage page, select Storage Area Network radio button
+        4. Click Next
+        4a. Enter the Image registry URL
+        4b. Enter the Image repository name
+        4c. Select the Secret key from the dropdown
+        4d. Create a docker-registry secret in ibm-spectrum-scale namespace with
+            Quay credentials fetched from config (san_quay_server, san_quay_username,
+            san_quay_password, san_quay_email)
+        5. On Connect Storage Area Network page, select AllNodes (Default) radio button
+        6. Provide LUN group name in the Name text field under LUN group details
+        7. Select a subset of LUNs from the table
+        8. Click on Connect and Create
+        9. Navigate to the external systems tab
+        10. Wait for the file system to be created
+        11. Verify the connection and file system status
+
+        Required config keys in your private cluster config YAML:
+            ENV_DATA:
+              san_image_registry_url: "quay.io"        # defaults to quay.io if not set
+              san_image_repository_name: "org/repo"
+              san_quay_server: "quay.io/org"
+              san_quay_username: "your-username"
+              san_quay_password: "your-password"  # pragma: allowlist secret
+              san_quay_email: "your-email@example.com"
+              san_iscsi_ip: "19X.16XX.1.1XX"            # iSCSI target portal IP
+              san_iscsi_iqn: "iqn.202X-XX.com.example:storage"  # iSCSI target IQN
+
+        """
+        logger.info("Starting FDF SAN connection test")
+
+        # Step 1: Navigate to External Storage Systems page
+        logger.info("Step 1: Navigate to Storage > External systems")
+        self.page_nav.nav_external_systems_page()
+        self.base_ui.take_screenshot("external_systems_page")
+
+        # Step 2: On the external systems page click on “Create External system” button
+        logger.info("Step 2: Click on Connect External system")
+        self.fusion_access.click_connect_external_systems()
+
+        # Step 3: Select Storage Area Network radio button
+        logger.info("Step 3: Select Storage Area Network option")
+        self.fusion_access.select_storage_area_network()
+        self.base_ui.take_screenshot("san_selected")
+
+        # Step 4: Click Next button
+        logger.info("Step 4: Click Next")
+        self.fusion_access.click_next_button()
+        self.base_ui.take_screenshot("san_configuration_page")
+
+        # Step 4a: Enter Image registry URL
+        image_registry_url = config.ENV_DATA.get("san_image_registry_url", "quay.io")
+        logger.info(f"Step 4a: Enter Image registry URL: {image_registry_url}")
+        self.fusion_access.enter_image_registry_url(image_registry_url)
+        self.base_ui.take_screenshot("image_registry_url_entered")
+
+        # Step 4b: Enter Image repository name
+        image_repository_name = config.ENV_DATA.get("san_image_repository_name")
+        logger.info(f"Step 4b: Enter Image repository name: {image_repository_name}")
+        self.fusion_access.enter_image_repository_name(image_repository_name)
+        self.base_ui.take_screenshot("image_repository_name_entered")
+
+        # Step 4c: Create docker-registry secret in ibm-spectrum-scale namespace
+        secret_name = "quayio-secret"
+        quay_server = config.ENV_DATA.get("san_quay_server")
+        quay_username = config.ENV_DATA.get("san_quay_username")
+        quay_password = config.ENV_DATA.get("san_quay_password")
+        quay_email = config.ENV_DATA.get("san_quay_email")
+        logger.info(
+            f"Step 4c: Creating docker-registry secret '{secret_name}' "
+            f"in ibm-spectrum-scale namespace"
+        )
+        ocp_obj = ocp.OCP(kind="secret", namespace="ibm-spectrum-scale")
+        ocp_obj.exec_oc_cmd(
+            f"create secret docker-registry {secret_name} "
+            f"--docker-server='{quay_server}' "
+            f"--docker-username='{quay_username}' "
+            f"--docker-password='{quay_password}' "
+            f"--docker-email='{quay_email}'"
+        )
+        logger.info(f"Waiting for secret '{secret_name}' to be created...")
+        ocp_obj.wait_for_resource(
+            condition="kubernetes.io/dockerconfigjson",
+            resource_name=secret_name,
+            column="TYPE",
+            timeout=60,
+        )
+        logger.info(f"Secret '{secret_name}' created successfully")
+
+        # Step 4d: Select Secret key from dropdown
+        logger.info("Step 4d: Select Secret key from dropdown")
+        self.fusion_access.select_secret_key()
+        self.base_ui.take_screenshot("secret_key_selected")
+
+        # Step 5: Select AllNodes (Default) radio button
+        logger.info("Step 5: Select All Nodes (Default)")
+        self.fusion_access.select_all_nodes_option()
+        self.base_ui.take_screenshot("all_nodes_selected")
+
+        # Step 6: Provide LUN group name
+        lun_group_name = create_unique_resource_name("test", "lungroup")
+        logger.info(f"Step 6: Enter LUN group name: {lun_group_name}")
+        self.fusion_access.enter_lun_group_name(lun_group_name)
+        self.base_ui.take_screenshot("lun_group_name_entered")
+
+        # Step 7: Select LUNs from the table
+        logger.info("Step 7: Select LUNs from the table")
+        selected_luns = self.fusion_access.select_luns_from_table()
+        logger.info(f"Selected LUNs: {selected_luns}")
+        self.base_ui.take_screenshot("luns_selected")
+
+        # Step 8: Click Connect and Create
+        logger.info("Step 8: Click Connect and Create")
+        self.fusion_access.click_connect_and_create()
+        self.base_ui.take_screenshot("connection_initiated")
+
+        # Step 9: Wait for backend processing then navigate back
+        logger.info("Step 9: Waiting 30 seconds for backend to process the request...")
+        sleep(60)
+
+        # Step 10: Refresh browser and wait for page to load completely
+        logger.info("Step 10: Refreshing browser and waiting for page to load...")
+        self.base_ui.driver.refresh()
+        self.base_ui.page_has_loaded()
+        self.base_ui.take_screenshot("browser_refreshed")
+
+        # Step 10a: Navigate to external systems page and click on SAN_Storage
+        logger.info("Step 10a: Navigate to Storage > External systems > SAN_Storage")
+        self.page_nav.nav_external_systems_page()
+        self.fusion_access.navigate_to_san_storage_tab()
+        self.base_ui.take_screenshot("file_systems_tab")
+
+        # Step 11: Wait for LUN group creation and verify SAN Scale state
+        logger.info("Step 11: Wait for LUN group creation and verify SAN Scale state")
+        logger.info("Waiting for filesystem creation")
+        self.fusion_access.wait_for_filesystem_and_verify_connection(
+            lun_group_name=lun_group_name,
+        )

--- a/tests/cross_functional/ui/fusion_access/test_create_filesystem.py
+++ b/tests/cross_functional/ui/fusion_access/test_create_filesystem.py
@@ -14,8 +14,6 @@ from ocs_ci.framework.pytest_customization.marks import (
     fusion_access_required,
     ignore_leftovers,
 )
-from ocs_ci.ocs.ui.page_objects.page_navigator import PageNavigator
-from ocs_ci.ocs.ui.base_ui import BaseUI
 from ocs_ci.framework import config
 from ocs_ci.ocs import ocp
 from ocs_ci.helpers.helpers import (
@@ -87,10 +85,7 @@ class TestFDFSANConnection(ManageTest):
         Args:
             setup_ui_class_factory: Factory fixture to setup UI session
         """
-        setup_ui_class_factory()
-        self.page_nav = PageNavigator()
-        self.base_ui = BaseUI()
-        self.fusion_access = FusionAccessUI()
+        self.setup_ui_class_factory = setup_ui_class_factory
 
     @tier1
     @pytest.mark.polarion_id("OCS-5500")
@@ -133,36 +128,40 @@ class TestFDFSANConnection(ManageTest):
         """
         logger.info("Starting FDF SAN connection test")
 
+        # Initialise UI session and page object — FusionAccessUI inherits both
+        self.setup_ui_class_factory()
+        fusion_access = FusionAccessUI()
+
         # Step 1: Navigate to External Storage Systems page
         logger.info("Step 1: Navigate to Storage > External systems")
-        self.page_nav.nav_external_systems_page()
-        self.base_ui.take_screenshot("external_systems_page")
+        fusion_access.nav_external_systems_page()
+        fusion_access.take_screenshot("external_systems_page")
 
         # Step 2: On the external systems page click on “Create External system” button
         logger.info("Step 2: Click on Connect External system")
-        self.fusion_access.click_connect_external_systems()
+        fusion_access.click_connect_external_systems()
 
         # Step 3: Select Storage Area Network radio button
         logger.info("Step 3: Select Storage Area Network option")
-        self.fusion_access.select_storage_area_network()
-        self.base_ui.take_screenshot("san_selected")
+        fusion_access.select_storage_area_network()
+        fusion_access.take_screenshot("san_selected")
 
         # Step 4: Click Next button
         logger.info("Step 4: Click Next")
-        self.fusion_access.click_next_button()
-        self.base_ui.take_screenshot("san_configuration_page")
+        fusion_access.click_next_button()
+        fusion_access.take_screenshot("san_configuration_page")
 
         # Step 4a: Enter Image registry URL
         image_registry_url = config.ENV_DATA.get("san_image_registry_url", "quay.io")
         logger.info(f"Step 4a: Enter Image registry URL: {image_registry_url}")
-        self.fusion_access.enter_image_registry_url(image_registry_url)
-        self.base_ui.take_screenshot("image_registry_url_entered")
+        fusion_access.enter_image_registry_url(image_registry_url)
+        fusion_access.take_screenshot("image_registry_url_entered")
 
         # Step 4b: Enter Image repository name
         image_repository_name = config.ENV_DATA.get("san_image_repository_name")
         logger.info(f"Step 4b: Enter Image repository name: {image_repository_name}")
-        self.fusion_access.enter_image_repository_name(image_repository_name)
-        self.base_ui.take_screenshot("image_repository_name_entered")
+        fusion_access.enter_image_repository_name(image_repository_name)
+        fusion_access.take_screenshot("image_repository_name_entered")
 
         # Step 4c: Create docker-registry secret in ibm-spectrum-scale namespace
         secret_name = "quayio-secret"
@@ -194,30 +193,30 @@ class TestFDFSANConnection(ManageTest):
 
         # Step 4d: Select Secret key from dropdown
         logger.info("Step 4d: Select Secret key from dropdown")
-        self.fusion_access.select_secret_key()
-        self.base_ui.take_screenshot("secret_key_selected")
+        fusion_access.select_secret_key()
+        fusion_access.take_screenshot("secret_key_selected")
 
         # Step 5: Select AllNodes (Default) radio button
         logger.info("Step 5: Select All Nodes (Default)")
-        self.fusion_access.select_all_nodes_option()
-        self.base_ui.take_screenshot("all_nodes_selected")
+        fusion_access.select_all_nodes_option()
+        fusion_access.take_screenshot("all_nodes_selected")
 
         # Step 6: Provide LUN group name
         lun_group_name = create_unique_resource_name("test", "lungroup")
         logger.info(f"Step 6: Enter LUN group name: {lun_group_name}")
-        self.fusion_access.enter_lun_group_name(lun_group_name)
-        self.base_ui.take_screenshot("lun_group_name_entered")
+        fusion_access.enter_lun_group_name(lun_group_name)
+        fusion_access.take_screenshot("lun_group_name_entered")
 
         # Step 7: Select LUNs from the table
         logger.info("Step 7: Select LUNs from the table")
-        selected_luns = self.fusion_access.select_luns_from_table()
+        selected_luns = fusion_access.select_luns_from_table()
         logger.info(f"Selected LUNs: {selected_luns}")
-        self.base_ui.take_screenshot("luns_selected")
+        fusion_access.take_screenshot("luns_selected")
 
         # Step 8: Click Connect and Create
         logger.info("Step 8: Click Connect and Create")
-        self.fusion_access.click_connect_and_create()
-        self.base_ui.take_screenshot("connection_initiated")
+        fusion_access.click_connect_and_create()
+        fusion_access.take_screenshot("connection_initiated")
 
         # Step 9: Wait for backend to process the request before navigating away
         logger.info("Step 9: Waiting 60 seconds for backend to process the request...")
@@ -225,21 +224,21 @@ class TestFDFSANConnection(ManageTest):
 
         # Step 10: Refresh browser and wait for page to fully settle
         logger.info("Step 10: Refreshing browser and waiting for page to load...")
-        self.base_ui.driver.refresh()
-        self.base_ui.page_has_loaded()
+        fusion_access.refresh_page()
+        fusion_access.page_has_loaded()
         sleep(10)
-        self.base_ui.take_screenshot("browser_refreshed")
+        fusion_access.take_screenshot("browser_refreshed")
 
         # Step 10a: Navigate to external systems page and click on SAN_Storage.
         logger.info("Step 10a: Navigate to Storage > External systems > SAN_Storage")
-        self.base_ui.page_has_loaded()
-        self.page_nav.nav_external_systems_page()
-        self.fusion_access.navigate_to_san_storage_tab()
-        self.base_ui.take_screenshot("file_systems_tab")
+        fusion_access.page_has_loaded()
+        fusion_access.nav_external_systems_page()
+        fusion_access.navigate_to_san_storage_tab()
+        fusion_access.take_screenshot("file_systems_tab")
 
         # Step 11: Wait for LUN group creation and verify SAN Scale state
         logger.info("Step 11: Wait for LUN group creation and verify SAN Scale state")
         logger.info("Waiting for filesystem creation")
-        self.fusion_access.wait_for_filesystem_and_verify_connection(
+        fusion_access.wait_for_filesystem_and_verify_connection(
             lun_group_name=lun_group_name,
         )

--- a/tests/cross_functional/ui/fusion_access/test_create_filesystem.py
+++ b/tests/cross_functional/ui/fusion_access/test_create_filesystem.py
@@ -1,4 +1,5 @@
 import logging
+import re
 import pytest
 from time import sleep
 
@@ -53,6 +54,14 @@ class TestFDFSANConnection(ManageTest):
         """
         iscsi_ip = config.ENV_DATA.get("san_iscsi_ip")
         iscsi_iqn = config.ENV_DATA.get("san_iscsi_iqn")
+
+        # Validate values before interpolating into a shell command.
+        # IP must be a dotted-decimal address; IQN must follow the iqn. format.
+        if not re.fullmatch(r"[\d]{1,3}(\.[\d]{1,3}){3}", iscsi_ip or ""):
+            raise ValueError(f"san_iscsi_ip '{iscsi_ip}' is not a valid IPv4 address")
+        if not re.fullmatch(r"iqn\.\d{4}-\d{2}\.[a-zA-Z0-9.\-:]+", iscsi_iqn or ""):
+            raise ValueError(f"san_iscsi_iqn '{iscsi_iqn}' is not a valid IQN")
+
         logger.info(
             f"Starting LUN discovery on all worker nodes "
             f"(portal: {iscsi_ip}, iqn: {iscsi_iqn})"
@@ -61,9 +70,9 @@ class TestFDFSANConnection(ManageTest):
         ocp_obj.exec_oc_cmd(
             f"get nodes -l node-role.kubernetes.io/worker --no-headers -o name "
             f"| xargs -I {{}} -- oc debug {{}} -- bash -c "
-            f"'chroot /host iscsiadm -m discovery -t st -p {iscsi_ip}; "
-            f"chroot /host iscsiadm --mode node --target {iscsi_iqn} "
-            f"--portal {iscsi_ip} -l' 2> /dev/null",
+            f'\'chroot /host iscsiadm -m discovery -t st -p "{iscsi_ip}"; '
+            f'chroot /host iscsiadm --mode node --target "{iscsi_iqn}" '
+            f'--portal "{iscsi_ip}" -l\' 2> /dev/null',
             shell=True,
         )
         logger.info("LUN discovery completed on all worker nodes")
@@ -171,7 +180,8 @@ class TestFDFSANConnection(ManageTest):
             f"--docker-server='{quay_server}' "
             f"--docker-username='{quay_username}' "
             f"--docker-password='{quay_password}' "
-            f"--docker-email='{quay_email}'"
+            f"--docker-email='{quay_email}'",
+            secrets=[quay_password, quay_username],
         )
         logger.info(f"Waiting for secret '{secret_name}' to be created...")
         ocp_obj.wait_for_resource(
@@ -209,18 +219,20 @@ class TestFDFSANConnection(ManageTest):
         self.fusion_access.click_connect_and_create()
         self.base_ui.take_screenshot("connection_initiated")
 
-        # Step 9: Wait for backend processing then navigate back
-        logger.info("Step 9: Waiting 30 seconds for backend to process the request...")
+        # Step 9: Wait for backend to process the request before navigating away
+        logger.info("Step 9: Waiting 60 seconds for backend to process the request...")
         sleep(60)
 
-        # Step 10: Refresh browser and wait for page to load completely
+        # Step 10: Refresh browser and wait for page to fully settle
         logger.info("Step 10: Refreshing browser and waiting for page to load...")
         self.base_ui.driver.refresh()
         self.base_ui.page_has_loaded()
+        sleep(10)
         self.base_ui.take_screenshot("browser_refreshed")
 
-        # Step 10a: Navigate to external systems page and click on SAN_Storage
+        # Step 10a: Navigate to external systems page and click on SAN_Storage.
         logger.info("Step 10a: Navigate to Storage > External systems > SAN_Storage")
+        self.base_ui.page_has_loaded()
         self.page_nav.nav_external_systems_page()
         self.fusion_access.navigate_to_san_storage_tab()
         self.base_ui.take_screenshot("file_systems_tab")

--- a/tests/cross_functional/ui/fusion_access/test_create_filesystem.py
+++ b/tests/cross_functional/ui/fusion_access/test_create_filesystem.py
@@ -9,6 +9,7 @@ from ocs_ci.framework.testlib import (
     ManageTest,
 )
 from ocs_ci.framework.pytest_customization.marks import (
+    magenta_squad,
     fusion_access_required,
     ignore_leftovers,
 )
@@ -22,6 +23,7 @@ logger = logging.getLogger(__name__)
 
 
 @ui
+@magenta_squad
 @fusion_access_required
 @ignore_leftovers
 class TestFDFSANConnection(ManageTest):


### PR DESCRIPTION
This pull request introduces the foundational infrastructure and initial test coverage for Fusion Access within the ocs-ci framework.

Core Infrastructure

New Directory Structure: Establishes the dedicated library and directory architecture required for Fusion Access components.
Library Development: Implements the backend logic and helper functions to support Fusion Access operations.
Test Implementation

End-to-End Validation: Includes a new test case designed to automate the following lifecycle:

Provisioning of external storage systems.
Configuration of LUN groups.
Creation of filesystems.
Verification: Integrated validation steps to ensure resources are created correctly and meet functional requirements.

Includes code suggested by Bob

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added deployment configuration to enable Fusion Access.
  - Implemented UI automation coverage for the Fusion SAN connect-and-create workflow, including secret selection, LUN group setup, and connectivity/health verification.

- **Tests**
  - Added an end-to-end UI test for connecting SAN storage and creating a filesystem, followed by validation of successful connection.
  - Introduced a pytest skip marker so Fusion Access tests run only when Fusion Access is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->