### PR TITLE
fix: use node-type-aware timeout in test_registry_reboot_node[master]

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -1592,12 +1592,6 @@ NODE_NOT_READY = "NotReady"
 NODE_READY_SCHEDULING_DISABLED = "Ready,SchedulingDisabled"
 NODE_NOT_READY_SCHEDULING_DISABLED = "NotReady,SchedulingDisabled"
 
-# Node ready wait timeouts — master (control-plane) nodes take longer to
-# recover after a reboot because etcd quorum and kube-apiserver must restart
-# before the kubelet can re-register with the API server.
-NODE_READY_TIMEOUT_MASTER = 1800  # 30 minutes
-NODE_READY_TIMEOUT_WORKER = 900  # 15 minutes
-
 # Volume modes
 VOLUME_MODE_BLOCK = "Block"
 VOLUME_MODE_FILESYSTEM = "Filesystem"

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -1592,6 +1592,12 @@ NODE_NOT_READY = "NotReady"
 NODE_READY_SCHEDULING_DISABLED = "Ready,SchedulingDisabled"
 NODE_NOT_READY_SCHEDULING_DISABLED = "NotReady,SchedulingDisabled"
 
+# Node ready wait timeouts — master (control-plane) nodes take longer to
+# recover after a reboot because etcd quorum and kube-apiserver must restart
+# before the kubelet can re-register with the API server.
+NODE_READY_TIMEOUT_MASTER = 1800  # 30 minutes
+NODE_READY_TIMEOUT_WORKER = 900  # 15 minutes
+
 # Volume modes
 VOLUME_MODE_BLOCK = "Block"
 VOLUME_MODE_FILESYSTEM = "Filesystem"

--- a/tests/functional/workloads/ocp/registry/test_registry_reboot_node.py
+++ b/tests/functional/workloads/ocp/registry/test_registry_reboot_node.py
@@ -5,6 +5,8 @@ import logging
 from ocs_ci.ocs.constants import (
     MASTER_MACHINE,
     WORKER_MACHINE,
+    NODE_READY_TIMEOUT_MASTER,
+    NODE_READY_TIMEOUT_WORKER,
 )
 from ocs_ci.ocs.ocp import wait_for_cluster_connectivity
 from ocs_ci.ocs.registry import (
@@ -79,12 +81,18 @@ class TestRegistryRebootNode(E2ETest):
             (CommandFailed, TimeoutError, AssertionError, ResourceWrongStatusException),
             tries=28,
             delay=15,
+            backoff=1,
         )(wait_for_cluster_connectivity)(tries=400)
-        retry(
-            (CommandFailed, TimeoutError, AssertionError, ResourceWrongStatusException),
-            tries=28,
-            delay=15,
-        )(wait_for_nodes_status)(timeout=900)
+
+        # Master (control-plane) nodes take longer to recover than workers:
+        # they must re-establish etcd quorum and restart kube-apiserver before
+        # the kubelet re-registers, so allow 30 min instead of 15 min.
+        node_ready_timeout = (
+            NODE_READY_TIMEOUT_MASTER
+            if node_type == MASTER_MACHINE
+            else NODE_READY_TIMEOUT_WORKER
+        )
+        wait_for_nodes_status(timeout=node_ready_timeout)
 
         # Validate cluster health ok and all pods are running
         self.sanity_helpers.health_check(tries=40)

--- a/tests/functional/workloads/ocp/registry/test_registry_reboot_node.py
+++ b/tests/functional/workloads/ocp/registry/test_registry_reboot_node.py
@@ -5,8 +5,6 @@ import logging
 from ocs_ci.ocs.constants import (
     MASTER_MACHINE,
     WORKER_MACHINE,
-    NODE_READY_TIMEOUT_MASTER,
-    NODE_READY_TIMEOUT_WORKER,
 )
 from ocs_ci.ocs.ocp import wait_for_cluster_connectivity
 from ocs_ci.ocs.registry import (
@@ -84,14 +82,7 @@ class TestRegistryRebootNode(E2ETest):
             backoff=1,
         )(wait_for_cluster_connectivity)(tries=400)
 
-        # Master (control-plane) nodes take longer to recover than workers:
-        # they must re-establish etcd quorum and restart kube-apiserver before
-        # the kubelet re-registers, so allow 30 min instead of 15 min.
-        node_ready_timeout = (
-            NODE_READY_TIMEOUT_MASTER
-            if node_type == MASTER_MACHINE
-            else NODE_READY_TIMEOUT_WORKER
-        )
+        node_ready_timeout = 1800 if node_type == MASTER_MACHINE else 900
         wait_for_nodes_status(timeout=node_ready_timeout)
 
         # Validate cluster health ok and all pods are running


### PR DESCRIPTION
The [master] variant was intermittently failing with NodeStatusUnknown / NodeNotReady because:

1. wait_for_nodes_status was wrapped in retry() which defaults to backoff=2 (exponential). Each retry attempt runs a fresh 900s polling window, so retries kept resetting the wait instead of extending it. Fixed by removing the redundant retry wrapper — wait_for_nodes_status already polls internally via TimeoutSampler.

2. 900s (15 min) is sufficient for worker nodes but too short for control-plane nodes which must re-establish etcd quorum and restart kube-apiserver before the kubelet can re-register. Fixed by introducing NODE_READY_TIMEOUT_MASTER=1800s (30 min) and NODE_READY_TIMEOUT_WORKER=900s constants and selecting based on node_type at runtime.

Also added backoff=1 to the wait_for_cluster_connectivity retry to keep that call's delay linear rather than exponential.

Relates-to: TFA-R similar results OCS-1803 (test_registry_reboot_node[master])

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved registry recovery validation after node reboots.
  * Adjusted readiness timeouts based on node type to better accommodate master node recovery.
  * Added a brief backoff when checking cluster connectivity, improving reliability of post-reboot checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->