### PR TITLE
[release-4.18] WORKAROUND: pass z-stream version of OCP to AssistedInstallerCluster object

### DIFF
--- a/ocs_ci/deployment/baremetal.py
+++ b/ocs_ci/deployment/baremetal.py
@@ -968,7 +968,11 @@ class BAREMETALAI(BAREMETALBASE):
             self.ai_cluster = assisted_installer.AssistedInstallerCluster(
                 name=self.cluster_name,
                 cluster_path=self.cluster_path,
-                openshift_version=str(version.get_semantic_ocp_version_from_config()),
+                openshift_version=str(
+                    version.get_semantic_version(
+                        config.DEPLOYMENT["installer_version"], False
+                    )
+                ),
                 base_dns_domain=config.ENV_DATA["base_domain"],
                 api_vip=self.api_vip,
                 ingress_vip=self.ingress_vip,


### PR DESCRIPTION
This is not intended to be merged in this state, it is just a workaround for one-time deployments!

The aim of this PR/workaround is to be able to pass z-stream version of OCP to the Assisted Installer to be able to install non-latest OCP z-stream version.

This is a backport of https://github.com/red-hat-storage/ocs-ci/pull/15777