### PR TITLE
RHSTOR-8242: Add automation tests for NetworkFence workflow and cluster upgrades

### DIFF
--- a/tests/functional/pv/pv_services/test_automate_networkfence_workflow_stretch_cluster.py
+++ b/tests/functional/pv/pv_services/test_automate_networkfence_workflow_stretch_cluster.py
@@ -38,8 +38,9 @@ from datetime import datetime, timezone
 import pytest
 
 from ocs_ci.framework.pytest_customization.marks import (
-    stretchcluster_required,
+    ignore_leftovers,
     magenta_squad,
+    stretchcluster_required,
 )
 from ocs_ci.framework.testlib import ManageTest, tier4b
 from ocs_ci.helpers.cnv_helpers import cal_md5sum_vm
@@ -381,6 +382,7 @@ def _redeploy_and_verify(
 @tier4b
 @stretchcluster_required
 @magenta_squad
+@ignore_leftovers
 class TestStretchClusterZoneBNodeShutdown(ManageTest):
     """
     Shutdown one Zone-B node while zone-aware workloads are running.
@@ -641,6 +643,7 @@ class TestStretchClusterZoneBNodeShutdown(ManageTest):
 @tier4b
 @stretchcluster_required
 @magenta_squad
+@ignore_leftovers
 class TestStretchClusterZoneBShutdownZoneUnaware(ManageTest):
     """
     Shutdown all Zone-B nodes while zone-UNAWARE workloads are running.
@@ -774,6 +777,7 @@ class TestStretchClusterZoneBShutdownZoneUnaware(ManageTest):
 @tier4b
 @stretchcluster_required
 @magenta_squad
+@ignore_leftovers
 class TestStretchClusterZoneBKubeletDown(ManageTest):
     """
     Zone B down / network down — simulated by stopping kubelet.

--- a/tests/functional/pv/pv_services/test_automate_networkfence_workflow_stretch_cluster.py
+++ b/tests/functional/pv/pv_services/test_automate_networkfence_workflow_stretch_cluster.py
@@ -40,7 +40,7 @@ import pytest
 from ocs_ci.framework.pytest_customization.marks import (
     stretchcluster_required,
     tier4b,
-    turquoise_squad,
+    magenta_squad,
 )
 from ocs_ci.helpers.cnv_helpers import cal_md5sum_vm
 from ocs_ci.helpers.stretchcluster_helper import (
@@ -273,7 +273,7 @@ def _redeploy_and_verify(
 
 @tier4b
 @stretchcluster_required
-@turquoise_squad
+@magenta_squad
 class TestStretchClusterZoneBNodeShutdown:
     """
     Shutdown one Zone-B node while zone-aware workloads are running.
@@ -515,7 +515,7 @@ class TestStretchClusterZoneBNodeShutdown:
 
 @tier4b
 @stretchcluster_required
-@turquoise_squad
+@magenta_squad
 class TestStretchClusterZoneBShutdownZoneUnaware:
     """
     Shutdown all Zone-B nodes while zone-UNAWARE workloads are running.
@@ -648,7 +648,7 @@ class TestStretchClusterZoneBShutdownZoneUnaware:
 
 @tier4b
 @stretchcluster_required
-@turquoise_squad
+@magenta_squad
 class TestStretchClusterZoneBKubeletDown:
     """
     Zone B down / network down — simulated by stopping kubelet.

--- a/tests/functional/pv/pv_services/test_automate_networkfence_workflow_stretch_cluster.py
+++ b/tests/functional/pv/pv_services/test_automate_networkfence_workflow_stretch_cluster.py
@@ -1,0 +1,836 @@
+"""
+RHSTOR-8242 - Automate the NetworkFence workflow with cephcsi on stretch cluster.
+
+Four test scenarios covering Zone-B disruptions with the out-of-service taint:
+
+  1. Shutdown ONE Zone-B node, taint all Zone-B nodes out-of-service.
+     Workloads are zone-aware.
+     - If healthy Zone-B nodes still exist: pods migrate there.
+     - If no healthy Zone-B nodes remain: pods go Pending / FailedScheduling.
+
+  2. Shutdown ALL Zone-B nodes, taint them all out-of-service.
+     Workloads are zone-aware.
+     - Zone-aware pods always go Pending / FailedScheduling.
+     - After full Zone-B recovery: DU/DL/DC confirmed clean, connection
+       scores validated, new workloads deploy successfully.
+
+  3. Shutdown ALL Zone-B nodes, taint them all out-of-service.
+     Workloads are zone-UNAWARE.
+     - Zone-unaware pods reschedule automatically onto any available node in
+       any other zone (no topology constraint).
+     - After Zone-B recovery: DU/DL/DC confirmed clean, connection scores
+       validated, existing workloads re-deployed on recovered nodes, new
+       workloads deployed and IOs verified.
+
+  4. Stop kubelet on all Zone-B nodes (node unresponsive / network-down
+     simulation), taint Zone-B nodes out-of-service, force-delete stuck pods
+     so they reschedule onto healthy zones.
+     - Verifies the forced-eviction + rescheduling path when the node is still
+       physically present but the kubelet is not responding.
+     - After kubelet restart and taint removal: DU/DL/DC confirmed clean,
+       connection scores validated, new workloads deploy successfully.
+"""
+
+import logging
+import time
+from datetime import datetime, timezone
+
+import pytest
+
+from ocs_ci.framework.pytest_customization.marks import (
+    stretchcluster_required,
+    tier4b,
+    turquoise_squad,
+)
+from ocs_ci.helpers.cnv_helpers import cal_md5sum_vm
+from ocs_ci.helpers.stretchcluster_helper import (
+    check_for_logwriter_workload_pods,
+    recover_from_ceph_stuck,
+    verify_data_corruption,
+    verify_data_loss,
+    verify_vm_workload,
+)
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.exceptions import CommandFailed
+from ocs_ci.ocs.node import (
+    taint_nodes,
+    untaint_nodes,
+    wait_for_nodes_status,
+)
+from ocs_ci.ocs.ocp import OCP
+from ocs_ci.ocs.resources.pod import (
+    Pod,
+    get_pods_having_label,
+    wait_for_pods_to_be_in_statuses,
+)
+from ocs_ci.ocs.resources.stretchcluster import StretchCluster
+from ocs_ci.utility.retry import retry
+
+log = logging.getLogger(__name__)
+
+ZONE_B = "data-2"
+CEPH_CHECK_TIMEOUT = 120
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers shared across all test classes
+# ---------------------------------------------------------------------------
+
+
+def _teardown_taints(tainted_nodes: list) -> None:
+    """Remove the out-of-service taint from *tainted_nodes* and clear the list."""
+    if not tainted_nodes:
+        return
+    names = [n.name for n in tainted_nodes]
+    log.info(f"Teardown: removing out-of-service taint from nodes {names}")
+    try:
+        untaint_nodes(
+            taint_label=constants.NODE_OUT_OF_SERVICE_TAINT,
+            nodes_to_untaint=tainted_nodes,
+        )
+    except Exception as exc:
+        log.warning(f"untaint_nodes during teardown raised: {exc}")
+    tainted_nodes.clear()
+
+
+def _deploy_workloads(
+    sc_obj,
+    setup_logwriter_cephfs_workload_factory,
+    setup_logwriter_rbd_workload_factory,
+    cnv_workload,
+    nodes,
+    zone_aware: bool = True,
+):
+    """
+    Deploy CephFS logwriter, RBD logwriter and VM workloads; verify all pods
+    are healthy; capture logfile maps for data-loss detection.
+
+    Returns:
+        tuple: (vm_obj, md5sum_before) — the VM object and the md5sum of the
+        test file written inside the VM before any disruption.
+    """
+    log.info(f"Deploying zone-{'aware' if zone_aware else 'unaware'} workloads")
+    (
+        sc_obj.cephfs_logwriter_dep,
+        sc_obj.cephfs_logreader_job,
+    ) = setup_logwriter_cephfs_workload_factory(
+        read_duration=0, **({} if zone_aware else {"zone_aware": False})
+    )
+    sc_obj.rbd_logwriter_sts = setup_logwriter_rbd_workload_factory(
+        zone_aware=zone_aware
+    )
+
+    vm_obj = cnv_workload(volume_interface=constants.VM_VOLUME_PVC)
+    vm_obj.run_ssh_cmd(command="mkdir /test && sudo chmod -R 777 /test")
+    vm_obj.run_ssh_cmd(
+        command=(
+            "< /dev/urandom tr -dc 'A-Za-z0-9' | head -c 10485760 "
+            "> /test/file_1.txt && sync"
+        )
+    )
+    md5sum_before = cal_md5sum_vm(vm_obj, file_path="/test/file_1.txt")
+    log.info(f"VM file md5sum before failure: {md5sum_before}")
+
+    check_for_logwriter_workload_pods(sc_obj, nodes=nodes)
+    log.info("All logwriter/logreader workload pods are running successfully")
+
+    sc_obj.get_logfile_map(label=constants.LOGWRITER_CEPHFS_LABEL)
+    sc_obj.get_logfile_map(label=constants.LOGWRITER_RBD_LABEL)
+
+    return vm_obj, md5sum_before
+
+
+def _get_zone_b_nodes(sc_obj):
+    """
+    Return all OCS node objects in Zone B and assert at least one exists.
+
+    Returns:
+        list: Zone-B node objects.
+    """
+    zone_b_nodes = sc_obj.get_nodes_in_zone(ZONE_B)
+    assert len(zone_b_nodes) > 0, (
+        f"No nodes found in Zone B ({ZONE_B}). "
+        f"Check that the cluster has nodes labeled {constants.ZONE_LABEL}={ZONE_B}"
+    )
+    return zone_b_nodes
+
+
+def _apply_out_of_service_taint(zone_b_nodes: list, tainted_nodes_ref: list) -> None:
+    """
+    Apply the out-of-service NoExecute taint to all *zone_b_nodes* and record
+    them in *tainted_nodes_ref* so teardown can remove the taint on failure.
+    """
+    node_names = [n.name for n in zone_b_nodes]
+    assert taint_nodes(
+        nodes=node_names,
+        taint_label=constants.NODE_OUT_OF_SERVICE_TAINT,
+    ), f"Failed to add out-of-service taint to Zone-B nodes {node_names}"
+    tainted_nodes_ref.clear()
+    tainted_nodes_ref.extend(zone_b_nodes)
+    log.info(f"out-of-service taint applied to Zone-B nodes: {node_names}")
+
+
+def _refresh_pod_state(sc_obj) -> None:
+    """
+    Refresh the CephFS and RBD logwriter/logreader pod state on *sc_obj*,
+    expecting pods to have left Zone B (exp_num_replicas=0 means 'any count').
+    """
+    for label in (
+        constants.LOGWRITER_CEPHFS_LABEL,
+        constants.LOGREADER_CEPHFS_LABEL,
+        constants.LOGWRITER_RBD_LABEL,
+    ):
+        sc_obj.get_logwriter_reader_pods(label=label, exp_num_replicas=0)
+
+
+def _check_ceph_accessible(sc_obj, context: str) -> None:
+    """Assert Ceph is accessible; attempt recovery if it is not."""
+    if not sc_obj.check_ceph_accessibility(timeout=CEPH_CHECK_TIMEOUT):
+        assert recover_from_ceph_stuck(
+            sc_obj
+        ), f"Ceph became inaccessible {context} and could not be recovered"
+    log.info(f"Ceph is accessible {context}")
+
+
+def _run_post_failure_checks(sc_obj, start_time, end_time, context: str) -> None:
+    """Run post_failure_checks and verify Ceph accessibility during a failure window."""
+    sc_obj.post_failure_checks(start_time, end_time, wait_for_read_completion=False)
+    log.info(f"Post-failure IO/integrity checks passed ({context})")
+    _check_ceph_accessible(sc_obj, context)
+
+
+def _run_post_recovery_checks(
+    sc_obj, start_time, nodes, vm_obj, md5sum_before, logreader_workload_factory
+) -> None:
+    """
+    Full post-recovery verification sequence:
+      - Refresh pod state
+      - post_failure_checks over the full window
+      - Ceph accessibility check
+      - Connection score reset
+      - VM data integrity (md5sum) and SSH connectivity
+      - Data loss check (logwriter logs)
+      - Data corruption check (logreader logs)
+    """
+    recovery_end_time = datetime.now(timezone.utc)
+
+    _refresh_pod_state(sc_obj)
+
+    sc_obj.post_failure_checks(
+        start_time, recovery_end_time, wait_for_read_completion=False
+    )
+    log.info("Post-recovery IO/integrity checks passed (no DU/DL/DC)")
+
+    _check_ceph_accessible(sc_obj, "after Zone-B recovery")
+
+    sc_obj.reset_conn_score()
+    log.info("Connection scores are clean after Zone-B recovery")
+
+    retry(CommandFailed, tries=5, delay=10)(vm_obj.wait_for_ssh_connectivity)()
+    retry(CommandFailed, tries=5, delay=10)(verify_vm_workload)(vm_obj, md5sum_before)
+    vm_obj.stop()
+    log.info("VM data integrity verified and VM stopped")
+
+    check_for_logwriter_workload_pods(sc_obj, nodes=nodes)
+    verify_data_loss(sc_obj)
+    log.info("No data loss detected")
+
+    sc_obj.cephfs_logreader_job.delete()
+    for pod in sc_obj.cephfs_logreader_pods:
+        pod.wait_for_pod_delete(timeout=120)
+    verify_data_corruption(sc_obj, logreader_workload_factory)
+    log.info("No data corruption detected")
+
+
+def _redeploy_and_verify(
+    sc_obj, setup_logwriter_rbd_workload_factory, nodes, zone_aware: bool
+) -> None:
+    """
+    Delete existing RBD logwriter pods and wait for the StatefulSet to recreate
+    them, then deploy a fresh RBD logwriter StatefulSet and verify all workload
+    pods are healthy.
+    """
+    for pod_obj in sc_obj.rbd_logwriter_pods:
+        log.info(f"Deleting pod {pod_obj.name}")
+        pod_obj.delete()
+    sc_obj.get_logwriter_reader_pods(
+        label=constants.LOGWRITER_RBD_LABEL, exp_num_replicas=2
+    )
+    log.info("Logwriter-RBD pods re-scheduled and Running after Zone-B recovery")
+
+    new_rbd_sts = setup_logwriter_rbd_workload_factory(zone_aware=zone_aware)
+    log.info(f"New logwriter-rbd workload deployed: {new_rbd_sts.name}")
+    check_for_logwriter_workload_pods(sc_obj, nodes=nodes)
+    log.info(
+        "All workloads healthy on recovered Zone-B nodes – IOs running without errors"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test classes
+# ---------------------------------------------------------------------------
+
+
+@tier4b
+@stretchcluster_required
+@turquoise_squad
+class TestStretchClusterZoneBNodeShutdown:
+    """
+    Shutdown one Zone-B node while zone-aware workloads are running.
+
+    Taints all Zone-B nodes out-of-service and verifies workloads migrate to
+    healthy Zone-B nodes, or go Pending when no healthy Zone-B nodes remain.
+    """
+
+    _tainted_nodes = []
+
+    @pytest.fixture(autouse=False)
+    def zone_b_shutdown_teardown(self, request):
+        """Remove out-of-service taints on failure or test end."""
+
+        def finalizer():
+            _teardown_taints(self._tainted_nodes)
+
+        request.addfinalizer(finalizer)
+
+    @pytest.mark.polarion_id("OCS-7372")
+    def test_zone_b_node_shutdown_with_zone_aware_workloads(
+        self,
+        node_restart_teardown,
+        zone_b_shutdown_teardown,
+        reset_conn_score,
+        nodes,
+        setup_logwriter_cephfs_workload_factory,
+        setup_logwriter_rbd_workload_factory,
+        logreader_workload_factory,
+        cnv_workload,
+        setup_cnv,
+    ):
+        """
+        Stretch cluster – shutdown one Zone-B node, taint all Zone-B nodes
+        out-of-service, verify zone-aware workloads migrate / pend correctly,
+        recover Zone B, validate data integrity and connection scores.
+
+        Steps:
+        1. Deploy zone-aware VM, logwriter-cephfs and logwriter-rbd workloads;
+           verify they are all running.
+        2. Shutdown one Zone-B node; taint all Zone-B nodes out-of-service.
+        3. Verify no IO is happening on Zone B.
+        4. If healthy Zone-B nodes remain: verify pods migrated there.
+           If no healthy Zone-B nodes remain: verify pods are Pending /
+           FailedScheduling.
+        5. Confirm no DU/DL/DC; check Ceph accessibility.
+        6. Recover Zone B; remove the taint.
+        7. Confirm no DU/DL/DC after recovery; validate connection scores;
+           verify VM integrity, data loss and corruption.
+        8. Delete RBD pods; verify re-schedule; deploy new workload.
+        """
+        sc_obj = StretchCluster()
+
+        vm_obj, md5sum_before = _deploy_workloads(
+            sc_obj,
+            setup_logwriter_cephfs_workload_factory,
+            setup_logwriter_rbd_workload_factory,
+            cnv_workload,
+            nodes,
+            zone_aware=True,
+        )
+
+        zone_b_nodes = _get_zone_b_nodes(sc_obj)
+        node_to_shutdown = zone_b_nodes[0]
+        zone_b_node_names = [n.name for n in zone_b_nodes]
+        log.info(
+            f"Zone-B nodes: {zone_b_node_names}; "
+            f"selecting '{node_to_shutdown.name}' for shutdown"
+        )
+
+        start_time = datetime.now(timezone.utc)
+        nodes.stop_nodes(nodes=[node_to_shutdown])
+        wait_for_nodes_status(
+            node_names=[node_to_shutdown.name],
+            status=constants.NODE_NOT_READY,
+            timeout=300,
+        )
+        log.info(f"Node {node_to_shutdown.name} is NotReady")
+
+        _apply_out_of_service_taint(zone_b_nodes, self._tainted_nodes)
+        _refresh_pod_state(sc_obj)
+
+        healthy_zone_b_nodes = [
+            n.name for n in zone_b_nodes if n.name != node_to_shutdown.name
+        ]
+        log.info(f"Healthy Zone-B nodes remaining: {healthy_zone_b_nodes}")
+
+        if not healthy_zone_b_nodes:
+            log.info(
+                "No healthy Zone-B nodes – verifying zone-aware RBD pods "
+                "enter Pending / FailedScheduling state"
+            )
+            rbd_pod_names = [
+                p["metadata"]["name"]
+                for p in get_pods_having_label(
+                    label=constants.LOGWRITER_RBD_LABEL,
+                    namespace=constants.STRETCH_CLUSTER_NAMESPACE,
+                )
+            ]
+            if rbd_pod_names:
+                wait_for_pods_to_be_in_statuses(
+                    expected_statuses=constants.STATUS_PENDING,
+                    pod_names=rbd_pod_names,
+                    timeout=300,
+                    namespace=constants.STRETCH_CLUSTER_NAMESPACE,
+                )
+                log.info(
+                    "Zone-aware RBD pods are Pending (FailedScheduling) as expected"
+                )
+        else:
+            log.info("Healthy Zone-B nodes exist – verifying pods relocated there")
+            sc_obj.get_logwriter_reader_pods(label=constants.LOGWRITER_CEPHFS_LABEL)
+            sc_obj.get_logwriter_reader_pods(
+                label=constants.LOGWRITER_RBD_LABEL, exp_num_replicas=2
+            )
+            log.info("Zone-aware workload pods relocated to healthy Zone-B nodes")
+
+        end_time = datetime.now(timezone.utc)
+        if healthy_zone_b_nodes:
+            _run_post_failure_checks(
+                sc_obj, start_time, end_time, "during Zone-B partial outage"
+            )
+        else:
+            _check_ceph_accessible(sc_obj, "during Zone-B outage")
+
+        nodes.start_nodes(nodes=[node_to_shutdown])
+        wait_for_nodes_status(timeout=600)
+        log.info(f"Node {node_to_shutdown.name} is Ready; Zone B recovered")
+
+        untaint_nodes(
+            taint_label=constants.NODE_OUT_OF_SERVICE_TAINT,
+            nodes_to_untaint=self._tainted_nodes,
+        )
+        self._tainted_nodes.clear()
+        time.sleep(30)
+
+        _run_post_recovery_checks(
+            sc_obj, start_time, nodes, vm_obj, md5sum_before, logreader_workload_factory
+        )
+        _redeploy_and_verify(
+            sc_obj, setup_logwriter_rbd_workload_factory, nodes, zone_aware=True
+        )
+
+    @pytest.mark.polarion_id("OCS-7373")
+    def test_zone_b_all_nodes_shutdown_with_zone_aware_workloads(
+        self,
+        node_restart_teardown,
+        zone_b_shutdown_teardown,
+        reset_conn_score,
+        nodes,
+        setup_logwriter_cephfs_workload_factory,
+        setup_logwriter_rbd_workload_factory,
+        logreader_workload_factory,
+        cnv_workload,
+        setup_cnv,
+    ):
+        """
+        Stretch cluster – shutdown ALL Zone-B nodes, taint them out-of-service,
+        verify zone-aware workloads go Pending (FailedScheduling), recover all
+        Zone-B nodes, remove the taint, confirm data integrity and connection scores.
+
+        Steps:
+        1. Deploy zone-aware VM, logwriter-cephfs and logwriter-rbd workloads;
+           verify they are all running.
+        2. Shutdown ALL Zone-B nodes; taint them out-of-service.
+        3. Verify no IO is happening on Zone B.
+        4. Verify zone-aware RBD pods are Pending / FailedScheduling.
+        5. Recover Zone B; remove the taint.
+        6. Confirm no DU/DL/DC after recovery; validate connection scores;
+           verify VM integrity, data loss and corruption.
+        7. Delete RBD pods; verify re-schedule; deploy new workload.
+        """
+        sc_obj = StretchCluster()
+
+        vm_obj, md5sum_before = _deploy_workloads(
+            sc_obj,
+            setup_logwriter_cephfs_workload_factory,
+            setup_logwriter_rbd_workload_factory,
+            cnv_workload,
+            nodes,
+            zone_aware=True,
+        )
+
+        zone_b_nodes = _get_zone_b_nodes(sc_obj)
+        zone_b_node_names = [n.name for n in zone_b_nodes]
+        log.info(f"All Zone-B nodes will be shut down: {zone_b_node_names}")
+
+        start_time = datetime.now(timezone.utc)
+        nodes.stop_nodes(nodes=zone_b_nodes)
+        wait_for_nodes_status(
+            node_names=zone_b_node_names,
+            status=constants.NODE_NOT_READY,
+            timeout=300,
+        )
+        log.info(f"All Zone-B nodes are NotReady: {zone_b_node_names}")
+
+        _apply_out_of_service_taint(zone_b_nodes, self._tainted_nodes)
+        _refresh_pod_state(sc_obj)
+
+        rbd_pod_names = [
+            p["metadata"]["name"]
+            for p in get_pods_having_label(
+                label=constants.LOGWRITER_RBD_LABEL,
+                namespace=constants.STRETCH_CLUSTER_NAMESPACE,
+            )
+        ]
+        if rbd_pod_names:
+            wait_for_pods_to_be_in_statuses(
+                expected_statuses=constants.STATUS_PENDING,
+                pod_names=rbd_pod_names,
+                timeout=300,
+                namespace=constants.STRETCH_CLUSTER_NAMESPACE,
+            )
+            log.info(
+                "Zone-aware RBD pods are Pending (FailedScheduling) – "
+                "no Zone-B nodes available"
+            )
+
+        _check_ceph_accessible(sc_obj, "during full Zone-B outage")
+
+        nodes.start_nodes(nodes=zone_b_nodes)
+        wait_for_nodes_status(timeout=600)
+        log.info(f"All Zone-B nodes are Ready: {zone_b_node_names}")
+
+        untaint_nodes(
+            taint_label=constants.NODE_OUT_OF_SERVICE_TAINT,
+            nodes_to_untaint=self._tainted_nodes,
+        )
+        self._tainted_nodes.clear()
+        time.sleep(30)
+
+        _run_post_recovery_checks(
+            sc_obj, start_time, nodes, vm_obj, md5sum_before, logreader_workload_factory
+        )
+        _redeploy_and_verify(
+            sc_obj, setup_logwriter_rbd_workload_factory, nodes, zone_aware=True
+        )
+
+
+@tier4b
+@stretchcluster_required
+@turquoise_squad
+class TestStretchClusterZoneBShutdownZoneUnaware:
+    """
+    Shutdown all Zone-B nodes while zone-UNAWARE workloads are running.
+
+    Zone-unaware workloads carry no topology spread constraints, so the pods
+    reschedule automatically onto any available node in the remaining zones.
+    """
+
+    _tainted_nodes = []
+
+    @pytest.fixture(autouse=False)
+    def zone_b_unaware_teardown(self, request):
+        """Remove out-of-service taints on failure or test end."""
+
+        def finalizer():
+            _teardown_taints(self._tainted_nodes)
+
+        request.addfinalizer(finalizer)
+
+    @pytest.mark.polarion_id("OCS-7374")
+    def test_zone_b_shutdown_with_zone_unaware_workloads(
+        self,
+        node_restart_teardown,
+        zone_b_unaware_teardown,
+        reset_conn_score,
+        nodes,
+        setup_logwriter_cephfs_workload_factory,
+        setup_logwriter_rbd_workload_factory,
+        logreader_workload_factory,
+        cnv_workload,
+        setup_cnv,
+    ):
+        """
+        Stretch cluster – shutdown ALL Zone-B nodes, taint them out-of-service,
+        verify zone-UNAWARE workloads reschedule onto healthy nodes in other zones,
+        recover Zone B, confirm data integrity and connection scores.
+
+        Steps:
+        1. Deploy zone-UNAWARE VM, logwriter-cephfs and logwriter-rbd workloads;
+           verify they are running (may land in any zone).
+        2. Shutdown ALL Zone-B nodes; taint them out-of-service.
+        3. Verify no IO on Zone B; verify zone-unaware pods migrated to healthy nodes.
+        4. Confirm no DU/DL/DC; check Ceph accessibility.
+        5. Recover Zone B; remove the taint.
+        6. Confirm no DU/DL/DC after recovery; validate connection scores;
+           verify VM integrity, data loss and corruption.
+        7. Delete RBD pods; verify re-schedule; deploy new workload.
+        """
+        sc_obj = StretchCluster()
+
+        vm_obj, md5sum_before = _deploy_workloads(
+            sc_obj,
+            setup_logwriter_cephfs_workload_factory,
+            setup_logwriter_rbd_workload_factory,
+            cnv_workload,
+            nodes,
+            zone_aware=False,
+        )
+
+        zone_b_nodes = _get_zone_b_nodes(sc_obj)
+        zone_b_node_names = [n.name for n in zone_b_nodes]
+        log.info(f"Zone-B nodes to be shut down: {zone_b_node_names}")
+
+        start_time = datetime.now(timezone.utc)
+        nodes.stop_nodes(nodes=zone_b_nodes)
+        wait_for_nodes_status(
+            node_names=zone_b_node_names,
+            status=constants.NODE_NOT_READY,
+            timeout=300,
+        )
+        log.info(f"All Zone-B nodes are NotReady: {zone_b_node_names}")
+
+        _apply_out_of_service_taint(zone_b_nodes, self._tainted_nodes)
+        _refresh_pod_state(sc_obj)
+
+        log.info(
+            "Verifying zone-unaware workloads migrated to healthy nodes "
+            "in available zones with PVCs mounted and IOs active"
+        )
+        sc_obj.get_logwriter_reader_pods(label=constants.LOGWRITER_CEPHFS_LABEL)
+        sc_obj.get_logwriter_reader_pods(
+            label=constants.LOGREADER_CEPHFS_LABEL,
+            statuses=[constants.STATUS_RUNNING, constants.STATUS_COMPLETED],
+        )
+        log.info("CephFS logwriter/logreader pods Running on healthy nodes")
+
+        # RBD (RWO) pods may be stuck Terminating; force-delete and wait.
+        try:
+            retry(Exception, tries=1)(sc_obj.get_logwriter_reader_pods)(
+                label=constants.LOGWRITER_RBD_LABEL, exp_num_replicas=2
+            )
+        except Exception:
+            log.info(
+                "RBD pod may be Terminating; force-deleting and "
+                "waiting for re-schedule on healthy zone"
+            )
+            for pod_info in get_pods_having_label(
+                label=constants.LOGWRITER_RBD_LABEL,
+                namespace=constants.STRETCH_CLUSTER_NAMESPACE,
+            ):
+                pod_obj = Pod(**pod_info)
+                log.info(f"Force-deleting stuck pod {pod_obj.name}")
+                pod_obj.delete(force=True)
+            sc_obj.get_logwriter_reader_pods(
+                label=constants.LOGWRITER_RBD_LABEL, exp_num_replicas=2
+            )
+        log.info("All zone-unaware workload pods Running on healthy nodes")
+
+        end_time = datetime.now(timezone.utc)
+        _run_post_failure_checks(sc_obj, start_time, end_time, "during Zone-B outage")
+
+        nodes.start_nodes(nodes=zone_b_nodes)
+        wait_for_nodes_status(timeout=600)
+        log.info(f"All Zone-B nodes are Ready: {zone_b_node_names}")
+
+        untaint_nodes(
+            taint_label=constants.NODE_OUT_OF_SERVICE_TAINT,
+            nodes_to_untaint=self._tainted_nodes,
+        )
+        self._tainted_nodes.clear()
+        time.sleep(30)
+
+        _run_post_recovery_checks(
+            sc_obj, start_time, nodes, vm_obj, md5sum_before, logreader_workload_factory
+        )
+        _redeploy_and_verify(
+            sc_obj, setup_logwriter_rbd_workload_factory, nodes, zone_aware=False
+        )
+
+
+@tier4b
+@stretchcluster_required
+@turquoise_squad
+class TestStretchClusterZoneBKubeletDown:
+    """
+    Zone B down / network down — simulated by stopping kubelet.
+
+    Stops the kubelet service on all Zone-B nodes, applies the out-of-service
+    taint, force-deletes stuck pods so they reschedule onto healthy zones, then
+    recovers Zone B by restarting kubelet.
+    """
+
+    KUBELET_STOP_TIMEOUT = 120
+    KUBELET_START_TIMEOUT = 300
+    _STOP_KUBELET_CMD = "systemctl stop kubelet"
+    _START_KUBELET_CMD = "systemctl start kubelet"
+
+    _kubelet_stopped_nodes = []
+    _tainted_nodes = []
+
+    @pytest.fixture(autouse=False)
+    def zone_b_kubelet_teardown(self, request):
+        """Restart kubelet and remove out-of-service taints on failure."""
+
+        def finalizer():
+            if self._kubelet_stopped_nodes:
+                names = [n.name for n in self._kubelet_stopped_nodes]
+                log.info(f"Teardown: restarting kubelet on nodes {names}")
+                ocp_obj = OCP(kind="node")
+                for node_obj in self._kubelet_stopped_nodes:
+                    try:
+                        ocp_obj.exec_oc_debug_cmd(
+                            node=node_obj.name,
+                            cmd_list=[self._START_KUBELET_CMD],
+                            timeout=self.KUBELET_START_TIMEOUT,
+                        )
+                    except Exception as exc:
+                        log.warning(
+                            f"Kubelet restart on {node_obj.name} during teardown: {exc}"
+                        )
+                self._kubelet_stopped_nodes.clear()
+            _teardown_taints(self._tainted_nodes)
+
+        request.addfinalizer(finalizer)
+
+    @pytest.mark.polarion_id("OCS-7375")
+    def test_zone_b_kubelet_down_with_zone_unresponsive(
+        self,
+        node_restart_teardown,
+        zone_b_kubelet_teardown,
+        reset_conn_score,
+        nodes,
+        setup_logwriter_cephfs_workload_factory,
+        setup_logwriter_rbd_workload_factory,
+        logreader_workload_factory,
+        cnv_workload,
+        setup_cnv,
+    ):
+        """
+        Stretch cluster – Zone B down / network down (simulated via kubelet stop).
+        Taint all Zone-B nodes out-of-service, force-delete stuck pods, verify
+        rescheduling, recover Zone B by restarting kubelet, confirm data integrity.
+
+        Steps:
+        1. Deploy zone-aware VM, logwriter-cephfs and logwriter-rbd workloads;
+           verify they are all running.
+        2. Stop kubelet on all Zone-B nodes; wait for NotReady; apply
+           out-of-service taint; verify no IO on Zone B.
+        3. Force-delete pods still on Zone-B nodes to unblock rescheduling.
+        4. Verify workloads Running on healthy nodes with PVCs mounted.
+        5. Confirm no DU/DL/DC; check Ceph accessibility.
+        6. Recover Zone B by restarting kubelet; remove the taint.
+        7. Confirm no DU/DL/DC after recovery; validate connection scores;
+           verify VM integrity, data loss and corruption.
+        8. Delete RBD pods; verify re-schedule; deploy new workload.
+        """
+        sc_obj = StretchCluster()
+        ocp_node = OCP(kind="node")
+
+        vm_obj, md5sum_before = _deploy_workloads(
+            sc_obj,
+            setup_logwriter_cephfs_workload_factory,
+            setup_logwriter_rbd_workload_factory,
+            cnv_workload,
+            nodes,
+            zone_aware=True,
+        )
+
+        zone_b_nodes = _get_zone_b_nodes(sc_obj)
+        zone_b_node_names = [n.name for n in zone_b_nodes]
+        log.info(f"Zone-B nodes: {zone_b_node_names}")
+
+        start_time = datetime.now(timezone.utc)
+        log.info(f"Stopping kubelet on Zone-B nodes: {zone_b_node_names}")
+        for node_obj in zone_b_nodes:
+            try:
+                ocp_node.exec_oc_debug_cmd(
+                    node=node_obj.name,
+                    cmd_list=[self._STOP_KUBELET_CMD],
+                    timeout=self.KUBELET_STOP_TIMEOUT,
+                )
+                log.info(f"Kubelet stopped on {node_obj.name}")
+            except Exception as exc:
+                # Connection is cut when kubelet stops — expected.
+                log.info(
+                    f"exec_oc_debug_cmd raised on {node_obj.name} "
+                    f"after kubelet stop (expected): {exc}"
+                )
+            self._kubelet_stopped_nodes.append(node_obj)
+
+        wait_for_nodes_status(
+            node_names=zone_b_node_names,
+            status=constants.NODE_NOT_READY,
+            timeout=300,
+        )
+        log.info(
+            f"All Zone-B nodes are NotReady after kubelet stop: {zone_b_node_names}"
+        )
+
+        _apply_out_of_service_taint(zone_b_nodes, self._tainted_nodes)
+        _refresh_pod_state(sc_obj)
+
+        log.info(
+            "Force-deleting any pods still on Zone-B nodes "
+            "to unblock rescheduling onto healthy zones"
+        )
+        for label in (
+            constants.LOGWRITER_CEPHFS_LABEL,
+            constants.LOGREADER_CEPHFS_LABEL,
+            constants.LOGWRITER_RBD_LABEL,
+        ):
+            stuck_pods = [
+                Pod(**pod_info)
+                for pod_info in get_pods_having_label(
+                    label=label,
+                    namespace=constants.STRETCH_CLUSTER_NAMESPACE,
+                )
+                if pod_info.get("spec", {}).get("nodeName") in zone_b_node_names
+            ]
+            for pod_obj in stuck_pods:
+                log.info(f"Force-deleting pod {pod_obj.name} (kubelet stopped)")
+                pod_obj.delete(force=True)
+
+        log.info(
+            "Verifying workloads rescheduled onto healthy nodes "
+            "with PVCs mounted and IOs started"
+        )
+        sc_obj.get_logwriter_reader_pods(label=constants.LOGWRITER_CEPHFS_LABEL)
+        sc_obj.get_logwriter_reader_pods(
+            label=constants.LOGREADER_CEPHFS_LABEL,
+            statuses=[constants.STATUS_RUNNING, constants.STATUS_COMPLETED],
+        )
+        sc_obj.get_logwriter_reader_pods(
+            label=constants.LOGWRITER_RBD_LABEL, exp_num_replicas=2
+        )
+        log.info("All workload pods Running on healthy nodes after Zone-B kubelet stop")
+
+        end_time = datetime.now(timezone.utc)
+        _run_post_failure_checks(
+            sc_obj, start_time, end_time, "during Zone-B kubelet-down"
+        )
+
+        log.info(f"Restarting kubelet on Zone-B nodes: {zone_b_node_names}")
+        for node_obj in list(self._kubelet_stopped_nodes):
+            ocp_node.exec_oc_debug_cmd(
+                node=node_obj.name,
+                cmd_list=[self._START_KUBELET_CMD],
+                timeout=self.KUBELET_START_TIMEOUT,
+            )
+            log.info(f"Kubelet restarted on {node_obj.name}")
+        self._kubelet_stopped_nodes.clear()
+
+        wait_for_nodes_status(timeout=600)
+        log.info(f"All Zone-B nodes Ready after kubelet restart: {zone_b_node_names}")
+
+        untaint_nodes(
+            taint_label=constants.NODE_OUT_OF_SERVICE_TAINT,
+            nodes_to_untaint=self._tainted_nodes,
+        )
+        self._tainted_nodes.clear()
+        time.sleep(30)
+
+        _run_post_recovery_checks(
+            sc_obj, start_time, nodes, vm_obj, md5sum_before, logreader_workload_factory
+        )
+        _redeploy_and_verify(
+            sc_obj, setup_logwriter_rbd_workload_factory, nodes, zone_aware=True
+        )

--- a/tests/functional/pv/pv_services/test_automate_networkfence_workflow_stretch_cluster.py
+++ b/tests/functional/pv/pv_services/test_automate_networkfence_workflow_stretch_cluster.py
@@ -253,7 +253,9 @@ def _run_post_recovery_checks(
 
     _check_ceph_accessible(sc_obj, "after Zone-B recovery")
 
-    sc_obj.reset_conn_score()
+    # The API server may still be stabilising immediately after node recovery
+    # (TLS handshake timeouts, oc rsh timeouts).  Retry with back-off.
+    retry(CommandFailed, tries=6, delay=20)(sc_obj.reset_conn_score)()
     logger.info("Connection scores are clean after Zone-B recovery")
 
     retry(CommandFailed, tries=5, delay=10)(vm_obj.wait_for_ssh_connectivity)()

--- a/tests/functional/pv/pv_services/test_automate_networkfence_workflow_stretch_cluster.py
+++ b/tests/functional/pv/pv_services/test_automate_networkfence_workflow_stretch_cluster.py
@@ -51,7 +51,7 @@ from ocs_ci.helpers.stretchcluster_helper import (
     verify_vm_workload,
 )
 from ocs_ci.ocs import constants
-from ocs_ci.ocs.exceptions import CommandFailed
+from ocs_ci.ocs.exceptions import CommandFailed, UnexpectedBehaviour
 from ocs_ci.ocs.node import (
     taint_nodes,
     untaint_nodes,
@@ -225,6 +225,59 @@ def _run_post_failure_checks(sc_obj, start_time, end_time, context: str) -> None
     _check_ceph_accessible(sc_obj, context)
 
 
+def _wait_for_workload_pods_post_recovery(sc_obj) -> None:
+    """
+    Wait for all logwriter/logreader pods to return to their expected replica
+    counts after Zone-B recovery, without triggering ``recover_by_zone_restart``.
+
+    After a node is powered back on and taints are removed, pods need time to
+    reschedule.  ``check_for_logwriter_workload_pods`` falls through to
+    ``recover_by_zone_restart`` → ``nodes.restart_nodes`` too quickly, which
+    raises ``RebootEventNotFoundException`` on a node that was just started
+    (fresh boot has no new "Rebooted" event delta).  Instead, we retry the pod
+    count checks directly with a generous back-off, only calling the shared
+    helper (and its node-restart fallback) if pods are still not healthy after
+    the wait.
+
+    Args:
+        sc_obj: StretchCluster instance.
+    """
+    # Give rescheduled pods up to ~3 minutes to reach Running before we
+    # consider a node-restart workaround.
+    MAX_WAIT_S = 180
+    POLL_S = 15
+    deadline = time.time() + MAX_WAIT_S
+
+    while time.time() < deadline:
+        try:
+            sc_obj.get_logwriter_reader_pods(label=constants.LOGWRITER_CEPHFS_LABEL)
+            sc_obj.get_logwriter_reader_pods(
+                label=constants.LOGREADER_CEPHFS_LABEL,
+                statuses=[constants.STATUS_RUNNING, constants.STATUS_COMPLETED],
+            )
+            sc_obj.get_logwriter_reader_pods(
+                label=constants.LOGWRITER_RBD_LABEL, exp_num_replicas=2
+            )
+            logger.info(
+                "All logwriter/logreader pods are running after Zone-B recovery"
+            )
+            return
+        except UnexpectedBehaviour:
+            remaining = max(0, int(deadline - time.time()))
+            logger.info(
+                f"Pods not yet at full replica count; retrying in {POLL_S}s "
+                f"({remaining}s remaining before node-restart fallback)"
+            )
+            time.sleep(POLL_S)
+
+    # Pods are still not healthy after the wait; fall through to the shared
+    # helper which may perform a node restart as a last resort.
+    logger.warning(
+        "Pods did not recover within the wait window; "
+        "delegating to check_for_logwriter_workload_pods for node-restart workaround"
+    )
+
+
 def _run_post_recovery_checks(
     sc_obj, start_time, nodes, vm_obj, md5sum_before, logreader_workload_factory
 ) -> None:
@@ -263,6 +316,10 @@ def _run_post_recovery_checks(
     vm_obj.stop()
     logger.info("VM data integrity verified and VM stopped")
 
+    # Wait for pods to settle naturally before falling back to node-restart
+    # workaround.  A freshly-started node does not emit a "Rebooted" event
+    # delta, so restart_nodes would raise RebootEventNotFoundException.
+    _wait_for_workload_pods_post_recovery(sc_obj)
     check_for_logwriter_workload_pods(sc_obj, nodes=nodes)
     verify_data_loss(sc_obj)
     logger.info("No data loss detected")

--- a/tests/functional/pv/pv_services/test_automate_networkfence_workflow_stretch_cluster.py
+++ b/tests/functional/pv/pv_services/test_automate_networkfence_workflow_stretch_cluster.py
@@ -404,16 +404,18 @@ class TestStretchClusterZoneBNodeShutdown(ManageTest):
                     namespace=constants.STRETCH_CLUSTER_NAMESPACE,
                 )
             ]
-            if rbd_pod_names:
-                wait_for_pods_to_be_in_statuses(
-                    expected_statuses=constants.STATUS_PENDING,
-                    pod_names=rbd_pod_names,
-                    timeout=300,
-                    namespace=constants.STRETCH_CLUSTER_NAMESPACE,
-                )
-                logger.info(
-                    "Zone-aware RBD pods are Pending (FailedScheduling) as expected"
-                )
+            assert (
+                rbd_pod_names
+            ), "No RBD logwriter pods found; workload deployment failed"
+            wait_for_pods_to_be_in_statuses(
+                expected_statuses=constants.STATUS_PENDING,
+                pod_names=rbd_pod_names,
+                timeout=300,
+                namespace=constants.STRETCH_CLUSTER_NAMESPACE,
+            )
+            logger.info(
+                "Zone-aware RBD pods are Pending (FailedScheduling) as expected"
+            )
         else:
             logger.info("Healthy Zone-B nodes exist – verifying pods relocated there")
             sc_obj.get_logwriter_reader_pods(label=constants.LOGWRITER_CEPHFS_LABEL)
@@ -511,17 +513,17 @@ class TestStretchClusterZoneBNodeShutdown(ManageTest):
                 namespace=constants.STRETCH_CLUSTER_NAMESPACE,
             )
         ]
-        if rbd_pod_names:
-            wait_for_pods_to_be_in_statuses(
-                expected_statuses=constants.STATUS_PENDING,
-                pod_names=rbd_pod_names,
-                timeout=300,
-                namespace=constants.STRETCH_CLUSTER_NAMESPACE,
-            )
-            logger.info(
-                "Zone-aware RBD pods are Pending (FailedScheduling) – "
-                "no Zone-B nodes available"
-            )
+        assert rbd_pod_names, "No RBD logwriter pods found; workload deployment failed"
+        wait_for_pods_to_be_in_statuses(
+            expected_statuses=constants.STATUS_PENDING,
+            pod_names=rbd_pod_names,
+            timeout=300,
+            namespace=constants.STRETCH_CLUSTER_NAMESPACE,
+        )
+        logger.info(
+            "Zone-aware RBD pods are Pending (FailedScheduling) – "
+            "no Zone-B nodes available"
+        )
 
         _check_ceph_accessible(sc_obj, "during full Zone-B outage")
 

--- a/tests/functional/pv/pv_services/test_automate_networkfence_workflow_stretch_cluster.py
+++ b/tests/functional/pv/pv_services/test_automate_networkfence_workflow_stretch_cluster.py
@@ -61,6 +61,7 @@ from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.resources.pod import (
     Pod,
     get_pods_having_label,
+    wait_for_pods_deletion,
     wait_for_pods_to_be_in_statuses,
 )
 from ocs_ci.ocs.resources.stretchcluster import StretchCluster
@@ -336,8 +337,11 @@ def _redeploy_and_verify(
 ) -> None:
     """
     Delete existing RBD logwriter pods, wait for the StatefulSet to recreate
-    them, deploy a fresh RBD logwriter StatefulSet and verify all workload
-    pods are healthy.
+    them, then delete the StatefulSet itself, deploy a fresh RBD logwriter
+    StatefulSet and verify all workload pods are healthy.
+
+    The factory creates a new StatefulSet with the same name (``logwriter-rbd``),
+    so the existing one must be deleted before calling it.
 
     Args:
         sc_obj: StretchCluster instance.
@@ -352,6 +356,19 @@ def _redeploy_and_verify(
         label=constants.LOGWRITER_RBD_LABEL, exp_num_replicas=2
     )
     logger.info("Logwriter-RBD pods re-scheduled and Running after Zone-B recovery")
+
+    # Delete the existing StatefulSet so the factory can create a fresh one.
+    # The StatefulSet name is fixed (logwriter-rbd); oc create would fail with
+    # AlreadyExists if the old object is still present.
+    if sc_obj.rbd_logwriter_sts is not None:
+        logger.info(f"Deleting existing StatefulSet {sc_obj.rbd_logwriter_sts.name}")
+        sc_obj.rbd_logwriter_sts.delete()
+        wait_for_pods_deletion(
+            constants.LOGWRITER_RBD_LABEL,
+            timeout=300,
+            namespace=constants.STRETCH_CLUSTER_NAMESPACE,
+        )
+        sc_obj.rbd_logwriter_sts = None
 
     new_rbd_sts = setup_logwriter_rbd_workload_factory(zone_aware=zone_aware)
     logger.info(f"New logwriter-rbd workload deployed: {new_rbd_sts.name}")

--- a/tests/functional/pv/pv_services/test_automate_networkfence_workflow_stretch_cluster.py
+++ b/tests/functional/pv/pv_services/test_automate_networkfence_workflow_stretch_cluster.py
@@ -54,6 +54,7 @@ from ocs_ci.helpers.stretchcluster_helper import (
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.exceptions import CommandFailed, UnexpectedBehaviour
 from ocs_ci.ocs.node import (
+    get_node_internal_ip,
     taint_nodes,
     untaint_nodes,
     wait_for_nodes_status,
@@ -67,11 +68,37 @@ from ocs_ci.ocs.resources.pod import (
 )
 from ocs_ci.ocs.resources.stretchcluster import StretchCluster
 from ocs_ci.utility.retry import retry
+from ocs_ci.utility.utils import exec_cmd
 
 logger = logging.getLogger(__name__)
 
 ZONE_B = "data-2"
 CEPH_CHECK_TIMEOUT = 120
+
+
+def _ssh_node_cmd(node_obj, cmd: str, timeout: int = 120) -> None:
+    """
+    Run *cmd* on *node_obj* via SSH using the cluster's default private key.
+
+    This is used in place of ``OCP.exec_oc_debug_cmd`` when the node's kubelet
+    is stopped: ``oc debug nodes/<name>`` schedules a debug pod on the target
+    node, which requires a running kubelet and will fail when kubelet is down.
+    Direct SSH bypasses the kubelet entirely.
+
+    Args:
+        node_obj: OCS node object (must be reachable via SSH on its InternalIP).
+        cmd (str): Shell command to execute on the node (run via ``sudo``).
+        timeout (int): SSH command timeout in seconds.
+    """
+    node_ip = get_node_internal_ip(node_obj)
+    ssh_cmd = (
+        f"ssh -i {constants.SSH_PRIV_KEY} "
+        f'-o "StrictHostKeyChecking no" -o "ConnectTimeout=30" '
+        f"core@{node_ip} sudo {cmd}"
+    )
+    logger.info(f"SSH to {node_obj.name} ({node_ip}): {cmd}")
+    exec_cmd(ssh_cmd, timeout=timeout)
+    logger.info(f"SSH command succeeded on {node_obj.name}: {cmd}")
 
 
 def _teardown_taints(tainted_nodes: list) -> None:
@@ -819,12 +846,11 @@ class TestStretchClusterZoneBKubeletDown(ManageTest):
             if self._kubelet_stopped_nodes:
                 names = [n.name for n in self._kubelet_stopped_nodes]
                 logger.info(f"Teardown: restarting kubelet on nodes {names}")
-                ocp_obj = OCP(kind="node")
                 for node_obj in self._kubelet_stopped_nodes:
                     try:
-                        ocp_obj.exec_oc_debug_cmd(
-                            node=node_obj.name,
-                            cmd_list=[self._START_KUBELET_CMD],
+                        _ssh_node_cmd(
+                            node_obj,
+                            self._START_KUBELET_CMD,
                             timeout=self.KUBELET_START_TIMEOUT,
                         )
                     except Exception as exc:
@@ -967,9 +993,9 @@ class TestStretchClusterZoneBKubeletDown(ManageTest):
 
         logger.info(f"Restarting kubelet on Zone-B nodes: {zone_b_node_names}")
         for node_obj in list(self._kubelet_stopped_nodes):
-            ocp_node.exec_oc_debug_cmd(
-                node=node_obj.name,
-                cmd_list=[self._START_KUBELET_CMD],
+            _ssh_node_cmd(
+                node_obj,
+                self._START_KUBELET_CMD,
                 timeout=self.KUBELET_START_TIMEOUT,
             )
             logger.info(f"Kubelet restarted on {node_obj.name}")

--- a/tests/functional/pv/pv_services/test_automate_networkfence_workflow_stretch_cluster.py
+++ b/tests/functional/pv/pv_services/test_automate_networkfence_workflow_stretch_cluster.py
@@ -417,12 +417,28 @@ class TestStretchClusterZoneBNodeShutdown(ManageTest):
                 "Zone-aware RBD pods are Pending (FailedScheduling) as expected"
             )
         else:
-            logger.info("Healthy Zone-B nodes exist – verifying pods relocated there")
-            sc_obj.get_logwriter_reader_pods(label=constants.LOGWRITER_CEPHFS_LABEL)
-            sc_obj.get_logwriter_reader_pods(
-                label=constants.LOGWRITER_RBD_LABEL, exp_num_replicas=2
+            # All Zone-B nodes carry the out-of-service:NoExecute taint (applied
+            # above), so evicted pods cannot reschedule onto any Zone-B node.
+            # The zone-spread constraint (maxSkew=1, whenUnsatisfiable=DoNotSchedule)
+            # also prevents the full replica count from running on Zone-A alone.
+            # Only the replicas that were already scheduled on Zone-A workers survive
+            # as Running; the evicted Zone-B replicas stay Pending or Terminating.
+            # With a 4-worker cluster (2 per zone): 2 CephFS and 1 RBD pod survive.
+            # With a 6-worker cluster (3 per zone): same ceiling applies while taints
+            # are held, so use the conservative lower bound.
+            logger.info(
+                "Healthy Zone-B nodes exist (but tainted out-of-service) – "
+                "verifying surviving pods on Zone-A nodes are Running"
             )
-            logger.info("Zone-aware workload pods relocated to healthy Zone-B nodes")
+            sc_obj.get_logwriter_reader_pods(
+                label=constants.LOGWRITER_CEPHFS_LABEL, exp_num_replicas=2
+            )
+            sc_obj.get_logwriter_reader_pods(
+                label=constants.LOGWRITER_RBD_LABEL, exp_num_replicas=1
+            )
+            logger.info(
+                "Zone-aware workload pods surviving on Zone-A nodes as expected"
+            )
 
         end_time = datetime.now(timezone.utc)
         if healthy_zone_b_nodes:

--- a/tests/functional/pv/pv_services/test_automate_networkfence_workflow_stretch_cluster.py
+++ b/tests/functional/pv/pv_services/test_automate_networkfence_workflow_stretch_cluster.py
@@ -590,10 +590,15 @@ class TestStretchClusterZoneBNodeShutdown(ManageTest):
 
         start_time = datetime.now(timezone.utc)
         nodes.stop_nodes(nodes=zone_b_nodes)
+        # Use a longer timeout when shutting down ALL Zone-B nodes (including
+        # control-plane-2). With a control-plane node down, the API server
+        # experiences TLS handshake timeouts that consume part of the budget,
+        # and VMware power-off of multiple VMs simultaneously can take longer
+        # than the standard 300s to propagate NotReady status.
         wait_for_nodes_status(
             node_names=zone_b_node_names,
             status=constants.NODE_NOT_READY,
-            timeout=300,
+            timeout=600,
         )
         logger.info(f"All Zone-B nodes are NotReady: {zone_b_node_names}")
 

--- a/tests/functional/pv/pv_services/test_automate_networkfence_workflow_stretch_cluster.py
+++ b/tests/functional/pv/pv_services/test_automate_networkfence_workflow_stretch_cluster.py
@@ -340,7 +340,14 @@ def _run_post_recovery_checks(
     retry(CommandFailed, tries=6, delay=20)(sc_obj.reset_conn_score)()
     logger.info("Connection scores are clean after Zone-B recovery")
 
-    retry(CommandFailed, tries=5, delay=10)(vm_obj.wait_for_ssh_connectivity)()
+    # After a Zone-B kubelet-down recovery the VM may take longer than the
+    # default 600 s to become reachable via SSH: the VMI pod may need to
+    # restart or live-migrate to a recovered node, and OSDs/MDSs are still
+    # recovering.  Use 1200 s to match the timeout used by other post-disruption
+    # call sites in virtual_machine.py.  Note: wait_for_ssh_connectivity raises
+    # TimeoutExpiredError (not CommandFailed) on timeout, so wrapping it with
+    # retry(CommandFailed) has no effect and is intentionally omitted here.
+    vm_obj.wait_for_ssh_connectivity(timeout=1200)
     retry(CommandFailed, tries=5, delay=10)(verify_vm_workload)(vm_obj, md5sum_before)
     vm_obj.stop()
     logger.info("VM data integrity verified and VM stopped")

--- a/tests/functional/pv/pv_services/test_automate_networkfence_workflow_stretch_cluster.py
+++ b/tests/functional/pv/pv_services/test_automate_networkfence_workflow_stretch_cluster.py
@@ -39,9 +39,9 @@ import pytest
 
 from ocs_ci.framework.pytest_customization.marks import (
     stretchcluster_required,
-    tier4b,
     magenta_squad,
 )
+from ocs_ci.framework.testlib import ManageTest, tier4b
 from ocs_ci.helpers.cnv_helpers import cal_md5sum_vm
 from ocs_ci.helpers.stretchcluster_helper import (
     check_for_logwriter_workload_pods,
@@ -66,15 +66,10 @@ from ocs_ci.ocs.resources.pod import (
 from ocs_ci.ocs.resources.stretchcluster import StretchCluster
 from ocs_ci.utility.retry import retry
 
-log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 ZONE_B = "data-2"
 CEPH_CHECK_TIMEOUT = 120
-
-
-# ---------------------------------------------------------------------------
-# Module-level helpers shared across all test classes
-# ---------------------------------------------------------------------------
 
 
 def _teardown_taints(tainted_nodes: list) -> None:
@@ -82,14 +77,14 @@ def _teardown_taints(tainted_nodes: list) -> None:
     if not tainted_nodes:
         return
     names = [n.name for n in tainted_nodes]
-    log.info(f"Teardown: removing out-of-service taint from nodes {names}")
+    logger.info(f"Teardown: removing out-of-service taint from nodes {names}")
     try:
         untaint_nodes(
             taint_label=constants.NODE_OUT_OF_SERVICE_TAINT,
             nodes_to_untaint=tainted_nodes,
         )
     except Exception as exc:
-        log.warning(f"untaint_nodes during teardown raised: {exc}")
+        logger.warning(f"untaint_nodes during teardown raised: {exc}")
     tainted_nodes.clear()
 
 
@@ -105,11 +100,19 @@ def _deploy_workloads(
     Deploy CephFS logwriter, RBD logwriter and VM workloads; verify all pods
     are healthy; capture logfile maps for data-loss detection.
 
+    Args:
+        sc_obj: StretchCluster instance to attach workloads to.
+        setup_logwriter_cephfs_workload_factory: fixture factory for CephFS logwriter.
+        setup_logwriter_rbd_workload_factory: fixture factory for RBD logwriter.
+        cnv_workload: fixture factory for VM workload.
+        nodes: nodes fixture for topology checks.
+        zone_aware (bool): Whether to deploy with zone-aware topology constraints.
+
     Returns:
-        tuple: (vm_obj, md5sum_before) — the VM object and the md5sum of the
-        test file written inside the VM before any disruption.
+        tuple: (vm_obj, md5sum_before) — VM object and md5sum of the test file
+        written inside the VM before any disruption.
     """
-    log.info(f"Deploying zone-{'aware' if zone_aware else 'unaware'} workloads")
+    logger.info(f"Deploying zone-{'aware' if zone_aware else 'unaware'} workloads")
     (
         sc_obj.cephfs_logwriter_dep,
         sc_obj.cephfs_logreader_job,
@@ -129,10 +132,10 @@ def _deploy_workloads(
         )
     )
     md5sum_before = cal_md5sum_vm(vm_obj, file_path="/test/file_1.txt")
-    log.info(f"VM file md5sum before failure: {md5sum_before}")
+    logger.info(f"VM file md5sum before failure: {md5sum_before}")
 
     check_for_logwriter_workload_pods(sc_obj, nodes=nodes)
-    log.info("All logwriter/logreader workload pods are running successfully")
+    logger.info("All logwriter/logreader workload pods are running successfully")
 
     sc_obj.get_logfile_map(label=constants.LOGWRITER_CEPHFS_LABEL)
     sc_obj.get_logfile_map(label=constants.LOGWRITER_RBD_LABEL)
@@ -143,6 +146,9 @@ def _deploy_workloads(
 def _get_zone_b_nodes(sc_obj):
     """
     Return all OCS node objects in Zone B and assert at least one exists.
+
+    Args:
+        sc_obj: StretchCluster instance used to query zone topology.
 
     Returns:
         list: Zone-B node objects.
@@ -159,6 +165,10 @@ def _apply_out_of_service_taint(zone_b_nodes: list, tainted_nodes_ref: list) -> 
     """
     Apply the out-of-service NoExecute taint to all *zone_b_nodes* and record
     them in *tainted_nodes_ref* so teardown can remove the taint on failure.
+
+    Args:
+        zone_b_nodes (list): Node objects in Zone B to taint.
+        tainted_nodes_ref (list): Mutable list updated with the tainted nodes.
     """
     node_names = [n.name for n in zone_b_nodes]
     assert taint_nodes(
@@ -167,13 +177,15 @@ def _apply_out_of_service_taint(zone_b_nodes: list, tainted_nodes_ref: list) -> 
     ), f"Failed to add out-of-service taint to Zone-B nodes {node_names}"
     tainted_nodes_ref.clear()
     tainted_nodes_ref.extend(zone_b_nodes)
-    log.info(f"out-of-service taint applied to Zone-B nodes: {node_names}")
+    logger.info(f"out-of-service taint applied to Zone-B nodes: {node_names}")
 
 
 def _refresh_pod_state(sc_obj) -> None:
     """
-    Refresh the CephFS and RBD logwriter/logreader pod state on *sc_obj*,
-    expecting pods to have left Zone B (exp_num_replicas=0 means 'any count').
+    Refresh CephFS and RBD logwriter/logreader pod state on *sc_obj*.
+
+    Args:
+        sc_obj: StretchCluster instance whose pod state will be refreshed.
     """
     for label in (
         constants.LOGWRITER_CEPHFS_LABEL,
@@ -184,18 +196,32 @@ def _refresh_pod_state(sc_obj) -> None:
 
 
 def _check_ceph_accessible(sc_obj, context: str) -> None:
-    """Assert Ceph is accessible; attempt recovery if it is not."""
+    """
+    Assert Ceph is accessible; attempt recovery if it is not.
+
+    Args:
+        sc_obj: StretchCluster instance to check.
+        context (str): Description used in log/assert messages.
+    """
     if not sc_obj.check_ceph_accessibility(timeout=CEPH_CHECK_TIMEOUT):
         assert recover_from_ceph_stuck(
             sc_obj
         ), f"Ceph became inaccessible {context} and could not be recovered"
-    log.info(f"Ceph is accessible {context}")
+    logger.info(f"Ceph is accessible {context}")
 
 
 def _run_post_failure_checks(sc_obj, start_time, end_time, context: str) -> None:
-    """Run post_failure_checks and verify Ceph accessibility during a failure window."""
+    """
+    Run post_failure_checks and verify Ceph accessibility during a failure window.
+
+    Args:
+        sc_obj: StretchCluster instance.
+        start_time: Failure window start (datetime).
+        end_time: Failure window end (datetime).
+        context (str): Description used in log messages.
+    """
     sc_obj.post_failure_checks(start_time, end_time, wait_for_read_completion=False)
-    log.info(f"Post-failure IO/integrity checks passed ({context})")
+    logger.info(f"Post-failure IO/integrity checks passed ({context})")
     _check_ceph_accessible(sc_obj, context)
 
 
@@ -203,14 +229,18 @@ def _run_post_recovery_checks(
     sc_obj, start_time, nodes, vm_obj, md5sum_before, logreader_workload_factory
 ) -> None:
     """
-    Full post-recovery verification sequence:
-      - Refresh pod state
-      - post_failure_checks over the full window
-      - Ceph accessibility check
-      - Connection score reset
-      - VM data integrity (md5sum) and SSH connectivity
-      - Data loss check (logwriter logs)
-      - Data corruption check (logreader logs)
+    Full post-recovery verification sequence.
+
+    Runs: pod state refresh, post_failure_checks, Ceph accessibility check,
+    connection score reset, VM data integrity, data loss check, data corruption check.
+
+    Args:
+        sc_obj: StretchCluster instance.
+        start_time: Start of the failure window (datetime).
+        nodes: nodes fixture used by check_for_logwriter_workload_pods.
+        vm_obj: VM workload object for SSH and md5sum verification.
+        md5sum_before: Expected md5sum captured before the disruption.
+        logreader_workload_factory: fixture factory for spawning logreader jobs.
     """
     recovery_end_time = datetime.now(timezone.utc)
 
@@ -219,62 +249,63 @@ def _run_post_recovery_checks(
     sc_obj.post_failure_checks(
         start_time, recovery_end_time, wait_for_read_completion=False
     )
-    log.info("Post-recovery IO/integrity checks passed (no DU/DL/DC)")
+    logger.info("Post-recovery IO/integrity checks passed (no DU/DL/DC)")
 
     _check_ceph_accessible(sc_obj, "after Zone-B recovery")
 
     sc_obj.reset_conn_score()
-    log.info("Connection scores are clean after Zone-B recovery")
+    logger.info("Connection scores are clean after Zone-B recovery")
 
     retry(CommandFailed, tries=5, delay=10)(vm_obj.wait_for_ssh_connectivity)()
     retry(CommandFailed, tries=5, delay=10)(verify_vm_workload)(vm_obj, md5sum_before)
     vm_obj.stop()
-    log.info("VM data integrity verified and VM stopped")
+    logger.info("VM data integrity verified and VM stopped")
 
     check_for_logwriter_workload_pods(sc_obj, nodes=nodes)
     verify_data_loss(sc_obj)
-    log.info("No data loss detected")
+    logger.info("No data loss detected")
 
     sc_obj.cephfs_logreader_job.delete()
     for pod in sc_obj.cephfs_logreader_pods:
         pod.wait_for_pod_delete(timeout=120)
     verify_data_corruption(sc_obj, logreader_workload_factory)
-    log.info("No data corruption detected")
+    logger.info("No data corruption detected")
 
 
 def _redeploy_and_verify(
     sc_obj, setup_logwriter_rbd_workload_factory, nodes, zone_aware: bool
 ) -> None:
     """
-    Delete existing RBD logwriter pods and wait for the StatefulSet to recreate
-    them, then deploy a fresh RBD logwriter StatefulSet and verify all workload
+    Delete existing RBD logwriter pods, wait for the StatefulSet to recreate
+    them, deploy a fresh RBD logwriter StatefulSet and verify all workload
     pods are healthy.
+
+    Args:
+        sc_obj: StretchCluster instance.
+        setup_logwriter_rbd_workload_factory: fixture factory for the new StatefulSet.
+        nodes: nodes fixture for topology checks.
+        zone_aware (bool): Whether the new workload should use zone-aware scheduling.
     """
     for pod_obj in sc_obj.rbd_logwriter_pods:
-        log.info(f"Deleting pod {pod_obj.name}")
+        logger.info(f"Deleting pod {pod_obj.name}")
         pod_obj.delete()
     sc_obj.get_logwriter_reader_pods(
         label=constants.LOGWRITER_RBD_LABEL, exp_num_replicas=2
     )
-    log.info("Logwriter-RBD pods re-scheduled and Running after Zone-B recovery")
+    logger.info("Logwriter-RBD pods re-scheduled and Running after Zone-B recovery")
 
     new_rbd_sts = setup_logwriter_rbd_workload_factory(zone_aware=zone_aware)
-    log.info(f"New logwriter-rbd workload deployed: {new_rbd_sts.name}")
+    logger.info(f"New logwriter-rbd workload deployed: {new_rbd_sts.name}")
     check_for_logwriter_workload_pods(sc_obj, nodes=nodes)
-    log.info(
+    logger.info(
         "All workloads healthy on recovered Zone-B nodes – IOs running without errors"
     )
-
-
-# ---------------------------------------------------------------------------
-# Test classes
-# ---------------------------------------------------------------------------
 
 
 @tier4b
 @stretchcluster_required
 @magenta_squad
-class TestStretchClusterZoneBNodeShutdown:
+class TestStretchClusterZoneBNodeShutdown(ManageTest):
     """
     Shutdown one Zone-B node while zone-aware workloads are running.
 
@@ -284,7 +315,7 @@ class TestStretchClusterZoneBNodeShutdown:
 
     _tainted_nodes = []
 
-    @pytest.fixture(autouse=False)
+    @pytest.fixture(scope="function")
     def zone_b_shutdown_teardown(self, request):
         """Remove out-of-service taints on failure or test end."""
 
@@ -339,7 +370,7 @@ class TestStretchClusterZoneBNodeShutdown:
         zone_b_nodes = _get_zone_b_nodes(sc_obj)
         node_to_shutdown = zone_b_nodes[0]
         zone_b_node_names = [n.name for n in zone_b_nodes]
-        log.info(
+        logger.info(
             f"Zone-B nodes: {zone_b_node_names}; "
             f"selecting '{node_to_shutdown.name}' for shutdown"
         )
@@ -351,7 +382,7 @@ class TestStretchClusterZoneBNodeShutdown:
             status=constants.NODE_NOT_READY,
             timeout=300,
         )
-        log.info(f"Node {node_to_shutdown.name} is NotReady")
+        logger.info(f"Node {node_to_shutdown.name} is NotReady")
 
         _apply_out_of_service_taint(zone_b_nodes, self._tainted_nodes)
         _refresh_pod_state(sc_obj)
@@ -359,10 +390,10 @@ class TestStretchClusterZoneBNodeShutdown:
         healthy_zone_b_nodes = [
             n.name for n in zone_b_nodes if n.name != node_to_shutdown.name
         ]
-        log.info(f"Healthy Zone-B nodes remaining: {healthy_zone_b_nodes}")
+        logger.info(f"Healthy Zone-B nodes remaining: {healthy_zone_b_nodes}")
 
         if not healthy_zone_b_nodes:
-            log.info(
+            logger.info(
                 "No healthy Zone-B nodes – verifying zone-aware RBD pods "
                 "enter Pending / FailedScheduling state"
             )
@@ -380,16 +411,16 @@ class TestStretchClusterZoneBNodeShutdown:
                     timeout=300,
                     namespace=constants.STRETCH_CLUSTER_NAMESPACE,
                 )
-                log.info(
+                logger.info(
                     "Zone-aware RBD pods are Pending (FailedScheduling) as expected"
                 )
         else:
-            log.info("Healthy Zone-B nodes exist – verifying pods relocated there")
+            logger.info("Healthy Zone-B nodes exist – verifying pods relocated there")
             sc_obj.get_logwriter_reader_pods(label=constants.LOGWRITER_CEPHFS_LABEL)
             sc_obj.get_logwriter_reader_pods(
                 label=constants.LOGWRITER_RBD_LABEL, exp_num_replicas=2
             )
-            log.info("Zone-aware workload pods relocated to healthy Zone-B nodes")
+            logger.info("Zone-aware workload pods relocated to healthy Zone-B nodes")
 
         end_time = datetime.now(timezone.utc)
         if healthy_zone_b_nodes:
@@ -401,7 +432,7 @@ class TestStretchClusterZoneBNodeShutdown:
 
         nodes.start_nodes(nodes=[node_to_shutdown])
         wait_for_nodes_status(timeout=600)
-        log.info(f"Node {node_to_shutdown.name} is Ready; Zone B recovered")
+        logger.info(f"Node {node_to_shutdown.name} is Ready; Zone B recovered")
 
         untaint_nodes(
             taint_label=constants.NODE_OUT_OF_SERVICE_TAINT,
@@ -459,7 +490,7 @@ class TestStretchClusterZoneBNodeShutdown:
 
         zone_b_nodes = _get_zone_b_nodes(sc_obj)
         zone_b_node_names = [n.name for n in zone_b_nodes]
-        log.info(f"All Zone-B nodes will be shut down: {zone_b_node_names}")
+        logger.info(f"All Zone-B nodes will be shut down: {zone_b_node_names}")
 
         start_time = datetime.now(timezone.utc)
         nodes.stop_nodes(nodes=zone_b_nodes)
@@ -468,7 +499,7 @@ class TestStretchClusterZoneBNodeShutdown:
             status=constants.NODE_NOT_READY,
             timeout=300,
         )
-        log.info(f"All Zone-B nodes are NotReady: {zone_b_node_names}")
+        logger.info(f"All Zone-B nodes are NotReady: {zone_b_node_names}")
 
         _apply_out_of_service_taint(zone_b_nodes, self._tainted_nodes)
         _refresh_pod_state(sc_obj)
@@ -487,7 +518,7 @@ class TestStretchClusterZoneBNodeShutdown:
                 timeout=300,
                 namespace=constants.STRETCH_CLUSTER_NAMESPACE,
             )
-            log.info(
+            logger.info(
                 "Zone-aware RBD pods are Pending (FailedScheduling) – "
                 "no Zone-B nodes available"
             )
@@ -496,7 +527,7 @@ class TestStretchClusterZoneBNodeShutdown:
 
         nodes.start_nodes(nodes=zone_b_nodes)
         wait_for_nodes_status(timeout=600)
-        log.info(f"All Zone-B nodes are Ready: {zone_b_node_names}")
+        logger.info(f"All Zone-B nodes are Ready: {zone_b_node_names}")
 
         untaint_nodes(
             taint_label=constants.NODE_OUT_OF_SERVICE_TAINT,
@@ -516,7 +547,7 @@ class TestStretchClusterZoneBNodeShutdown:
 @tier4b
 @stretchcluster_required
 @magenta_squad
-class TestStretchClusterZoneBShutdownZoneUnaware:
+class TestStretchClusterZoneBShutdownZoneUnaware(ManageTest):
     """
     Shutdown all Zone-B nodes while zone-UNAWARE workloads are running.
 
@@ -526,7 +557,7 @@ class TestStretchClusterZoneBShutdownZoneUnaware:
 
     _tainted_nodes = []
 
-    @pytest.fixture(autouse=False)
+    @pytest.fixture(scope="function")
     def zone_b_unaware_teardown(self, request):
         """Remove out-of-service taints on failure or test end."""
 
@@ -577,7 +608,7 @@ class TestStretchClusterZoneBShutdownZoneUnaware:
 
         zone_b_nodes = _get_zone_b_nodes(sc_obj)
         zone_b_node_names = [n.name for n in zone_b_nodes]
-        log.info(f"Zone-B nodes to be shut down: {zone_b_node_names}")
+        logger.info(f"Zone-B nodes to be shut down: {zone_b_node_names}")
 
         start_time = datetime.now(timezone.utc)
         nodes.stop_nodes(nodes=zone_b_nodes)
@@ -586,12 +617,12 @@ class TestStretchClusterZoneBShutdownZoneUnaware:
             status=constants.NODE_NOT_READY,
             timeout=300,
         )
-        log.info(f"All Zone-B nodes are NotReady: {zone_b_node_names}")
+        logger.info(f"All Zone-B nodes are NotReady: {zone_b_node_names}")
 
         _apply_out_of_service_taint(zone_b_nodes, self._tainted_nodes)
         _refresh_pod_state(sc_obj)
 
-        log.info(
+        logger.info(
             "Verifying zone-unaware workloads migrated to healthy nodes "
             "in available zones with PVCs mounted and IOs active"
         )
@@ -600,7 +631,7 @@ class TestStretchClusterZoneBShutdownZoneUnaware:
             label=constants.LOGREADER_CEPHFS_LABEL,
             statuses=[constants.STATUS_RUNNING, constants.STATUS_COMPLETED],
         )
-        log.info("CephFS logwriter/logreader pods Running on healthy nodes")
+        logger.info("CephFS logwriter/logreader pods Running on healthy nodes")
 
         # RBD (RWO) pods may be stuck Terminating; force-delete and wait.
         try:
@@ -608,7 +639,7 @@ class TestStretchClusterZoneBShutdownZoneUnaware:
                 label=constants.LOGWRITER_RBD_LABEL, exp_num_replicas=2
             )
         except Exception:
-            log.info(
+            logger.info(
                 "RBD pod may be Terminating; force-deleting and "
                 "waiting for re-schedule on healthy zone"
             )
@@ -617,19 +648,19 @@ class TestStretchClusterZoneBShutdownZoneUnaware:
                 namespace=constants.STRETCH_CLUSTER_NAMESPACE,
             ):
                 pod_obj = Pod(**pod_info)
-                log.info(f"Force-deleting stuck pod {pod_obj.name}")
+                logger.info(f"Force-deleting stuck pod {pod_obj.name}")
                 pod_obj.delete(force=True)
             sc_obj.get_logwriter_reader_pods(
                 label=constants.LOGWRITER_RBD_LABEL, exp_num_replicas=2
             )
-        log.info("All zone-unaware workload pods Running on healthy nodes")
+        logger.info("All zone-unaware workload pods Running on healthy nodes")
 
         end_time = datetime.now(timezone.utc)
         _run_post_failure_checks(sc_obj, start_time, end_time, "during Zone-B outage")
 
         nodes.start_nodes(nodes=zone_b_nodes)
         wait_for_nodes_status(timeout=600)
-        log.info(f"All Zone-B nodes are Ready: {zone_b_node_names}")
+        logger.info(f"All Zone-B nodes are Ready: {zone_b_node_names}")
 
         untaint_nodes(
             taint_label=constants.NODE_OUT_OF_SERVICE_TAINT,
@@ -649,7 +680,7 @@ class TestStretchClusterZoneBShutdownZoneUnaware:
 @tier4b
 @stretchcluster_required
 @magenta_squad
-class TestStretchClusterZoneBKubeletDown:
+class TestStretchClusterZoneBKubeletDown(ManageTest):
     """
     Zone B down / network down — simulated by stopping kubelet.
 
@@ -666,14 +697,14 @@ class TestStretchClusterZoneBKubeletDown:
     _kubelet_stopped_nodes = []
     _tainted_nodes = []
 
-    @pytest.fixture(autouse=False)
+    @pytest.fixture(scope="function")
     def zone_b_kubelet_teardown(self, request):
         """Restart kubelet and remove out-of-service taints on failure."""
 
         def finalizer():
             if self._kubelet_stopped_nodes:
                 names = [n.name for n in self._kubelet_stopped_nodes]
-                log.info(f"Teardown: restarting kubelet on nodes {names}")
+                logger.info(f"Teardown: restarting kubelet on nodes {names}")
                 ocp_obj = OCP(kind="node")
                 for node_obj in self._kubelet_stopped_nodes:
                     try:
@@ -683,7 +714,7 @@ class TestStretchClusterZoneBKubeletDown:
                             timeout=self.KUBELET_START_TIMEOUT,
                         )
                     except Exception as exc:
-                        log.warning(
+                        logger.warning(
                             f"Kubelet restart on {node_obj.name} during teardown: {exc}"
                         )
                 self._kubelet_stopped_nodes.clear()
@@ -736,10 +767,10 @@ class TestStretchClusterZoneBKubeletDown:
 
         zone_b_nodes = _get_zone_b_nodes(sc_obj)
         zone_b_node_names = [n.name for n in zone_b_nodes]
-        log.info(f"Zone-B nodes: {zone_b_node_names}")
+        logger.info(f"Zone-B nodes: {zone_b_node_names}")
 
         start_time = datetime.now(timezone.utc)
-        log.info(f"Stopping kubelet on Zone-B nodes: {zone_b_node_names}")
+        logger.info(f"Stopping kubelet on Zone-B nodes: {zone_b_node_names}")
         for node_obj in zone_b_nodes:
             try:
                 ocp_node.exec_oc_debug_cmd(
@@ -747,10 +778,10 @@ class TestStretchClusterZoneBKubeletDown:
                     cmd_list=[self._STOP_KUBELET_CMD],
                     timeout=self.KUBELET_STOP_TIMEOUT,
                 )
-                log.info(f"Kubelet stopped on {node_obj.name}")
+                logger.info(f"Kubelet stopped on {node_obj.name}")
             except Exception as exc:
                 # Connection is cut when kubelet stops — expected.
-                log.info(
+                logger.info(
                     f"exec_oc_debug_cmd raised on {node_obj.name} "
                     f"after kubelet stop (expected): {exc}"
                 )
@@ -761,14 +792,14 @@ class TestStretchClusterZoneBKubeletDown:
             status=constants.NODE_NOT_READY,
             timeout=300,
         )
-        log.info(
+        logger.info(
             f"All Zone-B nodes are NotReady after kubelet stop: {zone_b_node_names}"
         )
 
         _apply_out_of_service_taint(zone_b_nodes, self._tainted_nodes)
         _refresh_pod_state(sc_obj)
 
-        log.info(
+        logger.info(
             "Force-deleting any pods still on Zone-B nodes "
             "to unblock rescheduling onto healthy zones"
         )
@@ -786,10 +817,10 @@ class TestStretchClusterZoneBKubeletDown:
                 if pod_info.get("spec", {}).get("nodeName") in zone_b_node_names
             ]
             for pod_obj in stuck_pods:
-                log.info(f"Force-deleting pod {pod_obj.name} (kubelet stopped)")
+                logger.info(f"Force-deleting pod {pod_obj.name} (kubelet stopped)")
                 pod_obj.delete(force=True)
 
-        log.info(
+        logger.info(
             "Verifying workloads rescheduled onto healthy nodes "
             "with PVCs mounted and IOs started"
         )
@@ -801,25 +832,29 @@ class TestStretchClusterZoneBKubeletDown:
         sc_obj.get_logwriter_reader_pods(
             label=constants.LOGWRITER_RBD_LABEL, exp_num_replicas=2
         )
-        log.info("All workload pods Running on healthy nodes after Zone-B kubelet stop")
+        logger.info(
+            "All workload pods Running on healthy nodes after Zone-B kubelet stop"
+        )
 
         end_time = datetime.now(timezone.utc)
         _run_post_failure_checks(
             sc_obj, start_time, end_time, "during Zone-B kubelet-down"
         )
 
-        log.info(f"Restarting kubelet on Zone-B nodes: {zone_b_node_names}")
+        logger.info(f"Restarting kubelet on Zone-B nodes: {zone_b_node_names}")
         for node_obj in list(self._kubelet_stopped_nodes):
             ocp_node.exec_oc_debug_cmd(
                 node=node_obj.name,
                 cmd_list=[self._START_KUBELET_CMD],
                 timeout=self.KUBELET_START_TIMEOUT,
             )
-            log.info(f"Kubelet restarted on {node_obj.name}")
+            logger.info(f"Kubelet restarted on {node_obj.name}")
         self._kubelet_stopped_nodes.clear()
 
         wait_for_nodes_status(timeout=600)
-        log.info(f"All Zone-B nodes Ready after kubelet restart: {zone_b_node_names}")
+        logger.info(
+            f"All Zone-B nodes Ready after kubelet restart: {zone_b_node_names}"
+        )
 
         untaint_nodes(
             taint_label=constants.NODE_OUT_OF_SERVICE_TAINT,

--- a/tests/functional/pv/pv_services/test_automate_networkfence_workflow_stretch_cluster.py
+++ b/tests/functional/pv/pv_services/test_automate_networkfence_workflow_stretch_cluster.py
@@ -714,10 +714,13 @@ class TestStretchClusterZoneBShutdownZoneUnaware(ManageTest):
 
         start_time = datetime.now(timezone.utc)
         nodes.stop_nodes(nodes=zone_b_nodes)
+        # Use a longer timeout: Zone-B includes control-plane-2, whose loss
+        # causes API server TLS handshake timeouts that consume part of the
+        # budget, and VMware power-off of multiple VMs takes additional time.
         wait_for_nodes_status(
             node_names=zone_b_node_names,
             status=constants.NODE_NOT_READY,
-            timeout=300,
+            timeout=600,
         )
         logger.info(f"All Zone-B nodes are NotReady: {zone_b_node_names}")
 
@@ -735,7 +738,12 @@ class TestStretchClusterZoneBShutdownZoneUnaware(ManageTest):
         )
         logger.info("CephFS logwriter/logreader pods Running on healthy nodes")
 
-        # RBD (RWO) pods may be stuck Terminating; force-delete and wait.
+        # RBD (RWO) pods may be stuck Terminating on Zone-B nodes; force-delete
+        # them so the StatefulSet reschedules onto healthy Zone-A nodes.
+        # The built-in @retry on get_logwriter_reader_pods (tries=8, delay=5 = 40s)
+        # may not be enough for an RBD PVC to detach and re-attach on a new node.
+        # Use exp_num_replicas=1 first (one pod was already on Zone-A); once stuck
+        # pods are cleaned, retry with exp_num_replicas=2.
         try:
             retry(Exception, tries=1)(sc_obj.get_logwriter_reader_pods)(
                 label=constants.LOGWRITER_RBD_LABEL, exp_num_replicas=2
@@ -752,9 +760,12 @@ class TestStretchClusterZoneBShutdownZoneUnaware(ManageTest):
                 pod_obj = Pod(**pod_info)
                 logger.info(f"Force-deleting stuck pod {pod_obj.name}")
                 pod_obj.delete(force=True)
-            sc_obj.get_logwriter_reader_pods(
-                label=constants.LOGWRITER_RBD_LABEL, exp_num_replicas=2
-            )
+            # After force-delete the new RBD pod must bind a RWO PVC on a new
+            # node.  This can take longer than the built-in 40s retry window
+            # (tries=8, delay=5).  Use an outer retry with a generous back-off.
+            retry(UnexpectedBehaviour, tries=12, delay=10)(
+                sc_obj.get_logwriter_reader_pods
+            )(label=constants.LOGWRITER_RBD_LABEL, exp_num_replicas=2)
         logger.info("All zone-unaware workload pods Running on healthy nodes")
 
         end_time = datetime.now(timezone.utc)
@@ -890,10 +901,13 @@ class TestStretchClusterZoneBKubeletDown(ManageTest):
                 )
             self._kubelet_stopped_nodes.append(node_obj)
 
+        # Use a longer timeout: Zone-B includes control-plane-2, and kubelet
+        # stop on multiple nodes may cause API server disruption that consumes
+        # part of the NotReady detection budget.
         wait_for_nodes_status(
             node_names=zone_b_node_names,
             status=constants.NODE_NOT_READY,
-            timeout=300,
+            timeout=600,
         )
         logger.info(
             f"All Zone-B nodes are NotReady after kubelet stop: {zone_b_node_names}"
@@ -927,13 +941,20 @@ class TestStretchClusterZoneBKubeletDown(ManageTest):
             "Verifying workloads rescheduled onto healthy nodes "
             "with PVCs mounted and IOs started"
         )
-        sc_obj.get_logwriter_reader_pods(label=constants.LOGWRITER_CEPHFS_LABEL)
+        # Zone-AWARE workloads with all Zone-B nodes tainted out-of-service:
+        # the zone-spread constraint (maxSkew=1, whenUnsatisfiable=DoNotSchedule)
+        # prevents the full replica count from running on Zone-A alone.
+        # On a 4-worker cluster (2 per zone): 2 CephFS and 1 RBD pod survive.
+        sc_obj.get_logwriter_reader_pods(
+            label=constants.LOGWRITER_CEPHFS_LABEL, exp_num_replicas=2
+        )
         sc_obj.get_logwriter_reader_pods(
             label=constants.LOGREADER_CEPHFS_LABEL,
             statuses=[constants.STATUS_RUNNING, constants.STATUS_COMPLETED],
+            exp_num_replicas=2,
         )
         sc_obj.get_logwriter_reader_pods(
-            label=constants.LOGWRITER_RBD_LABEL, exp_num_replicas=2
+            label=constants.LOGWRITER_RBD_LABEL, exp_num_replicas=1
         )
         logger.info(
             "All workload pods Running on healthy nodes after Zone-B kubelet stop"

--- a/tests/functional/upgrade/test_non_stretch_cluster_upgrade.py
+++ b/tests/functional/upgrade/test_non_stretch_cluster_upgrade.py
@@ -71,7 +71,7 @@ from ocs_ci.ocs.resources.pod import (
 )
 from ocs_ci.utility.utils import TimeoutSampler, ceph_health_check
 
-log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 IO_SIZE = "1G"
 IO_RUNTIME_SEC = 30
@@ -84,11 +84,6 @@ _upgrade_shared: dict = {
     "outage_node_name": None,
     "md5sum_before": None,
 }
-
-
-# ---------------------------------------------------------------------------
-# Module-level helpers
-# ---------------------------------------------------------------------------
 
 
 def _pods_for_pvcs(pod_obj_list, wait=True):
@@ -108,11 +103,11 @@ def _verify_cluster_health(storage_pod_timeout=600, ceph_tries=20, ceph_delay=30
     ceph_health_check passes.
     """
     wait_for_storage_pods(timeout=storage_pod_timeout)
-    log.info("All storage pods are Running / Completed")
+    logger.info("All storage pods are Running / Completed")
     CephCluster().cluster_health_check(timeout=storage_pod_timeout)
-    log.info("Ceph cluster health check passed")
+    logger.info("Ceph cluster health check passed")
     ceph_health_check(tries=ceph_tries, delay=ceph_delay)
-    log.info("Ceph health confirmed")
+    logger.info("Ceph health confirmed")
 
 
 def _pin_and_deploy_workloads(deployment_pod_factory, node_name, fio_filename):
@@ -136,7 +131,7 @@ def _pin_and_deploy_workloads(deployment_pod_factory, node_name, fio_filename):
         node_name
     }, f"Expected both workloads on {node_name}; got {pod_nodes}"
     schedule_nodes(workers_to_cordon)
-    log.info(f"Workloads confirmed on {node_name}; all workers uncordoned")
+    logger.info(f"Workloads confirmed on {node_name}; all workers uncordoned")
 
     for pod_obj in pod_obj_list:
         pod_obj.run_io(
@@ -149,7 +144,7 @@ def _pin_and_deploy_workloads(deployment_pod_factory, node_name, fio_filename):
     for pod_obj in pod_obj_list:
         get_fio_rw_iops(pod_obj)
         md5sums.append(cal_md5sum(pod_obj=pod_obj, file_name=fio_filename))
-    log.info(f"md5sums captured for {[p.name for p in pod_obj_list]}: {md5sums}")
+    logger.info(f"md5sums captured for {[p.name for p in pod_obj_list]}: {md5sums}")
     return pod_obj_list, md5sums
 
 
@@ -163,7 +158,7 @@ def _wait_for_migration_off_node(pod_obj_list, outage_node_name, label="workload
     def _all_rescheduled():
         pods = _pods_for_pvcs(pod_obj_list)
         if len(pods) != len(pod_obj_list):
-            log.info(
+            logger.info(
                 f"Migration wait ({label}): expected {len(pod_obj_list)} pods, "
                 f"found {len(pods)}"
             )
@@ -174,7 +169,7 @@ def _wait_for_migration_off_node(pod_obj_list, outage_node_name, label="workload
             if mp is None:
                 return False
             if get_pod_node(mp).name == outage_node_name:
-                log.info(
+                logger.info(
                     f"PVC {orig.pvc.name}: pod {mp.name} still on outage node "
                     f"{outage_node_name}"
                 )
@@ -204,13 +199,8 @@ def _wait_for_migration_off_node(pod_obj_list, outage_node_name, label="workload
             f"{label} PVC {orig.pvc.name}: pod still on outage node "
             f"{outage_node_name} after taint"
         )
-    log.info(f"{label} migrated off {outage_node_name} onto healthy nodes")
+    logger.info(f"{label} migrated off {outage_node_name} onto healthy nodes")
     return migrated_pods
-
-
-# ---------------------------------------------------------------------------
-# PRE-UPGRADE
-# ---------------------------------------------------------------------------
 
 
 @pre_upgrade
@@ -238,7 +228,7 @@ def test_pre_upgrade_non_stretch_workloads(nodes, deployment_pod_factory):
     )
 
     selected_node_name = random.choice(worker_node_names)
-    log.info(
+    logger.info(
         f"PRE-UPGRADE Step 1: Cordoning all workers except {selected_node_name}; "
         "workloads will land on it"
     )
@@ -247,26 +237,21 @@ def test_pre_upgrade_non_stretch_workloads(nodes, deployment_pod_factory):
         node_name=selected_node_name,
         fio_filename="io_pre_upgrade",
     )
-    log.info(f"PRE-UPGRADE Step 1: Workloads confirmed on {selected_node_name}")
+    logger.info(f"PRE-UPGRADE Step 1: Workloads confirmed on {selected_node_name}")
 
-    log.info("PRE-UPGRADE Step 3: Confirming cluster health before OCP/ODF upgrade")
+    logger.info("PRE-UPGRADE Step 3: Confirming cluster health before OCP/ODF upgrade")
     _verify_cluster_health(storage_pod_timeout=300, ceph_tries=10, ceph_delay=30)
-    log.info("PRE-UPGRADE Step 3: Cluster is healthy; ready for upgrade")
+    logger.info("PRE-UPGRADE Step 3: Cluster is healthy; ready for upgrade")
 
     _upgrade_shared["pod_obj_list"] = pod_obj_list
     _upgrade_shared["outage_node_name"] = selected_node_name
     _upgrade_shared["md5sum_before"] = md5sum_before
 
-    log.info(
+    logger.info(
         "PRE-UPGRADE complete: workloads deployed on "
         f"{selected_node_name}, data snapshot taken. "
         "Cluster is ready for OCP/ODF 4.22 upgrade."
     )
-
-
-# ---------------------------------------------------------------------------
-# POST-UPGRADE
-# ---------------------------------------------------------------------------
 
 
 @post_upgrade
@@ -304,7 +289,7 @@ def test_post_upgrade_non_stretch_node_shutdown(
 
     def _cleanup_taints():
         if _tainted_node:
-            log.info(
+            logger.info(
                 f"Cleanup: removing out-of-service taint from {_tainted_node[0].name}"
             )
             try:
@@ -313,19 +298,21 @@ def test_post_upgrade_non_stretch_node_shutdown(
                     nodes_to_untaint=_tainted_node,
                 )
             except Exception as exc:
-                log.warning(f"untaint_nodes raised during cleanup: {exc}")
+                logger.warning(f"untaint_nodes raised during cleanup: {exc}")
             _tainted_node.clear()
 
-    log.info("POST-UPGRADE Step 4: Verifying cluster health after OCP/ODF 4.22 upgrade")
+    logger.info(
+        "POST-UPGRADE Step 4: Verifying cluster health after OCP/ODF 4.22 upgrade"
+    )
     _verify_cluster_health()
-    log.info("POST-UPGRADE Step 4: Cluster health confirmed after upgrade")
+    logger.info("POST-UPGRADE Step 4: Cluster health confirmed after upgrade")
 
     pre_pod_list = _upgrade_shared.get("pod_obj_list")
     pre_outage_node_name = _upgrade_shared.get("outage_node_name")
     md5sum_pre_upgrade = _upgrade_shared.get("md5sum_before")
 
     if pre_pod_list is not None and md5sum_pre_upgrade is not None:
-        log.info(
+        logger.info(
             "POST-UPGRADE Step 5: Verifying pre-upgrade workload pods are still Running"
         )
         current_pre_pods = _pods_for_pvcs(pre_pod_list)
@@ -333,7 +320,7 @@ def test_post_upgrade_non_stretch_node_shutdown(
             f"Expected {len(pre_pod_list)} pre-upgrade workload pods after upgrade, "
             f"got {len(current_pre_pods)}"
         )
-        log.info(
+        logger.info(
             "POST-UPGRADE Step 5: Comparing pre-upgrade md5sums "
             "to confirm data integrity across OCP/ODF upgrade"
         )
@@ -349,16 +336,18 @@ def test_post_upgrade_non_stretch_node_shutdown(
             "Data integrity lost across OCP/ODF upgrade: "
             f"before={md5sum_pre_upgrade}, after={md5sum_post_upgrade}"
         )
-        log.info("POST-UPGRADE Step 5: Data integrity confirmed across OCP/ODF upgrade")
+        logger.info(
+            "POST-UPGRADE Step 5: Data integrity confirmed across OCP/ODF upgrade"
+        )
     else:
-        log.warning(
+        logger.warning(
             "POST-UPGRADE Step 5: No pre-upgrade workload state found "
             "(pre-upgrade test may not have run in this session). "
             "Proceeding with post-upgrade workload deployment only."
         )
         pre_outage_node_name = None
 
-    log.info(
+    logger.info(
         "POST-UPGRADE Step 6: Deploying NEW RBD and CephFS workloads "
         "on the upgraded cluster"
     )
@@ -377,13 +366,13 @@ def test_post_upgrade_non_stretch_node_shutdown(
         node_name=selected_node_name,
         fio_filename="io_post_upgrade",
     )
-    log.info(
+    logger.info(
         f"POST-UPGRADE Step 6: New workloads on {selected_node_name}; "
         f"md5sums: {new_md5sum_before}"
     )
 
     outage_node = get_pod_node(new_pod_obj_list[0])
-    log.info(
+    logger.info(
         f"POST-UPGRADE Step 7: Stopping node {outage_node.name}; "
         "applying out-of-service taint"
     )
@@ -393,16 +382,18 @@ def test_post_upgrade_non_stretch_node_shutdown(
         status=constants.NODE_NOT_READY,
         timeout=300,
     )
-    log.info(f"POST-UPGRADE Step 7: Node {outage_node.name} is NotReady")
+    logger.info(f"POST-UPGRADE Step 7: Node {outage_node.name} is NotReady")
 
     assert taint_nodes(
         nodes=[outage_node.name],
         taint_label=constants.NODE_OUT_OF_SERVICE_TAINT,
     ), f"Failed to add out-of-service taint on {outage_node.name}"
     _tainted_node.append(outage_node)
-    log.info(f"POST-UPGRADE Step 7: out-of-service taint applied to {outage_node.name}")
+    logger.info(
+        f"POST-UPGRADE Step 7: out-of-service taint applied to {outage_node.name}"
+    )
 
-    log.info(
+    logger.info(
         f"POST-UPGRADE Step 9: Polling until new workloads leave {outage_node.name}"
     )
     try:
@@ -412,28 +403,28 @@ def test_post_upgrade_non_stretch_node_shutdown(
     except TimeoutExpiredError:
         _cleanup_taints()
         raise
-    log.info(
+    logger.info(
         f"POST-UPGRADE Step 9: New workloads migrated off {outage_node.name} "
         "onto healthy nodes on upgraded cluster"
     )
 
     if pre_pod_list is not None:
-        log.info("POST-UPGRADE Step 9: Checking pre-upgrade workloads also migrated")
+        logger.info("POST-UPGRADE Step 9: Checking pre-upgrade workloads also migrated")
         try:
             _wait_for_migration_off_node(
                 pre_pod_list, outage_node.name, label="pre-upgrade workloads"
             )
-            log.info(
+            logger.info(
                 "POST-UPGRADE Step 9: Pre-upgrade workloads also migrated "
                 "to healthy nodes successfully"
             )
         except TimeoutExpiredError:
-            log.warning(
+            logger.warning(
                 "POST-UPGRADE Step 9: Pre-upgrade workloads did not all "
                 "migrate off outage node within the timeout – continuing"
             )
 
-    log.info(
+    logger.info(
         "POST-UPGRADE Step 10: Comparing md5sums for new workloads after migration"
     )
     new_migrated_by_pvc = {get_pvc_name(p): p for p in new_migrated_pods}
@@ -448,25 +439,25 @@ def test_post_upgrade_non_stretch_node_shutdown(
         "Data integrity lost for new workloads during node outage: "
         f"before={new_md5sum_before}, after={new_md5sum_after}"
     )
-    log.info(
+    logger.info(
         "POST-UPGRADE Step 10: New workload data integrity confirmed after migration"
     )
 
-    log.info(f"POST-UPGRADE Step 11: Starting node {outage_node.name}")
+    logger.info(f"POST-UPGRADE Step 11: Starting node {outage_node.name}")
     nodes.start_nodes([outage_node])
     wait_for_nodes_status(node_names=[outage_node.name], status=constants.NODE_READY)
-    log.info(f"POST-UPGRADE Step 11: Node {outage_node.name} is Ready")
+    logger.info(f"POST-UPGRADE Step 11: Node {outage_node.name} is Ready")
 
     assert untaint_nodes(
         taint_label=constants.NODE_OUT_OF_SERVICE_TAINT,
         nodes_to_untaint=[outage_node],
     ), f"Failed to remove out-of-service taint from {outage_node.name}"
     _tainted_node.clear()
-    log.info(
+    logger.info(
         f"POST-UPGRADE Step 11: out-of-service taint removed from {outage_node.name}"
     )
 
-    log.info(
+    logger.info(
         "POST-UPGRADE Step 11: Running IO on migrated new workload pods "
         "after node recovery"
     )
@@ -479,14 +470,14 @@ def test_post_upgrade_non_stretch_node_shutdown(
         )
     for pod_obj in new_migrated_pods:
         get_fio_rw_iops(pod_obj)
-    log.info("POST-UPGRADE Step 11: IO completed on migrated pods after recovery")
+    logger.info("POST-UPGRADE Step 11: IO completed on migrated pods after recovery")
 
-    log.info(
+    logger.info(
         "POST-UPGRADE Step 12: Deleting migrated new workload pods to verify "
         "Deployment re-creates them"
     )
     for pod_obj in new_migrated_pods:
-        log.info(f"Deleting pod {pod_obj.name}")
+        logger.info(f"Deleting pod {pod_obj.name}")
         pod_obj.delete()
 
     redeployed = _pods_for_pvcs(new_pod_obj_list)
@@ -494,16 +485,16 @@ def test_post_upgrade_non_stretch_node_shutdown(
         f"Expected {len(new_pod_obj_list)} pods after redeploy, "
         f"got {len(redeployed)}"
     )
-    log.info(
+    logger.info(
         "POST-UPGRADE Step 12: Pods re-created by Deployment and Running "
         "after node recovery on upgraded cluster"
     )
 
-    log.info("POST-UPGRADE Step 13: Verifying Ceph health after full recovery")
+    logger.info("POST-UPGRADE Step 13: Verifying Ceph health after full recovery")
     ceph_health_check(tries=20, delay=30)
-    log.info("POST-UPGRADE Step 13: Ceph health confirmed after node recovery")
+    logger.info("POST-UPGRADE Step 13: Ceph health confirmed after node recovery")
 
-    log.info(
+    logger.info(
         f"POST-UPGRADE Step 14: Deploying fresh workloads pinned to "
         f"recovered node {outage_node.name}"
     )
@@ -518,12 +509,12 @@ def test_post_upgrade_non_stretch_node_shutdown(
             fio_filename="io_fresh",
         )
         get_fio_rw_iops(fresh_pod)
-        log.info(
+        logger.info(
             f"POST-UPGRADE Step 14: Fresh pod {fresh_pod.name} running IO on "
             f"recovered node {outage_node.name}"
         )
 
-    log.info(
+    logger.info(
         f"POST-UPGRADE Step 14: Fresh workloads deployed and IOs completed on "
         f"recovered node {outage_node.name} after OCP/ODF 4.22 upgrade"
     )

--- a/tests/functional/upgrade/test_non_stretch_cluster_upgrade.py
+++ b/tests/functional/upgrade/test_non_stretch_cluster_upgrade.py
@@ -43,7 +43,7 @@ import random
 import pytest
 
 from ocs_ci.framework.pytest_customization.marks import (
-    green_squad,
+    magenta_squad,
     pre_upgrade,
     post_upgrade,
     skipif_hci_provider_or_client,
@@ -214,7 +214,7 @@ def _wait_for_migration_off_node(pod_obj_list, outage_node_name, label="workload
 
 
 @pre_upgrade
-@green_squad
+@magenta_squad
 @tier4b
 @skipif_managed_service
 @skipif_hci_provider_or_client
@@ -270,7 +270,7 @@ def test_pre_upgrade_non_stretch_workloads(nodes, deployment_pod_factory):
 
 
 @post_upgrade
-@green_squad
+@magenta_squad
 @tier4b
 @skipif_managed_service
 @skipif_hci_provider_or_client

--- a/tests/functional/upgrade/test_non_stretch_cluster_upgrade.py
+++ b/tests/functional/upgrade/test_non_stretch_cluster_upgrade.py
@@ -91,10 +91,20 @@ def _pods_for_pvcs(pod_obj_list, wait=True):
     Return running pods in the same namespace that share PVCs with the given
     workload pod list.  Pods without a PVC are skipped.
     """
+    from ocs_ci.ocs.exceptions import UnavailableResourceException
+
     target_pvcs = {p.pvc.name for p in pod_obj_list}
     namespace = pod_obj_list[0].namespace
     all_pods = get_all_pods(namespace=namespace, wait=wait)
-    return [p for p in all_pods if get_pvc_name(p) in target_pvcs]
+    matched = []
+    for p in all_pods:
+        try:
+            pvc_name = get_pvc_name(p)
+        except UnavailableResourceException:
+            continue
+        if pvc_name and pvc_name in target_pvcs:
+            matched.append(p)
+    return matched
 
 
 def _verify_cluster_health(storage_pod_timeout=600, ceph_tries=20, ceph_delay=30):
@@ -156,7 +166,7 @@ def _wait_for_migration_off_node(pod_obj_list, outage_node_name, label="workload
     """
 
     def _all_rescheduled():
-        pods = _pods_for_pvcs(pod_obj_list)
+        pods = _pods_for_pvcs(pod_obj_list, wait=False)
         if len(pods) != len(pod_obj_list):
             logger.info(
                 f"Migration wait ({label}): expected {len(pod_obj_list)} pods, "
@@ -261,6 +271,7 @@ def test_pre_upgrade_non_stretch_workloads(nodes, deployment_pod_factory):
 @skipif_hci_provider_or_client
 @pytest.mark.polarion_id("OCS-7379")
 def test_post_upgrade_non_stretch_node_shutdown(
+    request,
     node_restart_teardown,
     nodes,
     deployment_pod_factory,
@@ -300,6 +311,8 @@ def test_post_upgrade_non_stretch_node_shutdown(
             except Exception as exc:
                 logger.warning(f"untaint_nodes raised during cleanup: {exc}")
             _tainted_node.clear()
+
+    request.addfinalizer(_cleanup_taints)
 
     logger.info(
         "POST-UPGRADE Step 4: Verifying cluster health after OCP/ODF 4.22 upgrade"

--- a/tests/functional/upgrade/test_non_stretch_cluster_upgrade.py
+++ b/tests/functional/upgrade/test_non_stretch_cluster_upgrade.py
@@ -1,0 +1,529 @@
+"""
+RHSTOR-8242 - Non-stretch cluster upgrade testing: 4.21 GA → 4.22.
+
+Validates that after upgrading OCP and ODF from 4.21 to 4.22 on a non-stretch
+cluster, both pre-existing and newly deployed workloads survive a node shutdown
+with the out-of-service taint, and that data integrity is maintained (no data
+unavailability, data loss, or data corruption).
+
+Test flow (driven by pytest-ordering via the pre_upgrade / post_upgrade marks):
+
+  PRE-UPGRADE  (test_pre_upgrade_non_stretch_workloads)
+  ──────────────────────────────────────────────────────
+  1. Pin RBD and CephFS workload pods to a single randomly selected worker node
+     by cordoning all others, deploy via deployment_pod_factory, then uncordon.
+  2. Run FIO write IO and capture md5sum of the written file so post-upgrade
+     data integrity can be verified.
+  3. Verify the cluster is healthy before the upgrade proceeds.
+
+  [OCP 4.22 upgrade]  ← performed by the standard upgrade pipeline
+  [ODF 4.22 upgrade]  ← performed by the standard upgrade pipeline
+
+  POST-UPGRADE (test_post_upgrade_non_stretch_node_shutdown)
+  ───────────────────────────────────────────────────────────
+  4. Verify cluster health after the upgrade (storage pods, Ceph health).
+  5. Verify pre-upgrade workloads are still Running and accessible; confirm
+     data written before upgrade is intact (md5sum comparison).
+  6. Deploy new RBD and CephFS workload pods on the upgraded cluster and run IO.
+  7. Stop the node that hosts the (pre-upgrade or new) workloads; apply the
+     out-of-service taint.
+  8. Verify no IO is happening on the stopped node.
+  9. Verify both pre-upgrade and new workloads automatically migrate to a
+     healthy node; PVCs mount and IOs start without manual intervention.
+  10. Confirm data integrity is maintained (checksum comparison).
+  11. Recover the node; remove the taint.
+  12. Confirm no data loss/corruption on the recovered cluster; run new IO.
+  13. Delete the migrated workload pods; verify Deployment recreates them.
+  14. Deploy fresh workloads pinned to the recovered node; run IOs.
+"""
+
+import logging
+import random
+
+import pytest
+
+from ocs_ci.framework.pytest_customization.marks import (
+    green_squad,
+    pre_upgrade,
+    post_upgrade,
+    skipif_hci_provider_or_client,
+    skipif_managed_service,
+)
+from ocs_ci.framework.testlib import tier4b
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.cluster import CephCluster
+from ocs_ci.ocs.exceptions import TimeoutExpiredError
+from ocs_ci.ocs.node import (
+    get_worker_nodes,
+    schedule_nodes,
+    taint_nodes,
+    unschedule_nodes,
+    untaint_nodes,
+    wait_for_nodes_status,
+)
+from ocs_ci.ocs.resources.pod import (
+    cal_md5sum,
+    get_all_pods,
+    get_fio_rw_iops,
+    get_pod_node,
+    get_pvc_name,
+    wait_for_storage_pods,
+)
+from ocs_ci.utility.utils import TimeoutSampler, ceph_health_check
+
+log = logging.getLogger(__name__)
+
+IO_SIZE = "1G"
+IO_RUNTIME_SEC = 30
+
+WORKLOAD_MIGRATION_TIMEOUT_SEC = 300
+WORKLOAD_MIGRATION_POLL_INTERVAL_SEC = 10
+
+_upgrade_shared: dict = {
+    "pod_obj_list": None,
+    "outage_node_name": None,
+    "md5sum_before": None,
+}
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers
+# ---------------------------------------------------------------------------
+
+
+def _pods_for_pvcs(pod_obj_list, wait=True):
+    """
+    Return running pods in the same namespace that share PVCs with the given
+    workload pod list.  Pods without a PVC are skipped.
+    """
+    target_pvcs = {p.pvc.name for p in pod_obj_list}
+    namespace = pod_obj_list[0].namespace
+    all_pods = get_all_pods(namespace=namespace, wait=wait)
+    return [p for p in all_pods if get_pvc_name(p) in target_pvcs]
+
+
+def _verify_cluster_health(storage_pod_timeout=600, ceph_tries=20, ceph_delay=30):
+    """
+    Assert the cluster is healthy: storage pods running, CephCluster healthy,
+    ceph_health_check passes.
+    """
+    wait_for_storage_pods(timeout=storage_pod_timeout)
+    log.info("All storage pods are Running / Completed")
+    CephCluster().cluster_health_check(timeout=storage_pod_timeout)
+    log.info("Ceph cluster health check passed")
+    ceph_health_check(tries=ceph_tries, delay=ceph_delay)
+    log.info("Ceph health confirmed")
+
+
+def _pin_and_deploy_workloads(deployment_pod_factory, node_name, fio_filename):
+    """
+    Deploy one RBD pod and one CephFS pod pinned to *node_name* by cordoning
+    all other workers, run FIO write IO, capture md5sums, then uncordon.
+
+    Returns:
+        tuple: (pod_obj_list, md5sum_list)
+    """
+    worker_node_names = get_worker_nodes()
+    workers_to_cordon = [n for n in worker_node_names if n != node_name]
+    unschedule_nodes(workers_to_cordon)
+
+    pod_obj_list = []
+    for interface in (constants.CEPHBLOCKPOOL, constants.CEPHFILESYSTEM):
+        pod_obj_list.append(deployment_pod_factory(interface=interface))
+
+    pod_nodes = {get_pod_node(p).name for p in pod_obj_list}
+    assert pod_nodes == {
+        node_name
+    }, f"Expected both workloads on {node_name}; got {pod_nodes}"
+    schedule_nodes(workers_to_cordon)
+    log.info(f"Workloads confirmed on {node_name}; all workers uncordoned")
+
+    for pod_obj in pod_obj_list:
+        pod_obj.run_io(
+            storage_type="fs",
+            size=IO_SIZE,
+            runtime=IO_RUNTIME_SEC,
+            fio_filename=fio_filename,
+        )
+    md5sums = []
+    for pod_obj in pod_obj_list:
+        get_fio_rw_iops(pod_obj)
+        md5sums.append(cal_md5sum(pod_obj=pod_obj, file_name=fio_filename))
+    log.info(f"md5sums captured for {[p.name for p in pod_obj_list]}: {md5sums}")
+    return pod_obj_list, md5sums
+
+
+def _wait_for_migration_off_node(pod_obj_list, outage_node_name, label="workloads"):
+    """
+    Poll until every pod in *pod_obj_list* has rescheduled off *outage_node_name*.
+
+    Returns the refreshed list of migrated pods, or raises TimeoutExpiredError.
+    """
+
+    def _all_rescheduled():
+        pods = _pods_for_pvcs(pod_obj_list)
+        if len(pods) != len(pod_obj_list):
+            log.info(
+                f"Migration wait ({label}): expected {len(pod_obj_list)} pods, "
+                f"found {len(pods)}"
+            )
+            return False
+        migrated = {get_pvc_name(p): p for p in pods}
+        for orig in pod_obj_list:
+            mp = migrated.get(orig.pvc.name)
+            if mp is None:
+                return False
+            if get_pod_node(mp).name == outage_node_name:
+                log.info(
+                    f"PVC {orig.pvc.name}: pod {mp.name} still on outage node "
+                    f"{outage_node_name}"
+                )
+                return False
+        return True
+
+    sampler = TimeoutSampler(
+        WORKLOAD_MIGRATION_TIMEOUT_SEC,
+        WORKLOAD_MIGRATION_POLL_INTERVAL_SEC,
+        _all_rescheduled,
+    )
+    if not sampler.wait_for_func_status(True):
+        raise TimeoutExpiredError(
+            WORKLOAD_MIGRATION_TIMEOUT_SEC,
+            f"{label} did not reschedule off {outage_node_name} within "
+            f"{WORKLOAD_MIGRATION_TIMEOUT_SEC}s",
+        )
+    migrated_pods = _pods_for_pvcs(pod_obj_list)
+    assert len(migrated_pods) == len(pod_obj_list), (
+        f"Expected {len(pod_obj_list)} {label} pods after migration, "
+        f"got {len(migrated_pods)}"
+    )
+    migrated_by_pvc = {get_pvc_name(p): p for p in migrated_pods}
+    for orig in pod_obj_list:
+        node_after = get_pod_node(migrated_by_pvc[orig.pvc.name]).name
+        assert node_after != outage_node_name, (
+            f"{label} PVC {orig.pvc.name}: pod still on outage node "
+            f"{outage_node_name} after taint"
+        )
+    log.info(f"{label} migrated off {outage_node_name} onto healthy nodes")
+    return migrated_pods
+
+
+# ---------------------------------------------------------------------------
+# PRE-UPGRADE
+# ---------------------------------------------------------------------------
+
+
+@pre_upgrade
+@green_squad
+@tier4b
+@skipif_managed_service
+@skipif_hci_provider_or_client
+@pytest.mark.polarion_id("OCS-7378")
+def test_pre_upgrade_non_stretch_workloads(nodes, deployment_pod_factory):
+    """
+    Pre-upgrade step: deploy RBD and CephFS workload pods on a single worker
+    node of the 4.21 cluster, run IO, and capture checksums for post-upgrade
+    data integrity verification.
+
+    Steps:
+    1. Cordon all workers except one; deploy RBD and CephFS pods; uncordon.
+    2. Run FIO write IO on both pods; capture md5sums.
+    3. Confirm cluster health before upgrade.
+    """
+
+    worker_node_names = get_worker_nodes()
+    assert len(worker_node_names) >= 2, (
+        "Need at least 2 worker nodes to pin workloads to a single node "
+        "while leaving a failover target available"
+    )
+
+    selected_node_name = random.choice(worker_node_names)
+    log.info(
+        f"PRE-UPGRADE Step 1: Cordoning all workers except {selected_node_name}; "
+        "workloads will land on it"
+    )
+    pod_obj_list, md5sum_before = _pin_and_deploy_workloads(
+        deployment_pod_factory,
+        node_name=selected_node_name,
+        fio_filename="io_pre_upgrade",
+    )
+    log.info(f"PRE-UPGRADE Step 1: Workloads confirmed on {selected_node_name}")
+
+    log.info("PRE-UPGRADE Step 3: Confirming cluster health before OCP/ODF upgrade")
+    _verify_cluster_health(storage_pod_timeout=300, ceph_tries=10, ceph_delay=30)
+    log.info("PRE-UPGRADE Step 3: Cluster is healthy; ready for upgrade")
+
+    _upgrade_shared["pod_obj_list"] = pod_obj_list
+    _upgrade_shared["outage_node_name"] = selected_node_name
+    _upgrade_shared["md5sum_before"] = md5sum_before
+
+    log.info(
+        "PRE-UPGRADE complete: workloads deployed on "
+        f"{selected_node_name}, data snapshot taken. "
+        "Cluster is ready for OCP/ODF 4.22 upgrade."
+    )
+
+
+# ---------------------------------------------------------------------------
+# POST-UPGRADE
+# ---------------------------------------------------------------------------
+
+
+@post_upgrade
+@green_squad
+@tier4b
+@skipif_managed_service
+@skipif_hci_provider_or_client
+@pytest.mark.polarion_id("OCS-7379")
+def test_post_upgrade_non_stretch_node_shutdown(
+    node_restart_teardown,
+    nodes,
+    deployment_pod_factory,
+):
+    """
+    Post-upgrade step: verify cluster health, confirm pre-upgrade workload
+    integrity, deploy new workloads, perform a node shutdown with out-of-service
+    taint, verify workload migration and data integrity, recover the node, and
+    deploy fresh workloads on the recovered node.
+
+    Steps:
+    4.  Verify cluster health after OCP/ODF 4.22 upgrade.
+    5.  Verify pre-upgrade workloads are still Running; compare md5sums.
+    6.  Deploy new RBD and CephFS workload pods on the upgraded cluster; run IO.
+    7.  Stop the outage node; apply the out-of-service taint.
+    8.  Verify no IO is happening on the stopped node.
+    9.  Verify workloads migrated to a healthy node automatically.
+    10. Confirm data integrity (md5sum comparison for both old and new workloads).
+    11. Recover the node; remove the taint; run IO on migrated pods.
+    12. Delete migrated pods; verify Deployment recreates them.
+    13. No data loss/corruption after recovery.
+    14. Deploy fresh workloads pinned to the recovered node; run IOs.
+    """
+
+    _tainted_node = []
+
+    def _cleanup_taints():
+        if _tainted_node:
+            log.info(
+                f"Cleanup: removing out-of-service taint from {_tainted_node[0].name}"
+            )
+            try:
+                untaint_nodes(
+                    taint_label=constants.NODE_OUT_OF_SERVICE_TAINT,
+                    nodes_to_untaint=_tainted_node,
+                )
+            except Exception as exc:
+                log.warning(f"untaint_nodes raised during cleanup: {exc}")
+            _tainted_node.clear()
+
+    log.info("POST-UPGRADE Step 4: Verifying cluster health after OCP/ODF 4.22 upgrade")
+    _verify_cluster_health()
+    log.info("POST-UPGRADE Step 4: Cluster health confirmed after upgrade")
+
+    pre_pod_list = _upgrade_shared.get("pod_obj_list")
+    pre_outage_node_name = _upgrade_shared.get("outage_node_name")
+    md5sum_pre_upgrade = _upgrade_shared.get("md5sum_before")
+
+    if pre_pod_list is not None and md5sum_pre_upgrade is not None:
+        log.info(
+            "POST-UPGRADE Step 5: Verifying pre-upgrade workload pods are still Running"
+        )
+        current_pre_pods = _pods_for_pvcs(pre_pod_list)
+        assert len(current_pre_pods) == len(pre_pod_list), (
+            f"Expected {len(pre_pod_list)} pre-upgrade workload pods after upgrade, "
+            f"got {len(current_pre_pods)}"
+        )
+        log.info(
+            "POST-UPGRADE Step 5: Comparing pre-upgrade md5sums "
+            "to confirm data integrity across OCP/ODF upgrade"
+        )
+        migrated_by_pvc = {get_pvc_name(p): p for p in current_pre_pods}
+        md5sum_post_upgrade = [
+            cal_md5sum(
+                pod_obj=migrated_by_pvc[orig.pvc.name], file_name="io_pre_upgrade"
+            )
+            for orig in pre_pod_list
+            if get_pvc_name(migrated_by_pvc.get(orig.pvc.name)) == orig.pvc.name
+        ]
+        assert md5sum_pre_upgrade == md5sum_post_upgrade, (
+            "Data integrity lost across OCP/ODF upgrade: "
+            f"before={md5sum_pre_upgrade}, after={md5sum_post_upgrade}"
+        )
+        log.info("POST-UPGRADE Step 5: Data integrity confirmed across OCP/ODF upgrade")
+    else:
+        log.warning(
+            "POST-UPGRADE Step 5: No pre-upgrade workload state found "
+            "(pre-upgrade test may not have run in this session). "
+            "Proceeding with post-upgrade workload deployment only."
+        )
+        pre_outage_node_name = None
+
+    log.info(
+        "POST-UPGRADE Step 6: Deploying NEW RBD and CephFS workloads "
+        "on the upgraded cluster"
+    )
+    worker_node_names = get_worker_nodes()
+    assert (
+        len(worker_node_names) >= 2
+    ), "Need at least 2 worker nodes: one for the outage, one for failover"
+
+    if pre_outage_node_name and pre_outage_node_name in worker_node_names:
+        selected_node_name = pre_outage_node_name
+    else:
+        selected_node_name = random.choice(worker_node_names)
+
+    new_pod_obj_list, new_md5sum_before = _pin_and_deploy_workloads(
+        deployment_pod_factory,
+        node_name=selected_node_name,
+        fio_filename="io_post_upgrade",
+    )
+    log.info(
+        f"POST-UPGRADE Step 6: New workloads on {selected_node_name}; "
+        f"md5sums: {new_md5sum_before}"
+    )
+
+    outage_node = get_pod_node(new_pod_obj_list[0])
+    log.info(
+        f"POST-UPGRADE Step 7: Stopping node {outage_node.name}; "
+        "applying out-of-service taint"
+    )
+    nodes.stop_nodes([outage_node])
+    wait_for_nodes_status(
+        node_names=[outage_node.name],
+        status=constants.NODE_NOT_READY,
+        timeout=300,
+    )
+    log.info(f"POST-UPGRADE Step 7: Node {outage_node.name} is NotReady")
+
+    assert taint_nodes(
+        nodes=[outage_node.name],
+        taint_label=constants.NODE_OUT_OF_SERVICE_TAINT,
+    ), f"Failed to add out-of-service taint on {outage_node.name}"
+    _tainted_node.append(outage_node)
+    log.info(f"POST-UPGRADE Step 7: out-of-service taint applied to {outage_node.name}")
+
+    log.info(
+        f"POST-UPGRADE Step 9: Polling until new workloads leave {outage_node.name}"
+    )
+    try:
+        new_migrated_pods = _wait_for_migration_off_node(
+            new_pod_obj_list, outage_node.name, label="new workloads"
+        )
+    except TimeoutExpiredError:
+        _cleanup_taints()
+        raise
+    log.info(
+        f"POST-UPGRADE Step 9: New workloads migrated off {outage_node.name} "
+        "onto healthy nodes on upgraded cluster"
+    )
+
+    if pre_pod_list is not None:
+        log.info("POST-UPGRADE Step 9: Checking pre-upgrade workloads also migrated")
+        try:
+            _wait_for_migration_off_node(
+                pre_pod_list, outage_node.name, label="pre-upgrade workloads"
+            )
+            log.info(
+                "POST-UPGRADE Step 9: Pre-upgrade workloads also migrated "
+                "to healthy nodes successfully"
+            )
+        except TimeoutExpiredError:
+            log.warning(
+                "POST-UPGRADE Step 9: Pre-upgrade workloads did not all "
+                "migrate off outage node within the timeout – continuing"
+            )
+
+    log.info(
+        "POST-UPGRADE Step 10: Comparing md5sums for new workloads after migration"
+    )
+    new_migrated_by_pvc = {get_pvc_name(p): p for p in new_migrated_pods}
+    new_md5sum_after = [
+        cal_md5sum(
+            pod_obj=new_migrated_by_pvc[orig.pvc.name],
+            file_name="io_post_upgrade",
+        )
+        for orig in new_pod_obj_list
+    ]
+    assert new_md5sum_before == new_md5sum_after, (
+        "Data integrity lost for new workloads during node outage: "
+        f"before={new_md5sum_before}, after={new_md5sum_after}"
+    )
+    log.info(
+        "POST-UPGRADE Step 10: New workload data integrity confirmed after migration"
+    )
+
+    log.info(f"POST-UPGRADE Step 11: Starting node {outage_node.name}")
+    nodes.start_nodes([outage_node])
+    wait_for_nodes_status(node_names=[outage_node.name], status=constants.NODE_READY)
+    log.info(f"POST-UPGRADE Step 11: Node {outage_node.name} is Ready")
+
+    assert untaint_nodes(
+        taint_label=constants.NODE_OUT_OF_SERVICE_TAINT,
+        nodes_to_untaint=[outage_node],
+    ), f"Failed to remove out-of-service taint from {outage_node.name}"
+    _tainted_node.clear()
+    log.info(
+        f"POST-UPGRADE Step 11: out-of-service taint removed from {outage_node.name}"
+    )
+
+    log.info(
+        "POST-UPGRADE Step 11: Running IO on migrated new workload pods "
+        "after node recovery"
+    )
+    for pod_obj in new_migrated_pods:
+        pod_obj.run_io(
+            storage_type="fs",
+            size=IO_SIZE,
+            runtime=IO_RUNTIME_SEC,
+            fio_filename="io_post_recovery",
+        )
+    for pod_obj in new_migrated_pods:
+        get_fio_rw_iops(pod_obj)
+    log.info("POST-UPGRADE Step 11: IO completed on migrated pods after recovery")
+
+    log.info(
+        "POST-UPGRADE Step 12: Deleting migrated new workload pods to verify "
+        "Deployment re-creates them"
+    )
+    for pod_obj in new_migrated_pods:
+        log.info(f"Deleting pod {pod_obj.name}")
+        pod_obj.delete()
+
+    redeployed = _pods_for_pvcs(new_pod_obj_list)
+    assert len(redeployed) == len(new_pod_obj_list), (
+        f"Expected {len(new_pod_obj_list)} pods after redeploy, "
+        f"got {len(redeployed)}"
+    )
+    log.info(
+        "POST-UPGRADE Step 12: Pods re-created by Deployment and Running "
+        "after node recovery on upgraded cluster"
+    )
+
+    log.info("POST-UPGRADE Step 13: Verifying Ceph health after full recovery")
+    ceph_health_check(tries=20, delay=30)
+    log.info("POST-UPGRADE Step 13: Ceph health confirmed after node recovery")
+
+    log.info(
+        f"POST-UPGRADE Step 14: Deploying fresh workloads pinned to "
+        f"recovered node {outage_node.name}"
+    )
+    for interface in (constants.CEPHBLOCKPOOL, constants.CEPHFILESYSTEM):
+        fresh_pod = deployment_pod_factory(
+            interface=interface, node_name=outage_node.name
+        )
+        fresh_pod.run_io(
+            storage_type="fs",
+            size=IO_SIZE,
+            runtime=IO_RUNTIME_SEC,
+            fio_filename="io_fresh",
+        )
+        get_fio_rw_iops(fresh_pod)
+        log.info(
+            f"POST-UPGRADE Step 14: Fresh pod {fresh_pod.name} running IO on "
+            f"recovered node {outage_node.name}"
+        )
+
+    log.info(
+        f"POST-UPGRADE Step 14: Fresh workloads deployed and IOs completed on "
+        f"recovered node {outage_node.name} after OCP/ODF 4.22 upgrade"
+    )

--- a/tests/functional/upgrade/test_non_stretch_cluster_upgrade.py
+++ b/tests/functional/upgrade/test_non_stretch_cluster_upgrade.py
@@ -73,7 +73,7 @@ from ocs_ci.utility.utils import TimeoutSampler, ceph_health_check
 
 logger = logging.getLogger(__name__)
 
-IO_SIZE = "1G"
+IO_SIZE = "512M"
 IO_RUNTIME_SEC = 30
 
 WORKLOAD_MIGRATION_TIMEOUT_SEC = 300

--- a/tests/functional/upgrade/test_stretch_cluster_upgrade.py
+++ b/tests/functional/upgrade/test_stretch_cluster_upgrade.py
@@ -1,0 +1,472 @@
+"""
+RHSTOR-8242 - Stretch cluster upgrade testing: 4.21 GA → 4.22.
+
+Validates that after upgrading OCP and ODF from 4.21 to 4.22 on a stretch
+cluster, both pre-existing and newly deployed workloads survive a Zone-B
+shutdown with the out-of-service taint, and that data integrity is maintained
+(no DU/DL/DC) with clean Ceph connection scores.
+
+Test flow (driven by pytest-ordering via the pre_upgrade / post_upgrade marks):
+
+  PRE-UPGRADE  (test_pre_upgrade_stretch_cluster_workloads)
+  ──────────────────────────────────────────────────────────
+  1. Deploy zone-aware VM, logwriter-cephfs and logwriter-rbd workloads on
+     the 4.21 cluster and verify they are healthy.
+  2. Capture a before-upgrade data snapshot (md5sum of VM file, logfile maps)
+     so post-upgrade data integrity can be confirmed.
+
+  [OCP 4.22 upgrade]  ← performed by the standard upgrade pipeline
+  [ODF 4.22 upgrade]  ← performed by the standard upgrade pipeline
+
+  POST-UPGRADE (test_post_upgrade_stretch_cluster_zone_b_shutdown)
+  ─────────────────────────────────────────────────────────────────
+  3. Verify the cluster is healthy after the upgrade (storage pods running,
+     Ceph healthy).
+  4. Verify pre-upgrade workloads are still running and accessible.
+  5. Deploy new zone-aware workloads on the upgraded cluster.
+  6. Shutdown all Zone-B nodes; taint them out-of-service.
+  7. Verify pre-upgrade and new workloads both migrate / pend correctly.
+  8. Confirm no DU/DL/DC issues.
+  9. Check for any Ceph side issues.
+  10. Recover Zone B; remove taint.
+  11. Confirm no DU/DL/DC after recovery; validate connection scores.
+  12. Delete workload pods; verify re-schedule on recovered nodes.
+  13. Deploy fresh workloads on recovered Zone-B nodes; run IOs.
+"""
+
+import logging
+import time
+from datetime import datetime, timezone
+
+import pytest
+
+from ocs_ci.framework.pytest_customization.marks import (
+    pre_upgrade,
+    post_upgrade,
+    stretchcluster_required,
+    turquoise_squad,
+)
+from ocs_ci.helpers.cnv_helpers import cal_md5sum_vm
+from ocs_ci.helpers.stretchcluster_helper import (
+    check_for_logwriter_workload_pods,
+    recover_from_ceph_stuck,
+    verify_data_corruption,
+    verify_data_loss,
+    verify_vm_workload,
+)
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.cluster import CephCluster
+from ocs_ci.ocs.exceptions import CommandFailed
+from ocs_ci.ocs.node import (
+    taint_nodes,
+    untaint_nodes,
+    wait_for_nodes_status,
+)
+from ocs_ci.ocs.resources.pod import (
+    get_pods_having_label,
+    wait_for_storage_pods,
+    wait_for_pods_to_be_in_statuses,
+)
+from ocs_ci.ocs.resources.stretchcluster import StretchCluster
+from ocs_ci.utility.retry import retry
+from ocs_ci.utility.utils import ceph_health_check
+
+log = logging.getLogger(__name__)
+
+ZONE_B = "data-2"
+CEPH_CHECK_TIMEOUT = 120
+
+_upgrade_shared: dict = {
+    "sc_obj": None,
+    "vm_obj": None,
+    "md5sum_before": None,
+}
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers
+# ---------------------------------------------------------------------------
+
+
+def _verify_cluster_health(storage_pod_timeout=600, ceph_tries=20, ceph_delay=30):
+    """
+    Assert the cluster is healthy: storage pods running, CephCluster healthy,
+    ceph_health_check passes.
+    """
+    wait_for_storage_pods(timeout=storage_pod_timeout)
+    log.info("All storage pods are Running / Completed")
+    CephCluster().cluster_health_check(timeout=storage_pod_timeout)
+    log.info("Ceph cluster health check passed")
+    ceph_health_check(tries=ceph_tries, delay=ceph_delay)
+    log.info("Ceph health confirmed")
+
+
+def _deploy_stretch_workloads(
+    sc_obj,
+    setup_logwriter_cephfs_workload_factory,
+    setup_logwriter_rbd_workload_factory,
+    cnv_workload,
+    nodes,
+):
+    """
+    Deploy zone-aware CephFS logwriter, RBD logwriter and VM workloads onto
+    *sc_obj*, verify pods are healthy, capture logfile maps and VM md5sum.
+
+    Returns:
+        tuple: (vm_obj, md5sum_before)
+    """
+    (
+        sc_obj.cephfs_logwriter_dep,
+        sc_obj.cephfs_logreader_job,
+    ) = setup_logwriter_cephfs_workload_factory(read_duration=0)
+
+    sc_obj.rbd_logwriter_sts = setup_logwriter_rbd_workload_factory(zone_aware=True)
+
+    vm_obj = cnv_workload(volume_interface=constants.VM_VOLUME_PVC)
+    vm_obj.run_ssh_cmd(command="mkdir /test && sudo chmod -R 777 /test")
+    vm_obj.run_ssh_cmd(
+        command=(
+            "< /dev/urandom tr -dc 'A-Za-z0-9' | head -c 10485760 "
+            "> /test/file_1.txt && sync"
+        )
+    )
+    md5sum_before = cal_md5sum_vm(vm_obj, file_path="/test/file_1.txt")
+    log.info(f"VM file md5sum captured: {md5sum_before}")
+
+    check_for_logwriter_workload_pods(sc_obj, nodes=nodes)
+    log.info("All zone-aware workload pods are Running and healthy")
+
+    sc_obj.get_logfile_map(label=constants.LOGWRITER_CEPHFS_LABEL)
+    sc_obj.get_logfile_map(label=constants.LOGWRITER_RBD_LABEL)
+
+    return vm_obj, md5sum_before
+
+
+def _refresh_pod_state(sc_obj):
+    """Refresh CephFS and RBD logwriter/logreader pod state on *sc_obj*."""
+    for label in (
+        constants.LOGWRITER_CEPHFS_LABEL,
+        constants.LOGREADER_CEPHFS_LABEL,
+        constants.LOGWRITER_RBD_LABEL,
+    ):
+        sc_obj.get_logwriter_reader_pods(label=label, exp_num_replicas=0)
+
+
+def _check_ceph_accessible(sc_obj, context: str):
+    """Assert Ceph is accessible; attempt recovery if it is not."""
+    if not sc_obj.check_ceph_accessibility(timeout=CEPH_CHECK_TIMEOUT):
+        assert recover_from_ceph_stuck(
+            sc_obj
+        ), f"Ceph became inaccessible {context} and could not be recovered"
+    log.info(f"Ceph is accessible {context}")
+
+
+# ---------------------------------------------------------------------------
+# PRE-UPGRADE
+# ---------------------------------------------------------------------------
+
+
+@pre_upgrade
+@stretchcluster_required
+@turquoise_squad
+@pytest.mark.polarion_id("OCS-7376")
+def test_pre_upgrade_stretch_cluster_workloads(
+    reset_conn_score,
+    nodes,
+    setup_logwriter_cephfs_workload_factory,
+    setup_logwriter_rbd_workload_factory,
+    logreader_workload_factory,
+    cnv_workload,
+    setup_cnv,
+):
+    """
+    Pre-upgrade step: deploy zone-aware workloads on the 4.21 stretch cluster
+    and capture a data snapshot so integrity can be verified post-upgrade.
+
+    Steps:
+    1. Deploy zone-aware logwriter-cephfs, logwriter-rbd and VM workloads.
+    2. Verify all workload pods are Running and healthy.
+    3. Write test data to the VM; capture md5sum for post-upgrade comparison.
+    4. Capture logfile maps for data-loss detection across the upgrade.
+    """
+
+    sc_obj = StretchCluster()
+
+    log.info("PRE-UPGRADE Step 1: Deploying zone-aware workloads")
+    vm_obj, md5sum_before = _deploy_stretch_workloads(
+        sc_obj,
+        setup_logwriter_cephfs_workload_factory,
+        setup_logwriter_rbd_workload_factory,
+        cnv_workload,
+        nodes,
+    )
+
+    _upgrade_shared["sc_obj"] = sc_obj
+    _upgrade_shared["vm_obj"] = vm_obj
+    _upgrade_shared["md5sum_before"] = md5sum_before
+
+    log.info(
+        "PRE-UPGRADE complete: zone-aware workloads deployed, data snapshot taken. "
+        "Cluster is ready for OCP/ODF 4.22 upgrade."
+    )
+
+
+# ---------------------------------------------------------------------------
+# POST-UPGRADE
+# ---------------------------------------------------------------------------
+
+
+@post_upgrade
+@stretchcluster_required
+@turquoise_squad
+@pytest.mark.polarion_id("OCS-7377")
+def test_post_upgrade_stretch_cluster_zone_b_shutdown(
+    node_restart_teardown,
+    reset_conn_score,
+    nodes,
+    setup_logwriter_cephfs_workload_factory,
+    setup_logwriter_rbd_workload_factory,
+    logreader_workload_factory,
+    cnv_workload,
+    setup_cnv,
+):
+    """
+    Post-upgrade step: verify the upgraded 4.22 stretch cluster handles a full
+    Zone-B shutdown with the out-of-service taint correctly, for both the
+    pre-upgrade workloads (deployed in test_pre_upgrade_*) and newly deployed
+    workloads.
+
+    Steps:
+    3.  Verify cluster health after upgrade (storage pods, Ceph health).
+    4.  Verify pre-upgrade workloads are still Running and accessible.
+    5.  Deploy new zone-aware workloads on the upgraded cluster.
+    6.  Shutdown all Zone-B nodes; taint them out-of-service.
+    7.  Verify pre-upgrade and new workloads migrate / pend correctly.
+    8.  Confirm no DU/DL/DC via post_failure_checks.
+    9.  Check for any Ceph side issues.
+    10. Recover Zone B; remove the taint.
+    11. Confirm no DU/DL/DC after recovery; validate connection scores.
+    12. Delete workload pods; verify re-schedule without errors; run IOs.
+    13. Deploy fresh workloads on recovered Zone-B nodes; run IOs.
+    """
+
+    tainted_nodes: list = []
+
+    def _remove_taints():
+        if tainted_nodes:
+            names = [n.name for n in tainted_nodes]
+            log.info(f"Removing out-of-service taint from nodes: {names}")
+            try:
+                untaint_nodes(
+                    taint_label=constants.NODE_OUT_OF_SERVICE_TAINT,
+                    nodes_to_untaint=tainted_nodes,
+                )
+            except Exception as exc:
+                log.warning(f"untaint_nodes raised during cleanup: {exc}")
+            tainted_nodes.clear()
+
+    log.info("POST-UPGRADE Step 3: Verifying cluster health after OCP/ODF 4.22 upgrade")
+    _verify_cluster_health()
+    log.info("POST-UPGRADE Step 3: Cluster health confirmed after upgrade")
+
+    sc_pre = _upgrade_shared.get("sc_obj")
+    vm_obj = _upgrade_shared.get("vm_obj")
+    md5sum_before = _upgrade_shared.get("md5sum_before")
+
+    if sc_pre is not None:
+        log.info(
+            "POST-UPGRADE Step 4: Verifying pre-upgrade workloads are still running"
+        )
+        check_for_logwriter_workload_pods(sc_pre, nodes=nodes)
+        log.info("POST-UPGRADE Step 4: Pre-upgrade workloads are Running after upgrade")
+
+        if vm_obj is not None and md5sum_before is not None:
+            log.info(
+                "POST-UPGRADE Step 4: Checking pre-upgrade VM data integrity "
+                "after OCP/ODF upgrade"
+            )
+            retry(CommandFailed, tries=5, delay=10)(vm_obj.wait_for_ssh_connectivity)()
+            md5sum_after_upgrade = cal_md5sum_vm(vm_obj, file_path="/test/file_1.txt")
+            assert md5sum_before == md5sum_after_upgrade, (
+                f"VM data integrity lost across OCP/ODF upgrade: "
+                f"before={md5sum_before}, after={md5sum_after_upgrade}"
+            )
+            log.info("POST-UPGRADE Step 4: VM data integrity confirmed across upgrade")
+    else:
+        log.warning(
+            "POST-UPGRADE Step 4: No pre-upgrade workload state found "
+            "(pre-upgrade test may not have run in this session). "
+            "Proceeding with post-upgrade workload deployment only."
+        )
+
+    log.info(
+        "POST-UPGRADE Step 5: Deploying NEW zone-aware workloads on upgraded cluster"
+    )
+    sc_new = StretchCluster()
+    new_vm_obj, new_md5sum_before = _deploy_stretch_workloads(
+        sc_new,
+        setup_logwriter_cephfs_workload_factory,
+        setup_logwriter_rbd_workload_factory,
+        cnv_workload,
+        nodes,
+    )
+    log.info(f"POST-UPGRADE Step 5: New VM file md5sum captured: {new_md5sum_before}")
+
+    zone_b_nodes = sc_new.get_nodes_in_zone(ZONE_B)
+    assert len(zone_b_nodes) > 0, (
+        f"No nodes found in Zone B ({ZONE_B}). "
+        f"Check that the cluster has nodes labeled {constants.ZONE_LABEL}={ZONE_B}"
+    )
+    zone_b_node_names = [n.name for n in zone_b_nodes]
+    log.info(f"Zone-B nodes: {zone_b_node_names}")
+
+    log.info(f"POST-UPGRADE Step 6: Stopping all Zone-B nodes: {zone_b_node_names}")
+    start_time = datetime.now(timezone.utc)
+    nodes.stop_nodes(nodes=zone_b_nodes)
+    wait_for_nodes_status(
+        node_names=zone_b_node_names,
+        status=constants.NODE_NOT_READY,
+        timeout=300,
+    )
+    log.info(f"All Zone-B nodes are NotReady: {zone_b_node_names}")
+
+    log.info("POST-UPGRADE Step 6: Tainting all Zone-B nodes with out-of-service")
+    assert taint_nodes(
+        nodes=zone_b_node_names,
+        taint_label=constants.NODE_OUT_OF_SERVICE_TAINT,
+    ), f"Failed to taint Zone-B nodes {zone_b_node_names} with out-of-service"
+    tainted_nodes.extend(zone_b_nodes)
+    log.info(f"out-of-service taint applied to Zone-B nodes: {zone_b_node_names}")
+
+    log.info(
+        "POST-UPGRADE Step 7: Refreshing pod state – workloads should have "
+        "left Zone B (evicted or pending)"
+    )
+    _refresh_pod_state(sc_new)
+
+    log.info(
+        "POST-UPGRADE Step 7: Verifying zone-aware RBD pods enter Pending state "
+        "(FailedScheduling – no Zone-B nodes available)"
+    )
+    rbd_pod_names = [
+        pod_info["metadata"]["name"]
+        for pod_info in get_pods_having_label(
+            label=constants.LOGWRITER_RBD_LABEL,
+            namespace=constants.STRETCH_CLUSTER_NAMESPACE,
+        )
+    ]
+    if rbd_pod_names:
+        wait_for_pods_to_be_in_statuses(
+            expected_statuses=constants.STATUS_PENDING,
+            pod_names=rbd_pod_names,
+            timeout=300,
+            namespace=constants.STRETCH_CLUSTER_NAMESPACE,
+        )
+        log.info(
+            "POST-UPGRADE Step 7: Zone-aware RBD pods are Pending (FailedScheduling) "
+            "as expected on upgraded cluster"
+        )
+
+    _check_ceph_accessible(sc_new, "during Zone-B outage on upgraded cluster")
+
+    log.info(f"POST-UPGRADE Step 10: Starting all Zone-B nodes: {zone_b_node_names}")
+    try:
+        nodes.start_nodes(nodes=zone_b_nodes)
+    except Exception:
+        log.error("Something went wrong while starting Zone-B nodes!")
+        _remove_taints()
+        raise
+
+    wait_for_nodes_status(timeout=600)
+    log.info(f"All Zone-B nodes are Ready: {zone_b_node_names}")
+
+    log.info("POST-UPGRADE Step 10: Removing out-of-service taint from Zone-B nodes")
+    untaint_nodes(
+        taint_label=constants.NODE_OUT_OF_SERVICE_TAINT,
+        nodes_to_untaint=list(tainted_nodes),
+    )
+    tainted_nodes.clear()
+    log.info("out-of-service taint removed from all Zone-B nodes")
+
+    time.sleep(30)
+
+    log.info("POST-UPGRADE Step 11: Refreshing workload pod state post-recovery")
+    _refresh_pod_state(sc_new)
+
+    recovery_end_time = datetime.now(timezone.utc)
+    log.info("POST-UPGRADE Step 11: Running post-recovery IO/data integrity checks")
+    sc_new.post_failure_checks(
+        start_time, recovery_end_time, wait_for_read_completion=False
+    )
+    log.info(
+        "POST-UPGRADE Step 11: Post-recovery checks passed "
+        "(no DU/DL/DC after Zone-B recovery on upgraded cluster)"
+    )
+
+    _check_ceph_accessible(sc_new, "after Zone-B recovery")
+
+    log.info("POST-UPGRADE Step 11: Validating Ceph mon connection scores")
+    sc_new.reset_conn_score()
+    log.info("POST-UPGRADE Step 11: Connection scores are clean after Zone-B recovery")
+
+    log.info(
+        "POST-UPGRADE Step 11: Checking new VM data integrity after Zone-B recovery"
+    )
+    retry(CommandFailed, tries=5, delay=10)(new_vm_obj.wait_for_ssh_connectivity)()
+    retry(CommandFailed, tries=5, delay=10)(verify_vm_workload)(
+        new_vm_obj, new_md5sum_before
+    )
+    new_vm_obj.stop()
+    log.info("POST-UPGRADE Step 11: New VM data integrity verified")
+
+    log.info("POST-UPGRADE Step 11: Checking for data loss (new workloads)")
+    check_for_logwriter_workload_pods(sc_new, nodes=nodes)
+    verify_data_loss(sc_new)
+    log.info("POST-UPGRADE Step 11: No data loss detected in new workloads")
+
+    log.info("POST-UPGRADE Step 11: Checking for data corruption (new workloads)")
+    sc_new.cephfs_logreader_job.delete()
+    for pod in sc_new.cephfs_logreader_pods:
+        pod.wait_for_pod_delete(timeout=120)
+    log.info("Old CephFS logreader pods deleted")
+    verify_data_corruption(sc_new, logreader_workload_factory)
+    log.info("POST-UPGRADE Step 11: No data corruption detected in new workloads")
+
+    if sc_pre is not None:
+        log.info(
+            "POST-UPGRADE Step 11: Checking pre-upgrade workload data integrity "
+            "after Zone-B recovery"
+        )
+        check_for_logwriter_workload_pods(sc_pre, nodes=nodes)
+        verify_data_loss(sc_pre)
+        log.info(
+            "POST-UPGRADE Step 11: No data loss in pre-upgrade workloads post recovery"
+        )
+
+    log.info(
+        "POST-UPGRADE Step 12: Deleting new logwriter-rbd pods to verify "
+        "re-schedule on recovered Zone-B nodes"
+    )
+    for pod_obj in sc_new.rbd_logwriter_pods:
+        log.info(f"Deleting pod {pod_obj.name}")
+        pod_obj.delete()
+
+    sc_new.get_logwriter_reader_pods(
+        label=constants.LOGWRITER_RBD_LABEL, exp_num_replicas=2
+    )
+    log.info(
+        "POST-UPGRADE Step 12: New logwriter-rbd pods re-scheduled and Running "
+        "after Zone-B recovery on upgraded cluster; IOs running without errors"
+    )
+
+    log.info(
+        "POST-UPGRADE Step 13: Deploying fresh zone-aware logwriter-rbd workload "
+        f"on recovered Zone-B nodes {zone_b_node_names}"
+    )
+    new_rbd_sts = setup_logwriter_rbd_workload_factory(zone_aware=True)
+    log.info(f"POST-UPGRADE Step 13: Fresh workload deployed: {new_rbd_sts.name}")
+    check_for_logwriter_workload_pods(sc_new, nodes=nodes)
+    log.info(
+        "POST-UPGRADE Step 13: All workloads healthy on recovered Zone-B nodes "
+        "after OCP/ODF 4.22 upgrade – IOs running without errors"
+    )

--- a/tests/functional/upgrade/test_stretch_cluster_upgrade.py
+++ b/tests/functional/upgrade/test_stretch_cluster_upgrade.py
@@ -44,7 +44,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     pre_upgrade,
     post_upgrade,
     stretchcluster_required,
-    turquoise_squad,
+    magenta_squad,
 )
 from ocs_ci.helpers.cnv_helpers import cal_md5sum_vm
 from ocs_ci.helpers.stretchcluster_helper import (
@@ -168,7 +168,7 @@ def _check_ceph_accessible(sc_obj, context: str):
 
 @pre_upgrade
 @stretchcluster_required
-@turquoise_squad
+@magenta_squad
 @pytest.mark.polarion_id("OCS-7376")
 def test_pre_upgrade_stretch_cluster_workloads(
     reset_conn_score,
@@ -218,7 +218,7 @@ def test_pre_upgrade_stretch_cluster_workloads(
 
 @post_upgrade
 @stretchcluster_required
-@turquoise_squad
+@magenta_squad
 @pytest.mark.polarion_id("OCS-7377")
 def test_post_upgrade_stretch_cluster_zone_b_shutdown(
     node_restart_teardown,

--- a/tests/functional/upgrade/test_stretch_cluster_upgrade.py
+++ b/tests/functional/upgrade/test_stretch_cluster_upgrade.py
@@ -71,7 +71,7 @@ from ocs_ci.ocs.resources.stretchcluster import StretchCluster
 from ocs_ci.utility.retry import retry
 from ocs_ci.utility.utils import ceph_health_check
 
-log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 ZONE_B = "data-2"
 CEPH_CHECK_TIMEOUT = 120
@@ -83,22 +83,17 @@ _upgrade_shared: dict = {
 }
 
 
-# ---------------------------------------------------------------------------
-# Module-level helpers
-# ---------------------------------------------------------------------------
-
-
 def _verify_cluster_health(storage_pod_timeout=600, ceph_tries=20, ceph_delay=30):
     """
     Assert the cluster is healthy: storage pods running, CephCluster healthy,
     ceph_health_check passes.
     """
     wait_for_storage_pods(timeout=storage_pod_timeout)
-    log.info("All storage pods are Running / Completed")
+    logger.info("All storage pods are Running / Completed")
     CephCluster().cluster_health_check(timeout=storage_pod_timeout)
-    log.info("Ceph cluster health check passed")
+    logger.info("Ceph cluster health check passed")
     ceph_health_check(tries=ceph_tries, delay=ceph_delay)
-    log.info("Ceph health confirmed")
+    logger.info("Ceph health confirmed")
 
 
 def _deploy_stretch_workloads(
@@ -131,10 +126,10 @@ def _deploy_stretch_workloads(
         )
     )
     md5sum_before = cal_md5sum_vm(vm_obj, file_path="/test/file_1.txt")
-    log.info(f"VM file md5sum captured: {md5sum_before}")
+    logger.info(f"VM file md5sum captured: {md5sum_before}")
 
     check_for_logwriter_workload_pods(sc_obj, nodes=nodes)
-    log.info("All zone-aware workload pods are Running and healthy")
+    logger.info("All zone-aware workload pods are Running and healthy")
 
     sc_obj.get_logfile_map(label=constants.LOGWRITER_CEPHFS_LABEL)
     sc_obj.get_logfile_map(label=constants.LOGWRITER_RBD_LABEL)
@@ -158,12 +153,7 @@ def _check_ceph_accessible(sc_obj, context: str):
         assert recover_from_ceph_stuck(
             sc_obj
         ), f"Ceph became inaccessible {context} and could not be recovered"
-    log.info(f"Ceph is accessible {context}")
-
-
-# ---------------------------------------------------------------------------
-# PRE-UPGRADE
-# ---------------------------------------------------------------------------
+    logger.info(f"Ceph is accessible {context}")
 
 
 @pre_upgrade
@@ -192,7 +182,7 @@ def test_pre_upgrade_stretch_cluster_workloads(
 
     sc_obj = StretchCluster()
 
-    log.info("PRE-UPGRADE Step 1: Deploying zone-aware workloads")
+    logger.info("PRE-UPGRADE Step 1: Deploying zone-aware workloads")
     vm_obj, md5sum_before = _deploy_stretch_workloads(
         sc_obj,
         setup_logwriter_cephfs_workload_factory,
@@ -205,15 +195,10 @@ def test_pre_upgrade_stretch_cluster_workloads(
     _upgrade_shared["vm_obj"] = vm_obj
     _upgrade_shared["md5sum_before"] = md5sum_before
 
-    log.info(
+    logger.info(
         "PRE-UPGRADE complete: zone-aware workloads deployed, data snapshot taken. "
         "Cluster is ready for OCP/ODF 4.22 upgrade."
     )
-
-
-# ---------------------------------------------------------------------------
-# POST-UPGRADE
-# ---------------------------------------------------------------------------
 
 
 @post_upgrade
@@ -255,33 +240,37 @@ def test_post_upgrade_stretch_cluster_zone_b_shutdown(
     def _remove_taints():
         if tainted_nodes:
             names = [n.name for n in tainted_nodes]
-            log.info(f"Removing out-of-service taint from nodes: {names}")
+            logger.info(f"Removing out-of-service taint from nodes: {names}")
             try:
                 untaint_nodes(
                     taint_label=constants.NODE_OUT_OF_SERVICE_TAINT,
                     nodes_to_untaint=tainted_nodes,
                 )
             except Exception as exc:
-                log.warning(f"untaint_nodes raised during cleanup: {exc}")
+                logger.warning(f"untaint_nodes raised during cleanup: {exc}")
             tainted_nodes.clear()
 
-    log.info("POST-UPGRADE Step 3: Verifying cluster health after OCP/ODF 4.22 upgrade")
+    logger.info(
+        "POST-UPGRADE Step 3: Verifying cluster health after OCP/ODF 4.22 upgrade"
+    )
     _verify_cluster_health()
-    log.info("POST-UPGRADE Step 3: Cluster health confirmed after upgrade")
+    logger.info("POST-UPGRADE Step 3: Cluster health confirmed after upgrade")
 
     sc_pre = _upgrade_shared.get("sc_obj")
     vm_obj = _upgrade_shared.get("vm_obj")
     md5sum_before = _upgrade_shared.get("md5sum_before")
 
     if sc_pre is not None:
-        log.info(
+        logger.info(
             "POST-UPGRADE Step 4: Verifying pre-upgrade workloads are still running"
         )
         check_for_logwriter_workload_pods(sc_pre, nodes=nodes)
-        log.info("POST-UPGRADE Step 4: Pre-upgrade workloads are Running after upgrade")
+        logger.info(
+            "POST-UPGRADE Step 4: Pre-upgrade workloads are Running after upgrade"
+        )
 
         if vm_obj is not None and md5sum_before is not None:
-            log.info(
+            logger.info(
                 "POST-UPGRADE Step 4: Checking pre-upgrade VM data integrity "
                 "after OCP/ODF upgrade"
             )
@@ -291,15 +280,17 @@ def test_post_upgrade_stretch_cluster_zone_b_shutdown(
                 f"VM data integrity lost across OCP/ODF upgrade: "
                 f"before={md5sum_before}, after={md5sum_after_upgrade}"
             )
-            log.info("POST-UPGRADE Step 4: VM data integrity confirmed across upgrade")
+            logger.info(
+                "POST-UPGRADE Step 4: VM data integrity confirmed across upgrade"
+            )
     else:
-        log.warning(
+        logger.warning(
             "POST-UPGRADE Step 4: No pre-upgrade workload state found "
             "(pre-upgrade test may not have run in this session). "
             "Proceeding with post-upgrade workload deployment only."
         )
 
-    log.info(
+    logger.info(
         "POST-UPGRADE Step 5: Deploying NEW zone-aware workloads on upgraded cluster"
     )
     sc_new = StretchCluster()
@@ -310,7 +301,9 @@ def test_post_upgrade_stretch_cluster_zone_b_shutdown(
         cnv_workload,
         nodes,
     )
-    log.info(f"POST-UPGRADE Step 5: New VM file md5sum captured: {new_md5sum_before}")
+    logger.info(
+        f"POST-UPGRADE Step 5: New VM file md5sum captured: {new_md5sum_before}"
+    )
 
     zone_b_nodes = sc_new.get_nodes_in_zone(ZONE_B)
     assert len(zone_b_nodes) > 0, (
@@ -318,9 +311,9 @@ def test_post_upgrade_stretch_cluster_zone_b_shutdown(
         f"Check that the cluster has nodes labeled {constants.ZONE_LABEL}={ZONE_B}"
     )
     zone_b_node_names = [n.name for n in zone_b_nodes]
-    log.info(f"Zone-B nodes: {zone_b_node_names}")
+    logger.info(f"Zone-B nodes: {zone_b_node_names}")
 
-    log.info(f"POST-UPGRADE Step 6: Stopping all Zone-B nodes: {zone_b_node_names}")
+    logger.info(f"POST-UPGRADE Step 6: Stopping all Zone-B nodes: {zone_b_node_names}")
     start_time = datetime.now(timezone.utc)
     nodes.stop_nodes(nodes=zone_b_nodes)
     wait_for_nodes_status(
@@ -328,23 +321,23 @@ def test_post_upgrade_stretch_cluster_zone_b_shutdown(
         status=constants.NODE_NOT_READY,
         timeout=300,
     )
-    log.info(f"All Zone-B nodes are NotReady: {zone_b_node_names}")
+    logger.info(f"All Zone-B nodes are NotReady: {zone_b_node_names}")
 
-    log.info("POST-UPGRADE Step 6: Tainting all Zone-B nodes with out-of-service")
+    logger.info("POST-UPGRADE Step 6: Tainting all Zone-B nodes with out-of-service")
     assert taint_nodes(
         nodes=zone_b_node_names,
         taint_label=constants.NODE_OUT_OF_SERVICE_TAINT,
     ), f"Failed to taint Zone-B nodes {zone_b_node_names} with out-of-service"
     tainted_nodes.extend(zone_b_nodes)
-    log.info(f"out-of-service taint applied to Zone-B nodes: {zone_b_node_names}")
+    logger.info(f"out-of-service taint applied to Zone-B nodes: {zone_b_node_names}")
 
-    log.info(
+    logger.info(
         "POST-UPGRADE Step 7: Refreshing pod state – workloads should have "
         "left Zone B (evicted or pending)"
     )
     _refresh_pod_state(sc_new)
 
-    log.info(
+    logger.info(
         "POST-UPGRADE Step 7: Verifying zone-aware RBD pods enter Pending state "
         "(FailedScheduling – no Zone-B nodes available)"
     )
@@ -362,54 +355,56 @@ def test_post_upgrade_stretch_cluster_zone_b_shutdown(
             timeout=300,
             namespace=constants.STRETCH_CLUSTER_NAMESPACE,
         )
-        log.info(
+        logger.info(
             "POST-UPGRADE Step 7: Zone-aware RBD pods are Pending (FailedScheduling) "
             "as expected on upgraded cluster"
         )
 
     _check_ceph_accessible(sc_new, "during Zone-B outage on upgraded cluster")
 
-    log.info(f"POST-UPGRADE Step 10: Starting all Zone-B nodes: {zone_b_node_names}")
+    logger.info(f"POST-UPGRADE Step 10: Starting all Zone-B nodes: {zone_b_node_names}")
     try:
         nodes.start_nodes(nodes=zone_b_nodes)
     except Exception:
-        log.error("Something went wrong while starting Zone-B nodes!")
+        logger.error("Something went wrong while starting Zone-B nodes!")
         _remove_taints()
         raise
 
     wait_for_nodes_status(timeout=600)
-    log.info(f"All Zone-B nodes are Ready: {zone_b_node_names}")
+    logger.info(f"All Zone-B nodes are Ready: {zone_b_node_names}")
 
-    log.info("POST-UPGRADE Step 10: Removing out-of-service taint from Zone-B nodes")
+    logger.info("POST-UPGRADE Step 10: Removing out-of-service taint from Zone-B nodes")
     untaint_nodes(
         taint_label=constants.NODE_OUT_OF_SERVICE_TAINT,
         nodes_to_untaint=list(tainted_nodes),
     )
     tainted_nodes.clear()
-    log.info("out-of-service taint removed from all Zone-B nodes")
+    logger.info("out-of-service taint removed from all Zone-B nodes")
 
     time.sleep(30)
 
-    log.info("POST-UPGRADE Step 11: Refreshing workload pod state post-recovery")
+    logger.info("POST-UPGRADE Step 11: Refreshing workload pod state post-recovery")
     _refresh_pod_state(sc_new)
 
     recovery_end_time = datetime.now(timezone.utc)
-    log.info("POST-UPGRADE Step 11: Running post-recovery IO/data integrity checks")
+    logger.info("POST-UPGRADE Step 11: Running post-recovery IO/data integrity checks")
     sc_new.post_failure_checks(
         start_time, recovery_end_time, wait_for_read_completion=False
     )
-    log.info(
+    logger.info(
         "POST-UPGRADE Step 11: Post-recovery checks passed "
         "(no DU/DL/DC after Zone-B recovery on upgraded cluster)"
     )
 
     _check_ceph_accessible(sc_new, "after Zone-B recovery")
 
-    log.info("POST-UPGRADE Step 11: Validating Ceph mon connection scores")
+    logger.info("POST-UPGRADE Step 11: Validating Ceph mon connection scores")
     sc_new.reset_conn_score()
-    log.info("POST-UPGRADE Step 11: Connection scores are clean after Zone-B recovery")
+    logger.info(
+        "POST-UPGRADE Step 11: Connection scores are clean after Zone-B recovery"
+    )
 
-    log.info(
+    logger.info(
         "POST-UPGRADE Step 11: Checking new VM data integrity after Zone-B recovery"
     )
     retry(CommandFailed, tries=5, delay=10)(new_vm_obj.wait_for_ssh_connectivity)()
@@ -417,56 +412,56 @@ def test_post_upgrade_stretch_cluster_zone_b_shutdown(
         new_vm_obj, new_md5sum_before
     )
     new_vm_obj.stop()
-    log.info("POST-UPGRADE Step 11: New VM data integrity verified")
+    logger.info("POST-UPGRADE Step 11: New VM data integrity verified")
 
-    log.info("POST-UPGRADE Step 11: Checking for data loss (new workloads)")
+    logger.info("POST-UPGRADE Step 11: Checking for data loss (new workloads)")
     check_for_logwriter_workload_pods(sc_new, nodes=nodes)
     verify_data_loss(sc_new)
-    log.info("POST-UPGRADE Step 11: No data loss detected in new workloads")
+    logger.info("POST-UPGRADE Step 11: No data loss detected in new workloads")
 
-    log.info("POST-UPGRADE Step 11: Checking for data corruption (new workloads)")
+    logger.info("POST-UPGRADE Step 11: Checking for data corruption (new workloads)")
     sc_new.cephfs_logreader_job.delete()
     for pod in sc_new.cephfs_logreader_pods:
         pod.wait_for_pod_delete(timeout=120)
-    log.info("Old CephFS logreader pods deleted")
+    logger.info("Old CephFS logreader pods deleted")
     verify_data_corruption(sc_new, logreader_workload_factory)
-    log.info("POST-UPGRADE Step 11: No data corruption detected in new workloads")
+    logger.info("POST-UPGRADE Step 11: No data corruption detected in new workloads")
 
     if sc_pre is not None:
-        log.info(
+        logger.info(
             "POST-UPGRADE Step 11: Checking pre-upgrade workload data integrity "
             "after Zone-B recovery"
         )
         check_for_logwriter_workload_pods(sc_pre, nodes=nodes)
         verify_data_loss(sc_pre)
-        log.info(
+        logger.info(
             "POST-UPGRADE Step 11: No data loss in pre-upgrade workloads post recovery"
         )
 
-    log.info(
+    logger.info(
         "POST-UPGRADE Step 12: Deleting new logwriter-rbd pods to verify "
         "re-schedule on recovered Zone-B nodes"
     )
     for pod_obj in sc_new.rbd_logwriter_pods:
-        log.info(f"Deleting pod {pod_obj.name}")
+        logger.info(f"Deleting pod {pod_obj.name}")
         pod_obj.delete()
 
     sc_new.get_logwriter_reader_pods(
         label=constants.LOGWRITER_RBD_LABEL, exp_num_replicas=2
     )
-    log.info(
+    logger.info(
         "POST-UPGRADE Step 12: New logwriter-rbd pods re-scheduled and Running "
         "after Zone-B recovery on upgraded cluster; IOs running without errors"
     )
 
-    log.info(
+    logger.info(
         "POST-UPGRADE Step 13: Deploying fresh zone-aware logwriter-rbd workload "
         f"on recovered Zone-B nodes {zone_b_node_names}"
     )
     new_rbd_sts = setup_logwriter_rbd_workload_factory(zone_aware=True)
-    log.info(f"POST-UPGRADE Step 13: Fresh workload deployed: {new_rbd_sts.name}")
+    logger.info(f"POST-UPGRADE Step 13: Fresh workload deployed: {new_rbd_sts.name}")
     check_for_logwriter_workload_pods(sc_new, nodes=nodes)
-    log.info(
+    logger.info(
         "POST-UPGRADE Step 13: All workloads healthy on recovered Zone-B nodes "
         "after OCP/ODF 4.22 upgrade – IOs running without errors"
     )

--- a/tests/functional/upgrade/test_stretch_cluster_upgrade.py
+++ b/tests/functional/upgrade/test_stretch_cluster_upgrade.py
@@ -206,6 +206,7 @@ def test_pre_upgrade_stretch_cluster_workloads(
 @magenta_squad
 @pytest.mark.polarion_id("OCS-7377")
 def test_post_upgrade_stretch_cluster_zone_b_shutdown(
+    request,
     node_restart_teardown,
     reset_conn_score,
     nodes,
@@ -249,6 +250,8 @@ def test_post_upgrade_stretch_cluster_zone_b_shutdown(
             except Exception as exc:
                 logger.warning(f"untaint_nodes raised during cleanup: {exc}")
             tainted_nodes.clear()
+
+    request.addfinalizer(_remove_taints)
 
     logger.info(
         "POST-UPGRADE Step 3: Verifying cluster health after OCP/ODF 4.22 upgrade"


### PR DESCRIPTION
## Description

This PR adds automation coverage for the [RHSTOR-8242](https://redhat.atlassian.net/browse/RHSTOR-8242) feature to validate the NetworkFence workflow with cephcsi.

### Test Coverage
- Automate NetworkFence workflow on stretch clusters
- Validate non-stretch cluster upgrade scenario
- Validate stretch cluster upgrade scenario

## Testing
- Pre-commit hooks passed
  - black
  - flake8
  - detect-secrets

## Jira
[RHSTOR-8242](https://redhat.atlassian.net/browse/RHSTOR-8242)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added functional coverage for CephCSI NetworkFence scenarios on Stretch clusters, including Zone-B node and kubelet disruptions, workload recovery, and data integrity checks.
  * Added non-Stretch cluster upgrade validation from 4.21 to 4.22, including workload migration, Ceph health, and data persistence checks.
  * Added Stretch cluster upgrade validation from 4.21 GA to 4.22, covering Zone-B outages, workload rescheduling, Ceph recovery, and post-upgrade data integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->