### PR TITLE
 Add UI test for Erasure Coding pool creation and lifecycle

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -3598,6 +3598,16 @@ UI_INPUT_RULES_BLOCKING_POOL = {
     "rule4": UI_INPUT_RULES_GENERAL["rule3"],
 }
 
+EC_SUPPORTED_PROFILES = [
+    {"scheme": "2+2", "k": 2, "m": 2},
+    {"scheme": "4+2", "k": 4, "m": 2},
+    {"scheme": "5+2", "k": 5, "m": 2},
+    {"scheme": "6+2", "k": 6, "m": 2},
+    {"scheme": "8+3", "k": 8, "m": 3},
+    {"scheme": "8+4", "k": 8, "m": 4},
+    {"scheme": "8+6", "k": 8, "m": 6},
+]
+
 UI_INPUT_RULES_STORAGE_SYSTEM = {
     "rule1": UI_INPUT_RULES_GENERAL["rule4"],
     "rule2": UI_INPUT_RULES_GENERAL["rule1"],

--- a/ocs_ci/ocs/ui/page_objects/block_pools.py
+++ b/ocs_ci/ocs/ui/page_objects/block_pools.py
@@ -298,7 +298,12 @@ class StoragePools(CreateResourceForm, EditLabelForm, ResourceList):
         if ec_scheme is None:
             schemes = self.get_available_ec_schemes()
             recommended = [s["scheme"] for s in schemes if s["recommended"]]
-            ec_scheme = recommended[0] if recommended else schemes[0]["scheme"]
+            if not recommended:
+                raise ValueError(
+                    "No recommended EC scheme found and ec_scheme not specified. "
+                    f"Available schemes: {[s['scheme'] for s in schemes]}"
+                )
+            ec_scheme = recommended[0]
         self.select_ec_scheme(ec_scheme)
 
         if compression:

--- a/ocs_ci/ocs/ui/page_objects/block_pools.py
+++ b/ocs_ci/ocs/ui/page_objects/block_pools.py
@@ -1,7 +1,9 @@
+from ocs_ci.helpers.helpers import create_unique_resource_name
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.exceptions import CephHealthException
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.ui.base_ui import logger
+from ocs_ci.ocs.ui.helpers_ui import format_locator
 from ocs_ci.ocs.ui.page_objects.ceph_block_pool import CephBlockPool
 from ocs_ci.ocs.ui.page_objects.data_foundation_tabs_common import CreateResourceForm
 from ocs_ci.ocs.ui.page_objects.resource_list import ResourceList
@@ -107,7 +109,6 @@ class StoragePools(CreateResourceForm, EditLabelForm, ResourceList):
         self.select_search_by("name")
         self.clear_search()
         self.search(block_pool_name)
-        from ocs_ci.ocs.ui.helpers_ui import format_locator
 
         resource_actions = format_locator(
             self.generic_locators["actions_of_resource_from_list"],
@@ -144,18 +145,28 @@ class StoragePools(CreateResourceForm, EditLabelForm, ResourceList):
         """
         logger.info(f"Checking if the block pool {block_pool_name} exists")
 
-        from ocs_ci.ocs.ui.helpers_ui import format_locator
-
         block_pool_from_list = format_locator(
             self.generic_locators["resource_from_list_by_name"], block_pool_name
         )
 
         return self.check_element_presence(block_pool_from_list[::-1], timeout=10)
 
-    def proceed_resource_creation(self):
+    def proceed_resource_creation(self, volume_type="block"):
+        """
+        Proceeds to resource creation form and selects the volume type.
+
+        Args:
+            volume_type (str): 'block' or 'filesystem'. Default is 'block'.
+        """
         super().proceed_resource_creation()
         if self.ocs_version_semantic >= version.VERSION_4_17:
-            self.do_click(self.bp_loc["pool_type_block"])
+            if (
+                volume_type == "filesystem"
+                and self.ocs_version_semantic >= version.VERSION_4_22
+            ):
+                self.do_click(self.bp_loc["pool_type_filesystem"])
+            else:
+                self.do_click(self.bp_loc["pool_type_block"])
 
     def navigate_to_block_pool(self, block_pool_name: str):
         """
@@ -174,3 +185,163 @@ class StoragePools(CreateResourceForm, EditLabelForm, ResourceList):
         self.nav_to_resource_via_name(block_pool_name)
 
         return CephBlockPool()
+
+    def select_data_protection(self, protection_type):
+        """
+        Selects data protection policy on the pool creation form.
+
+        Args:
+            protection_type (str): 'replication' or 'erasure_coding'
+        """
+        locator_key = f"policy_{protection_type}"
+        logger.info(f"Selecting data protection policy: {protection_type}")
+        self.do_click(self.bp_loc[locator_key], enable_screenshot=True)
+
+    def get_available_ec_schemes(self):
+        """
+        Retrieves the list of available EC schemes from the scheme selection table.
+
+        Returns:
+            list[dict]: Each dict has 'scheme' (str), 'overhead' (str),
+                        and 'recommended' (bool).
+        """
+        self.wait_for_element_to_be_visible(
+            self.bp_loc["ec_scheme_table_rows"], timeout=15
+        )
+        rows = self.get_elements(self.bp_loc["ec_scheme_table_rows"])
+        schemes = []
+        for row in rows:
+            scheme_cell = row.find_element(
+                self.bp_loc["ec_row_scheme_cell"][1],
+                self.bp_loc["ec_row_scheme_cell"][0],
+            )
+            scheme_text = scheme_cell.text.strip()
+            has_badge = bool(
+                row.find_elements(
+                    self.bp_loc["ec_recommended_badge"][1],
+                    self.bp_loc["ec_recommended_badge"][0],
+                )
+            )
+            recommended = has_badge and "Recommended" in scheme_cell.text
+            overhead_cell = row.find_element(
+                self.bp_loc["ec_row_overhead_cell"][1],
+                self.bp_loc["ec_row_overhead_cell"][0],
+            )
+            scheme_name = scheme_text.replace("Recommended", "").strip()
+            schemes.append(
+                {
+                    "scheme": scheme_name,
+                    "overhead": overhead_cell.text.strip(),
+                    "recommended": recommended,
+                }
+            )
+        logger.info(f"Available EC schemes: {schemes}")
+        return schemes
+
+    def select_ec_scheme(self, scheme):
+        """
+        Selects an erasure coding scheme from the scheme table.
+
+        Args:
+            scheme (str): EC scheme identifier (e.g., '4+2')
+        """
+        logger.info(f"Selecting EC scheme: {scheme}")
+        locator = format_locator(self.bp_loc["ec_scheme_radio"], scheme)
+        self.do_click(locator, enable_screenshot=True)
+
+    def get_recommended_ec_scheme(self):
+        """
+        Returns the scheme string marked as 'Recommended'.
+
+        Returns:
+            str or None: The recommended scheme string, or None if not found.
+        """
+        schemes = self.get_available_ec_schemes()
+        for s in schemes:
+            if s["recommended"]:
+                return s["scheme"]
+        return None
+
+    def create_ec_pool(
+        self,
+        pool_name=None,
+        volume_type="block",
+        ec_scheme=None,
+        compression=True,
+    ):
+        """
+        Create an erasure coded storage pool via UI.
+
+        Args:
+            pool_name (str): Pool name suffix. Auto-generated if None.
+            volume_type (str): 'block' or 'filesystem'.
+            ec_scheme (str): EC scheme like '4+2'. If None, selects Recommended.
+            compression (bool): Enable compression checkbox.
+
+        Returns:
+            tuple: (full_pool_name, pool_status_ready)
+        """
+        if pool_name is None:
+            pool_name = create_unique_resource_name("test", "ec-pool")
+
+        logger.info(
+            f"Creating EC pool: name={pool_name}, type={volume_type}, "
+            f"scheme={ec_scheme}, compression={compression}"
+        )
+
+        self.proceed_resource_creation(volume_type=volume_type)
+
+        self.do_send_keys(self.bp_loc["pool_name_input"], pool_name)
+
+        self.select_data_protection("erasure_coding")
+
+        if ec_scheme is None:
+            schemes = self.get_available_ec_schemes()
+            recommended = [s["scheme"] for s in schemes if s["recommended"]]
+            ec_scheme = recommended[0] if recommended else schemes[0]["scheme"]
+        self.select_ec_scheme(ec_scheme)
+
+        if compression:
+            self.do_click(self.bp_loc["conpression_checkbox"])
+
+        self.do_click(self.bp_loc["pool_confirm_create"])
+
+        wait_for_text_result = self.wait_until_expected_text_is_found(
+            self.bp_loc["pool_state_inside_pool"], "Ready", timeout=60
+        )
+
+        full_pool_name = pool_name
+        if volume_type == "filesystem":
+            full_pool_name = f"ocs-storagecluster-cephfilesystem-{pool_name}"
+
+        if wait_for_text_result:
+            logger.info(f"EC pool {full_pool_name} created and is Ready")
+        else:
+            logger.warning(f"EC pool {full_pool_name} created but did not reach Ready")
+
+        return full_pool_name, wait_for_text_result
+
+    def verify_pool_ec_scheme_in_list(self, pool_name, expected_scheme):
+        """
+        Verifies the pool's EC scheme display in the Storage pools list.
+
+        Args:
+            pool_name (str): Full pool name as shown in the list.
+            expected_scheme (str): Expected scheme like '4+2'.
+
+        Returns:
+            bool: True if the scheme is displayed correctly.
+        """
+        logger.info(
+            f"Verifying EC scheme for pool {pool_name} in list: "
+            f"expecting {expected_scheme}"
+        )
+        replicas_locator = format_locator(
+            self.bp_loc["pool_replicas_in_list"], pool_name
+        )
+        replicas_text = self.get_element_text(replicas_locator)
+        logger.info(f"Pool {pool_name} replicas text: '{replicas_text}'")
+
+        has_ec = "Erasure coding" in replicas_text
+        has_scheme = expected_scheme in replicas_text
+        return has_ec and has_scheme

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -1935,6 +1935,39 @@ block_pool = {
     ),
 }
 
+block_pool_4_22 = {
+    "pool_type_filesystem": ("type-filesystem", By.ID),
+    "pool_name_input": ("pool-name", By.ID),
+    "policy_replication": ("policy-replication", By.ID),
+    "policy_erasure_coding": ("policy-erasure-coding", By.ID),
+    "ec_scheme_table_rows": (
+        "//table[@aria-label='Erasure coding scheme selection']//tbody/tr",
+        By.XPATH,
+    ),
+    "ec_scheme_radio": (
+        "//tr[.//td[@data-label='Scheme (k+m)' and "
+        "starts-with(normalize-space(.), '{}')]]"
+        "//input[@name='radioGroup']",
+        By.XPATH,
+    ),
+    "ec_row_scheme_cell": (
+        ".//td[@data-label='Scheme (k+m)']",
+        By.XPATH,
+    ),
+    "ec_row_overhead_cell": (
+        ".//td[@data-label='Storage overhead']",
+        By.XPATH,
+    ),
+    "ec_recommended_badge": (
+        ".//span[contains(@class, 'c-badge')]",
+        By.XPATH,
+    ),
+    "pool_replicas_in_list": (
+        'span[data-test="{}-replicas"]',
+        By.CSS_SELECTOR,
+    ),
+}
+
 storageclass = {
     "create_storageclass_button": ("Create StorageClass", By.LINK_TEXT),
     "input_storageclass_name": ('input[id="storage-class-name"]', By.CSS_SELECTOR),
@@ -3797,7 +3830,12 @@ locators = {
             **validation_4_21,
             **validation_4_22,
         },
-        "block_pool": {**block_pool, **block_pool_4_12, **block_pool_4_13},
+        "block_pool": {
+            **block_pool,
+            **block_pool_4_12,
+            **block_pool_4_13,
+            **block_pool_4_22,
+        },
         "storageclass": {**storageclass, **storageclass_4_9},
         "bucketclass": bucketclass,
         "topology": topology,

--- a/tests/functional/ui/test_error_improvements.py
+++ b/tests/functional/ui/test_error_improvements.py
@@ -1,12 +1,16 @@
 import logging
 
+import pytest
 from flaky import flaky
 
+from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import (
     skipif_ibm_cloud_managed,
     skipif_managed_service,
     black_squad,
+    green_squad,
     polarion_id,
+    tier2,
     tier3,
     skipif_ocs_version,
     mcg,
@@ -18,10 +22,63 @@ from ocs_ci.framework.pytest_customization.marks import (
     jira,
 )
 from ocs_ci.framework.testlib import ManageTest
+from ocs_ci.helpers import helpers
+from ocs_ci.helpers.helpers import create_unique_resource_name
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.cluster import get_ec_metadata_pool_name, is_ec_pool_supported
+from ocs_ci.ocs.exceptions import CommandFailed
+from ocs_ci.ocs.node import get_osd_running_nodes
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.ui.page_objects.page_navigator import PageNavigator
 
 logger = logging.getLogger(__name__)
+
+
+def _force_delete_ec_pool(pool_name, pool_type):
+    """
+    Force-delete an EC pool via CLI as a teardown fallback.
+
+    Args:
+        pool_name (str): Full pool name.
+        pool_type (str): 'block' or 'filesystem'.
+    """
+    namespace = config.ENV_DATA.get("cluster_namespace", "openshift-storage")
+
+    if pool_type == "block":
+        try:
+            OCP().exec_oc_cmd(
+                f"delete cephblockpool {pool_name} -n {namespace} "
+                "--force --grace-period=0"
+            )
+            logger.info(f"Force-deleted CephBlockPool {pool_name}")
+        except CommandFailed:
+            logger.debug(f"CephBlockPool {pool_name} already deleted or not found")
+    else:
+        suffix = pool_name.replace("ocs-storagecluster-cephfilesystem-", "")
+        try:
+            cf = OCP(kind="CephFilesystem", namespace=namespace)
+            cf_data = cf.get(resource_name="ocs-storagecluster-cephfilesystem")
+            data_pools = cf_data.get("spec", {}).get("dataPools", [])
+            for i, dp in enumerate(data_pools):
+                if dp.get("name") == suffix:
+                    cf.patch(
+                        resource_name="ocs-storagecluster-cephfilesystem",
+                        params=(
+                            f'[{{"op": "remove", ' f'"path": "/spec/dataPools/{i}"}}]'
+                        ),
+                        format_type="json",
+                    )
+                    logger.info(
+                        f"Force-deleted CephFilesystem data pool {suffix} "
+                        f"(index {i})"
+                    )
+                    break
+            else:
+                logger.debug(f"CephFilesystem data pool {suffix} not found")
+        except CommandFailed:
+            logger.debug(
+                f"CephFilesystem data pool {suffix} already deleted or not found"
+            )
 
 
 @ui
@@ -161,3 +218,238 @@ class TestErrorMessageImprovements(ManageTest):
             "Use an existing StorageClass", "Next"
         )
         storage_systems_tab.check_error_messages()
+
+
+@ui
+@tier2
+@green_squad
+@runs_on_provider
+@skipif_ibm_cloud_managed
+@skipif_managed_service
+@skipif_ocs_version("<4.22")
+class TestECPoolCreation(ManageTest):
+    """
+    Test Erasure Coded pool creation, scheme validation, IO, and lifecycle via UI.
+    """
+
+    @pytest.fixture(autouse=True)
+    def skip_if_ec_not_supported(self):
+        if not is_ec_pool_supported():
+            pytest.skip("EC pools not supported on this cluster")
+
+    @pytest.fixture()
+    def ec_pool_teardown(self, request):
+        """
+        Registers CLI-based force-deletion as a session-end finalizer
+        for any EC pools created during the test.
+        """
+        created_pools = []
+
+        def finalizer():
+            for name, ptype in created_pools:
+                _force_delete_ec_pool(name, ptype)
+
+        request.addfinalizer(finalizer)
+        return created_pools
+
+    @pytest.fixture()
+    def ec_io_cleanup(self, request):
+        """
+        Tracks StorageClass and Secret objects created for IO verification
+        and cleans them up in finalizer.
+        """
+        resources = []
+
+        def finalizer():
+            for obj in reversed(resources):
+                try:
+                    obj.delete()
+                    obj.ocp.wait_for_delete(obj.name, timeout=60)
+                except CommandFailed:
+                    logger.warning(f"Failed to delete {obj.kind}/{obj.name}")
+
+        request.addfinalizer(finalizer)
+        return resources
+
+    @pytest.mark.parametrize(
+        argnames=["pool_type"],
+        argvalues=[
+            pytest.param("block"),
+            pytest.param("filesystem"),
+        ],
+    )
+    def test_create_ec_pool(
+        self,
+        setup_ui_class,
+        ec_pool_teardown,
+        ec_io_cleanup,
+        pvc_factory,
+        pod_factory,
+        pool_type,
+    ):
+        """
+        Create an EC storage pool via UI, verify EC scheme selection,
+        run IO on the pool, then delete the pool.
+
+        Steps:
+            1. Navigate to Storage pools, click Create
+            2. Select volume type (block or filesystem)
+            3. Select Erasure coding under Data protection policy
+            4. Verify available EC schemes match cluster node count
+            5. Verify Recommended badge on appropriate scheme
+            6. Enable compression, select Recommended scheme, create pool
+            7. Verify pool in list shows correct EC scheme and Ready status
+            8. Create StorageClass + PVC + Pod on the new EC pool, run FIO
+            9. Verify IO completes without errors
+            10. Delete pool via UI
+        """
+        num_osd_hosts = len(get_osd_running_nodes())
+        logger.info(f"Cluster has {num_osd_hosts} OSD hosts")
+
+        expected_schemes = [
+            p["scheme"]
+            for p in constants.EC_SUPPORTED_PROFILES
+            if p["k"] + p["m"] <= num_osd_hosts
+        ]
+        logger.info(f"Expected available EC schemes: {expected_schemes}")
+
+        storage_pools = PageNavigator().navigate_storage_pools_page()
+        storage_pools.proceed_resource_creation(volume_type=pool_type)
+
+        pool_name = create_unique_resource_name("test", "ec-pool")
+        storage_pools.do_send_keys(storage_pools.bp_loc["pool_name_input"], pool_name)
+        storage_pools.select_data_protection("erasure_coding")
+
+        available = storage_pools.get_available_ec_schemes()
+        available_names = [s["scheme"] for s in available]
+        assert available_names == expected_schemes, (
+            f"EC schemes mismatch: UI shows {available_names}, "
+            f"expected {expected_schemes}"
+        )
+
+        recommended = [s for s in available if s["recommended"]]
+        assert recommended, "No EC scheme marked as Recommended"
+        recommended_scheme = recommended[0]["scheme"]
+        logger.info(f"Recommended EC scheme: {recommended_scheme}")
+
+        k, m = [int(x) for x in recommended_scheme.split("+")]
+        assert k + m + 1 <= num_osd_hosts, (
+            f"Recommended scheme {recommended_scheme} requires {k + m + 1} hosts "
+            f"but cluster has {num_osd_hosts}"
+        )
+
+        non_recommended = [s for s in available if not s["recommended"]]
+        for s in non_recommended:
+            nk, nm = [int(x) for x in s["scheme"].split("+")]
+            assert nk + nm + 1 > num_osd_hosts, (
+                f"Scheme {s['scheme']} should be Recommended "
+                f"(k+m+1={nk + nm + 1} <= {num_osd_hosts} hosts)"
+            )
+
+        storage_pools.do_click(storage_pools.bp_loc["conpression_checkbox"])
+
+        storage_pools.select_ec_scheme(recommended_scheme)
+        storage_pools.do_click(storage_pools.bp_loc["pool_confirm_create"])
+
+        full_pool_name = pool_name
+        if pool_type == "filesystem":
+            full_pool_name = f"ocs-storagecluster-cephfilesystem-{pool_name}"
+
+        ec_pool_teardown.append((full_pool_name, pool_type))
+
+        assert storage_pools.wait_until_expected_text_is_found(
+            storage_pools.bp_loc["pool_state_inside_pool"], "Ready", timeout=60
+        ), f"EC pool {full_pool_name} did not reach Ready state"
+
+        logger.info(f"EC pool created: {full_pool_name}")
+
+        storage_pools_page = PageNavigator().navigate_storage_pools_page()
+        assert storage_pools_page.verify_pool_ec_scheme_in_list(
+            full_pool_name, recommended_scheme
+        ), (
+            f"Pool {full_pool_name} not showing EC scheme "
+            f"{recommended_scheme} in list"
+        )
+
+        # --- IO verification on the UI-created EC pool ---
+        logger.info("Creating StorageClass and running IO on the new EC pool")
+        if pool_type == "block":
+            interface_type = constants.CEPHBLOCKPOOL
+            secret_obj = helpers.create_secret(interface_type=interface_type)
+            ec_io_cleanup.append(secret_obj)
+            sc_obj = helpers.create_storage_class(
+                interface_type=interface_type,
+                interface_name=get_ec_metadata_pool_name(),
+                secret_name=secret_obj.name,
+                data_pool_name=full_pool_name,
+            )
+            ec_io_cleanup.append(sc_obj)
+            access_mode = constants.ACCESS_MODE_RWO
+        else:
+            interface_type = constants.CEPHFILESYSTEM
+            secret_obj = helpers.create_secret(interface_type=interface_type)
+            ec_io_cleanup.append(secret_obj)
+            sc_obj = helpers.create_storage_class(
+                interface_type=interface_type,
+                interface_name=full_pool_name,
+                secret_name=secret_obj.name,
+            )
+            ec_io_cleanup.append(sc_obj)
+            access_mode = constants.ACCESS_MODE_RWX
+
+        logger.info(f"StorageClass '{sc_obj.name}' created for EC pool")
+
+        pvc_obj = pvc_factory(
+            interface=interface_type,
+            storageclass=sc_obj,
+            access_mode=access_mode,
+            size=5,
+        )
+        logger.info(f"PVC '{pvc_obj.name}' bound")
+
+        pod_obj = pod_factory(interface=interface_type, pvc=pvc_obj)
+        logger.info(f"Pod '{pod_obj.name}' running, starting IO")
+
+        pod_obj.run_io(storage_type="fs", size="256M", runtime=30)
+        fio_result = pod_obj.get_fio_results()
+        err_count = fio_result.get("jobs")[0].get("error")
+        assert err_count == 0, (
+            f"IO error on EC pool {full_pool_name}. " f"FIO result: {fio_result}"
+        )
+        logger.info("IO completed without errors on EC pool")
+
+        # --- Clean up IO resources before pool deletion ---
+        logger.info("Deleting IO pod, PVC, StorageClass and Secret")
+        pod_obj.delete(wait=True)
+        pod_obj.ocp.wait_for_delete(pod_obj.name, timeout=120)
+        logger.info(f"Pod '{pod_obj.name}' deleted")
+
+        pvc_obj.delete(wait=True)
+        pvc_obj.ocp.wait_for_delete(pvc_obj.name, timeout=120)
+        logger.info(f"PVC '{pvc_obj.name}' deleted")
+
+        sc_obj.delete()
+        sc_obj.ocp.wait_for_delete(sc_obj.name, timeout=60)
+        logger.info(f"StorageClass '{sc_obj.name}' deleted")
+
+        secret_obj.delete()
+        secret_obj.ocp.wait_for_delete(secret_obj.name, timeout=60)
+        logger.info(f"Secret '{secret_obj.name}' deleted")
+
+        ec_io_cleanup.clear()
+
+        # --- Delete pool via UI ---
+        storage_pools_page = PageNavigator().navigate_storage_pools_page()
+        assert storage_pools_page.delete_block_pool(
+            full_pool_name
+        ), f"Failed to delete pool {full_pool_name} via UI"
+
+        storage_pools_page.page_has_loaded()
+        assert not storage_pools_page.is_block_pool_exist(
+            full_pool_name
+        ), f"Pool {full_pool_name} still exists after deletion"
+
+        ec_pool_teardown.clear()
+        logger.info(
+            f"EC pool {full_pool_name} successfully created, IO verified, and deleted"
+        )

--- a/tests/functional/ui/test_error_improvements.py
+++ b/tests/functional/ui/test_error_improvements.py
@@ -26,10 +26,12 @@ from ocs_ci.helpers import helpers
 from ocs_ci.helpers.helpers import create_unique_resource_name
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.cluster import get_ec_metadata_pool_name, is_ec_pool_supported
-from ocs_ci.ocs.exceptions import CommandFailed
+from ocs_ci.ocs.exceptions import CommandFailed, TimeoutExpiredError
 from ocs_ci.ocs.node import get_osd_running_nodes
 from ocs_ci.ocs.ocp import OCP
+from ocs_ci.ocs.resources import pod
 from ocs_ci.ocs.ui.page_objects.page_navigator import PageNavigator
+from ocs_ci.utility.utils import TimeoutSampler
 
 logger = logging.getLogger(__name__)
 
@@ -236,6 +238,13 @@ class TestECPoolCreation(ManageTest):
     def skip_if_ec_not_supported(self):
         if not is_ec_pool_supported():
             pytest.skip("EC pools not supported on this cluster")
+        num_osd_hosts = len(get_osd_running_nodes())
+        min_k_plus_m = min(p["k"] + p["m"] for p in constants.EC_SUPPORTED_PROFILES)
+        if num_osd_hosts < min_k_plus_m:
+            pytest.skip(
+                f"Cluster has {num_osd_hosts} OSD hosts but smallest EC "
+                f"profile requires {min_k_plus_m}"
+            )
 
     @pytest.fixture()
     def ec_pool_teardown(self, request):
@@ -265,7 +274,7 @@ class TestECPoolCreation(ManageTest):
                 try:
                     obj.delete()
                     obj.ocp.wait_for_delete(obj.name, timeout=60)
-                except CommandFailed:
+                except (CommandFailed, TimeoutExpiredError):
                     logger.warning(f"Failed to delete {obj.kind}/{obj.name}")
 
         request.addfinalizer(finalizer)
@@ -444,6 +453,14 @@ class TestECPoolCreation(ManageTest):
             full_pool_name
         ), f"Failed to delete pool {full_pool_name} via UI"
 
+        ct_pod = pod.get_ceph_tools_pod()
+        logger.info(f"Waiting for Ceph pool '{full_pool_name}' to be removed")
+        for pools in TimeoutSampler(180, 10, ct_pod.exec_ceph_cmd, "ceph osd pool ls"):
+            if full_pool_name not in pools:
+                logger.info(f"Ceph pool '{full_pool_name}' removed successfully")
+                break
+
+        storage_pools_page = PageNavigator().navigate_storage_pools_page()
         storage_pools_page.page_has_loaded()
         assert not storage_pools_page.is_block_pool_exist(
             full_pool_name

--- a/tests/functional/z_cluster/nodes/test_nodes_maintenance.py
+++ b/tests/functional/z_cluster/nodes/test_nodes_maintenance.py
@@ -7,14 +7,8 @@ from subprocess import TimeoutExpired
 
 from ocs_ci.ocs.exceptions import (
     CephHealthException,
-    CommandFailed,
     ResourceWrongStatusException,
     ResourceNotFoundError,
-    TimeoutExpiredError,
-)
-from ocs_ci.utility.decorators import (
-    enable_high_recovery_during_rebalance_flag,
-    switch_to_provider_for_function,
 )
 from ocs_ci.utility.retry import retry
 from ocs_ci.utility.utils import ceph_health_check_base, TimeoutSampler
@@ -29,8 +23,6 @@ from ocs_ci.ocs.node import (
     remove_nodes,
     get_osd_running_nodes,
     get_node_objs,
-    get_mon_running_nodes,
-    get_node_mon_ids,
     generate_new_nodes_and_osd_running_nodes_ipi,
 )
 from ocs_ci.ocs.cluster import validate_existence_of_blocking_pdb
@@ -40,7 +32,6 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_hci_provider,
     skipif_rosa_hcp,
     skipif_compact_mode,
-    runs_on_provider,
 )
 from ocs_ci.framework.testlib import (
     tier1,
@@ -55,17 +46,8 @@ from ocs_ci.framework.testlib import (
     skipif_managed_service,
     skipif_more_than_three_workers,
 )
-from ocs_ci.helpers.ceph_helpers import get_ec_drain_thresholds, get_mon_quorum_count
 from ocs_ci.helpers.sanity_helpers import Sanity, SanityExternalCluster
-from ocs_ci.ocs.cluster import CephCluster, get_pgs_brief_dump, get_specific_pool_pgid
 from ocs_ci.ocs.resources import pod
-from ocs_ci.ocs.resources.pod import (
-    cal_md5sum,
-    verify_data_integrity,
-    get_ceph_tools_pod,
-    wait_for_storage_pods,
-    get_fio_rw_iops,
-)
 from ocs_ci.helpers.helpers import (
     label_worker_node,
     remove_label_from_worker_node,

--- a/tests/functional/z_cluster/nodes/test_nodes_maintenance.py
+++ b/tests/functional/z_cluster/nodes/test_nodes_maintenance.py
@@ -7,8 +7,14 @@ from subprocess import TimeoutExpired
 
 from ocs_ci.ocs.exceptions import (
     CephHealthException,
+    CommandFailed,
     ResourceWrongStatusException,
     ResourceNotFoundError,
+    TimeoutExpiredError,
+)
+from ocs_ci.utility.decorators import (
+    enable_high_recovery_during_rebalance_flag,
+    switch_to_provider_for_function,
 )
 from ocs_ci.utility.retry import retry
 from ocs_ci.utility.utils import ceph_health_check_base, TimeoutSampler
@@ -23,6 +29,8 @@ from ocs_ci.ocs.node import (
     remove_nodes,
     get_osd_running_nodes,
     get_node_objs,
+    get_mon_running_nodes,
+    get_node_mon_ids,
     generate_new_nodes_and_osd_running_nodes_ipi,
 )
 from ocs_ci.ocs.cluster import validate_existence_of_blocking_pdb
@@ -32,6 +40,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_hci_provider,
     skipif_rosa_hcp,
     skipif_compact_mode,
+    runs_on_provider,
 )
 from ocs_ci.framework.testlib import (
     tier1,
@@ -46,8 +55,17 @@ from ocs_ci.framework.testlib import (
     skipif_managed_service,
     skipif_more_than_three_workers,
 )
+from ocs_ci.helpers.ceph_helpers import get_ec_drain_thresholds, get_mon_quorum_count
 from ocs_ci.helpers.sanity_helpers import Sanity, SanityExternalCluster
+from ocs_ci.ocs.cluster import CephCluster, get_pgs_brief_dump, get_specific_pool_pgid
 from ocs_ci.ocs.resources import pod
+from ocs_ci.ocs.resources.pod import (
+    cal_md5sum,
+    verify_data_integrity,
+    get_ceph_tools_pod,
+    wait_for_storage_pods,
+    get_fio_rw_iops,
+)
 from ocs_ci.helpers.helpers import (
     label_worker_node,
     remove_label_from_worker_node,
@@ -626,14 +644,10 @@ class TestECNodeOperations(ManageTest):
         Initialize sanity helpers and register a finalizer to restart
         any stopped nodes. Skip on client clusters.
 
-        Adjusts two Ceph settings for EC node-failure testing:
-        - osdMaintenanceTimeout=0 on CephCluster CR so Rook releases
-          the noout flag immediately instead of holding it for 30 min.
-        - mon_osd_min_in_ratio=0.3 so Ceph can mark all down OSDs as
-          out even when >25% of OSDs are offline (default 0.75 blocks
-          the last OSD, stalling EC recovery).
-
-        Both are restored to their original values in the finalizer.
+        Sets osdMaintenanceTimeout to 0 on the CephCluster CR so Rook's
+        disruption controller releases the noout flag immediately instead
+        of holding it for 30 minutes. Restores the original value in the
+        finalizer.
 
         """
         with config.RunWithProviderConfigContextIfAvailable():
@@ -645,9 +659,10 @@ class TestECNodeOperations(ManageTest):
             self.sanity_helpers = Sanity()
             self.stopped_node_objs = []
             self._nodes = nodes
-            self._test_pod = None
 
-            # --- osdMaintenanceTimeout on CephCluster CR ---
+            # Lower osdMaintenanceTimeout so Rook releases the noout
+            # flag immediately after detecting OSDs down, instead of
+            # holding it for the default 30 minutes.
             ceph_cluster_ocp = ocp.OCP(
                 kind=constants.CEPH_CLUSTER,
                 namespace=config.ENV_DATA["cluster_namespace"],
@@ -656,7 +671,9 @@ class TestECNodeOperations(ManageTest):
             ceph_cluster_cr = ceph_cluster_ocp.get()
             dm = ceph_cluster_cr.get("spec", {}).get("disruptionManagement", {})
             original_timeout = dm.get("osdMaintenanceTimeout")
-            log.info(f"Setting osdMaintenanceTimeout to 0 (was: {original_timeout})")
+            log.info(
+                f"Setting osdMaintenanceTimeout to 0 " f"(was: {original_timeout})"
+            )
             ceph_cluster_ocp.patch(
                 params='[{"op": "add", "path": '
                 '"/spec/disruptionManagement/osdMaintenanceTimeout", '
@@ -664,123 +681,52 @@ class TestECNodeOperations(ManageTest):
                 format_type="json",
             )
 
-            # --- mon_osd_min_in_ratio via ceph config ---
-            # Default 0.75 blocks auto-out when >25% OSDs are down,
-            # leaving the last OSD as down+in and stalling EC recovery.
-            ct_pod = get_ceph_tools_pod()
-            original_min_in_ratio = ct_pod.exec_ceph_cmd(
-                "ceph config get mon mon_osd_min_in_ratio"
-            )
-            original_min_in_ratio = str(original_min_in_ratio).strip()
-            log.info(
-                f"Setting mon_osd_min_in_ratio to 0.3 "
-                f"(was: {original_min_in_ratio})"
-            )
-            ct_pod.exec_ceph_cmd("ceph config set mon mon_osd_min_in_ratio 0.3")
-
-            def settings_finalizer():
-                """Restore Ceph settings — runs LAST (registered first)."""
+            def finalizer():
                 with config.RunWithProviderConfigContextIfAvailable():
-                    log.info("Finalizer: restoring cluster settings")
-                    try:
-                        if original_timeout is not None:
-                            log.info(
-                                f"Finalizer: restoring osdMaintenanceTimeout "
-                                f"to {original_timeout}"
-                            )
-                            ceph_cluster_ocp.patch(
-                                params='[{"op": "replace", "path": '
-                                '"/spec/disruptionManagement/'
-                                'osdMaintenanceTimeout", '
-                                f'"value": {original_timeout}}}]',
-                                format_type="json",
-                            )
-                        else:
-                            log.info(
-                                "Finalizer: removing osdMaintenanceTimeout "
-                                "(was not set originally)"
-                            )
-                            try:
-                                ceph_cluster_ocp.patch(
-                                    params='[{"op": "remove", "path": '
-                                    '"/spec/disruptionManagement/'
-                                    'osdMaintenanceTimeout"}]',
-                                    format_type="json",
-                                )
-                            except CommandFailed:
-                                log.info(
-                                    "osdMaintenanceTimeout already absent, "
-                                    "skipping removal"
-                                )
-                    except CommandFailed as e:
-                        log.error(
-                            f"Finalizer: failed to restore "
-                            f"osdMaintenanceTimeout: {e}"
-                        )
-
-                    try:
-                        restore_pod = get_ceph_tools_pod()
+                    # Restore osdMaintenanceTimeout
+                    if original_timeout is not None:
                         log.info(
-                            f"Finalizer: restoring mon_osd_min_in_ratio "
-                            f"to {original_min_in_ratio}"
+                            f"Finalizer: restoring osdMaintenanceTimeout "
+                            f"to {original_timeout}"
                         )
-                        restore_pod.exec_ceph_cmd(
-                            f"ceph config set mon mon_osd_min_in_ratio "
-                            f"{original_min_in_ratio}"
+                        ceph_cluster_ocp.patch(
+                            params='[{"op": "replace", "path": '
+                            '"/spec/disruptionManagement/'
+                            'osdMaintenanceTimeout", '
+                            f'"value": {original_timeout}}}]',
+                            format_type="json",
                         )
-                    except CommandFailed as e:
-                        log.error(
-                            f"Finalizer: failed to restore "
-                            f"mon_osd_min_in_ratio: {e}"
-                        )
-
-            request.addfinalizer(settings_finalizer)
-
-    def _register_node_restart_finalizer(self, request):
-        """Register a finalizer for node restart and pod cleanup.
-
-        Must be called from the test method AFTER pod_factory is used,
-        so LIFO ordering ensures this runs BEFORE pod_factory's
-        finalizer. This prevents pod delete from hanging on volume
-        detach while nodes are still down.
-        """
-
-        def node_restart_finalizer():
-            with config.RunWithProviderConfigContextIfAvailable():
-                # Force-delete the test pod so pod_factory's
-                # finalizer won't hang on volume detach.
-                if self._test_pod and not self._test_pod._is_deleted:
-                    log.info(
-                        f"Finalizer: force-deleting test pod " f"{self._test_pod.name}"
-                    )
-                    try:
-                        self._test_pod.delete(force=True)
-                        self._test_pod._is_deleted = True
-                    except CommandFailed:
-                        log.warning("Finalizer: test pod already deleted")
-                        self._test_pod._is_deleted = True
-
-                # Restart any stopped nodes
-                if self.stopped_node_objs:
-                    log.info(
-                        f"Finalizer: restarting "
-                        f"{len(self.stopped_node_objs)} stopped nodes"
-                    )
-                    try:
-                        self._nodes.start_nodes(self.stopped_node_objs)
+                    else:
                         log.info(
-                            "Finalizer: waiting for storage pods and "
-                            "Ceph recovery after node restart"
+                            "Finalizer: removing osdMaintenanceTimeout " "(was not set)"
                         )
-                        wait_for_storage_pods(timeout=600)
-                    except (
-                        CommandFailed,
-                        ResourceWrongStatusException,
-                        TimeoutExpiredError,
-                    ) as e:
-                        log.error(f"Finalizer start_nodes failed: {e}")
+                        ceph_cluster_ocp.patch(
+                            params='[{"op": "remove", "path": '
+                            '"/spec/disruptionManagement/'
+                            'osdMaintenanceTimeout"}]',
+                            format_type="json",
+                        )
 
-        request.addfinalizer(node_restart_finalizer)
+                    if self.stopped_node_objs:
+                        log.info(
+                            f"Finalizer: restarting "
+                            f"{len(self.stopped_node_objs)} stopped nodes"
+                        )
+                        try:
+                            self._nodes.start_nodes(self.stopped_node_objs)
+                            log.info(
+                                "Finalizer: waiting for storage pods and "
+                                "Ceph recovery after node restart"
+                            )
+                            wait_for_storage_pods(timeout=600)
+                        except (
+                            CommandFailed,
+                            ResourceWrongStatusException,
+                            TimeoutExpiredError,
+                        ) as e:
+                            log.error(f"Finalizer start_nodes failed: {e}")
+
+            request.addfinalizer(finalizer)
 
     @enable_high_recovery_during_rebalance_flag
     @switch_to_provider_for_function
@@ -846,24 +792,21 @@ class TestECNodeOperations(ManageTest):
                 break
 
             # Check if remaining non-clean PGs are only topology-limited:
-            # PGs with "undersized" can't recover while a host is down
-            # because CRUSH can't place all EC chunks on the remaining
-            # hosts. These resolve only when the node returns. Match
-            # any active+undersized variant (may include degraded,
-            # remapped, etc.).
+            # active+undersized+degraded PGs can't recover while a host
+            # is down because CRUSH can't place all EC chunks on the
+            # remaining hosts. These resolve only when the node returns.
             topology_stuck = sum(
                 s["count"]
                 for s in pg_states
-                if "active" in s["state_name"]
-                and "undersized" in s["state_name"]
-                and "clean" not in s["state_name"]
+                if s["state_name"] == "active+undersized+degraded"
             )
             recoverable_dirty = total - clean_count - topology_stuck
             if recoverable_dirty == 0 and clean_count > 0:
                 log.info(
                     f"Recovery complete: {clean_count}/{total} PGs clean, "
                     f"{topology_stuck} PG(s) topology-limited "
-                    f"(undersized, will resolve when node returns)"
+                    f"(active+undersized+degraded, will resolve when "
+                    f"node returns)"
                 )
                 break
 
@@ -901,17 +844,6 @@ class TestECNodeOperations(ManageTest):
             time.sleep(interval)
 
     @switch_to_provider_for_function
-    def _log_ceph_status_on_io_failure(self):
-        """Log ceph status to help diagnose write IO failures."""
-        try:
-            ct_pod = self._get_resilient_ceph_tools_pod()
-            status = ct_pod.exec_ceph_cmd("ceph status")
-            log.warning(f"Ceph status at IO failure: {status}")
-        except (CommandFailed, TimeoutExpiredError):
-            log.warning("Could not retrieve ceph status after IO failure")
-
-    @switch_to_provider_for_function
-    @enable_high_recovery_during_rebalance_flag
     def _wait_for_stable_degraded(self, ct_pod, timeout=600, checks=3, interval=20):
         """Wait until PG states stabilize in a degraded condition."""
         stable_count = 0
@@ -940,24 +872,16 @@ class TestECNodeOperations(ManageTest):
 
     @switch_to_provider_for_function
     def _run_write_io(self, pod_obj):
-        """Run a small FIO write and wait for completion.
-
-        On failure, logs ceph status for diagnostics before re-raising.
-        """
-        try:
-            pod_obj.run_io(
-                storage_type="fs",
-                size="64M",
-                io_direction="wo",
-                runtime=0,
-                bs="4K",
-                fio_filename="drain_write_test",
-            )
-            get_fio_rw_iops(pod_obj)
-        except (CommandFailed, TimeoutExpiredError, TimeoutError) as e:
-            log.warning(f"Write IO failed: {e}")
-            self._log_ceph_status_on_io_failure()
-            raise
+        """Run a small FIO write and wait for completion."""
+        pod_obj.run_io(
+            storage_type="fs",
+            size="64M",
+            io_direction="wo",
+            runtime=0,
+            bs="4K",
+            fio_filename="drain_write_test",
+        )
+        get_fio_rw_iops(pod_obj)
 
     @switch_to_provider_for_function
     def _try_write_io(self, pod_obj):
@@ -974,8 +898,7 @@ class TestECNodeOperations(ManageTest):
             )
             get_fio_rw_iops(pod_obj)
             return True
-        except (CommandFailed, TimeoutExpiredError, TimeoutError):
-            self._log_ceph_status_on_io_failure()
+        except (CommandFailed, TimeoutExpiredError):
             return False
 
     @switch_to_provider_for_function
@@ -1175,10 +1098,10 @@ class TestECNodeOperations(ManageTest):
     @tier4a
     @runs_on_provider
     @skipif_managed_service
-    @pytest.mark.polarion_id("OCS-8057")
+    @ignore_leftovers  # Pod/PVC cleanup may hang on degraded EC storage
+    @pytest.mark.polarion_id("OCS-XXXX")
     def test_ec_gradual_node_shutdown(
         self,
-        request,
         nodes,
         node_restart_teardown,
         pvc_factory,
@@ -1203,8 +1126,22 @@ class TestECNodeOperations(ManageTest):
             ), f"Not enough OSD hosts ({total_hosts}) for EC pool (need {size})"
 
             # Phase 1: Create workload on a master node (never shut down)
-            pod_obj, original_md5 = self._create_workload_on_master(
-                pvc_factory, pod_factory
+            master_nodes = get_nodes(node_type=constants.MASTER_MACHINE)
+            master_node_name = master_nodes[0].name if master_nodes else None
+            # Explicitly use the default RBD SC to avoid picking up
+            # leftover day-2 SCs on HCI platforms (the auto-detection
+            # picks the first SC matching the RBD provisioner).
+            from ocs_ci.ocs.resources.ocs import OCS
+
+            sc_ocp = ocp.OCP(
+                kind="StorageClass",
+                resource_name=constants.DEFAULT_STORAGECLASS_RBD,
+            )
+            sc_obj = OCS(**sc_ocp.get())
+            pvc_obj = pvc_factory(
+                interface=constants.CEPHBLOCKPOOL,
+                size=5,
+                storageclass=sc_obj,
             )
             # Register node restart finalizer AFTER pod_factory so
             # LIFO runs it BEFORE pod_factory's delete finalizer.
@@ -1276,6 +1213,10 @@ class TestECNodeOperations(ManageTest):
                 )
                 shutdown_node_obj = get_node_objs([node_name])[0]
                 self.stopped_node_objs.append(shutdown_node_obj)
+                log.info(
+                    f"Shutting down node {node_name} ({i}/{max_shutdowns}), "
+                    f"{live_hosts} hosts will remain"
+                )
                 nodes.stop_nodes([shutdown_node_obj])
 
                 log.test_step(
@@ -1359,6 +1300,8 @@ class TestECNodeOperations(ManageTest):
             assert ceph_cluster.wait_for_rebalance(
                 timeout=3600, repeat=3
             ), "Post-recovery rebalance did not complete"
+
+            # Clear the list so the finalizer does not re-start them
             self.stopped_node_objs.clear()
 
             log.test_step("Post-recovery: verifying chunk distribution")
@@ -1388,10 +1331,9 @@ class TestECNodeOperations(ManageTest):
     @runs_on_provider
     @skipif_managed_service
     @ignore_leftovers
-    @pytest.mark.polarion_id("OCS-8058")
+    @pytest.mark.polarion_id("OCS-YYYY")
     def test_ec_bulk_node_shutdown_data_integrity(
         self,
-        request,
         nodes,
         node_restart_teardown,
         pvc_factory,
@@ -1411,24 +1353,32 @@ class TestECNodeOperations(ManageTest):
             thresholds = get_ec_drain_thresholds()
             m = thresholds["m"]
             size = thresholds["size"]
-            min_size = thresholds["min_size"]
             total_hosts = thresholds["total_osd_hosts"]
-            if total_hosts < size:
-                pytest.skip(
-                    f"Not enough OSD hosts ({total_hosts}) "
-                    f"for EC pool (need {size})"
-                )
+            assert (
+                total_hosts >= size
+            ), f"Not enough OSD hosts ({total_hosts}) for EC pool (need {size})"
 
             shutdown_order = self._get_eligible_shutdown_order()
-            if len(shutdown_order) < m:
-                pytest.skip(
-                    f"Need at least {m} eligible worker OSD nodes for bulk "
-                    f"shutdown, only {len(shutdown_order)} available"
-                )
+            assert len(shutdown_order) >= m, (
+                f"Need at least {m} eligible worker OSD nodes for bulk "
+                f"shutdown, only {len(shutdown_order)} available"
+            )
 
             # Phase 1: Create workload on a master node (never shut down)
-            pod_obj, original_md5 = self._create_workload_on_master(
-                pvc_factory, pod_factory
+            master_nodes = get_nodes(node_type=constants.MASTER_MACHINE)
+            master_node_name = master_nodes[0].name if master_nodes else None
+
+            from ocs_ci.ocs.resources.ocs import OCS
+
+            sc_ocp = ocp.OCP(
+                kind="StorageClass",
+                resource_name=constants.DEFAULT_STORAGECLASS_RBD,
+            )
+            sc_obj = OCS(**sc_ocp.get())
+            pvc_obj = pvc_factory(
+                interface=constants.CEPHBLOCKPOOL,
+                size=5,
+                storageclass=sc_obj,
             )
             self._register_node_restart_finalizer(request)
 
@@ -1446,11 +1396,10 @@ class TestECNodeOperations(ManageTest):
             for node_name in targets:
                 node_mons = get_node_mon_ids(node_name)
                 mons_on_targets += len(node_mons)
-            if (quorum_count - mons_on_targets) < 2:
-                pytest.skip(
-                    f"Bulk shutdown would break mon quorum: "
-                    f"{quorum_count} in quorum, {mons_on_targets} on targets"
-                )
+            assert (quorum_count - mons_on_targets) >= 2, (
+                f"Bulk shutdown would break mon quorum: "
+                f"{quorum_count} in quorum, {mons_on_targets} on targets"
+            )
 
             # Phase 4: Bulk shutdown
             self._log_banner(
@@ -1458,6 +1407,7 @@ class TestECNodeOperations(ManageTest):
             )
             target_node_objs = get_node_objs(targets)
             self.stopped_node_objs.extend(target_node_objs)
+            log.info(f"Powering off {len(target_node_objs)} nodes simultaneously")
             nodes.stop_nodes(target_node_objs)
 
             log.test_step("Waiting 30s for Ceph to detect OSD failures")

--- a/tests/functional/z_cluster/nodes/test_nodes_maintenance.py
+++ b/tests/functional/z_cluster/nodes/test_nodes_maintenance.py
@@ -644,10 +644,14 @@ class TestECNodeOperations(ManageTest):
         Initialize sanity helpers and register a finalizer to restart
         any stopped nodes. Skip on client clusters.
 
-        Sets osdMaintenanceTimeout to 0 on the CephCluster CR so Rook's
-        disruption controller releases the noout flag immediately instead
-        of holding it for 30 minutes. Restores the original value in the
-        finalizer.
+        Adjusts two Ceph settings for EC node-failure testing:
+        - osdMaintenanceTimeout=0 on CephCluster CR so Rook releases
+          the noout flag immediately instead of holding it for 30 min.
+        - mon_osd_min_in_ratio=0.3 so Ceph can mark all down OSDs as
+          out even when >25% of OSDs are offline (default 0.75 blocks
+          the last OSD, stalling EC recovery).
+
+        Both are restored to their original values in the finalizer.
 
         """
         with config.RunWithProviderConfigContextIfAvailable():
@@ -659,10 +663,9 @@ class TestECNodeOperations(ManageTest):
             self.sanity_helpers = Sanity()
             self.stopped_node_objs = []
             self._nodes = nodes
+            self._test_pod = None
 
-            # Lower osdMaintenanceTimeout so Rook releases the noout
-            # flag immediately after detecting OSDs down, instead of
-            # holding it for the default 30 minutes.
+            # --- osdMaintenanceTimeout on CephCluster CR ---
             ceph_cluster_ocp = ocp.OCP(
                 kind=constants.CEPH_CLUSTER,
                 namespace=config.ENV_DATA["cluster_namespace"],
@@ -671,9 +674,7 @@ class TestECNodeOperations(ManageTest):
             ceph_cluster_cr = ceph_cluster_ocp.get()
             dm = ceph_cluster_cr.get("spec", {}).get("disruptionManagement", {})
             original_timeout = dm.get("osdMaintenanceTimeout")
-            log.info(
-                f"Setting osdMaintenanceTimeout to 0 " f"(was: {original_timeout})"
-            )
+            log.info(f"Setting osdMaintenanceTimeout to 0 (was: {original_timeout})")
             ceph_cluster_ocp.patch(
                 params='[{"op": "add", "path": '
                 '"/spec/disruptionManagement/osdMaintenanceTimeout", '
@@ -681,52 +682,123 @@ class TestECNodeOperations(ManageTest):
                 format_type="json",
             )
 
-            def finalizer():
+            # --- mon_osd_min_in_ratio via ceph config ---
+            # Default 0.75 blocks auto-out when >25% OSDs are down,
+            # leaving the last OSD as down+in and stalling EC recovery.
+            ct_pod = get_ceph_tools_pod()
+            original_min_in_ratio = ct_pod.exec_ceph_cmd(
+                "ceph config get mon mon_osd_min_in_ratio"
+            )
+            original_min_in_ratio = str(original_min_in_ratio).strip()
+            log.info(
+                f"Setting mon_osd_min_in_ratio to 0.3 "
+                f"(was: {original_min_in_ratio})"
+            )
+            ct_pod.exec_ceph_cmd("ceph config set mon mon_osd_min_in_ratio 0.3")
+
+            def settings_finalizer():
+                """Restore Ceph settings — runs LAST (registered first)."""
                 with config.RunWithProviderConfigContextIfAvailable():
-                    # Restore osdMaintenanceTimeout
-                    if original_timeout is not None:
-                        log.info(
-                            f"Finalizer: restoring osdMaintenanceTimeout "
-                            f"to {original_timeout}"
-                        )
-                        ceph_cluster_ocp.patch(
-                            params='[{"op": "replace", "path": '
-                            '"/spec/disruptionManagement/'
-                            'osdMaintenanceTimeout", '
-                            f'"value": {original_timeout}}}]',
-                            format_type="json",
-                        )
-                    else:
-                        log.info(
-                            "Finalizer: removing osdMaintenanceTimeout " "(was not set)"
-                        )
-                        ceph_cluster_ocp.patch(
-                            params='[{"op": "remove", "path": '
-                            '"/spec/disruptionManagement/'
-                            'osdMaintenanceTimeout"}]',
-                            format_type="json",
-                        )
-
-                    if self.stopped_node_objs:
-                        log.info(
-                            f"Finalizer: restarting "
-                            f"{len(self.stopped_node_objs)} stopped nodes"
-                        )
-                        try:
-                            self._nodes.start_nodes(self.stopped_node_objs)
+                    log.info("Finalizer: restoring cluster settings")
+                    try:
+                        if original_timeout is not None:
                             log.info(
-                                "Finalizer: waiting for storage pods and "
-                                "Ceph recovery after node restart"
+                                f"Finalizer: restoring osdMaintenanceTimeout "
+                                f"to {original_timeout}"
                             )
-                            wait_for_storage_pods(timeout=600)
-                        except (
-                            CommandFailed,
-                            ResourceWrongStatusException,
-                            TimeoutExpiredError,
-                        ) as e:
-                            log.error(f"Finalizer start_nodes failed: {e}")
+                            ceph_cluster_ocp.patch(
+                                params='[{"op": "replace", "path": '
+                                '"/spec/disruptionManagement/'
+                                'osdMaintenanceTimeout", '
+                                f'"value": {original_timeout}}}]',
+                                format_type="json",
+                            )
+                        else:
+                            log.info(
+                                "Finalizer: removing osdMaintenanceTimeout "
+                                "(was not set originally)"
+                            )
+                            try:
+                                ceph_cluster_ocp.patch(
+                                    params='[{"op": "remove", "path": '
+                                    '"/spec/disruptionManagement/'
+                                    'osdMaintenanceTimeout"}]',
+                                    format_type="json",
+                                )
+                            except CommandFailed:
+                                log.info(
+                                    "osdMaintenanceTimeout already absent, "
+                                    "skipping removal"
+                                )
+                    except CommandFailed as e:
+                        log.error(
+                            f"Finalizer: failed to restore "
+                            f"osdMaintenanceTimeout: {e}"
+                        )
 
-            request.addfinalizer(finalizer)
+                    try:
+                        restore_pod = get_ceph_tools_pod()
+                        log.info(
+                            f"Finalizer: restoring mon_osd_min_in_ratio "
+                            f"to {original_min_in_ratio}"
+                        )
+                        restore_pod.exec_ceph_cmd(
+                            f"ceph config set mon mon_osd_min_in_ratio "
+                            f"{original_min_in_ratio}"
+                        )
+                    except CommandFailed as e:
+                        log.error(
+                            f"Finalizer: failed to restore "
+                            f"mon_osd_min_in_ratio: {e}"
+                        )
+
+            request.addfinalizer(settings_finalizer)
+
+    def _register_node_restart_finalizer(self, request):
+        """Register a finalizer for node restart and pod cleanup.
+
+        Must be called from the test method AFTER pod_factory is used,
+        so LIFO ordering ensures this runs BEFORE pod_factory's
+        finalizer. This prevents pod delete from hanging on volume
+        detach while nodes are still down.
+        """
+
+        def node_restart_finalizer():
+            with config.RunWithProviderConfigContextIfAvailable():
+                # Force-delete the test pod so pod_factory's
+                # finalizer won't hang on volume detach.
+                if self._test_pod and not self._test_pod._is_deleted:
+                    log.info(
+                        f"Finalizer: force-deleting test pod " f"{self._test_pod.name}"
+                    )
+                    try:
+                        self._test_pod.delete(force=True)
+                        self._test_pod._is_deleted = True
+                    except CommandFailed:
+                        log.warning("Finalizer: test pod already deleted")
+                        self._test_pod._is_deleted = True
+
+                # Restart any stopped nodes
+                if self.stopped_node_objs:
+                    log.info(
+                        f"Finalizer: restarting "
+                        f"{len(self.stopped_node_objs)} stopped nodes"
+                    )
+                    try:
+                        self._nodes.start_nodes(self.stopped_node_objs)
+                        log.info(
+                            "Finalizer: waiting for storage pods and "
+                            "Ceph recovery after node restart"
+                        )
+                        wait_for_storage_pods(timeout=600)
+                    except (
+                        CommandFailed,
+                        ResourceWrongStatusException,
+                        TimeoutExpiredError,
+                    ) as e:
+                        log.error(f"Finalizer start_nodes failed: {e}")
+
+        request.addfinalizer(node_restart_finalizer)
 
     @enable_high_recovery_during_rebalance_flag
     @switch_to_provider_for_function
@@ -792,21 +864,24 @@ class TestECNodeOperations(ManageTest):
                 break
 
             # Check if remaining non-clean PGs are only topology-limited:
-            # active+undersized+degraded PGs can't recover while a host
-            # is down because CRUSH can't place all EC chunks on the
-            # remaining hosts. These resolve only when the node returns.
+            # PGs with "undersized" can't recover while a host is down
+            # because CRUSH can't place all EC chunks on the remaining
+            # hosts. These resolve only when the node returns. Match
+            # any active+undersized variant (may include degraded,
+            # remapped, etc.).
             topology_stuck = sum(
                 s["count"]
                 for s in pg_states
-                if s["state_name"] == "active+undersized+degraded"
+                if "active" in s["state_name"]
+                and "undersized" in s["state_name"]
+                and "clean" not in s["state_name"]
             )
             recoverable_dirty = total - clean_count - topology_stuck
             if recoverable_dirty == 0 and clean_count > 0:
                 log.info(
                     f"Recovery complete: {clean_count}/{total} PGs clean, "
                     f"{topology_stuck} PG(s) topology-limited "
-                    f"(active+undersized+degraded, will resolve when "
-                    f"node returns)"
+                    f"(undersized, will resolve when node returns)"
                 )
                 break
 
@@ -844,6 +919,17 @@ class TestECNodeOperations(ManageTest):
             time.sleep(interval)
 
     @switch_to_provider_for_function
+    def _log_ceph_status_on_io_failure(self):
+        """Log ceph status to help diagnose write IO failures."""
+        try:
+            ct_pod = self._get_resilient_ceph_tools_pod()
+            status = ct_pod.exec_ceph_cmd("ceph status")
+            log.warning(f"Ceph status at IO failure: {status}")
+        except (CommandFailed, TimeoutExpiredError):
+            log.warning("Could not retrieve ceph status after IO failure")
+
+    @switch_to_provider_for_function
+    @enable_high_recovery_during_rebalance_flag
     def _wait_for_stable_degraded(self, ct_pod, timeout=600, checks=3, interval=20):
         """Wait until PG states stabilize in a degraded condition."""
         stable_count = 0
@@ -872,16 +958,24 @@ class TestECNodeOperations(ManageTest):
 
     @switch_to_provider_for_function
     def _run_write_io(self, pod_obj):
-        """Run a small FIO write and wait for completion."""
-        pod_obj.run_io(
-            storage_type="fs",
-            size="64M",
-            io_direction="wo",
-            runtime=0,
-            bs="4K",
-            fio_filename="drain_write_test",
-        )
-        get_fio_rw_iops(pod_obj)
+        """Run a small FIO write and wait for completion.
+
+        On failure, logs ceph status for diagnostics before re-raising.
+        """
+        try:
+            pod_obj.run_io(
+                storage_type="fs",
+                size="64M",
+                io_direction="wo",
+                runtime=0,
+                bs="4K",
+                fio_filename="drain_write_test",
+            )
+            get_fio_rw_iops(pod_obj)
+        except (CommandFailed, TimeoutExpiredError, TimeoutError) as e:
+            log.warning(f"Write IO failed: {e}")
+            self._log_ceph_status_on_io_failure()
+            raise
 
     @switch_to_provider_for_function
     def _try_write_io(self, pod_obj):
@@ -898,7 +992,8 @@ class TestECNodeOperations(ManageTest):
             )
             get_fio_rw_iops(pod_obj)
             return True
-        except (CommandFailed, TimeoutExpiredError):
+        except (CommandFailed, TimeoutExpiredError, TimeoutError):
+            self._log_ceph_status_on_io_failure()
             return False
 
     @switch_to_provider_for_function
@@ -1098,10 +1193,10 @@ class TestECNodeOperations(ManageTest):
     @tier4a
     @runs_on_provider
     @skipif_managed_service
-    @ignore_leftovers  # Pod/PVC cleanup may hang on degraded EC storage
-    @pytest.mark.polarion_id("OCS-XXXX")
+    @pytest.mark.polarion_id("OCS-8057")
     def test_ec_gradual_node_shutdown(
         self,
+        request,
         nodes,
         node_restart_teardown,
         pvc_factory,
@@ -1126,22 +1221,8 @@ class TestECNodeOperations(ManageTest):
             ), f"Not enough OSD hosts ({total_hosts}) for EC pool (need {size})"
 
             # Phase 1: Create workload on a master node (never shut down)
-            master_nodes = get_nodes(node_type=constants.MASTER_MACHINE)
-            master_node_name = master_nodes[0].name if master_nodes else None
-            # Explicitly use the default RBD SC to avoid picking up
-            # leftover day-2 SCs on HCI platforms (the auto-detection
-            # picks the first SC matching the RBD provisioner).
-            from ocs_ci.ocs.resources.ocs import OCS
-
-            sc_ocp = ocp.OCP(
-                kind="StorageClass",
-                resource_name=constants.DEFAULT_STORAGECLASS_RBD,
-            )
-            sc_obj = OCS(**sc_ocp.get())
-            pvc_obj = pvc_factory(
-                interface=constants.CEPHBLOCKPOOL,
-                size=5,
-                storageclass=sc_obj,
+            pod_obj, original_md5 = self._create_workload_on_master(
+                pvc_factory, pod_factory
             )
             # Register node restart finalizer AFTER pod_factory so
             # LIFO runs it BEFORE pod_factory's delete finalizer.
@@ -1213,10 +1294,6 @@ class TestECNodeOperations(ManageTest):
                 )
                 shutdown_node_obj = get_node_objs([node_name])[0]
                 self.stopped_node_objs.append(shutdown_node_obj)
-                log.info(
-                    f"Shutting down node {node_name} ({i}/{max_shutdowns}), "
-                    f"{live_hosts} hosts will remain"
-                )
                 nodes.stop_nodes([shutdown_node_obj])
 
                 log.test_step(
@@ -1300,8 +1377,6 @@ class TestECNodeOperations(ManageTest):
             assert ceph_cluster.wait_for_rebalance(
                 timeout=3600, repeat=3
             ), "Post-recovery rebalance did not complete"
-
-            # Clear the list so the finalizer does not re-start them
             self.stopped_node_objs.clear()
 
             log.test_step("Post-recovery: verifying chunk distribution")
@@ -1331,9 +1406,10 @@ class TestECNodeOperations(ManageTest):
     @runs_on_provider
     @skipif_managed_service
     @ignore_leftovers
-    @pytest.mark.polarion_id("OCS-YYYY")
+    @pytest.mark.polarion_id("OCS-8058")
     def test_ec_bulk_node_shutdown_data_integrity(
         self,
+        request,
         nodes,
         node_restart_teardown,
         pvc_factory,
@@ -1353,32 +1429,24 @@ class TestECNodeOperations(ManageTest):
             thresholds = get_ec_drain_thresholds()
             m = thresholds["m"]
             size = thresholds["size"]
+            min_size = thresholds["min_size"]
             total_hosts = thresholds["total_osd_hosts"]
-            assert (
-                total_hosts >= size
-            ), f"Not enough OSD hosts ({total_hosts}) for EC pool (need {size})"
+            if total_hosts < size:
+                pytest.skip(
+                    f"Not enough OSD hosts ({total_hosts}) "
+                    f"for EC pool (need {size})"
+                )
 
             shutdown_order = self._get_eligible_shutdown_order()
-            assert len(shutdown_order) >= m, (
-                f"Need at least {m} eligible worker OSD nodes for bulk "
-                f"shutdown, only {len(shutdown_order)} available"
-            )
+            if len(shutdown_order) < m:
+                pytest.skip(
+                    f"Need at least {m} eligible worker OSD nodes for bulk "
+                    f"shutdown, only {len(shutdown_order)} available"
+                )
 
             # Phase 1: Create workload on a master node (never shut down)
-            master_nodes = get_nodes(node_type=constants.MASTER_MACHINE)
-            master_node_name = master_nodes[0].name if master_nodes else None
-
-            from ocs_ci.ocs.resources.ocs import OCS
-
-            sc_ocp = ocp.OCP(
-                kind="StorageClass",
-                resource_name=constants.DEFAULT_STORAGECLASS_RBD,
-            )
-            sc_obj = OCS(**sc_ocp.get())
-            pvc_obj = pvc_factory(
-                interface=constants.CEPHBLOCKPOOL,
-                size=5,
-                storageclass=sc_obj,
+            pod_obj, original_md5 = self._create_workload_on_master(
+                pvc_factory, pod_factory
             )
             self._register_node_restart_finalizer(request)
 
@@ -1396,10 +1464,11 @@ class TestECNodeOperations(ManageTest):
             for node_name in targets:
                 node_mons = get_node_mon_ids(node_name)
                 mons_on_targets += len(node_mons)
-            assert (quorum_count - mons_on_targets) >= 2, (
-                f"Bulk shutdown would break mon quorum: "
-                f"{quorum_count} in quorum, {mons_on_targets} on targets"
-            )
+            if (quorum_count - mons_on_targets) < 2:
+                pytest.skip(
+                    f"Bulk shutdown would break mon quorum: "
+                    f"{quorum_count} in quorum, {mons_on_targets} on targets"
+                )
 
             # Phase 4: Bulk shutdown
             self._log_banner(
@@ -1407,7 +1476,6 @@ class TestECNodeOperations(ManageTest):
             )
             target_node_objs = get_node_objs(targets)
             self.stopped_node_objs.extend(target_node_objs)
-            log.info(f"Powering off {len(target_node_objs)} nodes simultaneously")
             nodes.stop_nodes(target_node_objs)
 
             log.test_step("Waiting 30s for Ceph to detect OSD failures")


### PR DESCRIPTION
                                                  
  Changes:                                                                                                                                                                                                                                                                       
  - ocs_ci/ocs/constants.py — Add EC_SUPPORTED_PROFILES constant (7 supported EC schemes)                                                                                                                                                                                        
  - ocs_ci/ocs/ui/views.py — Add block_pool_4_22 locators for EC pool creation form (volume type, data protection policy, EC scheme table, recommended badge, pool replicas in list)
  - ocs_ci/ocs/ui/page_objects/block_pools.py — Extend StoragePools POM with EC methods: select_data_protection(), get_available_ec_schemes(), select_ec_scheme(), create_ec_pool(), verify_pool_ec_scheme_in_list(), and filesystem volume type support in proceed_resource_creation()
  - tests/functional/ui/test_error_improvements.py — Add TestECPoolCreation class with parametrized test (block/filesystem) that creates EC pool via UI, validates available schemes against node count, verifies Recommended badge logic, runs FIO IO on the pool, verifies pool in list, and deletes via UI with CLI fallback teardown

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added erasure-coded (EC) storage pool creation, including version-gated filesystem vs block workflows (with added OCP 4.22 UI support).
  * Introduced EC scheme discovery in the UI, including “Recommended” scheme detection, scheme selection, optional compression, and confirmation of the chosen scheme in the storage pools list.

* **Bug Fixes**
  * Improved EC pool deletion/teardown behavior to reliably remove pools even when already partially cleaned up.

* **Tests**
  * Added end-to-end functional coverage for EC pool creation (block + filesystem), including forced cleanup and workload verification with automated IO checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->