### PR TITLE
UI-test_blocking_pool_creation_rules-fix

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6594,6 +6594,11 @@ def cephblockpool_factory_ui_fixture(request, setup_ui):
                     f"Could not delete block pool {instance.name} from UI."
                     " Deleted from CLI"
                 )
+            cbp_ocp = OCP(
+                kind=constants.CEPHBLOCKPOOL,
+                namespace=config.ENV_DATA["cluster_namespace"],
+            )
+            cbp_ocp.wait_for_delete(resource_name=instance.name, timeout=300)
 
     request.addfinalizer(finalizer)
     return factory

--- a/tests/functional/ui/test_error_improvements.py
+++ b/tests/functional/ui/test_error_improvements.py
@@ -116,7 +116,6 @@ class TestErrorMessageImprovements(ManageTest):
         namespace_store_tab.check_error_messages()
 
     @polarion_id("OCS-4873")
-    @skipif_hci_provider_or_client
     def test_blocking_pool_creation_rules(self, cephblockpool_factory_ui_class):
         """
         Test to verify


### PR DESCRIPTION
address leftover failure:

```
exclude_labels = ['app=must-gather', 'app=s3cli', 'must-gather-helper-pod=']
exclude_job_owned_pods = True


def get_status_after_execution(exclude_labels=None, exclude_job_owned_pods=True):
    """
    Set the environment status and assign it into ENV_STATUS_PRE dictionary.
    In addition compare the dict before the execution and after using DeepDiff

    Args:
        exclude_labels (list): App labels to ignore leftovers
        exclude_job_owned_pods (bool): If True, exclude pods owned by Jobs

    Raises:
         ResourceLeftoversException: In case there are leftovers in the
            environment after the execution
    """
    get_environment_status(
        config.RUN["ENV_STATUS_POST"],
        exclude_labels=exclude_labels,
        exclude_job_owned_pods=exclude_job_owned_pods,
    )

    pod_diff = compare_dicts(
        config.RUN["ENV_STATUS_PRE"]["pod"], config.RUN["ENV_STATUS_POST"]["pod"]
    )
    sc_diff = compare_dicts(
        config.RUN["ENV_STATUS_PRE"]["sc"], config.RUN["ENV_STATUS_POST"]["sc"]
    )
    pv_diff = compare_dicts(
        config.RUN["ENV_STATUS_PRE"]["pv"], config.RUN["ENV_STATUS_POST"]["pv"]
    )
    pvc_diff = compare_dicts(
        config.RUN["ENV_STATUS_PRE"]["pvc"], config.RUN["ENV_STATUS_POST"]["pvc"]
    )
    namespace_diff = compare_dicts(
        config.RUN["ENV_STATUS_PRE"]["namespace"],
        config.RUN["ENV_STATUS_POST"]["namespace"],
    )
    volumesnapshot_diff = compare_dicts(
        config.RUN["ENV_STATUS_PRE"]["vs"], config.RUN["ENV_STATUS_POST"]["vs"]
    )
    if config.RUN["cephcluster"]:
        cephfs_diff = compare_dicts(
            config.RUN["ENV_STATUS_PRE"]["cephfs"],
            config.RUN["ENV_STATUS_POST"]["cephfs"],
        )
        cephbp_diff = compare_dicts(
            config.RUN["ENV_STATUS_PRE"]["cephbp"],
            config.RUN["ENV_STATUS_POST"]["cephbp"],
        )
        diffs_dict = {
            "pods": pod_diff,
            "storageClasses": sc_diff,
            "cephfs": cephfs_diff,
            "cephbp": cephbp_diff,
            "pvs": pv_diff,
            "pvcs": pvc_diff,
            "namespaces": namespace_diff,
            "vs": volumesnapshot_diff,
        }
    elif config.RUN["lvm"]:
        lv_diff = compare_dicts(
            config.RUN["ENV_STATUS_PRE"]["lv"],
            config.RUN["ENV_STATUS_POST"]["lv"],
        )
        diffs_dict = {
            "pods": pod_diff,
            "storageClasses": sc_diff,
            "pvs": pv_diff,
            "pvcs": pvc_diff,
            "namespaces": namespace_diff,
            "vs": volumesnapshot_diff,
            "lv": lv_diff,
        }

    leftover_detected = False

    leftovers = {"Leftovers added": [], "Leftovers removed": []}
    for kind, kind_diff in diffs_dict.items():
        if not kind_diff:
            continue
        if kind_diff[0]:
            leftovers["Leftovers added"].append({f"***{kind}***": kind_diff[0]})
            leftover_detected = True
        if kind_diff[1]:
            leftovers["Leftovers removed"].append({f"***{kind}***": kind_diff[1]})
            leftover_detected = True
    if leftover_detected:

      raise exceptions.ResourceLeftoversException(
            f"\nThere are leftovers in the environment after test case:"
            f"\nResources added:\n{yaml.dump(leftovers['Leftovers added'])}"
            f"\nResources "
            f"removed:\n {yaml.dump(leftovers['Leftovers removed'])}"
        )
E           ocs_ci.ocs.exceptions.ResourceLeftoversException:
E           There are leftovers in the environment after test case:
E           Resources added:
E           - 'cephbp':
E             - apiVersion: ceph.rook.io/v1
E               kind: CephBlockPool
E               metadata:
E                 creationTimestamp: '2026-07-10T01:00:42Z'
E                 deletionGracePeriodSeconds: 0
E                 deletionTimestamp: '2026-07-10T01:05:42Z'
E                 finalizers:
E                 - cephblockpool.ceph.rook.io
E                 generation: 3
E                 name: rbd-pool-test-ed9a7ef2bf2d4f4c984f2a9fe1
E                 namespace: openshift-storage
E                 resourceVersion: '1072498'
E                 uid: ce29aba7-4f77-40d6-8d57-3c1f6f558d0c
E               spec:
E                 application: ''
E                 compressionMode: none
E                 deviceClass: ssd
E                 enableCrushUpdates: true
E                 erasureCoded:
E                   codingChunks: 0
E                   dataChunks: 0
E                 failureDomain: host
E                 mirroring: {}
E                 parameters:
E                   compression_mode: none
E                 quotas: {}
E                 replicated:
E                   size: 3
E                 statusCheck:
E                   mirror: {}
E               status:
E                 cephx:
E                   peerToken: {}
E                 conditions:
E                 - lastHeartbeatTime: '2026-07-10T01:05:53Z'
E                   lastTransitionTime: '2026-07-10T01:05:43Z'
E                   message: pool "rbd-pool-test-ed9a7ef2bf2d4f4c984f2a9fe1" is empty and can
E                     be deleted
E                   reason: PoolEmpty
E                   status: 'False'
E                   type: PoolDeletionIsBlocked
E                 - lastHeartbeatTime: '2026-07-10T01:05:53Z'
E                   lastTransitionTime: '2026-07-10T01:05:53Z'
E                   message: CephBlockPool "openshift-storage/rbd-pool-test-ed9a7ef2bf2d4f4c984f2a9fe1"
E                     has no dependent custom resources blocking deletion
E                   reason: ObjectHasNoDependents
E                   status: 'False'
E                   type: DeletionIsBlocked
E                 info:
E                   failureDomain: host
E                   type: Replicated
E                 mirroringInfo: {}
E                 mirroringStatus: {}
E                 observedGeneration: 2
E                 phase: Ready
E                 poolID: 36
E                 snapshotScheduleStatus: {}
E
E           Resources removed:
E            []

ocs_ci/utility/environment_check.py:304: ResourceLeftoversException
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup reliability when CephBlockPool deletion via the UI fails, including verifying the resource is removed from the cluster before teardown completes.
* **Tests**
  * Expanded functional test coverage by enabling the `test_blocking_pool_creation_rules` test in additional environments (removed an environment-based skip).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->