### PR TITLE
Fixing DNS deletion issue (cherry-pick to release-4.20)

### DIFF
--- a/ocs_ci/deployment/ibmcloud.py
+++ b/ocs_ci/deployment/ibmcloud.py
@@ -224,7 +224,7 @@ class IBMCloudIPI(CloudDeploymentBase):
             super(IBMCloudIPI, self).destroy_cluster(log_level)
             self.destroy_cluster_from_existing_vpc(prefix)
             logger.info("IBM Cloud cluster destroyed successfully")
-            ibmcloud.delete_dns_records(prefix)
+            ibmcloud.delete_dns_records(self.cluster_name)
             logger.info("DNS records deleted successfully")
         else:
             resource_group = self.get_resource_group()


### PR DESCRIPTION
## Summary
Cherry-pick of #15764 to release-4.20.

Fixes DNS deletion during IBM Cloud cluster teardown — was passing `prefix` (infra ID) instead of `self.cluster_name` to `delete_dns_records()`.

## Original PR
https://github.com/red-hat-storage/ocs-ci/pull/15764