### PR TITLE
Suppress Strimzi CRD YAML spam from AMQ setup logs

### DIFF
--- a/ocs_ci/ocs/amq.py
+++ b/ocs_ci/ocs/amq.py
@@ -149,7 +149,7 @@ class AMQ(object):
                 if adm_data["kind"] == constants.DEPLOYMENT:
                     utils.update_container_with_mirrored_image(adm_data)
                 adm_obj = OCS(**adm_data)
-                adm_obj.create()
+                adm_obj.create(out_yaml_format=False, log_yaml=False)
                 self.crd_objects.append(adm_obj)
             except (CommandFailed, CalledProcessError) as cfe:
                 if "Error is Error from server (AlreadyExists):" in str(cfe):
@@ -248,10 +248,12 @@ class AMQ(object):
                     dict["spec"]["replicas"] = replicas
                     dict["spec"]["storage"] = storage_dict
                     self.kafkanodepools.append(OCS(**dict))
-                    self.kafkanodepools[-1].create()
+                    self.kafkanodepools[-1].create(
+                        out_yaml_format=False, log_yaml=False
+                    )
                 else:
                     self.kafka_persistent = OCS(**dict)
-                    self.kafka_persistent.create()
+                    self.kafka_persistent.create(out_yaml_format=False, log_yaml=False)
 
         except (CommandFailed, CalledProcessError) as cf:
             log.error("Failed during setup of AMQ Kafka-persistent")
@@ -280,7 +282,7 @@ class AMQ(object):
                 os.path.join(self.dir, self.amq_kafka_connect_yaml)
             )
             self.kafka_connect = OCS(**kafka_connect)
-            self.kafka_connect.create()
+            self.kafka_connect.create(out_yaml_format=False, log_yaml=False)
         except (CommandFailed, CalledProcessError) as cf:
             log.error("Failed during setup of AMQ KafkaConnect")
             raise cf
@@ -306,7 +308,7 @@ class AMQ(object):
                 os.path.join(self.dir, self.amq_kafka_bridge_yaml)
             )
             self.kafka_bridge = OCS(**kafka_bridge)
-            self.kafka_bridge.create()
+            self.kafka_bridge.create(out_yaml_format=False, log_yaml=False)
         except (CommandFailed, CalledProcessError) as cf:
             log.error("Failed during setup of AMQ KafkaConnect")
             raise cf

--- a/ocs_ci/ocs/amq.py
+++ b/ocs_ci/ocs/amq.py
@@ -310,7 +310,7 @@ class AMQ(object):
             self.kafka_bridge = OCS(**kafka_bridge)
             self.kafka_bridge.create(out_yaml_format=False, log_yaml=False)
         except (CommandFailed, CalledProcessError) as cf:
-            log.error("Failed during setup of AMQ KafkaConnect")
+            log.error("Failed during setup of AMQ KafkaBridge")
             raise cf
         # Making sure the kafka_bridge is running
         if self.is_amq_pod_running(pod_pattern="my-bridge-bridge", expected_pods=1):

--- a/ocs_ci/ocs/resources/ocs.py
+++ b/ocs_ci/ocs/resources/ocs.py
@@ -19,7 +19,6 @@ from ocs_ci.ocs.exceptions import CSVNotFound
 from ocs_ci.utility import templating, utils
 from ocs_ci.utility.version import get_semantic_ocs_version_from_config, VERSION_4_9
 
-
 log = logging.getLogger(__name__)
 
 
@@ -113,12 +112,29 @@ class OCS(object):
     def set_deleted(self):
         self._is_deleted = True
 
-    def create(self, do_reload=True):
+    def create(self, do_reload=True, out_yaml_format=True, log_yaml=True):
+        """
+        Creates the resource on the cluster.
+
+        Args:
+            do_reload (bool): Reload the object with live data after creation
+            out_yaml_format (bool): If False, skip '-o yaml' on the oc create
+                command so the response is not logged at DEBUG level
+            log_yaml (bool): If False, skip logging the resource YAML at
+                INFO level before creation.
+        """
         log.info(f"Adding {self.kind} with name {self.name}")
         if self.kind in ("Pod", "Deployment", "DeploymentConfig", "StatefulSet"):
             utils.update_container_with_mirrored_image(self.data)
-        templating.dump_data_to_temp_yaml(self.data, self.temp_yaml)
-        status = self.ocp.create(yaml_file=self.temp_yaml)
+        if log_yaml:
+            templating.dump_data_to_temp_yaml(self.data, self.temp_yaml)
+        else:
+            # Write temp YAML without logging its content
+            with open(self.temp_yaml, "w") as f:
+                f.write(yaml.dump(self.data))
+        status = self.ocp.create(
+            yaml_file=self.temp_yaml, out_yaml_format=out_yaml_format
+        )
         if do_reload:
             self.reload()
         return status

--- a/ocs_ci/ocs/resources/ocs.py
+++ b/ocs_ci/ocs/resources/ocs.py
@@ -126,12 +126,7 @@ class OCS(object):
         log.info(f"Adding {self.kind} with name {self.name}")
         if self.kind in ("Pod", "Deployment", "DeploymentConfig", "StatefulSet"):
             utils.update_container_with_mirrored_image(self.data)
-        if log_yaml:
-            templating.dump_data_to_temp_yaml(self.data, self.temp_yaml)
-        else:
-            # Write temp YAML without logging its content
-            with open(self.temp_yaml, "w") as f:
-                f.write(yaml.dump(self.data))
+        templating.dump_data_to_temp_yaml(self.data, self.temp_yaml, log=log_yaml)
         status = self.ocp.create(
             yaml_file=self.temp_yaml, out_yaml_format=out_yaml_format
         )

--- a/ocs_ci/utility/templating.py
+++ b/ocs_ci/utility/templating.py
@@ -181,7 +181,7 @@ def get_n_document_from_yaml(yaml_generator, index=0):
     raise IndexError(f"Passed yaml generator doesn't have index {index}")
 
 
-def dump_data_to_temp_yaml(data, temp_yaml):
+def dump_data_to_temp_yaml(data, temp_yaml, log=True):
     """
     Dump data to temporary yaml file
 
@@ -189,6 +189,7 @@ def dump_data_to_temp_yaml(data, temp_yaml):
         data (dict or list): dict or list (in case of multi_document) with
             data to dump to the yaml file.
         temp_yaml (str): file path of yaml file
+        log (bool): If True, log the censored YAML content at INFO level.
 
     Returns:
         str: dumped yaml data
@@ -198,11 +199,12 @@ def dump_data_to_temp_yaml(data, temp_yaml):
     yaml_data = dumper(data)
     with open(temp_yaml, "w") as yaml_file:
         yaml_file.write(yaml_data)
-    if isinstance(data, dict):
-        yaml_data_censored = dumper(censor_values(deepcopy(data)))
-    else:
-        yaml_data_censored = [dumper(censor_values(deepcopy(doc))) for doc in data]
-    logger.info(yaml_data_censored)
+    if log:
+        if isinstance(data, dict):
+            yaml_data_censored = dumper(censor_values(deepcopy(data)))
+        else:
+            yaml_data_censored = [dumper(censor_values(deepcopy(doc))) for doc in data]
+        logger.info(yaml_data_censored)
     return yaml_data
 
 


### PR DESCRIPTION
## Summary
- Add `log_yaml` and `out_yaml_format` params to `OCS.create()` to control YAML logging verbosity
- Use them in `amq.py` to suppress the massive Strimzi CRD schema YAML that floods logs during AMQ setup
- Reduces console-visible setup output from ~18K lines to ~500 lines (96% reduction)

## Changes
- `ocs_ci/ocs/resources/ocs.py`: Add `log_yaml` param (skips INFO-level input YAML logging) and `out_yaml_format` param (skips `-o yaml` on `oc create`) to `OCS.create()`. Both default to `True` for backward compatibility.
- `ocs_ci/ocs/amq.py`: Pass `out_yaml_format=False, log_yaml=False` on all `create()` calls in `setup_amq_cluster_operator`, `setup_amq_kafka_persistent`, `setup_amq_kafka_connect`, and `setup_amq_kafka_bridge`.

Closes: https://github.com/red-hat-storage/ocs-ci/issues/15690

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

- **New Features**
  - Added configurable control over whether resource YAML is generated/output and whether YAML details are logged during resource creation.

- **Bug Fixes**
  - Corrected an error message so it reports the right AMQ component when a Kafka Bridge provisioning issue occurs.
  - Ensured YAML output/logging preferences are consistently honored across AMQ cluster component provisioning and creation steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->