### PR TITLE
[release-4.21]: Increase default vSphere VM start timeout

### DIFF
--- a/conf/README.md
+++ b/conf/README.md
@@ -192,7 +192,7 @@ version.
 * `hub_cluster_name` - Name of the Management cluster. Applicable for Agent deployments, where the hub cluster is pre-created.
 * `hub_cluster_path` - Path to the Management cluster directory to store auth_path, credentials files or cluster related files.
 * `partitioned_disk_primary_affinity` - Configure primaryAffinity for OSDs on partitioned disks, https://access.redhat.com/solutions/5807201 (default: "0.0")
-* `vsphere_vm_start_timeout` - Number of seconds to wait for vsphere vms to start up (default: 240)
+* `vsphere_vm_start_timeout` - Number of seconds to wait for vsphere vms to start up (default: 900)
 
 #### REPORTING
 

--- a/ocs_ci/utility/vsphere.py
+++ b/ocs_ci/utility/vsphere.py
@@ -623,7 +623,7 @@ class VSPHERE(object):
         WaitForTasks(tasks, self._si)
 
         if wait:
-            wait_time = config.DEPLOYMENT.get("vsphere_vm_start_timeout", 240)
+            wait_time = config.DEPLOYMENT.get("vsphere_vm_start_timeout", 900)
             for ips in TimeoutSampler(wait_time, 3, self.get_vms_ips, vms):
                 logger.info(
                     f"Waiting for VMs {[vm.name for vm in vms]} to power on "


### PR DESCRIPTION
VMs occasionally take longer than 240s to obtain an IP after power-on
during LSO disk attachment, causing deployment failures even though the
VM eventually becomes reachable.

Fixes: https://github.com/red-hat-storage/ocs-ci/issues/15723

Signed-off-by: vavuthu [vavuthu@redhat.com](mailto:vavuthu@redhat.com)