### PR TITLE
Add cnsa_remote_mount mark

### DIFF
--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -438,10 +438,13 @@ ms_provider_and_consumer_required = pytest.mark.skipif(
     ),
     reason="Test runs ONLY on Managed service with provider and consumer clusters",
 )
+
 fdf_required = pytest.mark.skipif(
     not config.DEPLOYMENT.get("fdf_cluster"),
     reason="Test runs ONLY on FDF cluster",
 )
+
+cnsa_remote_mount = pytest.mark.cnsa_remote_mount
 
 
 # when run_on_all_clients marker is used, there needs to be added cluster_index

--- a/tests/cross_functional/scale/test_multiple_storage_coexistence.py
+++ b/tests/cross_functional/scale/test_multiple_storage_coexistence.py
@@ -9,6 +9,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     orange_squad,
     fdf_required,
     skipif_ocs_version,
+    cnsa_remote_mount,
 )
 from ocs_ci.framework.testlib import ManageTest, tier1
 from ocs_ci.ocs import constants, exceptions
@@ -52,8 +53,8 @@ def create_custom_secret(name, namespace, data_dict, secret_type="Opaque"):
 @orange_squad
 @fdf_required
 @skipif_ocs_version("<4.21")
+@cnsa_remote_mount
 class TestMultiStorageCoexistence(ManageTest):
-
     @pytest.fixture(autouse=True)
     def setup_scale_infrastructure(self, request):
         """

--- a/tests/functional/ui/test_scale.py
+++ b/tests/functional/ui/test_scale.py
@@ -10,6 +10,7 @@ from ocs_ci.framework.testlib import (
     polarion_id,
     fdf_required,
     runs_on_provider,
+    cnsa_remote_mount,
 )
 from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import black_squad
@@ -23,6 +24,7 @@ FILESYSTEM_2 = "fs2"
 
 @fdf_required
 @runs_on_provider
+@cnsa_remote_mount
 class TestScaleConnection(object):
     """
     Test connecting Scale cluster


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added support for identifying test scenarios that require a CNSA remote-mount environment.
  * Updated storage coexistence and scale connection test suites to run with the appropriate remote-mount configuration.
  * Existing test behavior and coverage remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->