### PR TITLE
deployment/cnv: wait for HyperConverged healthy before enabling softw…

### DIFF
--- a/ocs_ci/deployment/cnv.py
+++ b/ocs_ci/deployment/cnv.py
@@ -419,10 +419,10 @@ class CNVInstaller(object):
                 if sample == "healthy":
                     logger.info("HyperConverged cluster is healthy")
                     return
-        except exceptions.TimeoutExpiredError:
+        except exceptions.TimeoutExpiredError as exc:
             raise exceptions.TimeoutExpiredError(
                 f"HyperConverged did not reach 'healthy' status within {timeout}s"
-            )
+            ) from exc
 
     def check_hyperconverged_healthy(self, raise_exception=True):
         """

--- a/ocs_ci/deployment/cnv.py
+++ b/ocs_ci/deployment/cnv.py
@@ -385,6 +385,43 @@ class CNVInstaller(object):
         # validate that HyperConverged systemHealthStatus is healthy
         return self.check_hyperconverged_healthy(raise_exception=raise_exception)
 
+    def wait_for_hyperconverged_healthy(self, timeout=300, sleep=30):
+        """
+        Wait until HyperConverged systemHealthStatus becomes 'healthy'.
+
+        This is needed before annotating HyperConverged (e.g. enabling software
+        emulation) because the SSP operator admission webhook
+        (ssp-operator-service) is only available once the cluster reaches a
+        healthy state.  Attempting to annotate while health is still 'error'
+        causes the webhook to deny the request with
+        "no endpoints available for service ssp-operator-service".
+
+        Args:
+            timeout (int): Maximum seconds to wait (default 300).
+            sleep (int): Seconds between polling attempts (default 30).
+
+        Raises:
+            TimeoutExpiredError: If health does not become 'healthy' within timeout.
+        """
+        logger.info(
+            f"Waiting up to {timeout}s for HyperConverged systemHealthStatus to become 'healthy'"
+        )
+        ocp = OCP(kind=constants.HYPERCONVERGED, namespace=self.namespace)
+        for sample in TimeoutSampler(
+            timeout=timeout,
+            sleep=sleep,
+            func=lambda: ocp.get(resource_name=constants.KUBEVIRT_HYPERCONVERGED)
+            .get("status", {})
+            .get("systemHealthStatus"),
+        ):
+            logger.info(f"HyperConverged systemHealthStatus: {sample}")
+            if sample == "healthy":
+                logger.info("HyperConverged cluster is healthy")
+                return
+        raise exceptions.TimeoutExpiredError(
+            f"HyperConverged did not reach 'healthy' status within {timeout}s"
+        )
+
     def check_hyperconverged_healthy(self, raise_exception=True):
         """
         Validate that HyperConverged systemHealthStatus is healthy.
@@ -689,6 +726,12 @@ class CNVInstaller(object):
         self.deploy_hyper_converged()
         # Post CNV installation checks
         self.post_install_verification()
+        # Wait for HyperConverged to become healthy before annotating.
+        # The SSP operator admission webhook (ssp-operator-service) is only
+        # available once systemHealthStatus == "healthy"; attempting to annotate
+        # earlier results in "no endpoints available for service
+        # ssp-operator-service" errors from the webhook.
+        self.wait_for_hyperconverged_healthy()
         # Enable software emulation
         self.enable_software_emulation()
         # Download and extract the virtctl binary to bin_dir

--- a/ocs_ci/deployment/cnv.py
+++ b/ocs_ci/deployment/cnv.py
@@ -407,20 +407,22 @@ class CNVInstaller(object):
             f"Waiting up to {timeout}s for HyperConverged systemHealthStatus to become 'healthy'"
         )
         ocp = OCP(kind=constants.HYPERCONVERGED, namespace=self.namespace)
-        for sample in TimeoutSampler(
-            timeout=timeout,
-            sleep=sleep,
-            func=lambda: ocp.get(resource_name=constants.KUBEVIRT_HYPERCONVERGED)
-            .get("status", {})
-            .get("systemHealthStatus"),
-        ):
-            logger.info(f"HyperConverged systemHealthStatus: {sample}")
-            if sample == "healthy":
-                logger.info("HyperConverged cluster is healthy")
-                return
-        raise exceptions.TimeoutExpiredError(
-            f"HyperConverged did not reach 'healthy' status within {timeout}s"
-        )
+        try:
+            for sample in TimeoutSampler(
+                timeout=timeout,
+                sleep=sleep,
+                func=lambda: ocp.get(resource_name=constants.KUBEVIRT_HYPERCONVERGED)
+                .get("status", {})
+                .get("systemHealthStatus"),
+            ):
+                logger.info(f"HyperConverged systemHealthStatus: {sample}")
+                if sample == "healthy":
+                    logger.info("HyperConverged cluster is healthy")
+                    return
+        except exceptions.TimeoutExpiredError:
+            raise exceptions.TimeoutExpiredError(
+                f"HyperConverged did not reach 'healthy' status within {timeout}s"
+            )
 
     def check_hyperconverged_healthy(self, raise_exception=True):
         """


### PR DESCRIPTION
…are emulation

When deploy_cnv() called enable_software_emulation() immediately after post_install_verification(), the HyperConverged systemHealthStatus was still "error". In that state the SSP operator admission webhook (ssp-operator-service) has no endpoints yet, causing every `oc annotate` attempt to be rejected:

  Error from server (InternalError): admission webhook
  "validate-hco.kubevirt.io" denied the request: failed calling webhook
  "validation.v1beta3.ssp.kubevirt.io": no endpoints available for
  service "ssp-operator-service"

post_install_verification() uses raise_exception=False so the unhealthy state was logged as a warning and execution continued regardless. The existing @retry(CommandFailed, tries=3) on enable_software_emulation was not enough to bridge the gap because it retried the annotation blindly rather than waiting for SSP readiness.

Fix: add CNVInstaller.wait_for_hyperconverged_healthy() which uses TimeoutSampler to poll systemHealthStatus every 30 s (up to 300 s) and blocks until the value is "healthy". Call it in deploy_cnv() between post_install_verification() and enable_software_emulation() so the SSP webhook endpoints are guaranteed to be live before the annotation is attempted.

Fixes: #15703 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CNV deployment now pauses after creating the HyperConverged custom resource to confirm the system health status reaches **healthy** before proceeding with later setup steps.
  * If the healthy state is not reached within the allotted time, the deployment now stops with a clear timeout error instead of continuing prematurely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->