### PR TITLE
Add object browser UI tests for preview and directory hierarchy

### DIFF
--- a/ocs_ci/ocs/ui/base_ui.py
+++ b/ocs_ci/ocs/ui/base_ui.py
@@ -689,7 +689,7 @@ class BaseUI:
 
         Usage::
 
-            with self.new_tab(some_locator):
+            with self.run_in_new_tab(some_locator):
                 content = self.driver.find_element(By.TAG_NAME, "pre").text
 
         Args:
@@ -713,10 +713,10 @@ class BaseUI:
             WebDriverWait(driver, timeout).until(
                 lambda d: len(d.window_handles) > len(original_handles)
             )
-        except TimeoutException:
+        except TimeoutException as err:
             raise TimeoutException(
                 f"No new tab opened within {timeout}s after clicking {locator}"
-            )
+            ) from err
 
         new_handle = (set(driver.window_handles) - original_handles).pop()
         driver.switch_to.window(new_handle)

--- a/ocs_ci/ocs/ui/base_ui.py
+++ b/ocs_ci/ocs/ui/base_ui.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 from pathlib import Path
 import datetime
 import logging
@@ -679,6 +680,53 @@ class BaseUI:
 
         """
         self.driver.refresh()
+
+    @contextmanager
+    def run_in_new_tab(self, locator, timeout=15):
+        """
+        Click a locator that opens a new browser tab, switch to it, and
+        guarantee cleanup on exit.
+
+        Usage::
+
+            with self.new_tab(some_locator):
+                content = self.driver.find_element(By.TAG_NAME, "pre").text
+
+        Args:
+            locator: Selenium locator tuple that triggers a new tab on click.
+            timeout (int): Seconds to wait for the new tab to appear.
+
+        Yields:
+            The WebDriver instance, now focused on the new tab.
+
+        Raises:
+            TimeoutException: If no new tab opens within ``timeout`` seconds.
+
+        """
+        driver = SeleniumDriver()
+        parent_handle = driver.current_window_handle
+        original_handles = set(driver.window_handles)
+
+        self.do_click(locator, enable_screenshot=True)
+
+        try:
+            WebDriverWait(driver, timeout).until(
+                lambda d: len(d.window_handles) > len(original_handles)
+            )
+        except TimeoutException:
+            raise TimeoutException(
+                f"No new tab opened within {timeout}s after clicking {locator}"
+            )
+
+        new_handle = (set(driver.window_handles) - original_handles).pop()
+        driver.switch_to.window(new_handle)
+        try:
+            yield driver
+        finally:
+            if new_handle in driver.window_handles:
+                driver.switch_to.window(new_handle)
+                driver.close()
+            driver.switch_to.window(parent_handle)
 
     def navigate_backward(self):
         """

--- a/ocs_ci/ocs/ui/page_objects/buckets_tab.py
+++ b/ocs_ci/ocs/ui/page_objects/buckets_tab.py
@@ -677,6 +677,35 @@ class BucketsTab(ObjectStorage, ConfirmDialog):
         self.page_has_loaded()
         logger.info(f"Navigated into folder: {folder_name}")
 
+    def wait_for_object_listed(self, object_name, timeout=30):
+        """
+        Wait for an object or folder to appear in the object browser listing.
+
+        Args:
+            object_name (str): Name of the object or folder to wait for.
+            timeout (int): Seconds to wait before timing out.
+
+        """
+        locator = format_locator(self.bucket_tab["file_name_text"], object_name)
+        WebDriverWait(self.driver, timeout).until(
+            lambda d: self.get_elements(locator),
+            message=f"'{object_name}' not found in object browser within {timeout}s",
+        )
+
+    def is_object_listed(self, object_name):
+        """
+        Check if an object or folder is visible in the object browser listing.
+
+        Args:
+            object_name (str): Name of the object or folder.
+
+        Returns:
+            bool: True if the object is listed, False otherwise.
+
+        """
+        locator = format_locator(self.bucket_tab["file_name_text"], object_name)
+        return bool(self.get_elements(locator))
+
     def navigate_to_folder_and_enable_versions(
         self,
         folder_name: str,
@@ -785,26 +814,23 @@ class BucketsTab(ObjectStorage, ConfirmDialog):
 
         new_handles = set(self.driver.window_handles) - original_handles
         preview_handle = new_handles.pop()
-        self.driver.switch_to.window(preview_handle)
-        blob_url = self.driver.current_url
-        logger.info(f"Preview tab opened with URL: {blob_url}")
+        try:
+            self.driver.switch_to.window(preview_handle)
+            blob_url = self.driver.current_url
+            logger.info(f"Preview tab opened with URL: {blob_url}")
 
-        # Fetch the blob content from the app window's JS context.
-        # execute_async_script injects a callback (cb) as the last JS argument;
-        # calling cb(value) is the only way to return data to Python - if cb is
-        # never called, the driver's script timeout fires and returns None.
-        # The .catch ensures cb is always invoked even on fetch failure.
-        self.driver.switch_to.window(parent_handle)
-        content = self.driver.execute_async_script(
-            "var cb = arguments[arguments.length - 1];"
-            "fetch(arguments[0]).then(r => r.text()).then(cb)"
-            ".catch(e => cb('ERROR:' + e));",
-            blob_url,
-        )
-
-        self.driver.switch_to.window(preview_handle)
-        self.driver.close()
-        self.driver.switch_to.window(parent_handle)
+            self.driver.switch_to.window(parent_handle)
+            content = self.driver.execute_async_script(
+                "var cb = arguments[arguments.length - 1];"
+                "fetch(arguments[0]).then(r => r.text()).then(cb)"
+                ".catch(e => cb('ERROR:' + e));",
+                blob_url,
+            )
+        finally:
+            if preview_handle in self.driver.window_handles:
+                self.driver.switch_to.window(preview_handle)
+                self.driver.close()
+            self.driver.switch_to.window(parent_handle)
 
         if not isinstance(content, str):
             raise RuntimeError(
@@ -813,6 +839,9 @@ class BucketsTab(ObjectStorage, ConfirmDialog):
                 f"timed out or the blob URL '{blob_url}' was not accessible from "
                 f"the app window."
             )
+
+        if content.startswith("ERROR:"):
+            raise RuntimeError(f"Blob fetch for '{object_key}' failed: {content}")
 
         logger.info(f"Preview content length for '{object_key}': {len(content)}")
         return content

--- a/ocs_ci/ocs/ui/page_objects/buckets_tab.py
+++ b/ocs_ci/ocs/ui/page_objects/buckets_tab.py
@@ -660,6 +660,7 @@ class BucketsTab(ObjectStorage, ConfirmDialog):
         logger.info(f"Looking for bucket link with text: {bucket_name}")
         bucket_link_locator = f"//tr//a[contains(text(), '{bucket_name}')]"
         self.do_click((bucket_link_locator, By.XPATH))
+        self.page_has_loaded()
         logger.info(f"Successfully navigated into bucket: {bucket_name}")
 
     def navigate_into_folder(self, folder_name: str) -> None:
@@ -673,6 +674,7 @@ class BucketsTab(ObjectStorage, ConfirmDialog):
             self.bucket_tab["folder_link_by_name"], folder_name
         )
         self.do_click(folder_locator)
+        self.page_has_loaded()
         logger.info(f"Navigated into folder: {folder_name}")
 
     def navigate_to_folder_and_enable_versions(

--- a/ocs_ci/ocs/ui/page_objects/buckets_tab.py
+++ b/ocs_ci/ocs/ui/page_objects/buckets_tab.py
@@ -11,6 +11,7 @@ from selenium.common.exceptions import (
     TimeoutException,
     StaleElementReferenceException,
 )
+from selenium.webdriver.support.ui import WebDriverWait
 
 from ocs_ci.ocs.ui.helpers_ui import format_locator
 from ocs_ci.ocs.ocp import get_ocp_url
@@ -661,6 +662,19 @@ class BucketsTab(ObjectStorage, ConfirmDialog):
         self.do_click((bucket_link_locator, By.XPATH))
         logger.info(f"Successfully navigated into bucket: {bucket_name}")
 
+    def navigate_into_folder(self, folder_name: str) -> None:
+        """
+        Click a folder link in the object browser to navigate into it.
+
+        Args:
+            folder_name (str): Name of the folder to navigate into.
+        """
+        folder_locator = format_locator(
+            self.bucket_tab["folder_link_by_name"], folder_name
+        )
+        self.do_click(folder_locator)
+        logger.info(f"Navigated into folder: {folder_name}")
+
     def navigate_to_folder_and_enable_versions(
         self,
         folder_name: str,
@@ -734,3 +748,69 @@ class BucketsTab(ObjectStorage, ConfirmDialog):
         self.do_click(self.bucket_tab["permissions_tab"])
         self.do_click(self.bucket_tab["bucket_policy_tab"])
         return BucketsTabPermissions()
+
+    def preview_object_content(self, object_key, timeout=15):
+        """
+        Open the Preview of an object in the object browser and return its
+        text content.
+
+        Assumes the object contains UTF-8 text. The blob is fetched via
+        Response.text(), so binary objects will produce garbled output.
+
+        Args:
+            object_key (str): The S3 object key visible in the object browser.
+            timeout (int): Seconds to wait for the preview tab to open.
+
+        Returns:
+            str: The text content of the previewed object.
+
+        Raises:
+            RuntimeError: If the blob fetch did not return a string (e.g.
+                the async script timed out and returned None, or the JS
+                fetch failed and returned a non-string error).
+
+        """
+        parent_handle = self.driver.current_window_handle
+        original_handles = set(self.driver.window_handles)
+
+        kebab_locator = format_locator(self.bucket_tab["object_row_kebab"], object_key)
+        self.do_click(kebab_locator, enable_screenshot=True)
+        self.do_click(self.bucket_tab["object_action_preview"], enable_screenshot=True)
+
+        WebDriverWait(self.driver, timeout).until(
+            lambda d: len(d.window_handles) > len(original_handles)
+        )
+
+        new_handles = set(self.driver.window_handles) - original_handles
+        preview_handle = new_handles.pop()
+        self.driver.switch_to.window(preview_handle)
+        blob_url = self.driver.current_url
+        logger.info(f"Preview tab opened with URL: {blob_url}")
+
+        # Fetch the blob content from the app window's JS context.
+        # execute_async_script injects a callback (cb) as the last JS argument;
+        # calling cb(value) is the only way to return data to Python - if cb is
+        # never called, the driver's script timeout fires and returns None.
+        # The .catch ensures cb is always invoked even on fetch failure.
+        self.driver.switch_to.window(parent_handle)
+        content = self.driver.execute_async_script(
+            "var cb = arguments[arguments.length - 1];"
+            "fetch(arguments[0]).then(r => r.text()).then(cb)"
+            ".catch(e => cb('ERROR:' + e));",
+            blob_url,
+        )
+
+        self.driver.switch_to.window(preview_handle)
+        self.driver.close()
+        self.driver.switch_to.window(parent_handle)
+
+        if not isinstance(content, str):
+            raise RuntimeError(
+                f"Blob fetch for '{object_key}' returned {type(content).__name__} "
+                f"instead of str (value: {content!r}). The async script may have "
+                f"timed out or the blob URL '{blob_url}' was not accessible from "
+                f"the app window."
+            )
+
+        logger.info(f"Preview content length for '{object_key}': {len(content)}")
+        return content

--- a/ocs_ci/ocs/ui/page_objects/buckets_tab.py
+++ b/ocs_ci/ocs/ui/page_objects/buckets_tab.py
@@ -785,8 +785,7 @@ class BucketsTab(ObjectStorage, ConfirmDialog):
         Open the Preview of an object in the object browser and return its
         text content.
 
-        Assumes the object contains UTF-8 text. The blob is fetched via
-        Response.text(), so binary objects will produce garbled output.
+        Assumes the object contains UTF-8 text.
 
         Args:
             object_key (str): The S3 object key visible in the object browser.
@@ -795,53 +794,15 @@ class BucketsTab(ObjectStorage, ConfirmDialog):
         Returns:
             str: The text content of the previewed object.
 
-        Raises:
-            RuntimeError: If the blob fetch did not return a string (e.g.
-                the async script timed out and returned None, or the JS
-                fetch failed and returned a non-string error).
-
         """
-        parent_handle = self.driver.current_window_handle
-        original_handles = set(self.driver.window_handles)
-
         kebab_locator = format_locator(self.bucket_tab["object_row_kebab"], object_key)
         self.do_click(kebab_locator, enable_screenshot=True)
-        self.do_click(self.bucket_tab["object_action_preview"], enable_screenshot=True)
 
-        WebDriverWait(self.driver, timeout).until(
-            lambda d: len(d.window_handles) > len(original_handles)
-        )
-
-        new_handles = set(self.driver.window_handles) - original_handles
-        preview_handle = new_handles.pop()
-        try:
-            self.driver.switch_to.window(preview_handle)
-            blob_url = self.driver.current_url
-            logger.info(f"Preview tab opened with URL: {blob_url}")
-
-            self.driver.switch_to.window(parent_handle)
-            content = self.driver.execute_async_script(
-                "var cb = arguments[arguments.length - 1];"
-                "fetch(arguments[0]).then(r => r.text()).then(cb)"
-                ".catch(e => cb('ERROR:' + e));",
-                blob_url,
-            )
-        finally:
-            if preview_handle in self.driver.window_handles:
-                self.driver.switch_to.window(preview_handle)
-                self.driver.close()
-            self.driver.switch_to.window(parent_handle)
-
-        if not isinstance(content, str):
-            raise RuntimeError(
-                f"Blob fetch for '{object_key}' returned {type(content).__name__} "
-                f"instead of str (value: {content!r}). The async script may have "
-                f"timed out or the blob URL '{blob_url}' was not accessible from "
-                f"the app window."
-            )
-
-        if content.startswith("ERROR:"):
-            raise RuntimeError(f"Blob fetch for '{object_key}' failed: {content}")
+        locator = self.bucket_tab["object_action_preview"]
+        with self.run_in_new_tab(locator, timeout=timeout):
+            # Read the content directly from the DOM - browsers consistently
+            # render text/plain blobs inside a <pre> tag.
+            content = self.driver.find_element(By.TAG_NAME, "pre").text
 
         logger.info(f"Preview content length for '{object_key}': {len(content)}")
         return content

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -3377,11 +3377,7 @@ bucket_tab = {
         By.XPATH,
     ),
     "object_action_preview": (
-        "//button[contains(@class,'c-menu__item')" " and normalize-space()='Preview']",
-        By.XPATH,
-    ),
-    "object_action_download": (
-        "//button[contains(@class,'c-menu__item')" " and normalize-space()='Download']",
+        "//button[normalize-space()='Preview']",
         By.XPATH,
     ),
     "folder_link_by_name": (
@@ -3389,7 +3385,7 @@ bucket_tab = {
         By.XPATH,
     ),
     "refresh_objects_button": (
-        "//button[contains(@class,'c-button') and .//span[text()='Refresh']]",
+        "//button[.//span[text()='Refresh']]",
         By.XPATH,
     ),
 }

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -3377,17 +3377,19 @@ bucket_tab = {
         By.XPATH,
     ),
     "object_action_preview": (
-        "//button[contains(@class,'pf-v6-c-menu__item')"
-        " and normalize-space()='Preview']",
+        "//button[contains(@class,'c-menu__item')" " and normalize-space()='Preview']",
         By.XPATH,
     ),
     "object_action_download": (
-        "//button[contains(@class,'pf-v6-c-menu__item')"
-        " and normalize-space()='Download']",
+        "//button[contains(@class,'c-menu__item')" " and normalize-space()='Download']",
         By.XPATH,
     ),
     "folder_link_by_name": (
-        "//td[@data-label='Name']//a[contains(text(), '{}')]",
+        "//td[@data-label='Name']//a[contains(., '{}')]",
+        By.XPATH,
+    ),
+    "refresh_objects_button": (
+        "//button[contains(@class,'c-button') and .//span[text()='Refresh']]",
         By.XPATH,
     ),
 }

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -3370,6 +3370,26 @@ bucket_tab = {
         "//span[text()='Secret name']/ancestor::div[contains(@class, 'form__group')]//span[@class='odf-resource-item']",
         By.XPATH,
     ),
+    # Object row actions (object browser)
+    "object_row_kebab": (
+        "//tr[.//td[@data-label='Name' and contains(normalize-space(),'{}')]]"
+        "//button[@aria-label='Kebab toggle']",
+        By.XPATH,
+    ),
+    "object_action_preview": (
+        "//button[contains(@class,'pf-v6-c-menu__item')"
+        " and normalize-space()='Preview']",
+        By.XPATH,
+    ),
+    "object_action_download": (
+        "//button[contains(@class,'pf-v6-c-menu__item')"
+        " and normalize-space()='Download']",
+        By.XPATH,
+    ),
+    "folder_link_by_name": (
+        "//td[@data-label='Name']//a[contains(text(), '{}')]",
+        By.XPATH,
+    ),
 }
 s3_vector_tab = {
     # S3 Vector sub-tab within Buckets page

--- a/tests/functional/object/mcg/ui/test_mcg_ui.py
+++ b/tests/functional/object/mcg/ui/test_mcg_ui.py
@@ -43,7 +43,6 @@ from ocs_ci.ocs.bucket_utils import (
 )
 from ocs_ci.ocs.ui.helpers_ui import format_locator
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -679,6 +678,7 @@ class TestBucketCreate:
         logger.info("Pagination test completed successfully")
 
     @tier1
+    @pytest.mark.polarion_id("OCS-6651")
     def test_namespace_bucket_object_preview(
         self,
         setup_ui_class_factory,
@@ -749,6 +749,7 @@ class TestBucketCreate:
         logger.info("Preview content matches the original uploaded data")
 
     @tier1
+    @pytest.mark.polarion_id("OCS-6652")
     def test_obc_bucket_directory_hierarchy_and_preview(
         self,
         request,

--- a/tests/functional/object/mcg/ui/test_mcg_ui.py
+++ b/tests/functional/object/mcg/ui/test_mcg_ui.py
@@ -40,13 +40,10 @@ from ocs_ci.ocs.bucket_utils import (
     s3_put_object,
     wait_for_bucket_count_stability,
 )
-from selenium.webdriver.support.ui import WebDriverWait
-
 from ocs_ci.ocs.resources.objectbucket import (
     get_s3_credentials_from_obc,
     wait_for_obc_phase,
 )
-from ocs_ci.ocs.ui.helpers_ui import format_locator
 
 logger = logging.getLogger(__name__)
 
@@ -733,14 +730,8 @@ class TestBucketCreate:
 
         # 4. Verify the object key is listed in the object browser
         logger.test_step("Verify object key is listed in the object browser")
-        file_locator = format_locator(
-            bucket_ui.bucket_tab["file_name_text"], object_key
-        )
-        elements = bucket_ui.get_elements(file_locator)
-        assert elements, (
-            f"Object '{object_key}' not found in object browser "
-            f"for bucket '{bucket_name}'"
-        )
+        bucket_ui.do_click(bucket_ui.bucket_tab["refresh_objects_button"])
+        bucket_ui.wait_for_object_listed(object_key)
         logger.info(f"Object '{object_key}' is visible in the object browser")
 
         # 5. Open Preview for the object and verify the content matches
@@ -802,7 +793,7 @@ class TestBucketCreate:
                 obc_ocp.delete(resource_name=bucket_name)
                 logger.info(f"Cleaned up OBC: {bucket_name}")
             except Exception:
-                logger.warning(f"Failed to clean up OBC: {bucket_name}")
+                logger.warning(f"Failed to clean up OBC: {bucket_name}", exc_info=True)
 
         request.addfinalizer(cleanup_obc)
 
@@ -818,29 +809,23 @@ class TestBucketCreate:
             s3_put_object(mcg_obj, s3_bucket_name, key, data=content)
             logger.info(f"Uploaded {key} to {s3_bucket_name}")
 
-        # 4. Verify the hierarchy in the object browser
+        # 3. Verify the hierarchy in the object browser
         logger.test_step("Verify directory hierarchy in the object browser")
         bucket_ui.navigate_to_bucket(s3_bucket_name)
         bucket_ui.do_click(bucket_ui.bucket_tab["refresh_objects_button"])
-
-        folder_locator = format_locator(bucket_ui.bucket_tab["file_name_text"], "d1")
-        WebDriverWait(bucket_ui.driver, 30).until(
-            lambda d: bucket_ui.get_elements(folder_locator),
-            message="d1/ not found at bucket root within 30s",
-        )
+        bucket_ui.wait_for_object_listed("d1")
 
         bucket_ui.navigate_into_folder("d1")
         for subfolder in ("d1.1", "d1.2"):
-            locator = format_locator(bucket_ui.bucket_tab["file_name_text"], subfolder)
-            assert bucket_ui.get_elements(locator), f"{subfolder}/ not found in d1/"
+            assert bucket_ui.is_object_listed(
+                subfolder
+            ), f"{subfolder}/ not found in d1/"
 
-        # 5. Verify leaf files via preview - first branch
+        # 4. Verify leaf files via preview - first branch
         logger.test_step("Verify f1.txt content via preview (d1/d1.1/d2.1/)")
         bucket_ui.navigate_into_folder("d1.1")
         bucket_ui.navigate_into_folder("d2.1")
-
-        file_locator = format_locator(bucket_ui.bucket_tab["file_name_text"], "f1.txt")
-        assert bucket_ui.get_elements(file_locator), "f1.txt not found in d2.1/"
+        assert bucket_ui.is_object_listed("f1.txt"), "f1.txt not found in d2.1/"
 
         preview = bucket_ui.preview_object_content("f1.txt")
         assert (
@@ -855,8 +840,7 @@ class TestBucketCreate:
         bucket_ui.navigate_into_folder("d1.2")
         bucket_ui.navigate_into_folder("d2.2")
 
-        file_locator = format_locator(bucket_ui.bucket_tab["file_name_text"], "f2.txt")
-        assert bucket_ui.get_elements(file_locator), "f2.txt not found in d2.2/"
+        assert bucket_ui.is_object_listed("f2.txt"), "f2.txt not found in d2.2/"
 
         preview = bucket_ui.preview_object_content("f2.txt")
         assert (

--- a/tests/functional/object/mcg/ui/test_mcg_ui.py
+++ b/tests/functional/object/mcg/ui/test_mcg_ui.py
@@ -38,8 +38,13 @@ from ocs_ci.ocs.ui.page_objects.page_navigator import PageNavigator
 from ocs_ci.ocs.scale_noobaa_lib import fetch_noobaa_storage_class_name
 from ocs_ci.ocs.bucket_utils import (
     s3_put_object,
-    sync_object_directory,
     wait_for_bucket_count_stability,
+)
+from selenium.webdriver.support.ui import WebDriverWait
+
+from ocs_ci.ocs.resources.objectbucket import (
+    get_s3_credentials_from_obc,
+    wait_for_obc_phase,
 )
 from ocs_ci.ocs.ui.helpers_ui import format_locator
 
@@ -677,7 +682,7 @@ class TestBucketCreate:
 
         logger.info("Pagination test completed successfully")
 
-    @tier1
+    @tier2
     @pytest.mark.polarion_id("OCS-6651")
     def test_namespace_bucket_object_preview(
         self,
@@ -748,24 +753,22 @@ class TestBucketCreate:
         )
         logger.info("Preview content matches the original uploaded data")
 
-    @tier1
+    @tier2
     @pytest.mark.polarion_id("OCS-6652")
     def test_obc_bucket_directory_hierarchy_and_preview(
         self,
         request,
         setup_ui_class_factory,
         mcg_obj,
-        awscli_pod,
     ):
         """
         Verify directory hierarchy and file preview in an OBC bucket.
 
         Steps:
         1. Create an OBC bucket via the UI
-        2. Create a nested directory on the awscli pod
-        3. Upload the directory to the bucket via AWS CLI sync
-        4. Verify the hierarchy is presented in the bucket's object browser
-        5. Verify the leaf files' content via the UI preview option
+        2. Upload objects with nested folder keys via S3 API
+        3. Verify the hierarchy is presented in the bucket's object browser
+        4. Verify the leaf files' content via the UI preview option
 
         """
         # 1. Create an OBC bucket via the UI
@@ -776,56 +779,55 @@ class TestBucketCreate:
         _, bucket_name = bucket_ui.create_bucket_ui(method="obc", return_name=True)
         logger.info(f"Created OBC bucket via UI: {bucket_name}")
 
+        wait_for_obc_phase(
+            bucket_name,
+            config.ENV_DATA["cluster_namespace"],
+            constants.STATUS_BOUND,
+            timeout=60,
+        )
+
+        obc_creds = get_s3_credentials_from_obc(
+            bucket_name, config.ENV_DATA["cluster_namespace"]
+        )
+        s3_bucket_name = obc_creds["bucket_name"]
+        logger.info(f"OBC '{bucket_name}' maps to S3 bucket '{s3_bucket_name}'")
+
+        obc_ocp = OCP(
+            kind=constants.OBC,
+            namespace=config.ENV_DATA["cluster_namespace"],
+        )
+
         def cleanup_obc():
             try:
-                OCP(
-                    kind="ObjectBucketClaim",
-                    namespace=config.ENV_DATA["cluster_namespace"],
-                ).delete(resource_name=bucket_name)
+                obc_ocp.delete(resource_name=bucket_name)
                 logger.info(f"Cleaned up OBC: {bucket_name}")
             except Exception:
                 logger.warning(f"Failed to clean up OBC: {bucket_name}")
 
         request.addfinalizer(cleanup_obc)
 
-        # 2. Create a nested directory on the awscli pod
-        logger.test_step("Create nested directory structure on awscli pod")
+        # 2. Upload objects with folder-like keys to create a hierarchy
+        logger.test_step("Upload objects with nested folder keys via S3 API")
         f1_content = "Content of leaf file f1"
         f2_content = "Content of leaf file f2"
-        base_dir = f"/tmp/hierarchy-test-{uuid.uuid4().hex[:8]}"
-
-        awscli_pod.exec_cmd_on_pod(
-            command=(
-                f"mkdir -p {base_dir}/d1/d1.1/d2.1 {base_dir}/d1/d1.2/d2.2 && "
-                f"printf '%s' '{f1_content}' > {base_dir}/d1/d1.1/d2.1/f1.txt && "
-                f"printf '%s' '{f2_content}' > {base_dir}/d1/d1.2/d2.2/f2.txt"
-            ),
-            out_yaml_format=False,
-        )
-
-        def cleanup_pod_dir():
-            try:
-                awscli_pod.exec_cmd_on_pod(
-                    command=f"rm -rf {base_dir}", out_yaml_format=False
-                )
-            except Exception:
-                pass
-
-        request.addfinalizer(cleanup_pod_dir)
-
-        # 3. Upload the directory to the bucket via AWS CLI sync
-        logger.test_step("Sync directory to bucket via AWS CLI")
-        sync_object_directory(
-            awscli_pod, f"{base_dir}/", f"s3://{bucket_name}", s3_obj=mcg_obj
-        )
-        logger.info(f"Synced {base_dir}/ to s3://{bucket_name}")
+        object_keys = {
+            "d1/d1.1/d2.1/f1.txt": f1_content,
+            "d1/d1.2/d2.2/f2.txt": f2_content,
+        }
+        for key, content in object_keys.items():
+            s3_put_object(mcg_obj, s3_bucket_name, key, data=content)
+            logger.info(f"Uploaded {key} to {s3_bucket_name}")
 
         # 4. Verify the hierarchy in the object browser
         logger.test_step("Verify directory hierarchy in the object browser")
-        bucket_ui.navigate_to_bucket(bucket_name)
+        bucket_ui.navigate_to_bucket(s3_bucket_name)
+        bucket_ui.do_click(bucket_ui.bucket_tab["refresh_objects_button"])
 
         folder_locator = format_locator(bucket_ui.bucket_tab["file_name_text"], "d1")
-        assert bucket_ui.get_elements(folder_locator), "d1/ not found at bucket root"
+        WebDriverWait(bucket_ui.driver, 30).until(
+            lambda d: bucket_ui.get_elements(folder_locator),
+            message="d1/ not found at bucket root within 30s",
+        )
 
         bucket_ui.navigate_into_folder("d1")
         for subfolder in ("d1.1", "d1.2"):
@@ -848,7 +850,7 @@ class TestBucketCreate:
 
         # Verify second branch
         logger.test_step("Verify f2.txt content via preview (d1/d1.2/d2.2/)")
-        bucket_ui.navigate_to_bucket(bucket_name)
+        bucket_ui.navigate_to_bucket(s3_bucket_name)
         bucket_ui.navigate_into_folder("d1")
         bucket_ui.navigate_into_folder("d1.2")
         bucket_ui.navigate_into_folder("d2.2")

--- a/tests/functional/object/mcg/ui/test_mcg_ui.py
+++ b/tests/functional/object/mcg/ui/test_mcg_ui.py
@@ -1,6 +1,7 @@
 import logging
 import sys
 import time
+import uuid
 
 from ocs_ci.framework.logger_helper import log_step
 from ocs_ci.framework.pytest_customization.marks import (
@@ -35,7 +36,12 @@ from ocs_ci.ocs.ui.page_objects.object_bucket_claims_tab import (
 from ocs_ci.ocs.ui.page_objects.buckets_tab import BucketsTab
 from ocs_ci.ocs.ui.page_objects.page_navigator import PageNavigator
 from ocs_ci.ocs.scale_noobaa_lib import fetch_noobaa_storage_class_name
-from ocs_ci.ocs.bucket_utils import wait_for_bucket_count_stability
+from ocs_ci.ocs.bucket_utils import (
+    s3_put_object,
+    sync_object_directory,
+    wait_for_bucket_count_stability,
+)
+from ocs_ci.ocs.ui.helpers_ui import format_locator
 
 
 logger = logging.getLogger(__name__)
@@ -671,3 +677,186 @@ class TestBucketCreate:
         ), "Returned to first page but buckets don't match"
 
         logger.info("Pagination test completed successfully")
+
+    @tier1
+    def test_namespace_bucket_object_preview(
+        self,
+        setup_ui_class_factory,
+        mcg_obj,
+        bucket_factory,
+    ):
+        """
+        Verify object listing and preview in a namespace bucket.
+
+        Steps:
+        1. Create an AWS namespacestore, bucketclass, and namespace bucket
+        2. Upload a text object to the bucket via the S3 API
+        3. Navigate to the bucket in the ODF console object browser
+        4. Verify the object key is listed in the object browser
+        5. Open Preview for the object and verify the content matches
+
+        """
+        # 1. Create an AWS namespacestore, bucketclass, and namespace bucket
+        logger.test_step("Create AWS namespace bucket via bucket_factory")
+        bucketclass_dict = {
+            "interface": "OC",
+            "namespace_policy_dict": {
+                "type": "Single",
+                "namespacestore_dict": {"aws": [(1, "eu-central-1")]},
+            },
+        }
+        ns_bucket = bucket_factory(
+            amount=1,
+            interface=bucketclass_dict["interface"],
+            bucketclass=bucketclass_dict,
+        )[0]
+        bucket_name = ns_bucket.name
+        logger.info(f"Namespace bucket created: {bucket_name}")
+
+        # 2. Upload a text object to the bucket via the S3 API
+        logger.test_step("Upload text object via S3 API")
+        object_key = f"preview-test-{uuid.uuid4().hex[:8]}.txt"
+        expected_content = "Hello from namespace bucket preview test"
+        s3_put_object(mcg_obj, bucket_name, object_key, expected_content)
+        logger.info(f"Uploaded object '{object_key}' to bucket '{bucket_name}'")
+
+        # 3. Navigate to the bucket in the ODF console object browser
+        logger.test_step("Navigate to bucket in ODF console object browser")
+        setup_ui_class_factory()
+        bucket_ui = BucketsTab()
+        bucket_ui.navigate_to_bucket(bucket_name)
+
+        # 4. Verify the object key is listed in the object browser
+        logger.test_step("Verify object key is listed in the object browser")
+        file_locator = format_locator(
+            bucket_ui.bucket_tab["file_name_text"], object_key
+        )
+        elements = bucket_ui.get_elements(file_locator)
+        assert elements, (
+            f"Object '{object_key}' not found in object browser "
+            f"for bucket '{bucket_name}'"
+        )
+        logger.info(f"Object '{object_key}' is visible in the object browser")
+
+        # 5. Open Preview for the object and verify the content matches
+        logger.test_step("Preview object and verify content matches uploaded data")
+        preview_content = bucket_ui.preview_object_content(object_key)
+        assert preview_content == expected_content, (
+            f"Preview content mismatch.\n"
+            f"Expected: {expected_content!r}\n"
+            f"Got:      {preview_content!r}"
+        )
+        logger.info("Preview content matches the original uploaded data")
+
+    @tier1
+    def test_obc_bucket_directory_hierarchy_and_preview(
+        self,
+        request,
+        setup_ui_class_factory,
+        mcg_obj,
+        awscli_pod,
+    ):
+        """
+        Verify directory hierarchy and file preview in an OBC bucket.
+
+        Steps:
+        1. Create an OBC bucket via the UI
+        2. Create a nested directory on the awscli pod
+        3. Upload the directory to the bucket via AWS CLI sync
+        4. Verify the hierarchy is presented in the bucket's object browser
+        5. Verify the leaf files' content via the UI preview option
+
+        """
+        # 1. Create an OBC bucket via the UI
+        logger.test_step("Create OBC bucket via the UI")
+        setup_ui_class_factory()
+        bucket_ui = BucketsTab()
+        bucket_ui.nav_object_storage_page()
+        _, bucket_name = bucket_ui.create_bucket_ui(method="obc", return_name=True)
+        logger.info(f"Created OBC bucket via UI: {bucket_name}")
+
+        def cleanup_obc():
+            try:
+                OCP(
+                    kind="ObjectBucketClaim",
+                    namespace=config.ENV_DATA["cluster_namespace"],
+                ).delete(resource_name=bucket_name)
+                logger.info(f"Cleaned up OBC: {bucket_name}")
+            except Exception:
+                logger.warning(f"Failed to clean up OBC: {bucket_name}")
+
+        request.addfinalizer(cleanup_obc)
+
+        # 2. Create a nested directory on the awscli pod
+        logger.test_step("Create nested directory structure on awscli pod")
+        f1_content = "Content of leaf file f1"
+        f2_content = "Content of leaf file f2"
+        base_dir = f"/tmp/hierarchy-test-{uuid.uuid4().hex[:8]}"
+
+        awscli_pod.exec_cmd_on_pod(
+            command=(
+                f"mkdir -p {base_dir}/d1/d1.1/d2.1 {base_dir}/d1/d1.2/d2.2 && "
+                f"printf '%s' '{f1_content}' > {base_dir}/d1/d1.1/d2.1/f1.txt && "
+                f"printf '%s' '{f2_content}' > {base_dir}/d1/d1.2/d2.2/f2.txt"
+            ),
+            out_yaml_format=False,
+        )
+
+        def cleanup_pod_dir():
+            try:
+                awscli_pod.exec_cmd_on_pod(
+                    command=f"rm -rf {base_dir}", out_yaml_format=False
+                )
+            except Exception:
+                pass
+
+        request.addfinalizer(cleanup_pod_dir)
+
+        # 3. Upload the directory to the bucket via AWS CLI sync
+        logger.test_step("Sync directory to bucket via AWS CLI")
+        sync_object_directory(
+            awscli_pod, f"{base_dir}/", f"s3://{bucket_name}", s3_obj=mcg_obj
+        )
+        logger.info(f"Synced {base_dir}/ to s3://{bucket_name}")
+
+        # 4. Verify the hierarchy in the object browser
+        logger.test_step("Verify directory hierarchy in the object browser")
+        bucket_ui.navigate_to_bucket(bucket_name)
+
+        folder_locator = format_locator(bucket_ui.bucket_tab["file_name_text"], "d1")
+        assert bucket_ui.get_elements(folder_locator), "d1/ not found at bucket root"
+
+        bucket_ui.navigate_into_folder("d1")
+        for subfolder in ("d1.1", "d1.2"):
+            locator = format_locator(bucket_ui.bucket_tab["file_name_text"], subfolder)
+            assert bucket_ui.get_elements(locator), f"{subfolder}/ not found in d1/"
+
+        # 5. Verify leaf files via preview - first branch
+        logger.test_step("Verify f1.txt content via preview (d1/d1.1/d2.1/)")
+        bucket_ui.navigate_into_folder("d1.1")
+        bucket_ui.navigate_into_folder("d2.1")
+
+        file_locator = format_locator(bucket_ui.bucket_tab["file_name_text"], "f1.txt")
+        assert bucket_ui.get_elements(file_locator), "f1.txt not found in d2.1/"
+
+        preview = bucket_ui.preview_object_content("f1.txt")
+        assert (
+            preview == f1_content
+        ), f"f1.txt preview mismatch.\nExpected: {f1_content!r}\nGot: {preview!r}"
+        logger.info("f1.txt preview content verified")
+
+        # Verify second branch
+        logger.test_step("Verify f2.txt content via preview (d1/d1.2/d2.2/)")
+        bucket_ui.navigate_to_bucket(bucket_name)
+        bucket_ui.navigate_into_folder("d1")
+        bucket_ui.navigate_into_folder("d1.2")
+        bucket_ui.navigate_into_folder("d2.2")
+
+        file_locator = format_locator(bucket_ui.bucket_tab["file_name_text"], "f2.txt")
+        assert bucket_ui.get_elements(file_locator), "f2.txt not found in d2.2/"
+
+        preview = bucket_ui.preview_object_content("f2.txt")
+        assert (
+            preview == f2_content
+        ), f"f2.txt preview mismatch.\nExpected: {f2_content!r}\nGot: {preview!r}"
+        logger.info("f2.txt preview content verified")

--- a/tests/functional/object/mcg/ui/test_mcg_ui.py
+++ b/tests/functional/object/mcg/ui/test_mcg_ui.py
@@ -836,6 +836,8 @@ class TestBucketCreate:
         # Verify second branch
         logger.test_step("Verify f2.txt content via preview (d1/d1.2/d2.2/)")
         bucket_ui.navigate_to_bucket(s3_bucket_name)
+        bucket_ui.do_click(bucket_ui.bucket_tab["refresh_objects_button"])
+        bucket_ui.wait_for_object_listed("d1")
         bucket_ui.navigate_into_folder("d1")
         bucket_ui.navigate_into_folder("d1.2")
         bucket_ui.navigate_into_folder("d2.2")


### PR DESCRIPTION
## Summary

- Add two new tier2 UI tests for the ODF console object browser
- `test_namespace_bucket_object_preview` - creates a namespace bucket, uploads an object, and verifies its content via the browser's Preview action
- `test_obc_bucket_directory_hierarchy_and_preview` - creates an OBC bucket, uploads objects with nested folder keys, navigates the directory hierarchy in the browser, and verifies leaf file content via Preview

## Changes

- **views.py**: Add 5 new locators to `bucket_tab` for object browser interaction (kebab menu, preview/download actions, folder links, refresh button). All locators use version-free PatternFly class selectors for upgrade resilience
- **buckets_tab.py**: Add `navigate_into_folder()`, `preview_object_content()` methods, and `page_has_loaded()` calls after navigation clicks for DOM stability
- **test_mcg_ui.py**: Add both test methods to the existing `TestBucketCreate` class

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the bucket object browser with folder navigation.
  - Added in-browser previews for text objects from row actions.
  - Added reliable handling for previews opened in a new browser tab.
- **Bug Fixes**
  - Improved navigation reliability by waiting for page loads.
  - Improved object listing responsiveness with refresh and availability checks before preview.
- **Tests**
  - Added UI coverage for previews in namespace bucket scenarios.
  - Added UI coverage for directory hierarchies and preview verification in OBC bucket scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->