### PR TITLE
[release-4.18]: Add config override for vsphere vm start timeout

### DIFF
--- a/conf/README.md
+++ b/conf/README.md
@@ -177,6 +177,7 @@ version.
 * `fdf_pre_release_registry`: Registry where the pre-release image of FDF is hosted.
 * `fdf_pre_release_image_digest`: sha256 of the pre-release image of FDF to deploy.
 * `konflux_build` - Set to True if build is made by Konflux build system.
+* `vsphere_vm_start_timeout` - Number of seconds to wait for vsphere vms to start up (default: 900)
 
 #### REPORTING
 

--- a/ocs_ci/utility/vsphere.py
+++ b/ocs_ci/utility/vsphere.py
@@ -602,7 +602,8 @@ class VSPHERE(object):
         WaitForTasks(tasks, self._si)
 
         if wait:
-            for ips in TimeoutSampler(240, 3, self.get_vms_ips, vms):
+            wait_time = config.DEPLOYMENT.get("vsphere_vm_start_timeout", 900)
+            for ips in TimeoutSampler(wait_time, 3, self.get_vms_ips, vms):
                 logger.info(
                     f"Waiting for VMs {[vm.name for vm in vms]} to power on "
                     f"based on network connectivity. Current VMs IPs: {ips}"


### PR DESCRIPTION
backports https://github.com/red-hat-storage/ocs-ci/pull/14640 and https://github.com/red-hat-storage/ocs-ci/pull/15724

Signed-off-by: vavuthu [vavuthu@redhat.com](mailto:vavuthu@redhat.com)