### PR TITLE
Update exteranal mode template for CephX changes

### DIFF
--- a/ocs_ci/templates/ocs-deployment/toolbox_pod.yaml
+++ b/ocs_ci/templates/ocs-deployment/toolbox_pod.yaml
@@ -21,7 +21,13 @@ spec:
       - name: rook-ceph-tools
         image: rook/ceph:v1.4.9
         command: ["/tini"]
-        args: ["-g", "--", "/usr/local/bin/toolbox.sh"]
+        args:
+          - -g
+          - --
+          - |
+            mkdir -p /var/lib/rook-ceph-mon
+            echo "${ROOK_CEPH_SECRET}" > /var/lib/rook-ceph-mon/secret.keyring
+            /usr/local/bin/toolbox.sh
         imagePullPolicy: IfNotPresent
         env:
           - name: ROOK_CEPH_USERNAME


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Rook Ceph toolbox startup process by ensuring the required monitoring directory and secret keyring are available before the toolbox launches.
  * Helps provide more reliable toolbox access in deployments where the Ceph monitor secret is required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->