### PR TITLE
Fix LSO deployment failure after control-plane node restart

### DIFF
--- a/ocs_ci/utility/vsphere.py
+++ b/ocs_ci/utility/vsphere.py
@@ -438,7 +438,9 @@ class VSPHERE(object):
             self.start_vms(vms=[vm])
         # Importing here to avoid circular dependencies
         from ocs_ci.ocs.node import get_compute_node_names, wait_for_nodes_status
+        from ocs_ci.ocs.ocp import wait_for_cluster_connectivity
 
+        wait_for_cluster_connectivity(tries=120, delay=5)
         compute_nodes = get_compute_node_names()
         try:
             wait_for_nodes_status(compute_nodes, NODE_READY)


### PR DESCRIPTION
Signed-off-by: vavuthu [vavuthu@redhat.com](mailto:vavuthu@redhat.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when starting virtual machines with SSD disks by waiting for cluster connectivity before proceeding.
  * Reduced the likelihood of readiness failures during node startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->