### PR TITLE
Deprecate test_stop_start_node_validate_topology

### DIFF
--- a/tests/cross_functional/ui/test_odf_topology.py
+++ b/tests/cross_functional/ui/test_odf_topology.py
@@ -706,7 +706,7 @@ class TestODFTopology(object):
     @ignore_leftovers
     @polarion_id("OCS-4905")
     @skipif_hci_provider_or_client
-    def test_stop_start_node_validate_topology(
+    def deprecated_test_stop_start_node_validate_topology(
         self, nodes, setup_ui_class, teardown_nodes_job, threading_lock
     ):
         """


### PR DESCRIPTION
## Summary
- Deprecate `test_stop_start_node_validate_topology` by adding `deprecated_` prefix to the test method name

## Test plan
- [ ] Verify the test is no longer collected by pytest

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Deprecated the automated test covering ODF Topology behavior during worker node stop and restart.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->