### PR TITLE
[release-4.19]: Add config override for vsphere vm start timeout

### DIFF
--- a/conf/README.md
+++ b/conf/README.md
@@ -184,6 +184,7 @@ version.
 * `fdf_upgrade_image_digest`: sha256 of the pre-release image for FDF upgrade. If not provided, automatically retrieved using skopeo.
 * `storage_cluster_override` - Dictionary with data which will allow you to dynamically override data in storageCluster CR.
 * `konflux_build` - Set to True if build is made by Konflux build system.
+* `vsphere_vm_start_timeout` - Number of seconds to wait for vsphere vms to start up (default: 900)
 
 #### REPORTING
 

--- a/ocs_ci/utility/vsphere.py
+++ b/ocs_ci/utility/vsphere.py
@@ -623,7 +623,8 @@ class VSPHERE(object):
         WaitForTasks(tasks, self._si)
 
         if wait:
-            for ips in TimeoutSampler(240, 3, self.get_vms_ips, vms):
+            wait_time = config.DEPLOYMENT.get("vsphere_vm_start_timeout", 900)
+            for ips in TimeoutSampler(wait_time, 3, self.get_vms_ips, vms):
                 logger.info(
                     f"Waiting for VMs {[vm.name for vm in vms]} to power on "
                     f"based on network connectivity. Current VMs IPs: {ips}"


### PR DESCRIPTION
backports https://github.com/red-hat-storage/ocs-ci/pull/14640 and https://github.com/red-hat-storage/ocs-ci/pull/15724

Signed-off-by: vavuthu [vavuthu@redhat.com](mailto:vavuthu@redhat.com)