### PR TITLE
Add post_upgrade marker to test_deny_http_noobaa

### DIFF
--- a/tests/functional/object/mcg/test_deny_http.py
+++ b/tests/functional/object/mcg/test_deny_http.py
@@ -16,6 +16,7 @@ import pytest
 from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import (
     mcg,
+    post_upgrade,
     red_squad,
     runs_on_provider,
     skipif_external_mode,
@@ -204,6 +205,7 @@ class TestDenyHTTP:
             return True
 
     @tier2
+    @post_upgrade
     @skipif_external_mode
     @skipif_ocs_version("<4.22")
     def test_deny_http_noobaa(self, mcg_obj, bucket_factory, revert_deny_http):


### PR DESCRIPTION
This PR content:  
Mark `test_deny_http_noobaa` with `@post_upgrade` so it also runs on upgraded clusters, ensuring the NooBaa denyHTTP feature works correctly after an ODF upgrade.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the NooBaa HTTP denial test to run as part of post-upgrade validation.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->