### PR TITLE
adress FDF and EC deploy issues

### DIFF
--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -181,7 +181,6 @@ from ocs_ci.utility.ssl_certs import (
     configure_custom_api_cert,
     get_root_ca_cert,
 )
-from ocs_ci.ocs.resources.rgw import create_ec_cephobjectstore
 from ocs_ci.utility.storage_cluster_setup import StorageClusterSetup
 from ocs_ci.utility.utils import (
     ceph_health_check,
@@ -2411,14 +2410,6 @@ class Deployment(object):
 
         # Enable console plugin
         enable_console_plugin()
-
-        if (
-            config.DEPLOYMENT.get("ec_default_pools")
-            and not config.DEPLOYMENT.get("external_mode")
-            and not config.ENV_DATA.get("mcg_only_deployment")
-            and version.get_semantic_ocs_version_from_config() < version.VERSION_4_22
-        ):
-            create_ec_cephobjectstore()
 
         # validate PDB creation of MON, MDS, OSD pods
         if not config.DEPLOYMENT["external_mode"]:

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -2267,14 +2267,7 @@ class Deployment(object):
             config.ENV_DATA.get("odf_provider_mode_deployment", False)
             and not config.ENV_DATA["skip_ocs_deployment"]
         ):
-            path = "/spec/routeAdmission"
-            value = '{wildcardPolicy: "WildcardsAllowed"}'
-            params = f"""[{{"op": "add", "path": "{path}", "value": {value}}}]"""
-            patch_cmd = (
-                f"patch {constants.INGRESSCONTROLLER} -n {constants.OPENSHIFT_INGRESS_OPERATOR_NAMESPACE} "
-                + f"default --type json -p '{params}'"
-            )
-            OCP().exec_oc_cmd(command=patch_cmd)
+            enable_wildcard_routes()
 
             # Mark master nodes schedulable if mark_masters_schedulable: True
             if config.ENV_DATA.get("mark_masters_schedulable", True):
@@ -2423,6 +2416,7 @@ class Deployment(object):
             config.DEPLOYMENT.get("ec_default_pools")
             and not config.DEPLOYMENT.get("external_mode")
             and not config.ENV_DATA.get("mcg_only_deployment")
+            and version.get_semantic_ocs_version_from_config() < version.VERSION_4_22
         ):
             create_ec_cephobjectstore()
 
@@ -3169,6 +3163,27 @@ class Deployment(object):
         except CommandFailed:
             mch_running = False
         return mch_running
+
+
+def enable_wildcard_routes():
+    """
+    Enable wildcard routes on the default IngressController.
+
+    KubeVirt-based hosted clusters create passthrough routes with
+    ``wildcardPolicy: Subdomain`` so that all ``*.apps.<client>.*``
+    traffic is forwarded to the hosted cluster's own router.
+    Without this patch the route is rejected with
+    ``wildcard routes are not allowed``.
+    """
+    logger.info("Enabling wildcard routes on default IngressController")
+    path = "/spec/routeAdmission"
+    value = '{wildcardPolicy: "WildcardsAllowed"}'
+    params = f"""[{{"op": "add", "path": "{path}", "value": {value}}}]"""
+    patch_cmd = (
+        f"patch {constants.INGRESSCONTROLLER} -n {constants.OPENSHIFT_INGRESS_OPERATOR_NAMESPACE} "
+        + f"default --type json -p '{params}'"
+    )
+    ocp.OCP().exec_oc_cmd(command=patch_cmd)
 
 
 def validate_acm_hub_install():

--- a/ocs_ci/deployment/fusion_data_foundation.py
+++ b/ocs_ci/deployment/fusion_data_foundation.py
@@ -76,6 +76,11 @@ class FusionDataFoundationDeployment:
         """
 
         logger.info("Installing IBM Fusion Data Foundation")
+        if config.ENV_DATA.get("odf_provider_mode_deployment", False):
+            from ocs_ci.deployment.deployment import enable_wildcard_routes
+
+            enable_wildcard_routes()
+
         if self.pre_release and not self.live_deployment:
             self.create_image_tag_mirror_set()
             self.create_image_digest_mirror_set()


### PR DESCRIPTION
Fix problem 
1. redundant code for DF deployment with EC (create cephobjectstore should be automatic with 4.22)
2. enable wildcard routes for FDF multicluster deployments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled wildcard routes automatically during ODF provider-mode deployments.
  * Added wildcard-route configuration to Fusion Data Foundation deployments when running in ODF provider-mode.

* **Bug Fixes**
  * Tightened EC default pool creation to only run when the environment conditions match, including restricting support to OCS versions below 4.22.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->