### PR TITLE
[release-4.20]: Add config override for vsphere vm start timeout

### DIFF
--- a/conf/README.md
+++ b/conf/README.md
@@ -188,6 +188,7 @@ version.
 * `enable_nested_virtualization` - Enable nested virtualization for vSphere platform primarily. Used for kubevirt on HCP Clusters. It sets options kvm_intel nested=1 options kvm_amd nested=1 in MachineConfig
 * `host_network` - Enable host network in the storage cluster CR and to be able to connect to the storage cluster from the host network or other scenarios where host network is required.
 * `partitioned_disk_on_workers` - Create a partition for OSD on the OS disk on worker nodes.
+* `vsphere_vm_start_timeout` - Number of seconds to wait for vsphere vms to start up (default: 900)
 
 #### REPORTING
 

--- a/ocs_ci/utility/vsphere.py
+++ b/ocs_ci/utility/vsphere.py
@@ -623,7 +623,8 @@ class VSPHERE(object):
         WaitForTasks(tasks, self._si)
 
         if wait:
-            for ips in TimeoutSampler(240, 3, self.get_vms_ips, vms):
+            wait_time = config.DEPLOYMENT.get("vsphere_vm_start_timeout", 900)
+            for ips in TimeoutSampler(wait_time, 3, self.get_vms_ips, vms):
                 logger.info(
                     f"Waiting for VMs {[vm.name for vm in vms]} to power on "
                     f"based on network connectivity. Current VMs IPs: {ips}"


### PR DESCRIPTION
backports #14640 and #15724

Signed-off-by: vavuthu [vavuthu@redhat.com](mailto:vavuthu@redhat.com)