### PR TITLE
Verify forceful deployment checkbox absent in non-LSO UI deployment

### DIFF
--- a/ocs_ci/ocs/ui/deployment_ui.py
+++ b/ocs_ci/ocs/ui/deployment_ui.py
@@ -8,7 +8,11 @@ from ocs_ci.ocs.ui.page_objects.page_navigator import PageNavigator
 from ocs_ci.utility.utils import TimeoutSampler
 from ocs_ci.utility import version
 from ocs_ci.ocs.resources import csv
-from ocs_ci.ocs.exceptions import TimeoutExpiredError, ConfigurationError
+from ocs_ci.ocs.exceptions import (
+    TimeoutExpiredError,
+    ConfigurationError,
+    UnexpectedBehaviour,
+)
 from ocs_ci.framework import config
 from ocs_ci.ocs import constants, defaults
 from ocs_ci.ocs.node import (
@@ -508,7 +512,7 @@ class DeploymentUI(PageNavigator):
         suppressed so that deployment is not interrupted.
 
         Raises:
-            ConfigurationError: If the checkbox element is found.
+            UnexpectedBehaviour: If the checkbox element is found.
 
         """
         logger.info(
@@ -533,18 +537,18 @@ class DeploymentUI(PageNavigator):
                 locator=self.dep_loc["enable_forceful_deployment"]
             )
             if elements:
-                raise ConfigurationError(
+                raise UnexpectedBehaviour(
                     "'Enable forceful deployment' checkbox should "
                     "not appear in non-LSO deployment flow"
                 )
             logger.info(
-                "'Enable forceful deployment' checkbox is not " "present, as expected"
+                "'Enable forceful deployment' checkbox is not present, as expected"
             )
-        except ConfigurationError:
+        except UnexpectedBehaviour:
             raise
         except (WebDriverException, OSError):
             logger.warning(
-                "Could not verify forceful deployment option, " "continuing deployment",
+                "Could not verify forceful deployment option, continuing deployment",
                 exc_info=True,
             )
 

--- a/ocs_ci/ocs/ui/deployment_ui.py
+++ b/ocs_ci/ocs/ui/deployment_ui.py
@@ -19,6 +19,7 @@ from ocs_ci.ocs.node import (
     label_nodes,
 )
 from ocs_ci.utility.operators import LocalStorageOperator
+from selenium.common.exceptions import WebDriverException
 from selenium.webdriver.common.by import By
 
 logger = logging.getLogger(__name__)
@@ -485,12 +486,64 @@ class DeploymentUI(PageNavigator):
         if self.ocp_version_semantic >= version.VERSION_4_7:
             logger.info("Next on step 'Select capacity and nodes'")
             self.do_click(locator=self.dep_loc["next"], enable_screenshot=True)
+            if ocs_version >= version.VERSION_4_22:
+                self.verify_forceful_deployment_option_disabled()
             self.configure_in_transit_encryption()
             self.configure_encryption()
 
         self.configure_data_protection()
 
         self.create_storage_cluster()
+
+    def verify_forceful_deployment_option_disabled(self):
+        """
+        Verify the 'Enable forceful deployment' checkbox is absent.
+
+        Attempts to navigate to the 'Advanced settings' wizard step
+        (if it exists) and then asserts the forceful deployment
+        checkbox is not present. In the non-LSO flow neither the
+        step nor the checkbox should appear.
+
+        Any exception other than finding the checkbox is logged and
+        suppressed so that deployment is not interrupted.
+
+        Raises:
+            ConfigurationError: If the checkbox element is found.
+
+        """
+        logger.info(
+            "Verify 'Enable forceful deployment' checkbox "
+            "is not present in non-LSO deployment flow"
+        )
+        try:
+            self.take_screenshot()
+            if self.check_element_text("Advanced settings"):
+                logger.info("'Advanced settings' step found, clicking it")
+                self.do_click(
+                    locator=(
+                        "//*[contains(text(), 'Advanced settings')]",
+                        By.XPATH,
+                    ),
+                    enable_screenshot=True,
+                )
+            elements = self.get_elements(
+                locator=self.dep_loc["enable_forceful_deployment"]
+            )
+            if elements:
+                raise ConfigurationError(
+                    "'Enable forceful deployment' checkbox should "
+                    "not appear in non-LSO deployment flow"
+                )
+            logger.info(
+                "'Enable forceful deployment' checkbox is not " "present, as expected"
+            )
+        except ConfigurationError:
+            raise
+        except (WebDriverException, OSError):
+            logger.warning(
+                "Could not verify forceful deployment option, " "continuing deployment",
+                exc_info=True,
+            )
 
     def configure_performance(self):
         """

--- a/ocs_ci/ocs/ui/deployment_ui.py
+++ b/ocs_ci/ocs/ui/deployment_ui.py
@@ -544,8 +544,6 @@ class DeploymentUI(PageNavigator):
             logger.info(
                 "'Enable forceful deployment' checkbox is not present, as expected"
             )
-        except UnexpectedBehaviour:
-            raise
         except (WebDriverException, OSError):
             logger.warning(
                 "Could not verify forceful deployment option, continuing deployment",

--- a/ocs_ci/ocs/ui/deployment_ui.py
+++ b/ocs_ci/ocs/ui/deployment_ui.py
@@ -515,6 +515,12 @@ class DeploymentUI(PageNavigator):
             "Verify 'Enable forceful deployment' checkbox "
             "is not present in non-LSO deployment flow"
         )
+        if "enable_forceful_deployment" not in self.dep_loc:
+            logger.info(
+                "Locator 'enable_forceful_deployment' not "
+                "defined, skipping verification"
+            )
+            return
         try:
             self.take_screenshot()
             if self.check_element_text("Advanced settings"):

--- a/ocs_ci/ocs/ui/deployment_ui.py
+++ b/ocs_ci/ocs/ui/deployment_ui.py
@@ -526,10 +526,7 @@ class DeploymentUI(PageNavigator):
             if self.check_element_text("Advanced settings"):
                 logger.info("'Advanced settings' step found, clicking it")
                 self.do_click(
-                    locator=(
-                        "//*[contains(text(), 'Advanced settings')]",
-                        By.XPATH,
-                    ),
+                    locator=self.dep_loc["advanced_settings_step"],
                     enable_screenshot=True,
                 )
             elements = self.get_elements(

--- a/ocs_ci/ocs/ui/deployment_ui.py
+++ b/ocs_ci/ocs/ui/deployment_ui.py
@@ -209,7 +209,12 @@ class DeploymentUI(PageNavigator):
         if ocs_version >= version.VERSION_4_20:
             logger.info("Navigate to Storage Cluster page")
 
-            self.nav_storage_cluster_default_page()
+            self.choose_expanded_mode(mode=True, locator=self.page_nav["Storage"])
+            self.do_click(
+                locator=self.page_nav["storage_cluster"],
+                timeout=90,
+            )
+            self.page_has_loaded(retries=15)
             logger.info("Click Configure ODF")
             self.do_click(locator=self.dep_loc["configure_odf"], enable_screenshot=True)
             self.do_click(

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -383,6 +383,10 @@ deployment_4_21 = {
 }
 
 deployment_4_22 = {
+    "advanced_settings_step": (
+        "//*[contains(text(), 'Advanced settings')]",
+        By.XPATH,
+    ),
     "enable_forceful_deployment": (
         "input#enable-forceful-deployment",
         By.CSS_SELECTOR,


### PR DESCRIPTION
See more details in the feature: https://redhat.atlassian.net/browse/RHSTOR-8102

Add `verify_forceful_deployment_option_disabled()` to the non-LSO UI deployment flow (ODF 4.22+) to verify the
  `Enable forceful deployment` checkbox is not present on the page.

  - If the `"Advanced settings"` wizard step is found, click into it first
  - Check for `input#enable-forceful-deployment` element using `get_elements()`
  - Only `ConfigurationError` (checkbox found) fails the deployment
  - `WebDriverException`/`OSError` are logged and suppressed to avoid blocking deployment


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added an additional deployment UI validation (for supported versions) to ensure the “Enable forceful deployment” option is not shown.
  * The verification captures a screenshot and, when needed, moves through the “Advanced settings” step before confirming the option is absent.
  * If the check can’t be completed due to runtime or system issues, the deployment continues instead of failing unexpectedly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->