### PR TITLE
Fix TypeError in mask_secrets when secret is None

### DIFF
--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -452,6 +452,8 @@ def mask_secrets(plaintext, secrets):
     """
     if secrets:
         for secret in secrets:
+            if secret is None:
+                continue
             if isinstance(plaintext, list):
                 plaintext = [string.replace(secret, "*" * 5) for string in plaintext]
             else:


### PR DESCRIPTION
Signed-off-by: vavuthu [vavuthu@redhat.com](mailto:vavuthu@redhat.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved secret masking to safely handle lists containing empty values.
  * Prevented errors when processing missing secret entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->