### PR TITLE
Implement MDS failover with I/O on EC 422

### DIFF
--- a/tests/functional/z_cluster/test_multiple_mds.py
+++ b/tests/functional/z_cluster/test_multiple_mds.py
@@ -9,17 +9,24 @@ import pytest
 
 from ocs_ci.framework.pytest_customization.marks import (
     brown_squad,
+    ec_allowed,
+    green_squad,
+    tier2,
     tier4c,
     skipif_external_mode,
     skipif_hci_client,
+    runs_on_provider,
+    polarion_id,
 )
 from ocs_ci.framework import config
+from ocs_ci.framework.testlib import ManageTest
 from ocs_ci.helpers import helpers
 from ocs_ci.ocs.cluster import (
     adjust_active_mds_count_storagecluster,
     get_active_mds_count_cephfilesystem,
     get_active_mds_pod_objs,
     get_mds_counts,
+    is_ec_pool_supported,
 )
 from ocs_ci.ocs.resources import pod
 from ocs_ci.helpers.sanity_helpers import Sanity
@@ -34,15 +41,16 @@ from tests.functional.z_cluster.nodes.test_node_replacement_proactive import (
 log = logging.getLogger(__name__)
 
 
-def verify_active_and_standby_mds_count(target_count):
+def verify_active_and_standby_mds_count(target_count, timeout=180):
     """
     Get the active and standby mds pod count from ceph command and verify it matches the target count.
 
     Args:
         target_count (int): The desired count of active and standby mds pods.
+        timeout (int): Timeout in seconds to wait for the target count.
 
     """
-    TimeoutSampler(timeout=180, sleep=10, func=get_mds_counts).wait_for_func_value(
+    TimeoutSampler(timeout=timeout, sleep=10, func=get_mds_counts).wait_for_func_value(
         (target_count, target_count)
     )
     log.info(f"Active and standby-replay MDS pod counts reached {target_count}.")
@@ -178,3 +186,226 @@ class TestMultipleMds:
         assert err_count == 0, (
             f"IO error on pod {pod_obj.name}. " f"FIO result: {fio_result}"
         )
+
+
+EC_POOL_NAME = "mds-test-ec-fs"
+EC_DATA_CHUNKS = 2
+EC_CODING_CHUNKS = 2
+
+
+@pytest.fixture()
+def cephfs_ec_storageclass(request):
+    """
+    Create a day-2 CephFS EC data pool and StorageClass for the test.
+
+    Always creates a new EC pool via StorageCluster patch regardless of
+    whether the cluster already has a day-1 EC pool.  The pool and
+    StorageClass are cleaned up after the test.
+
+    Returns:
+        tuple: (OCS StorageClass object, full Ceph pool name)
+    """
+    with config.RunWithProviderConfigContextIfAvailable():
+        if not is_ec_pool_supported():
+            pytest.skip("EC pools are not supported on this cluster")
+
+        min_hosts = EC_DATA_CHUNKS + EC_CODING_CHUNKS
+        osd_hosts = node.get_osd_running_nodes()
+        if len(osd_hosts) < min_hosts:
+            pytest.skip(
+                f"Not enough OSD hosts for {EC_DATA_CHUNKS}+{EC_CODING_CHUNKS} "
+                f"EC profile (need {min_hosts}, have {len(osd_hosts)})"
+            )
+
+        full_pool_name = helpers.create_cephfs_ec_pool(
+            EC_POOL_NAME, EC_DATA_CHUNKS, EC_CODING_CHUNKS
+        )
+        secret_obj = helpers.create_secret(interface_type=constants.CEPHFILESYSTEM)
+        sc_obj = helpers.create_storage_class(
+            interface_type=constants.CEPHFILESYSTEM,
+            interface_name=full_pool_name,
+            secret_name=secret_obj.name,
+        )
+        log.info(
+            f"Created CephFS EC StorageClass '{sc_obj.name}' for pool '{full_pool_name}'"
+        )
+
+    def finalizer():
+        with config.RunWithProviderConfigContextIfAvailable():
+            log.info("Cleaning up CephFS EC StorageClass and pool")
+            sc_obj.delete()
+            sc_obj.ocp.wait_for_delete(sc_obj.name)
+            secret_obj.delete()
+            secret_obj.ocp.wait_for_delete(secret_obj.name)
+            helpers.delete_cephfs_ec_pool(EC_POOL_NAME)
+
+    request.addfinalizer(finalizer)
+    return sc_obj, full_pool_name
+
+
+@ec_allowed
+@green_squad
+@runs_on_provider
+@skipif_hci_client
+@skipif_external_mode
+@pytest.mark.skipif(
+    not is_ec_pool_supported(),
+    reason="Erasure coded pools are not supported on this cluster",
+)
+class TestMdsScalingWithEcCephfs(ManageTest):
+    """
+    Tests for MDS scaling behaviour with CephFS EC data pool IO.
+    """
+
+    @pytest.fixture(autouse=True)
+    def teardown_mds(self, request):
+        """Restore activeMetadataServers to 1 after each test."""
+
+        def finalizer():
+            with config.RunWithProviderConfigContextIfAvailable():
+                adjust_active_mds_count_storagecluster(1)
+                log.info("Validate MDS pods are up and running")
+                for mds_pod in get_mds_pods():
+                    helpers.wait_for_resource_state(
+                        resource=mds_pod, state=constants.STATUS_RUNNING
+                    )
+                ceph_health_check()
+
+        request.addfinalizer(finalizer)
+
+    @tier2
+    @polarion_id("OCS-8063")
+    def test_mds_scale_with_ec_cephfs_io(
+        self, cephfs_ec_storageclass, pvc_factory, pod_factory
+    ):
+        """
+        Verify MDS scaling does not disrupt CephFS IO on an EC data pool.
+
+        Steps:
+        1. Create CephFS RWX PVC on EC pool
+        2. Run IO and verify EC pool usage increases
+        3. Scale MDS from 1 to 2
+        4. Verify active and standby MDS counts
+        5. Run IO again and verify it succeeds after scale-up
+        6. Scale MDS back from 2 to 1
+        7. Verify MDS counts restored
+        8. Run IO once more to confirm stability after scale-down
+        """
+        with config.RunWithProviderConfigContextIfAvailable():
+            sc_obj, full_pool_name = cephfs_ec_storageclass
+
+            pvc_obj = pvc_factory(
+                interface=constants.CEPHFILESYSTEM,
+                storageclass=sc_obj,
+                access_mode=constants.ACCESS_MODE_RWX,
+                size=10,
+            )
+            log.info(f"PVC '{pvc_obj.name}' created and bound")
+
+            pod_obj = pod_factory(interface=constants.CEPHFILESYSTEM, pvc=pvc_obj)
+            log.info(f"Pod '{pod_obj.name}' created")
+
+            baseline_usage = helpers.fetch_used_size(full_pool_name)
+            log.info(f"Baseline EC pool usage: {baseline_usage} GB")
+
+            log.info("Running initial IO before MDS scaling")
+            pod_obj.run_io(storage_type="fs", size="512M", runtime=30)
+            fio_result = pod_obj.get_fio_results()
+            err_count = fio_result.get("jobs")[0].get("error")
+            assert err_count == 0, (
+                f"IO error during initial IO on pod {pod_obj.name}. "
+                f"FIO result: {fio_result}"
+            )
+
+            post_io_usage = helpers.fetch_used_size(full_pool_name)
+            log.info(f"Post-IO EC pool usage: {post_io_usage} GB")
+            assert post_io_usage > baseline_usage, (
+                f"EC pool usage did not increase. "
+                f"Baseline: {baseline_usage}, Current: {post_io_usage}"
+            )
+
+            original_count = get_active_mds_count_cephfilesystem()
+            new_count = original_count + 1
+            log.info(f"Scaling MDS from {original_count} to {new_count}")
+            adjust_active_mds_count_storagecluster(new_count)
+            verify_active_and_standby_mds_count(new_count)
+
+            log.info("Running IO after MDS scale-up")
+            pod_obj.run_io(storage_type="fs", size="512M", runtime=30)
+            fio_result = pod_obj.get_fio_results()
+            err_count = fio_result.get("jobs")[0].get("error")
+            assert err_count == 0, (
+                f"IO error after MDS scale-up on pod {pod_obj.name}. "
+                f"FIO result: {fio_result}"
+            )
+
+            log.info(f"Scaling MDS back from {new_count} to {original_count}")
+            adjust_active_mds_count_storagecluster(original_count)
+            verify_active_and_standby_mds_count(original_count, timeout=420)
+
+            log.info("Running IO after MDS scale-down")
+            pod_obj.run_io(storage_type="fs", size="512M", runtime=30)
+            fio_result = pod_obj.get_fio_results()
+            err_count = fio_result.get("jobs")[0].get("error")
+            assert err_count == 0, (
+                f"IO error after MDS scale-down on pod {pod_obj.name}. "
+                f"FIO result: {fio_result}"
+            )
+
+    @tier4c
+    @polarion_id("OCS-8064")
+    def test_mds_failover_with_ec_cephfs_io(
+        self, cephfs_ec_storageclass, pvc_factory, pod_factory
+    ):
+        """
+        Verify MDS failover does not break CephFS IO on an EC data pool.
+
+        Steps:
+        1. Scale MDS from 1 to 2 (so a standby-replay is available)
+        2. Create CephFS RWX PVC on EC pool and start long-running IO
+        3. Fail the active MDS daemon via 'ceph mds fail'
+        4. Verify standby takes over (active + standby counts unchanged)
+        5. Verify IO completes without errors
+        """
+        with config.RunWithProviderConfigContextIfAvailable():
+            sc_obj, full_pool_name = cephfs_ec_storageclass
+
+            original_count = get_active_mds_count_cephfilesystem()
+            new_count = original_count + 1
+            log.info(f"Scaling MDS from {original_count} to {new_count}")
+            adjust_active_mds_count_storagecluster(new_count)
+            verify_active_and_standby_mds_count(new_count)
+
+            pvc_obj = pvc_factory(
+                interface=constants.CEPHFILESYSTEM,
+                storageclass=sc_obj,
+                access_mode=constants.ACCESS_MODE_RWX,
+                size=10,
+            )
+            pod_obj = pod_factory(interface=constants.CEPHFILESYSTEM, pvc=pvc_obj)
+            log.info(f"Pod '{pod_obj.name}' created on EC CephFS pool")
+
+            log.info("Starting long-running IO")
+            pod_obj.run_io(storage_type="fs", size="1G", runtime=180)
+
+            active_mds_pods = get_active_mds_pod_objs()
+            target_mds = random.choice(active_mds_pods)
+            log.info(f"Failing active MDS pod '{target_mds.name}'")
+            ct_pod = pod.get_ceph_tools_pod()
+            mds_daemon_name = next(
+                daemon["name"]
+                for daemon in ct_pod.exec_ceph_cmd("ceph fs status")["mdsmap"]
+                if daemon["state"] == "active" and daemon["name"] in target_mds.name
+            )
+            ct_pod.exec_ceph_cmd(f"ceph mds fail {mds_daemon_name}")
+
+            log.info("Verify MDS counts are restored after failover")
+            verify_active_and_standby_mds_count(new_count)
+
+            log.info("Waiting for IO to complete")
+            fio_result = pod_obj.get_fio_results()
+            err_count = fio_result.get("jobs")[0].get("error")
+            assert err_count == 0, (
+                f"IO error after MDS failover on pod {pod_obj.name}. "
+                f"FIO result: {fio_result}"
+            )


### PR DESCRIPTION
Two new tests verify MDS scale-up/down and failover don't disrupt CephFS IO on an erasure-coded data pool. Tests create a day-2 EC pool, run fio workloads during MDS operations, and validate data integrity. Guarded by is_ec_pool_supported to run on both EC and replica day-1 clusters.     

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for CephFS metadata server scaling and failover using erasure-coded storage.
  * Validated sustained read/write workloads while metadata servers scale up and down.
  * Added failover checks to ensure active replacement completes without I/O errors.
  * Introduced targeted capability gating for erasure-coded environments and improved scenario timing.
  * Added automatic cleanup and post-test health verification after each scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->