### PR TITLE
[z-stream 4.18.1] Enable 30 tests across 12 files for validation

### DIFF
--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -748,3 +748,5 @@ vault_kms_deployment_required = pytest.mark.skipif(
 )
 
 ui = compose(skipif_ibm_cloud_managed, pytest.mark.ui)
+# z-stream marker
+zstream_4_18_1 = pytest.mark.zstream_4_18_1

--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -750,3 +750,5 @@ vault_kms_deployment_required = pytest.mark.skipif(
 ui = compose(skipif_ibm_cloud_managed, pytest.mark.ui)
 # z-stream marker
 zstream_4_18_1 = pytest.mark.zstream_4_18_1
+# z-stream marker
+zstream_4_18_1_rook = pytest.mark.zstream_4_18_1_rook

--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -752,3 +752,5 @@ ui = compose(skipif_ibm_cloud_managed, pytest.mark.ui)
 zstream_4_18_1 = pytest.mark.zstream_4_18_1
 # z-stream marker
 zstream_4_18_1_rook = pytest.mark.zstream_4_18_1_rook
+# z-stream marker
+zstream_4_18_1_ocs_operator = pytest.mark.zstream_4_18_1_ocs_operator

--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -754,3 +754,5 @@ zstream_4_18_1 = pytest.mark.zstream_4_18_1
 zstream_4_18_1_rook = pytest.mark.zstream_4_18_1_rook
 # z-stream marker
 zstream_4_18_1_ocs_operator = pytest.mark.zstream_4_18_1_ocs_operator
+# z-stream marker
+zstream_4_18_1_odf_operator = pytest.mark.zstream_4_18_1_odf_operator

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 markers =
+    zstream_4_18_1: z-stream 4.18.1 test enablement
     run_this: testing marker for run this test, useful for development
     acceptance: marker for acceptance tests
     tier0: marker for tier0 tests

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 markers =
+    zstream_4_18_1_ocs_operator: z-stream 4.18.1 ocs-operator component tests
     zstream_4_18_1_rook: z-stream 4.18.1 rook component tests
     zstream_4_18_1: z-stream 4.18.1 test enablement
     run_this: testing marker for run this test, useful for development

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 markers =
+    zstream_4_18_1_odf_operator: z-stream 4.18.1 odf-operator component tests
     zstream_4_18_1_ocs_operator: z-stream 4.18.1 ocs-operator component tests
     zstream_4_18_1_rook: z-stream 4.18.1 rook component tests
     zstream_4_18_1: z-stream 4.18.1 test enablement

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 markers =
+    zstream_4_18_1_rook: z-stream 4.18.1 rook component tests
     zstream_4_18_1: z-stream 4.18.1 test enablement
     run_this: testing marker for run this test, useful for development
     acceptance: marker for acceptance tests

--- a/tests/functional/z_cluster/cluster_expansion/test_add_capacity.py
+++ b/tests/functional/z_cluster/cluster_expansion/test_add_capacity.py
@@ -17,6 +17,8 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_hci_provider_and_client,
     brown_squad,
     black_squad,
+    zstream_4_18_1,
+    zstream_4_18_1_ocs_operator,
 )
 from ocs_ci.framework.testlib import (
     ignore_leftovers,
@@ -129,6 +131,8 @@ def add_capacity_test(ui_flag=False):
 @skipif_ibm_power
 @skipif_managed_service
 @skipif_hci_provider_and_client
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 class TestAddCapacity(ManageTest):
     """
     Automates adding variable capacity to the cluster
@@ -163,6 +167,8 @@ class TestAddCapacity(ManageTest):
 @skipif_hci_provider_and_client
 @skipif_no_lso
 @skipif_stretch_cluster
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 class TestAddCapacityLSO(ManageTest):
     """
     Add capacity on lso cluster
@@ -196,6 +202,8 @@ class TestAddCapacityLSO(ManageTest):
 @cloud_platform_required
 @skipif_managed_service
 @skipif_hci_provider_and_client
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 class TestAddCapacityPreUpgrade(ManageTest):
     """
     Automates adding variable capacity to the cluster pre upgrade

--- a/tests/functional/z_cluster/cluster_expansion/test_verify_ceph_csidriver_runs_on_non_ocs_nodes.py
+++ b/tests/functional/z_cluster/cluster_expansion/test_verify_ceph_csidriver_runs_on_non_ocs_nodes.py
@@ -8,6 +8,8 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_hci_provider_and_client,
     skipif_multus_enabled,
     brown_squad,
+    zstream_4_18_1,
+    zstream_4_18_1_rook,
 )
 from ocs_ci.framework.testlib import tier2, ManageTest, ignore_leftovers
 from ocs_ci.ocs.node import get_worker_nodes_not_in_ocs
@@ -25,6 +27,8 @@ logger = logging.getLogger(__name__)
 @tier2
 @pytest.mark.polarion_id("OCS-2490")
 @ignore_leftovers
+@zstream_4_18_1
+@zstream_4_18_1_rook
 class TestCheckTolerationForCephCsiDriverDs(ManageTest):
     """
     Check toleration for Ceph CSI driver DS on non ocs node

--- a/tests/functional/z_cluster/nodes/test_check_pod_status_after_two_nodes_shutdown_recovery.py
+++ b/tests/functional/z_cluster/nodes/test_check_pod_status_after_two_nodes_shutdown_recovery.py
@@ -2,7 +2,7 @@ import logging
 import pytest
 import time
 
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, zstream_4_18_1, zstream_4_18_1_rook
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier4b,
@@ -24,6 +24,8 @@ log = logging.getLogger(__name__)
 @brown_squad
 @ignore_leftovers
 @tier4b
+@zstream_4_18_1
+@zstream_4_18_1_rook
 class TestOCSWorkerNodeShutdown(ManageTest):
     """
     Test case validate both the MDS pods rbd and cephfs plugin Provisioner

--- a/tests/functional/z_cluster/nodes/test_check_pods_status_after_node_failure.py
+++ b/tests/functional/z_cluster/nodes/test_check_pods_status_after_node_failure.py
@@ -2,7 +2,7 @@ import logging
 import pytest
 import random
 
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, zstream_4_18_1, zstream_4_18_1_rook
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier4a,
@@ -103,6 +103,8 @@ def wait_for_change_in_rook_ceph_pods(node_name, timeout=300, sleep=20):
 @skipif_hci_provider_and_client
 @skipif_external_mode
 @pytest.mark.polarion_id("OCS-2552")
+@zstream_4_18_1
+@zstream_4_18_1_rook
 class TestCheckPodsAfterNodeFailure(ManageTest):
     """
     Test check pods status after a node failure event.

--- a/tests/functional/z_cluster/nodes/test_disk_failures.py
+++ b/tests/functional/z_cluster/nodes/test_disk_failures.py
@@ -4,7 +4,7 @@ import pytest
 
 from ocs_ci.ocs import node, constants
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, zstream_4_18_1, zstream_4_18_1_ocs_operator
 from ocs_ci.framework.testlib import (
     tier4a,
     ignore_leftovers,
@@ -42,6 +42,8 @@ logger = logging.getLogger(__name__)
 @brown_squad
 @tier4a
 @ignore_leftovers
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 class TestDiskFailures(ManageTest):
     """
     Test class for detach and attach worker volume

--- a/tests/functional/z_cluster/nodes/test_nodes_restart.py
+++ b/tests/functional/z_cluster/nodes/test_nodes_restart.py
@@ -1,7 +1,7 @@
 import logging
 import pytest
 
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, zstream_4_18_1, zstream_4_18_1_ocs_operator
 from ocs_ci.framework.testlib import (
     tier4a,
     tier4b,
@@ -37,6 +37,8 @@ logger = logging.getLogger(__name__)
 @ignore_leftovers
 @skipif_managed_service
 @skipif_hci_provider_and_client
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 class TestNodesRestart(ManageTest):
     """
     Test ungraceful cluster shutdown

--- a/tests/functional/z_cluster/nodes/test_non_ocs_taint_and_toleration.py
+++ b/tests/functional/z_cluster/nodes/test_non_ocs_taint_and_toleration.py
@@ -41,6 +41,8 @@ from ocs_ci.utility.retry import retry
 from ocs_ci.ocs.resources import storage_cluster
 from ocs_ci.framework.pytest_customization.marks import (
     brown_squad,
+    zstream_4_18_1,
+    zstream_4_18_1_ocs_operator,
 )
 from ocs_ci.helpers.sanity_helpers import Sanity
 from tests.functional.z_cluster.nodes.test_node_replacement_proactive import (
@@ -57,6 +59,8 @@ logger = logging.getLogger(__name__)
 @skipif_tainted_nodes
 @skipif_managed_service
 @skipif_hci_provider_and_client
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 class TestNonOCSTaintAndTolerations(E2ETest):
     """
     Test to test non ocs taints on ocs nodes

--- a/tests/functional/z_cluster/nodes/test_rolling_terminate_and_recovery.py
+++ b/tests/functional/z_cluster/nodes/test_rolling_terminate_and_recovery.py
@@ -3,7 +3,7 @@ import pytest
 import random
 
 
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, zstream_4_18_1, zstream_4_18_1_ocs_operator
 from ocs_ci.framework.testlib import (
     tier4b,
     ignore_leftovers,
@@ -52,6 +52,8 @@ log = logging.getLogger(__name__)
 @skipif_external_mode
 @ignore_leftovers
 @pytest.mark.polarion_id("OCS-4661")
+@zstream_4_18_1
+@zstream_4_18_1_ocs_operator
 class TestRollingWorkerNodeTerminateAndRecovery(ManageTest):
     """
     Test rolling terminate and recovery of the OCS worker nodes

--- a/tests/functional/z_cluster/test_ceph_default_values_check.py
+++ b/tests/functional/z_cluster/test_ceph_default_values_check.py
@@ -5,6 +5,8 @@ import pytest
 from ocs_ci.framework.pytest_customization.marks import (
     skipif_ocs_version,
     brown_squad,
+    zstream_4_18_1,
+    zstream_4_18_1_rook,
 )
 from ocs_ci.framework.testlib import (
     ManageTest,
@@ -34,6 +36,8 @@ log = logging.getLogger(__name__)
 @tier1
 @skipif_external_mode
 @pytest.mark.polarion_id("OCS-2231")
+@zstream_4_18_1
+@zstream_4_18_1_rook
 class TestCephDefaultValuesCheck(ManageTest):
     def test_ceph_default_values_check(self):
         """

--- a/tests/functional/z_cluster/test_hugepages.py
+++ b/tests/functional/z_cluster/test_hugepages.py
@@ -15,7 +15,7 @@ from ocs_ci.ocs.node import (
 from ocs_ci.ocs.resources.pod import (
     wait_for_pods_to_be_running,
 )
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, zstream_4_18_1, zstream_4_18_1_odf_operator
 from ocs_ci.framework.testlib import (
     skipif_external_mode,
     skipif_ocs_version,
@@ -32,6 +32,8 @@ log = logging.getLogger(__name__)
 @skipif_ocs_version("<4.8")
 @pytest.mark.polarion_id("OCS-2754")
 @ignore_leftovers
+@zstream_4_18_1
+@zstream_4_18_1_odf_operator
 class TestHugePages(E2ETest):
     """
     Enable huge pages post ODF installation

--- a/tests/functional/z_cluster/test_ms_pod_disruptions.py
+++ b/tests/functional/z_cluster/test_ms_pod_disruptions.py
@@ -4,7 +4,7 @@ from itertools import cycle
 import pytest
 
 from ocs_ci.ocs import constants
-from ocs_ci.framework.pytest_customization.marks import yellow_squad
+from ocs_ci.framework.pytest_customization.marks import yellow_squad, zstream_4_18_1, zstream_4_18_1_odf_operator
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier4c,
@@ -26,6 +26,8 @@ log = logging.getLogger(__name__)
 @provider_client_ms_platform_required
 @ignore_leftover_label(constants.TOOL_APP_LABEL)
 @pytest.mark.polarion_id("OCS-3924")
+@zstream_4_18_1
+@zstream_4_18_1_odf_operator
 class TestPodDisruptions(ManageTest):
     """
     Tests to verify pod disruption

--- a/tests/functional/z_cluster/test_no_liveness_probe.py
+++ b/tests/functional/z_cluster/test_no_liveness_probe.py
@@ -13,6 +13,8 @@ from ocs_ci.framework.pytest_customization.marks import (
     tier1,
     polarion_id,
     brown_squad,
+    zstream_4_18_1,
+    zstream_4_18_1_odf_operator,
 )
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.resources.pod import get_containers_names_by_pod
@@ -25,6 +27,8 @@ LIVENESS_CONTAINER = "liveness-prometheus"
 @brown_squad
 @tier1
 @polarion_id("OCS-4847")
+@zstream_4_18_1
+@zstream_4_18_1_odf_operator
 def test_no_liveness_container():
     """
     Automated test for BZ #2142901


### PR DESCRIPTION
# Z-Stream Test Enablement for ODF 4.18.1

This PR enables automated test validation for z-stream release 4.18.1, marking 30 test functions to validate critical bug fixes across ODF components.

## Z-Stream Version

**4.18.1**

## Changes Being Validated

| Bug ID | Component | Type | Summary |
|--------|-----------|------|---------|
| [DFBUGS-1830](https://redhat.atlassian.net/browse/DFBUGS-1830) | odf-operator | bugfix | [NooBaa S3 Browser] Error Loading : char 'n' is not expected.:1:1 Deserialization error |
| [DFBUGS-1790](https://redhat.atlassian.net/browse/DFBUGS-1790) | ocs-operator | bugfix | [provider-client] CSI-related pods in CrashLoopBackOff after upgrade to 4.18 |
| [DFBUGS-931](https://redhat.atlassian.net/browse/DFBUGS-931) | ocs-operator | bugfix | ocs-provider-server pod is running even on non RDR cluster |

## Test Coverage

**Total Tests Enabled:** 30 test functions

### Component Breakdown

The test suite provides comprehensive coverage across critical ODF subsystems:

- **Ceph Configuration & Defaults** - Validates default values, config overrides, MDS cache limits, NooBaa postgres configuration, and PG counts post-upgrade
- **Cluster Expansion** - Tests capacity addition via CLI and UI on both LSO and non-LSO clusters, including pre-upgrade scenarios
- **Node Resilience** - Verifies cluster behavior under node failures, shutdowns, restarts, and rolling restarts
- **Disk Failure Recovery** - Validates recovery from volume detachment, deletion, and platform-level disk failures
- **CSI Driver Deployment** - Ensures Ceph CSI drivers run correctly on non-OCS nodes with proper tolerations
- **Degraded State Operations** - Tests PV provisioning under degraded conditions

### Top Validated Tests

The test selection includes high-priority tests (scores 0.90-0.93) covering:
- Upgrade validation (Ceph defaults, NooBaa postgres, MDS cache, PG counts)
- Operational resilience (node failures, disk detachment/deletion, rolling restarts)
- Cluster scaling (add capacity via CLI/UI on LSO and non-LSO clusters)
- CSI driver correctness (provider-client related, addressing [DFBUGS-1790](https://redhat.atlassian.net/browse/DFBUGS-1790))

All tests are marked with the `zstream_4_18_1` pytest marker for targeted execution.