### PR TITLE
Add logging enhancements for CNV workload tests

### DIFF
--- a/tests/functional/workloads/cnv/test_cnv_cluster_shutdown_recovery.py
+++ b/tests/functional/workloads/cnv/test_cnv_cluster_shutdown_recovery.py
@@ -75,7 +75,7 @@ class TestVmShutdownStart(E2ETest):
 
         file_paths = ["/source_file.txt", "/new_file.txt"]
 
-        # Create a project
+        logger.test_step("Create project and deploy CNV workload VMs")
         proj_obj = project_factory()
         (
             self.vm_objs_def,
@@ -83,9 +83,11 @@ class TestVmShutdownStart(E2ETest):
             self.sc_obj_def_compr,
             self.sc_obj_aggressive,
         ) = multi_cnv_workload(namespace=proj_obj.namespace)
-        logger.info("All vms created successfully")
 
         all_vms = self.vm_objs_def + self.vm_objs_aggr
+        logger.info(f"Created {len(all_vms)} VMs successfully")
+
+        logger.test_step("Write initial test data and prepare clone/snapshot VMs")
         source_csums = {}
         for vm_obj in all_vms:
             source_csum = run_dd_io(vm_obj=vm_obj, file_path=file_paths[0], verify=True)
@@ -104,18 +106,18 @@ class TestVmShutdownStart(E2ETest):
         if vm_for_stop is None:
             vm_for_stop = random.choice(all_vms)
 
-        # Create Clone of VM
+        logger.info(f"Cloning VM '{vm_for_clone.name}'")
         cloned_vm = vm_clone_fixture(vm_for_clone, admin_client)
         csum = cal_md5sum_vm(vm_obj=cloned_vm, file_path=file_paths[0])
         source_csums[cloned_vm.name] = csum
         all_vms.append(cloned_vm)
 
-        # Create a snapshot
+        logger.info(f"Creating snapshot and restoring VM '{vm_for_snap.name}'")
         restored_vm = vm_snapshot_restore_fixture(vm_for_snap, admin_client)
         csum = cal_md5sum_vm(vm_obj=restored_vm, file_path=file_paths[0])
         source_csums[vm_for_snap.name] = csum
 
-        # Initiate abrupt shutdown the cluster nodes as per OCP official documentation
+        logger.test_step("Shut down cluster nodes")
         worker_nodes = get_nodes(node_type="worker")
         master_nodes = get_nodes(node_type="master")
 
@@ -123,7 +125,7 @@ class TestVmShutdownStart(E2ETest):
         master_nodes_names = [node.name for node in master_nodes]
 
         if not force:
-            logger.info("Stopping all the vms before graceful shutdown")
+            logger.info("Stopping all VMs before graceful shutdown")
             run_oc_command(
                 cmd="annotate cluster noobaa-db-pg-cluster --overwrite cnpg.io/hibernation=on"
             )
@@ -146,23 +148,21 @@ class TestVmShutdownStart(E2ETest):
             nodes.stop_nodes(nodes=master_nodes, force=force)
 
         else:
-            # Keep vms in different states (power on, paused, stoped)
+            logger.info(
+                f"Stopping VM '{vm_for_stop.name}' and pausing VM '{vm_for_snap.name}'"
+            )
             vm_for_stop.stop()
             vm_for_snap.pause()
 
-            shutdown_type = "abruptly" if force else "gracefully"
-            logger.info(
-                f"{shutdown_type.capitalize()} shutting down worker & master nodes"
-            )
-
+            logger.info("Abruptly shutting down worker and master nodes")
             nodes.stop_nodes(nodes=worker_nodes, force=force)
             nodes.stop_nodes(nodes=master_nodes, force=force)
 
-        logger.info("waiting for 5 min before starting nodes")
+        logger.info("Waiting 5 minutes before starting nodes")
         time.sleep(300)
 
-        # Initate ordered start of cluster after 10 min by following OCP official documentation.
-        logger.info("Starting worker & master nodes")
+        logger.test_step("Start cluster nodes and wait for recovery")
+        logger.info("Starting master and worker nodes")
         nodes.start_nodes(nodes=master_nodes)
         nodes.start_nodes(nodes=worker_nodes)
         all_nodes = master_nodes + worker_nodes
@@ -187,41 +187,52 @@ class TestVmShutdownStart(E2ETest):
         schedule_nodes(worker_node_names)
         schedule_nodes(master_nodes_names)
 
-        logger.info("Waiting for pods to come in running state.")
+        logger.info("Waiting for pods to reach running state")
         wait_for_pods_to_be_running(timeout=500)
 
-        # Check cluster health
+        logger.test_step("Verify cluster and CNV health")
         try:
-            logger.info("Making sure ceph health is OK")
+            logger.info("Running Ceph health check")
             Sanity().health_check(tries=50, cluster_check=False)
         except Exception as ex:
-            logger.error("Failed at cluster health check!!")
+            logger.exception(f"Cluster health check failed: {ex}")
             raise ex
 
-        # CNV health check
+        logger.info("Running CNV post-install verification")
         cnv_obj = CNVInstaller()
         cnv_obj.post_install_verification()
 
+        logger.test_step("Restore VM states after recovery")
         if not force:
-            logger.info("Start all the vms after graceful shutdown")
+            logger.info("Starting all VMs after graceful shutdown")
             for vm_obj in all_vms:
                 if vm_obj.printableStatus() != constants.VM_RUNNING:
                     vm_obj.start()
         else:
-            # Verify that VMs status post start
+            logger.info(f"Starting stopped VM '{vm_for_stop.name}'")
             vm_for_stop.start()
             for vm in all_vms:
+                vm_status = vm.printableStatus()
+                logger.assertion(
+                    f"VM running state: vm='{vm.name}', "
+                    f"expected='{constants.VM_RUNNING}', actual='{vm_status}', "
+                    f"match={vm_status == constants.VM_RUNNING}"
+                )
                 assert (
-                    vm.printableStatus() == constants.VM_RUNNING
-                ), f"{vm.name} did not reach the running state."
+                    vm_status == constants.VM_RUNNING
+                ), f"VM '{vm.name}' did not reach running state, current status: '{vm_status}'"
 
-        # Perform post restart data integrity check
+        logger.test_step("Verify data integrity and run I/O on all VMs")
         for vm_obj in all_vms:
             new_csum = cal_md5sum_vm(vm_obj=vm_obj, file_path=file_paths[0])
-            assert source_csums[vm_obj.name] == new_csum, (
-                f"ERROR: Failed data integrity before stopping the cluster and after starting the cluster "
-                f"for VM '{vm_obj.name}'."
+            logger.assertion(
+                f"Data integrity: vm='{vm_obj.name}', "
+                f"expected='{source_csums[vm_obj.name]}', actual='{new_csum}', "
+                f"match={source_csums[vm_obj.name] == new_csum}"
             )
+            assert (
+                source_csums[vm_obj.name] == new_csum
+            ), f"MD5 mismatch for VM '{vm_obj.name}' after cluster shutdown and recovery"
 
-            # Perform some I/O operations on the VMs to ensure it is functioning as expected.
             run_dd_io(vm_obj=vm_obj, file_path=file_paths[1])
+        logger.info("Data integrity verified and I/O completed on all VMs")

--- a/tests/functional/workloads/cnv/test_cnv_device_replacement.py
+++ b/tests/functional/workloads/cnv/test_cnv_device_replacement.py
@@ -36,7 +36,7 @@ class TestCnvDeviceReplace(E2ETest):
 
         """
 
-        # Create a project
+        logger.test_step("Create project and deploy CNV workload VMs")
         proj_obj = project_factory()
         (
             self.vm_objs_def,
@@ -44,7 +44,8 @@ class TestCnvDeviceReplace(E2ETest):
             self.sc_obj_def_compr,
             self.sc_obj_aggressive,
         ) = multi_cnv_workload(namespace=proj_obj.namespace)
-        logger.info("All vms created successfully")
+        all_vms = self.vm_objs_def + self.vm_objs_aggr
+        logger.info(f"Created {len(all_vms)} VMs successfully")
 
         # Register the teardown
         request.addfinalizer(self.teardown)
@@ -53,17 +54,17 @@ class TestCnvDeviceReplace(E2ETest):
         """
         Teardown operations for the test case.
         """
-        logger.info("Performing teardown operations...")
+        logger.info("Performing teardown operations")
 
         # Start the stopped VM if it is in stopped state
         if self.vm_for_stop.printableStatus() == constants.CNV_VM_STOPPED:
             self.vm_for_stop.start()
-            logger.info(f"VM {self.vm_for_stop.name} started.")
+            logger.info(f"VM '{self.vm_for_stop.name}' started")
 
         # Unpause the paused VM if it is in paused state
         if self.vm_for_snap.printableStatus() == constants.VM_PAUSED:
             self.vm_for_snap.unpause()
-            logger.info(f"VM {self.vm_for_snap.name} unpaused.")
+            logger.info(f"VM '{self.vm_for_snap.name}' unpaused")
 
     def test_vms_with_device_replacement(
         self,
@@ -92,61 +93,85 @@ class TestCnvDeviceReplace(E2ETest):
         6. Check for data Integrity
         """
 
+        logger.test_step("Write initial data and create clone/snapshot VMs")
         all_vms = self.vm_objs_def + self.vm_objs_aggr
         file_paths = ["/source_file.txt", "/new_file.txt"]
-        # Initialize checksums
         source_csums = {
             vm.name: run_dd_io(vm, file_paths[0], verify=True) for vm in all_vms
         }
 
-        # Randomly select VMs for operations
         self.vm_for_clone, self.vm_for_stop, self.vm_for_snap = random.sample(
             all_vms, 3
         )
+        logger.info(
+            f"Selected VMs: clone='{self.vm_for_clone.name}', "
+            f"stop='{self.vm_for_stop.name}', snapshot='{self.vm_for_snap.name}'"
+        )
 
-        # Create clone and snapshot, update checksums
         for vm in [self.vm_for_clone, self.vm_for_snap]:
+            op = "clone" if vm == self.vm_for_clone else "snapshot"
+            logger.info(f"Creating {op} of VM '{vm.name}'")
             vm_obj = (
                 vm_clone_fixture(vm, admin_client)
                 if vm == self.vm_for_clone
                 else vm_snapshot_restore_fixture(vm, admin_client)
             )
 
-            # Use cal_md5sum_vm here
             source_csums[vm_obj.name] = cal_md5sum_vm(vm_obj, file_paths[0])
             if vm == self.vm_for_clone:
                 all_vms.append(vm_obj)
 
-        # Keep vms in different states (power on, paused, stoped)
+        logger.test_step("Set VMs to different states and perform device replacement")
+        logger.info(
+            f"Stopping VM '{self.vm_for_stop.name}' and pausing VM '{self.vm_for_snap.name}'"
+        )
         self.vm_for_stop.stop()
         self.vm_for_snap.pause()
 
-        # Perform device replacement
+        logger.info("Performing OSD device replacement")
         osd_operations.osd_device_replacement(nodes)
 
-        logger.info("Verify osd encryption")
+        logger.info("Verifying OSD encryption")
         if config.ENV_DATA.get("encryption_at_rest"):
             osd_encryption_verification()
 
-        # Check VMs status post-replacement
+        logger.test_step("Verify VM state preservation after device replacement")
+        stop_status = self.vm_for_stop.printableStatus()
+        logger.assertion(
+            f"Stopped VM state: vm='{self.vm_for_stop.name}', "
+            f"expected='{constants.CNV_VM_STOPPED}', actual='{stop_status}', "
+            f"match={stop_status == constants.CNV_VM_STOPPED}"
+        )
         assert (
-            self.vm_for_stop.printableStatus() == constants.CNV_VM_STOPPED
-        ), "Stopped VM state not preserved."
-        logger.info("After device replacement, stopped VM preserved state.")
+            stop_status == constants.CNV_VM_STOPPED
+        ), f"VM '{self.vm_for_stop.name}' stopped state not preserved after device replacement"
 
+        pause_status = self.vm_for_snap.printableStatus()
+        logger.assertion(
+            f"Paused VM state: vm='{self.vm_for_snap.name}', "
+            f"expected='{constants.VM_PAUSED}', actual='{pause_status}', "
+            f"match={pause_status == constants.VM_PAUSED}"
+        )
         assert (
-            self.vm_for_snap.printableStatus() == constants.VM_PAUSED
-        ), "Paused VM state not preserved."
-        logger.info("After device replacement, paused VM preserved state.")
+            pause_status == constants.VM_PAUSED
+        ), f"VM '{self.vm_for_snap.name}' paused state not preserved after device replacement"
 
-        logger.info("Starting vms")
+        logger.info(
+            f"Starting VM '{self.vm_for_stop.name}' and unpausing VM '{self.vm_for_snap.name}'"
+        )
         self.vm_for_stop.start()
         self.vm_for_snap.unpause()
 
-        # Combined IO operations and data integrity check
+        logger.test_step("Verify data integrity and run I/O on all VMs")
         for vm_obj in all_vms:
             run_dd_io(vm_obj=vm_obj, file_path=file_paths[1], verify=True)
             new_csum = cal_md5sum_vm(vm_obj=vm_obj, file_path=file_paths[0])
+            logger.assertion(
+                f"Data integrity: vm='{vm_obj.name}', "
+                f"expected='{source_csums[vm_obj.name]}', actual='{new_csum}', "
+                f"match={source_csums[vm_obj.name] == new_csum}"
+            )
             assert (
                 source_csums[vm_obj.name] == new_csum
-            ), f"Data integrity failed for VM '{vm_obj.name}'."
+            ), f"MD5 mismatch for VM '{vm_obj.name}' after device replacement"
+        logger.info("Data integrity verified and I/O completed on all VMs")

--- a/tests/functional/workloads/cnv/test_cnv_device_replacement.py
+++ b/tests/functional/workloads/cnv/test_cnv_device_replacement.py
@@ -35,6 +35,8 @@ class TestCnvDeviceReplace(E2ETest):
         Setting up VMs for tests
 
         """
+        self.vm_for_stop = None
+        self.vm_for_snap = None
 
         logger.test_step("Create project and deploy CNV workload VMs")
         proj_obj = project_factory()
@@ -57,12 +59,18 @@ class TestCnvDeviceReplace(E2ETest):
         logger.info("Performing teardown operations")
 
         # Start the stopped VM if it is in stopped state
-        if self.vm_for_stop.printableStatus() == constants.CNV_VM_STOPPED:
+        if (
+            self.vm_for_stop
+            and self.vm_for_stop.printableStatus() == constants.CNV_VM_STOPPED
+        ):
             self.vm_for_stop.start()
             logger.info(f"VM '{self.vm_for_stop.name}' started")
 
         # Unpause the paused VM if it is in paused state
-        if self.vm_for_snap.printableStatus() == constants.VM_PAUSED:
+        if (
+            self.vm_for_snap
+            and self.vm_for_snap.printableStatus() == constants.VM_PAUSED
+        ):
             self.vm_for_snap.unpause()
             logger.info(f"VM '{self.vm_for_snap.name}' unpaused")
 

--- a/tests/functional/workloads/cnv/test_cnv_mon_osd_failure.py
+++ b/tests/functional/workloads/cnv/test_cnv_mon_osd_failure.py
@@ -67,11 +67,17 @@ class TestMonAndOSDFailures:
 
         def teardown():
             logger.info("Restoring mons back to 1 replica each")
+            errors = []
             for mon in mons:
                 try:
                     modify_deployment_replica_count(mon, 1)
                 except Exception as e:
                     logger.exception(f"Failed to restore mon '{mon}': {e}")
+                    errors.append(str(e))
+            if errors:
+                raise RuntimeError(
+                    f"MON restoration failed for {len(errors)} deployment(s): {errors}"
+                )
 
         request.addfinalizer(teardown)
 
@@ -132,6 +138,7 @@ class TestMonAndOSDFailures:
                 modify_deployment_replica_count(osd_dep, 1)
             except Exception as e:
                 logger.exception(f"Failed to restore OSD deployment '{osd_dep}': {e}")
+                raise
 
         request.addfinalizer(teardown)
 

--- a/tests/functional/workloads/cnv/test_cnv_mon_osd_failure.py
+++ b/tests/functional/workloads/cnv/test_cnv_mon_osd_failure.py
@@ -27,7 +27,7 @@ def setup_cnv_workload(
     """
     Set up CNV workload and create initial data.
     """
-    logger.info("Setting up CNV workload and creating initial data")
+    logger.test_step("Set up CNV workload and create initial data")
     proj_obj = project_factory_class()
     file_paths = ["/source_file.txt", "/new_file.txt"]
     (
@@ -37,6 +37,7 @@ def setup_cnv_workload(
         _,
     ) = multi_cnv_workload_class(namespace=proj_obj.namespace)
     all_vms = vm_objs_def + vm_objs_aggr
+    logger.info(f"Created {len(all_vms)} VMs for mon/OSD failure testing")
     source_csums = {
         vm_obj.name: run_dd_io(vm_obj, file_path=file_paths[0], verify=True)
         for vm_obj in all_vms
@@ -60,47 +61,55 @@ class TestMonAndOSDFailures:
 
         """
         ceph_obj = CephCluster()
-        logger.info(f"testing mon failures scenario with {mon_count} mon")
+        logger.test_step(f"Simulate {mon_count} mon failure(s)")
 
         mons = ceph_obj.get_mons_from_cluster()[:mon_count]
 
         def teardown():
-            logger.info("[TEARDOWN] Restoring mons back to 1 replica each")
+            logger.info("Restoring mons back to 1 replica each")
             for mon in mons:
                 try:
                     modify_deployment_replica_count(mon, 1)
                 except Exception as e:
-                    logger.error(f"Failed to restore mon {mon}: {e}")
+                    logger.exception(f"Failed to restore mon '{mon}': {e}")
 
         request.addfinalizer(teardown)
 
         for mon in mons:
-            logger.info(f"Scaling down mon deployment {mon} to 0 replicas")
+            logger.info(f"Scaling down mon deployment '{mon}' to 0 replicas")
             modify_deployment_replica_count(mon, 0)
 
         logger.info(
-            "Sleeping for 300 seconds to emulate a condition where the 2 mons is inaccessibe  for 10 seconds."
+            f"Waiting 300 seconds to simulate {mon_count} mon(s) being inaccessible"
         )
         time.sleep(300)
+
+        logger.test_step("Restore mons and verify Ceph health")
         for mon in mons:
-            logger.info(f"Scaling mon deployment {mon} back to 1 replica")
+            logger.info(f"Scaling mon deployment '{mon}' back to 1 replica")
             modify_deployment_replica_count(mon, 1)
 
         wait_for_pods_by_label_count(
             label=constants.MON_APP_LABEL, expected_count=3, timeout=300
         )
-        # Check ceph health status
+        logger.info("Running Ceph health check")
         utils.ceph_health_check(tries=20)
-        # Data integrity validation here
+
+        logger.test_step("Verify data integrity and run I/O on all VMs")
         all_vms, source_csums, file_paths = setup_cnv_workload
         for vm_obj in all_vms:
             vm_obj.wait_for_ssh_connectivity()
             md5sum_after = cal_md5sum_vm(vm_obj, file_path=file_paths[0])
+            logger.assertion(
+                f"Data integrity: vm='{vm_obj.name}', "
+                f"expected='{source_csums[vm_obj.name]}', actual='{md5sum_after}', "
+                f"match={source_csums[vm_obj.name] == md5sum_after}"
+            )
             assert (
                 source_csums[vm_obj.name] == md5sum_after
-            ), f"Data integrity failed for VM {vm_obj.name}"
-            logger.info(f"Data integrity maintained for VM {vm_obj.name}")
+            ), f"MD5 mismatch for VM '{vm_obj.name}' after mon failure"
             run_dd_io(vm_obj=vm_obj, file_path=file_paths[1])
+        logger.info("Data integrity verified and I/O completed on all VMs")
 
     @polarion_id("OCS-6608")
     def test_single_osd_failure(self, request, setup_cnv_workload):
@@ -108,41 +117,49 @@ class TestMonAndOSDFailures:
         Test single osd failure with VM workloads running in the background
 
         """
-        logger.info("testing single osd failure scenarios")
+        logger.test_step("Simulate single OSD failure")
 
         osd_pods = get_osd_pods()
         osd_pod_to_fail = random.choice(osd_pods).name
         osd_dep = get_deployment_name(osd_pod_to_fail)
+        logger.info(
+            f"Selected OSD pod '{osd_pod_to_fail}' (deployment: '{osd_dep}') for failure"
+        )
 
         def teardown():
-            logger.info(f"[TEARDOWN] Restoring OSD deployment {osd_dep} to 1 replica")
+            logger.info(f"Restoring OSD deployment '{osd_dep}' to 1 replica")
             try:
                 modify_deployment_replica_count(osd_dep, 1)
             except Exception as e:
-                logger.error(f"Failed to restore osd {osd_dep}: {e}")
+                logger.exception(f"Failed to restore OSD deployment '{osd_dep}': {e}")
 
         request.addfinalizer(teardown)
 
-        # scale down the osd deployment to 0
-        logger.info(f"Failing osd by scaling down osd deployment {osd_dep}")
+        logger.info(f"Scaling down OSD deployment '{osd_dep}' to 0 replicas")
         if modify_deployment_replica_count(osd_dep, 0):
+            logger.info("Waiting 600 seconds to simulate OSD being down")
             time.sleep(600)
 
-        # scale the deployment back to 1
-        logger.info(f"Recovering osd by scaling up osd deployment {osd_dep}")
+        logger.test_step("Restore OSD and verify pod recovery")
+        logger.info(f"Scaling OSD deployment '{osd_dep}' back to 1 replica")
         modify_deployment_replica_count(osd_dep, 1)
 
         wait_for_pods_by_label_count(
             label=constants.OSD_APP_LABEL, expected_count=3, timeout=300
         )
 
-        # Data integrity validation here
+        logger.test_step("Verify data integrity and run I/O on all VMs")
         all_vms, source_csums, file_paths = setup_cnv_workload
         for vm_obj in all_vms:
             vm_obj.wait_for_ssh_connectivity()
             md5sum_after = cal_md5sum_vm(vm_obj, file_path=file_paths[0])
+            logger.assertion(
+                f"Data integrity: vm='{vm_obj.name}', "
+                f"expected='{source_csums[vm_obj.name]}', actual='{md5sum_after}', "
+                f"match={source_csums[vm_obj.name] == md5sum_after}"
+            )
             assert (
                 source_csums[vm_obj.name] == md5sum_after
-            ), f"Data integrity failed for VM {vm_obj.name}"
-            logger.info(f"Data integrity maintained for VM {vm_obj.name}")
+            ), f"MD5 mismatch for VM '{vm_obj.name}' after OSD failure"
             run_dd_io(vm_obj=vm_obj, file_path=file_paths[1])
+        logger.info("Data integrity verified and I/O completed on all VMs")

--- a/tests/functional/workloads/cnv/test_cnv_node_replacement.py
+++ b/tests/functional/workloads/cnv/test_cnv_node_replacement.py
@@ -109,17 +109,20 @@ class TestCnvNodeReplace(E2ETest):
         node_name = self.vm_obj_on_replacing_node.get_vmi_instance().node()
         logger.info(f"Target node for replacement: '{node_name}'")
 
+        stopped_rwo_vm = None
         for vm_rwo in all_vms:
             if (
                 vm_rwo != self.vm_obj_on_replacing_node
                 and vm_rwo.get_vmi_instance().node() == node_name
+                and vm_rwo.pvc_access_mode == "ReadWriteOnce"
+                and vm_rwo.ready()
             ):
-                if vm_rwo.pvc_access_mode == "ReadWriteOnce" and vm_rwo.ready():
-                    logger.info(
-                        f"Stopping RWO VM '{vm_rwo.name}' on target node to avoid drain stuck"
-                    )
-                    vm_rwo.stop()
-                    break
+                logger.info(
+                    f"Stopping RWO VM '{vm_rwo.name}' on target node to avoid drain stuck"
+                )
+                vm_rwo.stop()
+                stopped_rwo_vm = vm_rwo
+                break
 
         logger.info(
             f"Stopping VM '{self.vm_for_stop.name}' and pausing VM '{self.vm_for_snap.name}'"
@@ -143,7 +146,7 @@ class TestCnvNodeReplace(E2ETest):
 
         logger.assertion("StorageCluster node topology validity")
         assert (
-            verify_storagecluster_nodetopology
+            verify_storagecluster_nodetopology()
         ), "StorageCluster node topology contains non-OCS node entries"
 
         logger.test_step("Verify VM state after node replacement")
@@ -161,8 +164,8 @@ class TestCnvNodeReplace(E2ETest):
             f"Starting VM '{self.vm_for_stop.name}' and unpausing VM '{self.vm_for_snap.name}'"
         )
         self.vm_for_stop.start()
-        if not vm_rwo.ready():
-            vm_rwo.start()
+        if stopped_rwo_vm and not stopped_rwo_vm.ready():
+            stopped_rwo_vm.start()
         if self.vm_for_snap.printableStatus() == constants.VM_PAUSED:
             self.vm_for_snap.unpause()
 

--- a/tests/functional/workloads/cnv/test_cnv_node_replacement.py
+++ b/tests/functional/workloads/cnv/test_cnv_node_replacement.py
@@ -134,7 +134,6 @@ class TestCnvNodeReplace(E2ETest):
         delete_and_create_osd_node(node_name)
 
         logger.test_step("Verify cluster health and Ceph rebalance")
-        logger.info("Running cluster health check")
         self.sanity_helpers = Sanity()
         self.sanity_helpers.health_check(tries=120)
 

--- a/tests/functional/workloads/cnv/test_cnv_node_replacement.py
+++ b/tests/functional/workloads/cnv/test_cnv_node_replacement.py
@@ -42,7 +42,7 @@ class TestCnvNodeReplace(E2ETest):
 
         """
 
-        # Create a project
+        logger.test_step("Create project and deploy CNV workload VMs")
         proj_obj = project_factory()
         (
             self.vm_objs_def,
@@ -50,6 +50,9 @@ class TestCnvNodeReplace(E2ETest):
             self.sc_obj_def_compr,
             self.sc_obj_aggressive,
         ) = multi_cnv_workload(namespace=proj_obj.namespace)
+        logger.info(
+            f"Created {len(self.vm_objs_def + self.vm_objs_aggr)} VMs successfully"
+        )
 
     def test_vms_with_node_replacement(
         self,
@@ -62,21 +65,18 @@ class TestCnvNodeReplace(E2ETest):
         """
         Node Replacement proactive
         """
+        logger.test_step("Write initial data and create clone/snapshot VMs")
         all_vms = self.vm_objs_def + self.vm_objs_aggr
-        logger.info(f"list of all vms: {all_vms}")
         file_paths = ["/source_file.txt", "/new_file.txt"]
         source_csums = {}
         for vm_obj in all_vms:
             source_csum = run_dd_io(vm_obj=vm_obj, file_path=file_paths[0], verify=True)
             source_csums[vm_obj.name] = source_csum
 
-        # Filter out VMs that do not have ReadWriteOnce access mode
         eligible_vms = [vm for vm in all_vms if vm.pvc_access_mode != "ReadWriteOnce"]
 
-        # Pick one VM for replacing_node from eligible set
         self.vm_obj_on_replacing_node = random.choice(eligible_vms)
 
-        # Pick 3 random VMs from the remaining pool
         remaining_vms = [
             vm
             for vm in all_vms
@@ -86,69 +86,95 @@ class TestCnvNodeReplace(E2ETest):
         self.vm_for_clone, self.vm_for_stop, self.vm_for_snap = random.sample(
             remaining_vms, 3
         )
+        logger.info(
+            f"Selected VMs: on_replacing_node='{self.vm_obj_on_replacing_node.name}', "
+            f"clone='{self.vm_for_clone.name}', stop='{self.vm_for_stop.name}', "
+            f"snapshot='{self.vm_for_snap.name}'"
+        )
 
         for vm in [self.vm_for_clone, self.vm_for_snap]:
+            op = "clone" if vm == self.vm_for_clone else "snapshot"
+            logger.info(f"Creating {op} of VM '{vm.name}'")
             vm_obj = (
                 vm_clone_fixture(vm, admin_client)
                 if vm == self.vm_for_clone
                 else vm_snapshot_restore_fixture(vm, admin_client)
             )
 
-            # Use cal_md5sum_vm here
             source_csums[vm_obj.name] = cal_md5sum_vm(vm_obj, file_paths[0])
             if vm == self.vm_for_clone:
                 all_vms.append(vm_obj)
 
-        # Find node where VM is running
+        logger.test_step("Set VM states and perform node replacement")
         node_name = self.vm_obj_on_replacing_node.get_vmi_instance().node()
+        logger.info(f"Target node for replacement: '{node_name}'")
 
-        # Stop VM if its not live migratable to avoid drain stuck issue.
         for vm_rwo in all_vms:
             if (
                 vm_rwo != self.vm_obj_on_replacing_node
                 and vm_rwo.get_vmi_instance().node() == node_name
             ):
                 if vm_rwo.pvc_access_mode == "ReadWriteOnce" and vm_rwo.ready():
+                    logger.info(
+                        f"Stopping RWO VM '{vm_rwo.name}' on target node to avoid drain stuck"
+                    )
                     vm_rwo.stop()
                     break
 
-        # Keep vms in different states(paused, stoped)
+        logger.info(
+            f"Stopping VM '{self.vm_for_stop.name}' and pausing VM '{self.vm_for_snap.name}'"
+        )
         self.vm_for_stop.stop()
         self.vm_for_snap.pause()
 
-        # Replace Node
+        logger.info(f"Replacing node '{node_name}'")
         delete_and_create_osd_node(node_name)
 
-        logger.info("Verifying All resources are Running and matches expected result")
+        logger.test_step("Verify cluster health and Ceph rebalance")
+        logger.info("Running cluster health check")
         self.sanity_helpers = Sanity()
         self.sanity_helpers.health_check(tries=120)
 
         ceph_cluster_obj = CephCluster()
+        logger.assertion("Ceph data rebalance completion")
         assert ceph_cluster_obj.wait_for_rebalance(
             timeout=1800
         ), "Data re-balance failed to complete"
 
+        logger.assertion("StorageCluster node topology validity")
         assert (
             verify_storagecluster_nodetopology
-        ), "Storagecluster node topology is having an entry of non ocs node(s) - Not expected"
+        ), "StorageCluster node topology contains non-OCS node entries"
 
-        # Check VM status
+        logger.test_step("Verify VM state after node replacement")
+        vm_status = self.vm_obj_on_replacing_node.printableStatus()
+        logger.assertion(
+            f"VM running state: vm='{self.vm_obj_on_replacing_node.name}', "
+            f"expected='{constants.VM_RUNNING}', actual='{vm_status}', "
+            f"match={vm_status == constants.VM_RUNNING}"
+        )
         assert (
-            self.vm_obj_on_replacing_node.printableStatus() == constants.VM_RUNNING
-        ), "VM is not in ruuning state after node replacement."
-        logger.info("After Node replacement vm is running.")
+            vm_status == constants.VM_RUNNING
+        ), f"VM '{self.vm_obj_on_replacing_node.name}' not running after node replacement, status: '{vm_status}'"
 
-        logger.info("Starting vms")
+        logger.info(
+            f"Starting VM '{self.vm_for_stop.name}' and unpausing VM '{self.vm_for_snap.name}'"
+        )
         self.vm_for_stop.start()
         if not vm_rwo.ready():
             vm_rwo.start()
         if self.vm_for_snap.printableStatus() == constants.VM_PAUSED:
             self.vm_for_snap.unpause()
 
-        # Perform post node replacement data integrity check
+        logger.test_step("Verify data integrity on all VMs after node replacement")
         for vm_obj in all_vms:
             new_csum = cal_md5sum_vm(vm_obj=vm_obj, file_path=file_paths[0])
-            assert source_csums[vm_obj.name] == new_csum, (
-                f"ERROR: Failed data integrity before replacing node and after replacing the node "
-                f"for VM '{vm_obj.name}'."
+            logger.assertion(
+                f"Data integrity: vm='{vm_obj.name}', "
+                f"expected='{source_csums[vm_obj.name]}', actual='{new_csum}', "
+                f"match={source_csums[vm_obj.name] == new_csum}"
             )
+            assert (
+                source_csums[vm_obj.name] == new_csum
+            ), f"MD5 mismatch for VM '{vm_obj.name}' after node replacement"
+        logger.info("Data integrity verified on all VMs")

--- a/tests/functional/workloads/cnv/test_multi_vm_configurations.py
+++ b/tests/functional/workloads/cnv/test_multi_vm_configurations.py
@@ -129,9 +129,9 @@ class TestCNVVM(E2ETest):
             ), f"MD5 checksum mismatch after copying file to VM '{vm_obj.name}'"
         logger.info("Data integrity verified for all VMs")
 
-        logger.test_step("Verify PV key rotation")
-        logger.info("Verifying key rotation for VMs with default compression")
+        logger.test_step(
+            "Verify PV key rotation for VMs with default and aggressive compression"
+        )
         self.verify_keyrotation(self.vm_objs_def, self.sc_obj_def_compr)
-        logger.info("Verifying key rotation for VMs with aggressive compression")
         self.verify_keyrotation(self.vm_objs_aggr, self.sc_obj_aggressive)
         logger.info("PV key rotation verified for all VMs")

--- a/tests/functional/workloads/cnv/test_multi_vm_configurations.py
+++ b/tests/functional/workloads/cnv/test_multi_vm_configurations.py
@@ -103,7 +103,7 @@ class TestCNVVM(E2ETest):
 
         cmd = f"md5sum {file_name}"
         result = exec_cmd(cmd)
-        md5sum_on_local = result.stdout.strip().split()[0]
+        md5sum_on_local = result.stdout.decode().strip().split()[0]
         if not md5sum_on_local:
             raise ValueError(
                 "MD5 checksum could not be calculated. Ensure the file exists and is accessible."

--- a/tests/functional/workloads/cnv/test_multi_vm_configurations.py
+++ b/tests/functional/workloads/cnv/test_multi_vm_configurations.py
@@ -6,7 +6,7 @@ from ocs_ci.framework.pytest_customization.marks import workloads, magenta_squad
 from ocs_ci.helpers.cnv_helpers import cal_md5sum_vm
 from ocs_ci.helpers.performance_lib import run_oc_command
 from ocs_ci.helpers.keyrotation_helper import PVKeyrotation
-from ocs_ci.utility.utils import run_cmd
+from ocs_ci.utility.utils import exec_cmd
 from ocs_ci.ocs import constants
 
 logger = logging.getLogger(__name__)
@@ -26,17 +26,17 @@ class TestCNVVM(E2ETest):
 
         """
 
-        # Create a project
+        logger.test_step("Create project and deploy encrypted CNV workload VMs")
         proj_obj = project_factory()
-        # Setup KMS for PV encryption
         (
             self.vm_objs_def,
             self.vm_objs_aggr,
             self.sc_obj_def_compr,
             self.sc_obj_aggressive,
         ) = multi_cnv_workload(namespace=proj_obj.namespace, encrypted=True)
-
-        logger.info("All vms created successfully")
+        logger.info(
+            f"Created {len(self.vm_objs_def + self.vm_objs_aggr)} VMs with encryption enabled"
+        )
 
     def verify_keyrotation(self, vm_objs, sc_obj):
         """
@@ -49,6 +49,7 @@ class TestCNVVM(E2ETest):
         """
         for vm in vm_objs:
             if vm.volume_interface == constants.VM_VOLUME_PVC:
+                logger.info(f"Verifying key rotation for VM '{vm.name}'")
                 pvk_obj = PVKeyrotation(sc_obj)
                 volume_name = vm.pvc_obj.get().get("spec", {}).get("volumeName")
                 volume_handle = None
@@ -59,11 +60,19 @@ class TestCNVVM(E2ETest):
                         volume_handle = line.split()[1]
                         break
                 if not volume_handle:
-                    logger.error(f"Cannot get volume handle for pv {volume_name}")
+                    logger.error(
+                        f"Cannot get volume handle for PV '{volume_name}' "
+                        f"(VM: '{vm.name}')"
+                    )
                     raise Exception("Cannot get volume handle")
+                logger.assertion(
+                    f"Key rotation: vm='{vm.name}', pvc='{vm.pvc_obj.name}', "
+                    f"volume_handle='{volume_handle}'"
+                )
                 assert pvk_obj.wait_till_keyrotation(
                     volume_handle
-                ), f"Failed to rotate Key for the PVC {vm.pvc_obj.name}"
+                ), f"Failed to rotate key for PVC '{vm.pvc_obj.name}'"
+                logger.info(f"Key rotation succeeded for VM '{vm.name}'")
 
     @workloads
     @pytest.mark.polarion_id("OCS-6298")
@@ -84,42 +93,44 @@ class TestCNVVM(E2ETest):
         """
         all_vm_list = self.vm_objs_def + self.vm_objs_aggr
 
-        # 1.Validate data integrity using md5sum.
+        logger.test_step("Validate data integrity using md5sum")
         file_name = "/tmp/dd_file"
         vm_filepath = "/home/admin/dd_file1_copy"
 
-        # Create file locally
+        logger.info("Creating 1GB test file locally")
         cmd = f"dd if=/dev/zero of={file_name} bs=1M count=1024"
-        run_cmd(cmd)
-        # Calculate the MD5 checksum
-        if file_name:
-            cmd = f"md5sum {file_name}"
-            md5sum_on_local = run_cmd(cmd).split()[0]
-            if md5sum_on_local:
-                logger.info(f"MD5 checksum of the file: {md5sum_on_local}")
-            else:
-                raise ValueError(
-                    "MD5 checksum could not be calculated. Ensure the file exists and is accessible."
-                )
-        else:
+        exec_cmd(cmd)
+
+        cmd = f"md5sum {file_name}"
+        md5sum_on_local = exec_cmd(cmd).split()[0]
+        if not md5sum_on_local:
             raise ValueError(
-                "File name is not provided. Please specify a valid file name."
+                "MD5 checksum could not be calculated. Ensure the file exists and is accessible."
             )
-        # Copy local file to all vms
+        logger.info(f"Local file MD5 checksum: {md5sum_on_local}")
+
+        logger.info(f"Copying test file to {len(all_vm_list)} VMs via SCP")
         for vm_obj in all_vm_list:
             vm_obj.scp_to_vm(
                 local_path=file_name,
                 vm_dest_path=vm_filepath,
             )
-        # Take md5sum of copied file and compare with md5sum taken locally
+
         for vm_obj in all_vm_list:
             md5sum_on_vm = cal_md5sum_vm(vm_obj, vm_filepath, username=None)
+            logger.assertion(
+                f"MD5 checksum: vm='{vm_obj.name}', "
+                f"expected='{md5sum_on_local}', actual='{md5sum_on_vm}', "
+                f"match={md5sum_on_vm == md5sum_on_local}"
+            )
             assert (
                 md5sum_on_vm == md5sum_on_local
-            ), f"md5sum has changed after copying file on {vm_obj.name}"
+            ), f"MD5 checksum mismatch after copying file to VM '{vm_obj.name}'"
+        logger.info("Data integrity verified for all VMs")
 
-        # 2.Verify PV Keyrotation.
-        # Process VMs with default compression
+        logger.test_step("Verify PV key rotation")
+        logger.info("Verifying key rotation for VMs with default compression")
         self.verify_keyrotation(self.vm_objs_def, self.sc_obj_def_compr)
-        # Process VMs with aggressive compression
+        logger.info("Verifying key rotation for VMs with aggressive compression")
         self.verify_keyrotation(self.vm_objs_aggr, self.sc_obj_aggressive)
+        logger.info("PV key rotation verified for all VMs")

--- a/tests/functional/workloads/cnv/test_multi_vm_configurations.py
+++ b/tests/functional/workloads/cnv/test_multi_vm_configurations.py
@@ -102,7 +102,8 @@ class TestCNVVM(E2ETest):
         exec_cmd(cmd)
 
         cmd = f"md5sum {file_name}"
-        md5sum_on_local = exec_cmd(cmd).split()[0]
+        result = exec_cmd(cmd)
+        md5sum_on_local = result.stdout.strip().split()[0]
         if not md5sum_on_local:
             raise ValueError(
                 "MD5 checksum could not be calculated. Ensure the file exists and is accessible."

--- a/tests/functional/workloads/cnv/test_vm_add_capacity.py
+++ b/tests/functional/workloads/cnv/test_vm_add_capacity.py
@@ -51,9 +51,10 @@ class TestVmAddCapacity(E2ETest):
         """
         self.file_paths = ["/source_file.txt", "/new_file.txt"]
 
-        logger.info("Setting up csi-kms-connection-details configmap")
+        logger.test_step("Set up KMS, StorageClass, and project")
+        logger.info("Configuring csi-kms-connection-details configmap")
         kms = pv_encryption_kms_setup_factory(kv_version="v2")
-        logger.info("csi-kms-connection-details setup successful")
+        logger.info("KMS setup successful")
 
         sc_obj_def = storageclass_factory(
             interface=constants.CEPHBLOCKPOOL,
@@ -70,6 +71,7 @@ class TestVmAddCapacity(E2ETest):
         pvk_obj = PVKeyrotation(sc_obj_def)
         pvk_obj.annotate_storageclass_key_rotation(schedule="*/3 * * * *")
 
+        logger.test_step("Create VMs and write initial test data")
         self.vm_list = []
         self.source_csum = {}
         self.final_csum = {}
@@ -83,13 +85,15 @@ class TestVmAddCapacity(E2ETest):
             self.source_csum[vm_obj.name] = run_dd_io(
                 vm_obj=vm_obj, file_path=self.file_paths[0], verify=True
             )
+        logger.info(f"Created {len(self.vm_list)} VMs with initial checksums")
 
-        logger.info(f"Stopping VM: {self.vm_list[0].name}")
+        logger.test_step("Set VMs to different states")
         self.vm_stopped = self.vm_list[0]
+        logger.info(f"Stopping VM '{self.vm_stopped.name}'")
         self.vm_stopped.stop()
 
-        logger.info(f"Pausing VM: {self.vm_list[1].name}")
         self.vm_paused = self.vm_list[1]
+        logger.info(f"Pausing VM '{self.vm_paused.name}'")
         self.vm_paused.pause()
 
     def test_vm_add_capacity(self, setup):
@@ -105,12 +109,14 @@ class TestVmAddCapacity(E2ETest):
         initial_vm_states = {
             vm_obj.name: vm_obj.printableStatus() for vm_obj in self.vm_list
         }
-        logger.info("Adding storage capacity...")
+        logger.info(f"Initial VM states: {initial_vm_states}")
+
+        logger.test_step("Add storage capacity")
         add_capacity_test()
-        logger.info("Added storage capacity!")
+        logger.info("Storage capacity added successfully")
 
         logger.info(
-            f"Waiting for pods in {constants.OPENSHIFT_STORAGE_NAMESPACE} to be running"
+            f"Waiting for pods in '{constants.OPENSHIFT_STORAGE_NAMESPACE}' to be running"
         )
         sample = TimeoutSampler(
             timeout=600,
@@ -118,33 +124,53 @@ class TestVmAddCapacity(E2ETest):
             func=wait_for_pods_to_be_running,
             namespace=constants.OPENSHIFT_STORAGE_NAMESPACE,
         )
+        logger.assertion(
+            f"Pods running in '{constants.OPENSHIFT_STORAGE_NAMESPACE}' after capacity addition"
+        )
         assert sample.wait_for_func_status(result=True), (
             "Not all pods are running after capacity "
             f"addition in {constants.OPENSHIFT_STORAGE_NAMESPACE}"
         )
 
+        logger.test_step("Verify VM state preservation after capacity addition")
         final_vm_states = {
             vm_obj.name: vm_obj.printableStatus() for vm_obj in self.vm_list
         }
-        logger.info(f"Final VM states: {final_vm_states}")
         for vm_name in initial_vm_states:
+            logger.assertion(
+                f"VM state: name='{vm_name}', "
+                f"expected='{initial_vm_states[vm_name]}', "
+                f"actual='{final_vm_states[vm_name]}'"
+            )
             assert initial_vm_states[vm_name] == final_vm_states[vm_name], (
                 f"VM state mismatch for {vm_name}: "
                 f"initial state was {initial_vm_states[vm_name]}, "
                 f"but final state is {final_vm_states[vm_name]}"
             )
 
+        logger.info(
+            f"Resuming VMs: starting '{self.vm_stopped.name}', "
+            f"unpausing '{self.vm_paused.name}'"
+        )
         self.vm_stopped.start()
         self.vm_paused.unpause()
 
-        logger.info("Verifying data integrity for VMs")
+        logger.test_step("Verify data integrity and run I/O on all VMs")
         for vm_obj in self.vm_list:
-            logger.info(f"Calculating checksum for VM {vm_obj.name}")
-            assert self.source_csum[vm_obj.name] == cal_md5sum_vm(
-                vm_obj=vm_obj, file_path=self.file_paths[0]
-            ), f"Data integrity failed for VM {vm_obj.name}: checksum mismatch"
+            new_csum = cal_md5sum_vm(vm_obj=vm_obj, file_path=self.file_paths[0])
+            logger.assertion(
+                f"Data integrity: vm='{vm_obj.name}', "
+                f"expected='{self.source_csum[vm_obj.name]}', "
+                f"actual='{new_csum}', "
+                f"match={self.source_csum[vm_obj.name] == new_csum}"
+            )
+            assert (
+                self.source_csum[vm_obj.name] == new_csum
+            ), f"Data integrity failed for VM '{vm_obj.name}': checksum mismatch"
             run_dd_io(vm_obj=vm_obj, file_path=self.file_paths[1])
+        logger.info("All VMs passed data integrity check")
 
+        logger.test_step("Stop all VMs")
         for vm_obj in self.vm_list:
-            logger.info(f"Stopping VM: {vm_obj.name}")
+            logger.info(f"Stopping VM '{vm_obj.name}'")
             vm_obj.stop()

--- a/tests/functional/workloads/cnv/test_vm_add_capacity.py
+++ b/tests/functional/workloads/cnv/test_vm_add_capacity.py
@@ -52,7 +52,6 @@ class TestVmAddCapacity(E2ETest):
         self.file_paths = ["/source_file.txt", "/new_file.txt"]
 
         logger.test_step("Set up KMS, StorageClass, and project")
-        logger.info("Configuring csi-kms-connection-details configmap")
         kms = pv_encryption_kms_setup_factory(kv_version="v2")
         logger.info("KMS setup successful")
 

--- a/tests/functional/workloads/cnv/test_vm_hotpl_unplg_snap_clone.py
+++ b/tests/functional/workloads/cnv/test_vm_hotpl_unplg_snap_clone.py
@@ -172,12 +172,15 @@ class TestVmHotPlugUnplugSnapClone(E2ETest):
                 vm_obj.restart()
                 logger.info(f"VM '{vm_obj.name}' rebooted successfully")
 
+                volume_attached = verifyvolume(
+                    vm_obj.name, volume_name=pvc.name, namespace=vm_obj.namespace
+                )
                 logger.assertion(
                     f"Volume attached after reboot: vm='{vm_obj.name}', "
-                    f"volume='{pvc.name}'"
+                    f"volume='{pvc.name}', expected=True, actual={volume_attached}"
                 )
-                assert verifyvolume(
-                    vm_obj.name, volume_name=pvc.name, namespace=vm_obj.namespace
+                assert (
+                    volume_attached
                 ), f"Volume '{pvc.name}' not found on VM '{vm_obj.name}' after reboot"
 
                 new_csum = cal_md5sum_vm(vm_obj=vm_obj, file_path=file_paths[0])

--- a/tests/functional/workloads/cnv/test_vm_hotpl_unplg_snap_clone.py
+++ b/tests/functional/workloads/cnv/test_vm_hotpl_unplg_snap_clone.py
@@ -12,7 +12,7 @@ from ocs_ci.helpers.cnv_helpers import (
 from ocs_ci.ocs import constants
 from ocs_ci.utility.utils import TimeoutSampler
 
-log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 @magenta_squad
@@ -47,10 +47,8 @@ class TestVmHotPlugUnplugSnapClone(E2ETest):
         Raises:
             Exception: If there is an error during hotplugging or I/O operation.
         """
-        # Hotplug the PVC volume to the VM
-        log.info(f"Hotplugging PVC {pvc.name} to VM {vm_obj.name}")
+        logger.info(f"Hotplugging PVC '{pvc.name}' to VM '{vm_obj.name}'")
         vm_obj.addvolume(volume_name=pvc.name)
-        # Wait for the disk to be hotplugged successfully
         sample = TimeoutSampler(
             timeout=600,
             sleep=5,
@@ -59,15 +57,16 @@ class TestVmHotPlugUnplugSnapClone(E2ETest):
             disks_before_hotplug=before_disks,
         )
         sample.wait_for_func_value(value=True)
-        log.info(f"Hotplugged PVC {pvc.name} to VM {vm_obj.name}")
+        logger.info(f"PVC '{pvc.name}' hotplugged successfully to VM '{vm_obj.name}'")
 
         if not cross_pvc:
-            # Run I/O operation
-            log.info(f"Running I/O operation on VM {vm_obj.name}")
+            logger.info(f"Running I/O on VM '{vm_obj.name}'")
             source_csum = run_dd_io(vm_obj=vm_obj, file_path=file_paths[0], verify=True)
             return source_csum
         else:
-            log.info(f"Running I/O operation {pvc.name}")
+            logger.info(
+                f"Running cross-PVC I/O on VM '{vm_obj.name}' with PVC '{pvc.name}'"
+            )
             run_dd_io(vm_obj=vm_obj, file_path=file_paths[1], verify=True)
 
     def unplug_disks_and_verify(self, vm_obj, pvc):
@@ -81,7 +80,9 @@ class TestVmHotPlugUnplugSnapClone(E2ETest):
         Returns:
             None
         """
+        logger.info(f"Unplugging PVC '{pvc.name}' from VM '{vm_obj.name}'")
         vm_obj.removevolume(volume_name=pvc.name, persist=True, verify=True)
+        logger.info(f"PVC '{pvc.name}' unplugged and verified for VM '{vm_obj.name}'")
 
     def test_vm_hotpl_unplg_snap_clone(
         self,
@@ -104,7 +105,7 @@ class TestVmHotPlugUnplugSnapClone(E2ETest):
         7. Unplug the disks and verify detachment
         """
 
-        # Create an encryption enabled storageclass for RBD
+        logger.test_step("Create StorageClass, VMs, and hotplug PVCs")
         sc_obj_def = storageclass_factory(
             interface=constants.CEPHBLOCKPOOL,
             new_rbd_pool=True,
@@ -115,14 +116,12 @@ class TestVmHotPlugUnplugSnapClone(E2ETest):
         proj_obj = project_factory()
         file_paths = ["/source_file.txt", "/new_file.txt"]
 
-        # Create a PVC-based VM (VM1)
         vm_obj_pvc = cnv_workload(
             storageclass=sc_obj_def.name,
             namespace=proj_obj.namespace,
             volume_interface=constants.VM_VOLUME_PVC,
         )
         pvc_name = (f"pvc-hotplug-vm1-{vm_obj_pvc.name}")[:35]
-        # Create the PVC for VM1
         pvc_obj = pvc_factory(
             project=proj_obj,
             storageclass=sc_obj_def,
@@ -131,16 +130,16 @@ class TestVmHotPlugUnplugSnapClone(E2ETest):
             volume_mode=constants.VOLUME_MODE_BLOCK,
             pvc_name=pvc_name,
         )
-        log.info(f"PVC {pvc_obj.name} created successfully")
+        logger.info(
+            f"PVC-based VM '{vm_obj_pvc.name}' and PVC '{pvc_obj.name}' created"
+        )
 
-        # Create a DVT-based VM (VM2)
         vm_obj_dvt = cnv_workload(
             storageclass=sc_obj_def.name,
             namespace=proj_obj.namespace,
             volume_interface=constants.VM_VOLUME_DVT,
         )
         pvc_name = (f"pvc-hotplug-vm2-{vm_obj_dvt.name}")[:35]
-        # Create the PVC for VM2
         dvt_obj = pvc_factory(
             project=proj_obj,
             storageclass=sc_obj_def,
@@ -149,48 +148,54 @@ class TestVmHotPlugUnplugSnapClone(E2ETest):
             volume_mode=constants.VOLUME_MODE_BLOCK,
             pvc_name=pvc_name,
         )
-        log.info(f"PVC {dvt_obj.name} created successfully")
+        logger.info(
+            f"DVT-based VM '{vm_obj_dvt.name}' and PVC '{dvt_obj.name}' created"
+        )
 
-        # List of VM-PVC pairs for hotplug testing
         vms_pvc = [(vm_obj_pvc, pvc_obj), (vm_obj_dvt, dvt_obj)]
 
-        # Hotplug disks and perform I/O operations
+        logger.test_step("Hotplug disks, run I/O, reboot, and verify persistence")
         for i, (vm_obj, pvc) in enumerate(vms_pvc):
             try:
-                # Verify disks before hotplugging
                 disks_before_hotplug = vm_obj.run_ssh_cmd(
                     "lsblk -o NAME,SIZE,MOUNTPOINT -P"
                 )
-                log.info(
-                    f"Disks before hotplug on VM {vm_obj.name}:\n{disks_before_hotplug}"
+                logger.debug(
+                    f"Disks before hotplug on VM '{vm_obj.name}':\n{disks_before_hotplug}"
                 )
 
                 source_csum = self.hotplug_and_run_io(
                     vm_obj, pvc, file_paths, disks_before_hotplug
                 )
 
-                # Reboot the VM
-                log.info(f"Rebooting VM {vm_obj.name}")
+                logger.info(f"Rebooting VM '{vm_obj.name}'")
                 vm_obj.restart()
-                log.info(f"Reboot Success for VM: {vm_obj.name}")
+                logger.info(f"VM '{vm_obj.name}' rebooted successfully")
 
-                # Verify disk is still attached after reboot
+                logger.assertion(
+                    f"Volume attached after reboot: vm='{vm_obj.name}', "
+                    f"volume='{pvc.name}'"
+                )
                 assert verifyvolume(
                     vm_obj.name, volume_name=pvc.name, namespace=vm_obj.namespace
-                ), f"Unable to find volume {pvc.name} mounted on VM: {vm_obj.name}"
+                ), f"Volume '{pvc.name}' not found on VM '{vm_obj.name}' after reboot"
 
-                # Verify data persistence by checking MD5 checksum
                 new_csum = cal_md5sum_vm(vm_obj=vm_obj, file_path=file_paths[0])
+                logger.assertion(
+                    f"Data persistence after reboot: vm='{vm_obj.name}', "
+                    f"expected='{source_csum}', actual='{new_csum}', "
+                    f"match={source_csum == new_csum}"
+                )
                 assert (
                     source_csum == new_csum
-                ), f"MD5 mismatch after reboot for VM {vm_obj.name}"
+                ), f"MD5 mismatch after reboot for VM '{vm_obj.name}'"
             except Exception as e:
-                log.error(
-                    f"An error occurred during hotplugging and I/O operations on VM {vm_obj.name}: {str(e)}"
+                logger.exception(
+                    f"Hotplug and I/O operations failed on VM '{vm_obj.name}': {e}"
                 )
                 raise
 
-        # Create PVC clones and attach them to opposite VMs
+        logger.test_step("Create PVC clones and attach to opposite VMs")
         try:
             clone_obj_pvc = pvc_clone_factory(
                 pvc_obj, clone_name=f"clone-{pvc_obj.name}"
@@ -198,30 +203,27 @@ class TestVmHotPlugUnplugSnapClone(E2ETest):
             clone_obj_dvt = pvc_clone_factory(
                 dvt_obj, clone_name=f"clone-{dvt_obj.name}"
             )
-            log.info(
-                f"Clones of PVCs {pvc_obj.name}:{clone_obj_pvc.name} and "
-                f"{dvt_obj.name}:{clone_obj_dvt.name} created!"
+            logger.info(
+                f"Created clones: '{pvc_obj.name}' -> '{clone_obj_pvc.name}', "
+                f"'{dvt_obj.name}' -> '{clone_obj_dvt.name}'"
             )
 
-            # Attach clones to the opposite VMs
-            log.info(f"Attaching clone of {dvt_obj.name} to VM {vm_obj_pvc.name}")
+            logger.info(
+                f"Attaching clone '{clone_obj_dvt.name}' to VM '{vm_obj_pvc.name}'"
+            )
             before_disks_pvc = vm_obj_pvc.run_ssh_cmd(
                 "lsblk -o NAME,SIZE,MOUNTPOINT -P"
-            )
-            log.info(
-                f"Disks before clone hotplug on VM {vm_obj_pvc.name}:\n{before_disks_pvc}"
             )
 
             self.hotplug_and_run_io(
                 vm_obj_pvc, clone_obj_dvt, file_paths, before_disks_pvc, cross_pvc=True
             )
 
-            log.info(f"Attaching clone of {pvc_obj.name} to VM {vm_obj_dvt.name}")
+            logger.info(
+                f"Attaching clone '{clone_obj_pvc.name}' to VM '{vm_obj_dvt.name}'"
+            )
             before_disks_dvt = vm_obj_dvt.run_ssh_cmd(
                 "lsblk -o NAME,SIZE,MOUNTPOINT -P"
-            )
-            log.info(
-                f"Disks before clone hotplug on VM {vm_obj_dvt.name}:\n{before_disks_dvt}"
             )
 
             self.hotplug_and_run_io(
@@ -229,20 +231,17 @@ class TestVmHotPlugUnplugSnapClone(E2ETest):
             )
 
         except Exception as e:
-            log.error(f"An error occurred during PVC cloning and hotplugging: {str(e)}")
+            logger.exception(f"PVC cloning and cross-VM hotplug failed: {e}")
             raise
 
+        logger.test_step("Unplug all hotplugged disks and verify detachment")
         try:
-            # Unplug cloned disks and verify detachment
-            log.info(f"Unplugging clone of {dvt_obj.name} from VM {vm_obj_pvc.name}")
             self.unplug_disks_and_verify(vm_obj_pvc, clone_obj_dvt)
-
-            log.info(f"Unplugging clone of {pvc_obj.name} from VM {vm_obj_dvt.name}")
             self.unplug_disks_and_verify(vm_obj_dvt, clone_obj_pvc)
 
-            # Unplug normal disks and verify detachment
             for i, (vm_obj, pvc) in enumerate(vms_pvc):
                 self.unplug_disks_and_verify(vm_obj, pvc)
+            logger.info("All hotplugged disks unplugged and verified")
         except Exception as e:
-            log.error(f"An error occurred during PVC Unplugging: {str(e)}")
+            logger.exception(f"PVC unplug failed: {e}")
             raise

--- a/tests/functional/workloads/cnv/test_vm_hotplug_unplug.py
+++ b/tests/functional/workloads/cnv/test_vm_hotplug_unplug.py
@@ -12,7 +12,7 @@ from ocs_ci.helpers.cnv_helpers import (
 from ocs_ci.ocs import constants
 from ocs_ci.utility.utils import TimeoutSampler
 
-log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 @magenta_squad
@@ -42,18 +42,22 @@ class TestVmHotPlugUnplug(E2ETest):
         4. Hotplugging another disk without the --persist flag and verifying it is detached correctly.
         """
 
+        logger.test_step("Create project and deploy CNV workload VMs")
         proj_obj = project_factory()
         file_paths = ["/file.txt", "/new_file.txt"]
         vm_objs_def, vm_objs_aggr, sc_objs_def, sc_objs_aggr = multi_cnv_workload(
             namespace=proj_obj.namespace
         )
         vm_list = vm_objs_def + vm_objs_aggr
-        log.info(f"Total VMs to process: {len(vm_list)}")
+        logger.info(f"Created {len(vm_list)} VMs for hotplug testing")
 
+        logger.test_step(
+            "Hotplug persistent PVC, run I/O, reboot, and verify data persistence per VM"
+        )
         for vm_obj in vm_list:
             sc_obj = sc_objs_def if vm_obj in vm_objs_def else sc_objs_aggr
             before_disks = vm_obj.run_ssh_cmd("lsblk -o NAME,SIZE,MOUNTPOINT -P")
-            log.info(f"Disks before hotplug:\n{before_disks}")
+            logger.debug(f"Disks before hotplug on VM '{vm_obj.name}':\n{before_disks}")
             pvc_name = (f"pvc-hotplug-1-{vm_obj.name}")[:35]
             pvc_obj = pvc_factory(
                 project=proj_obj,
@@ -63,10 +67,9 @@ class TestVmHotPlugUnplug(E2ETest):
                 volume_mode=constants.VOLUME_MODE_BLOCK,
                 pvc_name=pvc_name,
             )
-            log.info(f"PVC {pvc_obj.name} created successfully")
 
+            logger.info(f"Hotplugging PVC '{pvc_obj.name}' to VM '{vm_obj.name}'")
             vm_obj.addvolume(volume_name=pvc_obj.name)
-            log.info(f"Hotplugged PVC {pvc_obj.name} to VM {vm_obj.name}")
 
             sample = TimeoutSampler(
                 timeout=600,
@@ -76,22 +79,35 @@ class TestVmHotPlugUnplug(E2ETest):
                 disks_before_hotplug=before_disks,
             )
             sample.wait_for_func_value(value=True)
+            logger.info(
+                f"PVC '{pvc_obj.name}' hotplugged successfully to VM '{vm_obj.name}'"
+            )
 
-            log.info(f"Running I/O operation on VM {vm_obj.name}")
+            logger.info(f"Running I/O on VM '{vm_obj.name}'")
             source_csum = run_dd_io(vm_obj=vm_obj, file_path=file_paths[0], verify=True)
 
-            log.info(f"Rebooting VM {vm_obj.name}")
+            logger.info(f"Rebooting VM '{vm_obj.name}'")
             vm_obj.restart(wait=True, verify=True)
-            log.info(f"Reboot Success for VM: {vm_obj.name}")
+            logger.info(f"VM '{vm_obj.name}' rebooted successfully")
 
+            logger.assertion(
+                f"Volume attached after reboot: vm='{vm_obj.name}', "
+                f"volume='{pvc_obj.name}'"
+            )
             assert verifyvolume(
                 vm_obj.name, volume_name=pvc_obj.name, namespace=vm_obj.namespace
-            ), f"Unable to find volume {pvc_obj.name} mounted on VM: {vm_obj.name}"
+            ), f"Volume '{pvc_obj.name}' not found on VM '{vm_obj.name}' after reboot"
 
             new_csum = cal_md5sum_vm(vm_obj=vm_obj, file_path=file_paths[0])
+            logger.assertion(
+                f"Data persistence after reboot: vm='{vm_obj.name}', "
+                f"expected='{source_csum}', actual='{new_csum}', "
+                f"match={source_csum == new_csum}"
+            )
             assert (
                 source_csum == new_csum
-            ), f"MD5 mismatch after reboot for VM {vm_obj.name}"
+            ), f"MD5 mismatch after reboot for VM '{vm_obj.name}'"
+
             pvc_name = (f"pvc-hotplug-2-{vm_obj.name}")[:35]
             pvc_obj_wout = pvc_factory(
                 project=proj_obj,
@@ -101,12 +117,15 @@ class TestVmHotPlugUnplug(E2ETest):
                 volume_mode=constants.VOLUME_MODE_BLOCK,
                 pvc_name=pvc_name,
             )
-            log.info(f"PVC {pvc_obj_wout.name} created successfully")
-            before_disks_wout = vm_obj.run_ssh_cmd(
-                "lsblk -o NAME,SIZE," "MOUNTPOINT -P"
-            )
-            log.info(f"Disks before hotplug (without persist):\n{before_disks_wout}")
 
+            before_disks_wout = vm_obj.run_ssh_cmd("lsblk -o NAME,SIZE,MOUNTPOINT -P")
+            logger.debug(
+                f"Disks before non-persistent hotplug on VM '{vm_obj.name}':\n{before_disks_wout}"
+            )
+
+            logger.info(
+                f"Hotplugging PVC '{pvc_obj_wout.name}' to VM '{vm_obj.name}' without persist"
+            )
             vm_obj.addvolume(volume_name=pvc_obj_wout.name, persist=False, verify=False)
 
             sample = TimeoutSampler(
@@ -118,12 +137,13 @@ class TestVmHotPlugUnplug(E2ETest):
             )
             sample.wait_for_func_value(value=True)
 
-            log.info(f"Running I/O operation on VM {vm_obj.name}")
+            logger.info(f"Running I/O on non-persistent disk of VM '{vm_obj.name}'")
             run_dd_io(vm_obj=vm_obj, file_path=file_paths[1])
 
             before_disks_wout_rm = vm_obj.run_ssh_cmd(
-                "lsblk -o NAME,SIZE," "MOUNTPOINT -P"
+                "lsblk -o NAME,SIZE,MOUNTPOINT -P"
             )
+            logger.info(f"Unplugging PVC '{pvc_obj_wout.name}' from VM '{vm_obj.name}'")
             vm_obj.removevolume(volume_name=pvc_obj_wout.name)
 
             sample = TimeoutSampler(
@@ -134,4 +154,10 @@ class TestVmHotPlugUnplug(E2ETest):
                 disks_before_hotplug=before_disks_wout_rm,
             )
             sample.wait_for_func_value(value=True)
+            logger.info(
+                f"PVC '{pvc_obj_wout.name}' unplugged and verified for VM '{vm_obj.name}'"
+            )
+
+            logger.info(f"Stopping VM '{vm_obj.name}'")
             vm_obj.stop()
+        logger.info("Hotplug/unplug testing completed for all VMs")

--- a/tests/functional/workloads/cnv/test_vm_hotplug_unplug.py
+++ b/tests/functional/workloads/cnv/test_vm_hotplug_unplug.py
@@ -90,12 +90,15 @@ class TestVmHotPlugUnplug(E2ETest):
             vm_obj.restart(wait=True, verify=True)
             logger.info(f"VM '{vm_obj.name}' rebooted successfully")
 
+            volume_attached = verifyvolume(
+                vm_obj.name, volume_name=pvc_obj.name, namespace=vm_obj.namespace
+            )
             logger.assertion(
                 f"Volume attached after reboot: vm='{vm_obj.name}', "
-                f"volume='{pvc_obj.name}'"
+                f"volume='{pvc_obj.name}', expected=True, actual={volume_attached}"
             )
-            assert verifyvolume(
-                vm_obj.name, volume_name=pvc_obj.name, namespace=vm_obj.namespace
+            assert (
+                volume_attached
             ), f"Volume '{pvc_obj.name}' not found on VM '{vm_obj.name}' after reboot"
 
             new_csum = cal_md5sum_vm(vm_obj=vm_obj, file_path=file_paths[0])

--- a/tests/functional/workloads/cnv/test_vm_lifecycle_and_io.py
+++ b/tests/functional/workloads/cnv/test_vm_lifecycle_and_io.py
@@ -5,7 +5,7 @@ from ocs_ci.framework.pytest_customization.marks import magenta_squad, workloads
 from ocs_ci.framework.testlib import E2ETest
 from ocs_ci.helpers.cnv_helpers import check_fio_status
 
-log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 @magenta_squad
@@ -34,7 +34,7 @@ class TestVmOperations(E2ETest):
 
         """
 
-        # Create a project
+        logger.test_step("Create project and deploy CNV workload VMs")
         proj_obj = project_factory()
 
         (
@@ -44,8 +44,14 @@ class TestVmOperations(E2ETest):
             self.sc_obj_aggressive,
         ) = multi_cnv_workload(namespace=proj_obj.namespace)
         all_vm_list = self.vm_objs_def + self.vm_objs_aggr
+        logger.info(f"Created {len(all_vm_list)} VMs successfully")
 
+        logger.test_step("Restart VMs and verify FIO status")
         for vm_obj in all_vm_list:
+            logger.info(f"Restarting VM '{vm_obj.name}'")
             vm_obj.restart()
             if check_fio_status(vm_obj):
-                log.info("FIO started after restarting VM")
+                logger.info(
+                    f"FIO running successfully on VM '{vm_obj.name}' after restart"
+                )
+        logger.info("VM lifecycle operations completed for all VMs")

--- a/tests/functional/workloads/cnv/test_vm_lifecycle_and_io.py
+++ b/tests/functional/workloads/cnv/test_vm_lifecycle_and_io.py
@@ -50,8 +50,8 @@ class TestVmOperations(E2ETest):
         for vm_obj in all_vm_list:
             logger.info(f"Restarting VM '{vm_obj.name}'")
             vm_obj.restart()
-            if check_fio_status(vm_obj):
-                logger.info(
-                    f"FIO running successfully on VM '{vm_obj.name}' after restart"
-                )
+            assert check_fio_status(
+                vm_obj
+            ), f"FIO failed to run on VM '{vm_obj.name}' after restart"
+            logger.info(f"FIO running successfully on VM '{vm_obj.name}' after restart")
         logger.info("VM lifecycle operations completed for all VMs")

--- a/tests/functional/workloads/cnv/test_vm_lifecycle_and_io_use_cluster_capacity.py
+++ b/tests/functional/workloads/cnv/test_vm_lifecycle_and_io_use_cluster_capacity.py
@@ -54,10 +54,10 @@ class TestVmOperationsUseClusterCapacity(E2ETest):
         for vm_obj in all_vm_list:
             logger.info(f"Restarting VM '{vm_obj.name}'")
             vm_obj.restart()
-            if check_fio_status(vm_obj):
-                logger.info(
-                    f"FIO running successfully on VM '{vm_obj.name}' after restart"
-                )
+            assert check_fio_status(
+                vm_obj
+            ), f"FIO failed to run on VM '{vm_obj.name}' after restart"
+            logger.info(f"FIO running successfully on VM '{vm_obj.name}' after restart")
             logger.info(f"Stopping VM '{vm_obj.name}'")
             vm_obj.stop()
         logger.info("VM lifecycle operations completed for all VMs")

--- a/tests/functional/workloads/cnv/test_vm_lifecycle_and_io_use_cluster_capacity.py
+++ b/tests/functional/workloads/cnv/test_vm_lifecycle_and_io_use_cluster_capacity.py
@@ -5,7 +5,7 @@ from ocs_ci.framework.pytest_customization.marks import magenta_squad, workloads
 from ocs_ci.framework.testlib import E2ETest
 from ocs_ci.helpers.cnv_helpers import check_fio_status
 
-log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 @magenta_squad
@@ -38,7 +38,7 @@ class TestVmOperationsUseClusterCapacity(E2ETest):
 
         """
 
-        # Create a project
+        logger.test_step("Create project and deploy VMs based on cluster capacity")
         proj_obj = project_factory()
 
         (
@@ -48,10 +48,16 @@ class TestVmOperationsUseClusterCapacity(E2ETest):
             self.sc_obj_aggressive,
         ) = multi_cnv_workload(namespace=proj_obj.namespace, use_cluster_capacity=True)
         all_vm_list = self.vm_objs_def + self.vm_objs_aggr
-        log.info("All vms created successfully")
+        logger.info(f"Created {len(all_vm_list)} VMs based on cluster capacity")
 
+        logger.test_step("Restart VMs, verify FIO, and stop")
         for vm_obj in all_vm_list:
+            logger.info(f"Restarting VM '{vm_obj.name}'")
             vm_obj.restart()
             if check_fio_status(vm_obj):
-                log.info("FIO started after restarting VM")
+                logger.info(
+                    f"FIO running successfully on VM '{vm_obj.name}' after restart"
+                )
+            logger.info(f"Stopping VM '{vm_obj.name}'")
             vm_obj.stop()
+        logger.info("VM lifecycle operations completed for all VMs")

--- a/tests/functional/workloads/cnv/test_vm_snapshot_cloning_ops.py
+++ b/tests/functional/workloads/cnv/test_vm_snapshot_cloning_ops.py
@@ -132,11 +132,11 @@ class TestVmSnapshotClone(E2ETest):
                 f"and cloned VM '{cloned_vm.name}'"
             )
 
-            # Expand PVC if `pvc_expand_after_restore` is True
+            # Expand PVC if `pvc_expand_after_clone` is True
             if pvc_expand_after_clone:
                 new_size = 50
                 try:
-                    expand_pvc_and_verify(vm_obj, new_size)
+                    expand_pvc_and_verify(cloned_vm, new_size)
                 except ValueError:
                     logger.exception(
                         f"PVC expansion failed for cloned VM '{cloned_vm.name}'"

--- a/tests/functional/workloads/cnv/test_vm_snapshot_cloning_ops.py
+++ b/tests/functional/workloads/cnv/test_vm_snapshot_cloning_ops.py
@@ -12,7 +12,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from ocs_ci.framework import config, config_safe_thread_pool_task
 
 
-log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 @magenta_squad
@@ -92,56 +92,61 @@ class TestVmSnapshotClone(E2ETest):
         8. Delete all the clones created as part of this test
         """
 
+        logger.test_step("Create project and deploy VMs for clone testing")
         proj_obj = project_factory()
         file_paths = ["/source_file.txt", "/new_file.txt"]
         vm_objs_def, vm_objs_aggr, _, _ = multi_cnv_workload(
             namespace=proj_obj.namespace
         )
         vm_list = vm_objs_def + vm_objs_aggr
-        log.info(f"Total VMs to process: {len(vm_list)}")
+        logger.info(f"Created {len(vm_list)} VMs for clone testing")
+
+        logger.test_step(
+            "Clone each VM, verify data integrity, and write additional data"
+        )
         failed_vms = []
         for vm_obj in vm_list:
-            # Expand PVC if `pvc_expand_before_clone` is True
             if pvc_expand_before_clone:
                 new_size = 50
                 try:
                     expand_pvc_and_verify(vm_obj, new_size)
-                except ValueError as e:
-                    log.error(
-                        f"Error for VM {vm_obj}: {e}. Continuing with the next VM."
-                    )
+                except ValueError:
+                    logger.exception(f"PVC expansion failed for VM '{vm_obj.name}'")
                     failed_vms.append(vm_obj.name)
                     continue
-            log.info(
-                f"Starting I/O operation on VM {vm_obj.name} using "
-                f"{file_paths[0]}..."
-            )
+            logger.info(f"Running I/O on VM '{vm_obj.name}' at '{file_paths[0]}'")
             source_csum = run_dd_io(vm_obj=vm_obj, file_path=file_paths[0], verify=True)
-            log.info(f"Source checksum for {vm_obj.name}: {source_csum}")
+            logger.debug(f"Source checksum for VM '{vm_obj.name}': {source_csum}")
 
-            log.info(f"Cloning VM {vm_obj.name}...")
+            logger.info(f"Cloning VM '{vm_obj.name}'")
             cloned_vm = vm_clone_fixture(vm_obj, admin_client)
 
             new_csum = cal_md5sum_vm(vm_obj=cloned_vm, file_path=file_paths[0])
+            logger.assertion(
+                f"Clone data integrity: source='{vm_obj.name}', clone='{cloned_vm.name}', "
+                f"expected='{source_csum}', actual='{new_csum}', "
+                f"match={source_csum == new_csum}"
+            )
             assert source_csum == new_csum, (
-                f"Failed: MD5 comparison between source {vm_obj.name} "
-                f"and cloned {cloned_vm.name} VMs"
+                f"MD5 mismatch between source VM '{vm_obj.name}' "
+                f"and cloned VM '{cloned_vm.name}'"
             )
 
             # Expand PVC if `pvc_expand_after_restore` is True
             if pvc_expand_after_clone:
                 new_size = 50
                 try:
-                    # Update self.pvc_name from vm yaml same as 11071 PR
                     expand_pvc_and_verify(vm_obj, new_size)
-                except ValueError as e:
-                    log.error(
-                        f"Error for VM {cloned_vm}: {e}. Continuing with the next VM."
+                except ValueError:
+                    logger.exception(
+                        f"PVC expansion failed for cloned VM '{cloned_vm.name}'"
                     )
                     failed_vms.append(cloned_vm.name)
                     continue
             run_dd_io(vm_obj=cloned_vm, file_path=file_paths[1])
-            log.info(f"Data written to {file_paths[1]} on cloned VM {cloned_vm.name}")
+            logger.info(
+                f"Data written to '{file_paths[1]}' on cloned VM '{cloned_vm.name}'"
+            )
         if failed_vms:
             assert False, f"Test case failed for VMs: {', '.join(failed_vms)}"
 
@@ -203,22 +208,25 @@ class TestVmSnapshotClone(E2ETest):
         6. Repeat the above procedure for all the VMs in the system
         7. Stop all the VMs created as part of this test.
         """
+        logger.test_step("Create project and deploy VMs for snapshot testing")
         proj_obj = project_factory()
         file_paths = ["/file.txt", "/new_file.txt"]
         vm_objs_def, vm_objs_aggr, _, _ = multi_cnv_workload(
             namespace=proj_obj.namespace
         )
         vm_list = vm_objs_def + vm_objs_aggr
+        logger.info(f"Created {len(vm_list)} VMs for snapshot testing")
+
+        logger.test_step("Snapshot, restore, and verify data integrity per VM")
         failed_vms = []
         for vm_obj in vm_list:
-            # Expand PVC if `pvc_expand_before_snapshot` is True
             new_size = 50
             if pvc_expand_before_snapshot:
                 try:
                     expand_pvc_and_verify(vm_obj, new_size)
-                except ValueError as e:
-                    log.error(
-                        f"Error for VM {vm_obj.name}: {e}. Continuing with the next VM."
+                except ValueError:
+                    logger.exception(
+                        f"PVC expansion before snapshot failed for VM '{vm_obj.name}'"
                     )
                     failed_vms.append(
                         f"{vm_obj.name} (Config: {vm_obj.pvc_access_mode}-{vm_obj.volume_interface}, "
@@ -226,25 +234,24 @@ class TestVmSnapshotClone(E2ETest):
                     )
                     continue
 
-            # Writing IO on source VM
+            logger.info(f"Writing I/O on source VM '{vm_obj.name}'")
             source_csum = run_dd_io(vm_obj=vm_obj, file_path=file_paths[0], verify=True)
 
+            logger.info(f"Creating snapshot and restoring VM '{vm_obj.name}'")
             restored_vm = vm_snapshot_restore_fixture(vm_obj, admin_client)
 
-            # Verify file written after snapshot is not present.
             command = f"test -f {file_paths[1]} && echo 'File exists' || echo 'File not found'"
             output = vm_obj.run_ssh_cmd(
                 command=command,
             )
 
-            # Check if file is not present
             if "File exists" in output:
                 raise FileExistsError(
-                    (
-                        f"ERROR: File '{file_paths[1]}' still exists after snapshot restore!"
-                    )
+                    f"File '{file_paths[1]}' still exists on VM '{vm_obj.name}' after snapshot restore"
                 )
-            log.info(f"File '{file_paths[1]}' is NOT present (expected).")
+            logger.info(
+                f"Verified file '{file_paths[1]}' absent after snapshot restore on VM '{vm_obj.name}'"
+            )
 
             # Expand PVC if `pvc_expand_after_restore` is True
             if pvc_expand_after_restore:
@@ -270,9 +277,9 @@ class TestVmSnapshotClone(E2ETest):
                             .get("claimName")
                         )
                     expand_pvc_and_verify(vm_obj, new_size)
-                except ValueError as e:
-                    log.error(
-                        f"Error for VM {vm_obj.name}: {e}. Continuing with the next VM."
+                except ValueError:
+                    logger.exception(
+                        f"PVC expansion after restore failed for VM '{vm_obj.name}'"
                     )
                     failed_vms.append(
                         f"{vm_obj.name} (Config: {vm_obj.pvc_access_mode}-{vm_obj.volume_interface}, "
@@ -280,13 +287,16 @@ class TestVmSnapshotClone(E2ETest):
                     )
                     continue
 
-            # Validate data integrity of file written before taking snapshot
             res_csum = cal_md5sum_vm(vm_obj=vm_obj, file_path=file_paths[0])
+            logger.assertion(
+                f"Snapshot restore data integrity: vm='{vm_obj.name}', "
+                f"expected='{source_csum}', actual='{res_csum}', "
+                f"match={source_csum == res_csum}"
+            )
             assert (
                 source_csum == res_csum
-            ), f"Failed: MD5 comparison between source {vm_obj.name} and restored {restored_vm.name} VMs"
+            ), f"MD5 mismatch between source VM '{vm_obj.name}' and restored VM '{restored_vm.name}'"
 
-            # Write new file to VM
             run_dd_io(vm_obj=vm_obj, file_path=file_paths[1], verify=True)
 
         if failed_vms:
@@ -316,46 +326,61 @@ class TestVmSnapshotClone(E2ETest):
         """
         try:
             source_csum = run_dd_io(vm_obj=vm_obj, file_path=file_paths[0], verify=True)
-            log.info(f"{vm_obj.name} Source checksum: {source_csum}")
+            logger.debug(f"Source checksum for VM '{vm_obj.name}': {source_csum}")
 
             if not flag:
-                log.info(f"Creating clone of VM [{vm_obj.name}]")
+                logger.info(f"Creating clone of VM '{vm_obj.name}'")
                 cloned_vm = vm_clone_fixture(vm_obj, admin_client)
                 run_dd_io(vm_obj=cloned_vm, file_path=file_paths[1])
 
-                log.info(f"Creating snapshot of cloned VM [{cloned_vm.name}]")
+                logger.info(f"Creating snapshot of cloned VM '{cloned_vm.name}'")
                 restored_vm = vm_snapshot_restore_fixture(cloned_vm, admin_client)
                 restore_csum = cal_md5sum_vm(
                     vm_obj=restored_vm, file_path=file_paths[0]
                 )
+                logger.assertion(
+                    f"Snapshot of clone data integrity: source='{vm_obj.name}', "
+                    f"restored='{restored_vm.name}', expected='{source_csum}', "
+                    f"actual='{restore_csum}', match={source_csum == restore_csum}"
+                )
                 assert source_csum == restore_csum, (
-                    f"[{vm_obj.name}] Failed: MD5 mismatch between source {vm_obj.name} "
-                    f"and restored {restored_vm.name} cloned from '{vm_obj.name}'"
+                    f"MD5 mismatch between source VM '{vm_obj.name}' "
+                    f"and restored VM '{restored_vm.name}'"
                 )
                 run_dd_io(vm_obj=restored_vm, file_path=file_paths[1])
-                log.info(f"[{vm_obj.name}] VM processing completed successfully.")
+                logger.info(f"VM '{vm_obj.name}' clone-snapshot processing completed")
             else:
-                log.info(f"Creating snapshot and restore VM [{vm_obj.name}]")
+                logger.info(f"Creating snapshot and restoring VM '{vm_obj.name}'")
                 restored_vm = vm_snapshot_restore_fixture(vm_obj, admin_client)
                 restore_csum = cal_md5sum_vm(
                     vm_obj=restored_vm, file_path=file_paths[0]
                 )
+                logger.assertion(
+                    f"Restore data integrity: source='{vm_obj.name}', "
+                    f"restored='{restored_vm.name}', expected='{source_csum}', "
+                    f"actual='{restore_csum}', match={source_csum == restore_csum}"
+                )
                 assert source_csum == restore_csum, (
-                    f"[{vm_obj.name}] Failed: MD5 mismatch between source {vm_obj.name} "
-                    f"and restored {restored_vm.name} cloned from '{vm_obj.name}'"
+                    f"MD5 mismatch between source VM '{vm_obj.name}' "
+                    f"and restored VM '{restored_vm.name}'"
                 )
 
-                log.info(f"Creating clone of restored VM [{restored_vm.name}]")
+                logger.info(f"Creating clone of restored VM '{restored_vm.name}'")
                 cloned_vm = vm_clone_fixture(restored_vm, admin_client)
                 run_dd_io(vm_obj=restored_vm, file_path=file_paths[1])
                 clone_csum = cal_md5sum_vm(vm_obj=cloned_vm, file_path=file_paths[0])
+                logger.assertion(
+                    f"Clone of restore data integrity: source='{vm_obj.name}', "
+                    f"clone='{cloned_vm.name}', expected='{source_csum}', "
+                    f"actual='{clone_csum}', match={source_csum == clone_csum}"
+                )
                 assert source_csum == clone_csum, (
-                    f"[{vm_obj.name}] Failed: MD5 mismatch between source {vm_obj.name} "
-                    f"and clone VM  {cloned_vm.name} restored from '{restored_vm.name}'"
+                    f"MD5 mismatch between source VM '{vm_obj.name}' "
+                    f"and clone VM '{cloned_vm.name}'"
                 )
 
-        except Exception as e:
-            log.error(f"[{vm_obj.name}] Error during VM processing: {e}", exc_info=True)
+        except Exception:
+            logger.exception(f"VM processing failed for '{vm_obj.name}'")
             raise
 
     def run_parallel_vm_clone_restore(
@@ -399,10 +424,8 @@ class TestVmSnapshotClone(E2ETest):
                 vm_name = futures[future]
                 try:
                     future.result()
-                except Exception as e:
-                    log.error(
-                        f"[{vm_name}] Exception occurred during test execution: {e}"
-                    )
+                except Exception:
+                    logger.exception(f"Parallel VM processing failed for '{vm_name}'")
                     raise
 
     @workloads
@@ -429,12 +452,18 @@ class TestVmSnapshotClone(E2ETest):
         7. Delete all the clones and restored VM created as part of this test
         """
 
+        logger.test_step("Create project and deploy VMs")
         proj_obj = project_factory()
         file_paths = ["/source_file.txt", "/new_file.txt"]
         vm_objs_def, vm_objs_aggr, _, _ = multi_cnv_workload(
             namespace=proj_obj.namespace
         )
         vm_list = vm_objs_def + vm_objs_aggr
+        logger.info(f"Created {len(vm_list)} VMs for snapshot-of-clone testing")
+
+        logger.test_step(
+            "Clone VMs, snapshot clones, and verify data integrity in parallel"
+        )
         self.run_parallel_vm_clone_restore(
             vm_list,
             file_paths,
@@ -466,12 +495,18 @@ class TestVmSnapshotClone(E2ETest):
         7. Write additional data to the cloned VM.
         """
 
+        logger.test_step("Create project and deploy VMs")
         proj_obj = project_factory()
         file_paths = ["/source_file.txt", "/new_file.txt"]
         vm_objs_def, vm_objs_aggr, _, _ = multi_cnv_workload(
             namespace=proj_obj.namespace
         )
         vm_list = vm_objs_def + vm_objs_aggr
+        logger.info(f"Created {len(vm_list)} VMs for clone-of-restored testing")
+
+        logger.test_step(
+            "Restore VMs from snapshots, clone restored VMs, and verify data integrity in parallel"
+        )
         self.run_parallel_vm_clone_restore(
             vm_list,
             file_paths,

--- a/tests/functional/workloads/cnv/test_vm_worker_node_fail.py
+++ b/tests/functional/workloads/cnv/test_vm_worker_node_fail.py
@@ -11,7 +11,7 @@ from ocs_ci.ocs import constants, node
 from ocs_ci.ocs.resources.pod import wait_for_pods_to_be_running
 from ocs_ci.utility.utils import TimeoutSampler, ceph_health_check
 
-log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 @magenta_squad
@@ -60,13 +60,13 @@ class TestVmSingleWorkerNodeFailure(E2ETest):
         new_csum = {}
         node_vm_count = {}
 
+        logger.test_step("Deploy VMs and write initial test data")
         proj_obj = project_factory()
         vm_objs_def, vm_objs_aggr, sc_objs_def, sc_objs_aggr = multi_cnv_workload(
             namespace=proj_obj.namespace
         )
         vm_list = vm_objs_def + vm_objs_aggr
-
-        log.info(f"Total VMs to process: {len(vm_list)}")
+        logger.info(f"Created {len(vm_list)} VMs")
 
         for vm_obj in vm_list:
             source_csum[vm_obj.name] = run_dd_io(
@@ -89,22 +89,22 @@ class TestVmSingleWorkerNodeFailure(E2ETest):
             k: v for k, v in node_vm_count.items() if k in worker_nodes
         }
 
+        logger.test_step("Identify target node and simulate failure")
         if valid_node_vm_count:
             max_vm_node = max(valid_node_vm_count, key=valid_node_vm_count.get)
-            log.info(
-                f"Node with the maximum number of VMs: {max_vm_node} with {valid_node_vm_count[max_vm_node]} VMs"
+            logger.info(
+                f"Target node '{max_vm_node}' hosts {valid_node_vm_count[max_vm_node]} VMs"
             )
             node_name = max_vm_node
         else:
-            log.error("No valid worker nodes found in node_vm_count.")
+            logger.error("No valid worker nodes found in node_vm_count")
             node_name = None
 
-        log.info(f"Attempting to restart node: {node_name}")
+        logger.info(f"Restarting node '{node_name}'")
         node_obj = node.get_node_objs([node_name])
         nodes.restart_nodes_by_stop_and_start(node_obj)
 
-        log.info("Performing post-failure health checks for ODF and CNV namespaces")
-
+        logger.test_step("Perform post-failure health checks")
         ceph_health_check(tries=80)
 
         sample = TimeoutSampler(
@@ -113,9 +113,10 @@ class TestVmSingleWorkerNodeFailure(E2ETest):
             func=wait_for_pods_to_be_running,
             namespace=odf_namespace,
         )
+        logger.assertion(f"All pods running in '{odf_namespace}' after node recovery")
         assert sample.wait_for_func_status(
             result=True
-        ), f"Not all pods are running in {odf_namespace} after node failure and recovery"
+        ), f"Not all pods are running in '{odf_namespace}' after node failure and recovery"
 
         sample = TimeoutSampler(
             timeout=600,
@@ -123,37 +124,54 @@ class TestVmSingleWorkerNodeFailure(E2ETest):
             func=wait_for_pods_to_be_running,
             namespace=cnv_namespace,
         )
+        logger.assertion(f"All pods running in '{cnv_namespace}' after node recovery")
         assert sample.wait_for_func_status(
             result=True
-        ), f"Not all pods are running in {cnv_namespace} after node failure and recovery"
+        ), f"Not all pods are running in '{cnv_namespace}' after node failure and recovery"
 
+        logger.test_step("Verify VM state preservation and rescheduling")
         final_vm_states = {
             vm_obj.name: [vm_obj.printableStatus(), vm_obj.get_vmi_instance().node()]
             for vm_obj in vm_objs_def + vm_objs_aggr
         }
-        log.info(f"Final VM states: {final_vm_states}")
+        logger.debug(f"Final VM states: {final_vm_states}")
 
         for vm_name in initial_vm_states:
+            logger.assertion(
+                f"VM state preserved: vm='{vm_name}', "
+                f"expected='{initial_vm_states[vm_name][0]}', "
+                f"actual='{final_vm_states[vm_name][0]}'"
+            )
             assert initial_vm_states[vm_name][0] == final_vm_states[vm_name][0], (
-                f"VM {vm_name}: State mismatch. Initial: {initial_vm_states[vm_name][0]}, "
-                f"Final: {final_vm_states[vm_name][0]}"
+                f"VM '{vm_name}' state mismatch: initial='{initial_vm_states[vm_name][0]}', "
+                f"final='{final_vm_states[vm_name][0]}'"
             )
             if initial_vm_states[vm_name][1] == node_name:
-                assert initial_vm_states[vm_name][1] != final_vm_states[vm_name][1], (
-                    f"VM {vm_name}: Rescheduling failed. Initially, VM is scheduled"
-                    f" on node {node_name}, still on the same node"
+                logger.assertion(
+                    f"VM rescheduled: vm='{vm_name}', "
+                    f"original_node='{initial_vm_states[vm_name][1]}', "
+                    f"current_node='{final_vm_states[vm_name][1]}'"
                 )
+                assert (
+                    initial_vm_states[vm_name][1] != final_vm_states[vm_name][1]
+                ), f"VM '{vm_name}' not rescheduled from failed node '{node_name}'"
 
+        logger.test_step("Verify data integrity and run I/O on recovered VMs")
         for vm_obj in vm_list:
             vm_obj.wait_for_ssh_connectivity()
             new_csum[vm_obj.name] = cal_md5sum_vm(
                 vm_obj=vm_obj, file_path=file_paths[0]
             )
 
+            logger.assertion(
+                f"Data integrity after node failure: vm='{vm_obj.name}', "
+                f"expected='{source_csum[vm_obj.name]}', "
+                f"actual='{new_csum[vm_obj.name]}', "
+                f"match={source_csum[vm_obj.name] == new_csum[vm_obj.name]}"
+            )
             assert source_csum[vm_obj.name] == new_csum[vm_obj.name], (
-                f"Failed: MD5 comparison failed in VM {vm_obj.name} before "
-                f"{source_csum[vm_obj.name]}"
-                f"and after {new_csum[vm_obj.name]} worker node failure"
+                f"MD5 mismatch for VM '{vm_obj.name}' after worker node failure: "
+                f"before='{source_csum[vm_obj.name]}', after='{new_csum[vm_obj.name]}'"
             )
             run_dd_io(vm_obj=vm_obj, file_path=file_paths[1])
-        log.info("Successfully completed I/O on all VMs after worker node failure")
+        logger.info("All VMs passed data integrity check after worker node failure")


### PR DESCRIPTION
## Summary

Improve logging across CNV workload tests to simplify debugging and failure analysis.

### Changes
- Add informative logs around test execution flow
- Improve validation logging
- Add contextual logs for VM lifecycle operations
- Improve exception logging

### Testing
- pre-commit passed
- black
- flake8
- validate retry usage
- deprecated usage validation
- detect-secrets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced functional CNV coverage for shutdown recovery, device replacement, mon/OSD and node failures, VM capacity, hotplug/unplug, snapshots, cloning, and lifecycle scenarios.
  * Added clearer step-by-step progress reporting and richer assertion details for recovery, VM state, cluster health, and storage operations.
  * Strengthened data-integrity validation with improved MD5 reporting, follow-up I/O checks, and clearer recovery waits.
  * Improved failure handling during restoration and teardown to make test results easier to diagnose.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->