### PR TITLE
Increase default vSphere VM start timeout

### DIFF
--- a/conf/README.md
+++ b/conf/README.md
@@ -192,7 +192,7 @@ version.
 * `hub_cluster_name` - Name of the Management cluster. Applicable for Agent deployments, where the hub cluster is pre-created.
 * `hub_cluster_path` - Path to the Management cluster directory to store auth_path, credentials files or cluster related files.
 * `partitioned_disk_primary_affinity` - Configure primaryAffinity for OSDs on partitioned disks, https://access.redhat.com/solutions/5807201 (default: "0.0")
-* `vsphere_vm_start_timeout` - Number of seconds to wait for vsphere vms to start up (default: 240)
+* `vsphere_vm_start_timeout` - Number of seconds to wait for vsphere vms to start up (default: 900)
 * `deploy_multiple_device_classes` - Deploy a second storageDeviceSet with a separate device class on LSO-backed vSphere clusters. When enabled, additional disks are attached to each worker node and a second device class (e.g. `localblock-1`) is added to the StorageCluster (Default: false)
 * `ec_default_pools` - Deploy ODF with Erasure Coding as the default pool type instead of replication. When true, the StorageCluster CR is patched with EC spec for block, file, and object pools. No user-facing replicated pools are created (Default: false)
 * `ec_data_chunks` - The k value for erasure coding — number of data chunks. Data is split into this many pieces. Requires `ec_default_pools: true` (Default: 2)

--- a/ocs_ci/utility/vsphere.py
+++ b/ocs_ci/utility/vsphere.py
@@ -625,7 +625,7 @@ class VSPHERE(object):
         WaitForTasks(tasks, self._si)
 
         if wait:
-            wait_time = config.DEPLOYMENT.get("vsphere_vm_start_timeout", 240)
+            wait_time = config.DEPLOYMENT.get("vsphere_vm_start_timeout", 900)
             for ips in TimeoutSampler(wait_time, 3, self.get_vms_ips, vms):
                 logger.info(
                     f"Waiting for VMs {[vm.name for vm in vms]} to power on "


### PR DESCRIPTION

VMs occasionally take longer than 240s to obtain an IP after power-on
  during LSO disk attachment, causing deployment failures even though the
  VM eventually becomes reachable.

Fixes: #15723

Signed-off-by: vavuthu [vavuthu@redhat.com](mailto:vavuthu@redhat.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the default VMware vSphere VM startup timeout from 240 to 900 seconds.
  * Improved reliability when waiting for virtual machines to become network-reachable after startup.

* **Documentation**
  * Updated the configuration documentation to reflect the new 900-second default timeout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->