### PR TITLE
INTEROP-9285: Filter non-ODF leftovers in environment_check

### DIFF
--- a/ocs_ci/utility/environment_check.py
+++ b/ocs_ci/utility/environment_check.py
@@ -13,6 +13,35 @@ from ocs_ci.ocs import ocp, defaults, constants, exceptions
 log = logging.getLogger(__name__)
 
 
+def _pv_or_pvc_storage_provisioner(item):
+    """
+    Extract the CSI provisioner driver name from a PV or PVC item.
+
+    Args:
+        item (dict): Kubernetes resource dictionary (PV or PVC)
+
+    Returns:
+        str: The provisioner driver name, or None if not detected
+    """
+    kind = item.get("kind")
+    if kind == constants.PV:
+        driver = item.get("spec", {}).get("csi", {}).get("driver")
+        if driver:
+            return driver
+        return (
+            item.get("metadata", {})
+            .get("annotations", {})
+            .get("pv.kubernetes.io/provisioned-by")
+        )
+    if kind == constants.PVC:
+        annotations = item.get("metadata", {}).get("annotations", {})
+        provisioner = annotations.get("volume.kubernetes.io/storage-provisioner")
+        if provisioner:
+            return provisioner
+        return annotations.get("volume.beta.kubernetes.io/storage-provisioner")
+    return None
+
+
 def compare_dicts(before, after):
     """
     Comparing 2 dicts and providing diff list of [added items, removed items]
@@ -100,6 +129,24 @@ def assign_get_values(
         ):
             log.debug("ignoring item in %s namespace: %s", ns, item)
             continue
+        if item.get("kind") in (constants.PV, constants.PVC):
+            provisioner = _pv_or_pvc_storage_provisioner(item)
+            if provisioner and provisioner not in constants.OCS_PROVISIONERS:
+                log.debug(
+                    "ignoring non-ODF %s provisioned by %s: %s",
+                    item.get("kind"),
+                    provisioner,
+                    item.get("metadata", {}).get("name"),
+                )
+                continue
+        if item.get("kind") == constants.STORAGECLASS:
+            owner_refs = item.get("metadata", {}).get("ownerReferences", [])
+            if any(ref.get("kind") == "StorageClient" for ref in owner_refs):
+                log.debug(
+                    "ignoring StorageClient-owned StorageClass: %s",
+                    item.get("metadata", {}).get("name"),
+                )
+                continue
         if item.get("kind") == constants.POD:
             name = item.get("metadata", {}).get("name", "")
             if name.endswith("-debug") or "-debug-" in name:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1389,6 +1389,62 @@ def storageclass_factory_fixture(
         instances.append(sc_obj)
         return sc_obj
 
+    def _strip_storageclient_owner_refs(instance):
+        """
+        Remove StorageClient ownerReferences from a StorageClass so that
+        the finalizer delete is not blocked by the ownership chain.
+
+        Only StorageClient entries are removed; other ownerReferences are
+        preserved.
+
+        Args:
+            instance: OCS StorageClass instance with .ocp and .name attrs
+        """
+        try:
+            sc_data = instance.ocp.get(resource_name=instance.name)
+        except CommandFailed as ex:
+            if "NotFound" in str(ex):
+                log.debug(
+                    f"StorageClass {instance.name} already removed, "
+                    "skipping ownerRef strip"
+                )
+                return
+            raise
+        owner_refs = sc_data.get("metadata", {}).get("ownerReferences") or []
+        sc_client_refs = [
+            ref for ref in owner_refs if ref.get("kind") == "StorageClient"
+        ]
+        if not sc_client_refs:
+            return
+        filtered_refs = [
+            ref for ref in owner_refs if ref.get("kind") != "StorageClient"
+        ]
+        patch_data = json.dumps(
+            {"metadata": {"ownerReferences": filtered_refs or None}}
+        )
+        try:
+            patched = instance.ocp.patch(
+                resource_name=instance.name,
+                params=patch_data,
+                format_type="merge",
+            )
+            if not patched:
+                log.warning(
+                    f"Patch did not confirm ownerReference removal for "
+                    f"StorageClass {instance.name}"
+                )
+                return
+        except CommandFailed as ex:
+            log.warning(
+                f"Failed to strip StorageClient ownerReferences from "
+                f"StorageClass {instance.name}: {ex}"
+            )
+            return
+        log.info(
+            f"Stripped StorageClient ownerReferences from "
+            f"StorageClass {instance.name}"
+        )
+
     def finalizer():
         """
         Delete the storageclass by deregistering from StorageConsumer first
@@ -1400,10 +1456,18 @@ def storageclass_factory_fixture(
         teardown_errors = []
         for instance in instances:
             try:
+                _strip_storageclient_owner_refs(instance)
+            except Exception as e:
+                log.warning(f"Failed to strip ownerRefs for {instance.name}: {e}")
+
+            try:
                 delete_storageclass_and_deregister(
                     sc_name=instance.name,
                     sc_ocp=instance.ocp,
                 )
+            except CommandFailed as ex:
+                log.error(f"Failed to delete storageclass {instance.name}: {ex}")
+                teardown_errors.append((instance.name, ex))
             except Exception as e:
                 log.error(f"Failed to delete storageclass {instance.name}: {e}")
                 teardown_errors.append((instance.name, e))


### PR DESCRIPTION
Add provisioner detection helper and filtering logic to environment_check.py so that PVs/PVCs from non-ODF CSI drivers and StorageClient-owned StorageClasses are excluded from the pre/post comparison, preventing false-positive ResourceLeftoversException errors.

In tests/conftest.py, add StorageClient ownerReference stripping before StorageClass deletion and NotFound tolerance so the finalizer does not fail when the SC is already removed.

Supersedes #15714, #15576, and #15157.

Tracked in: [INTEROP-9285](https://redhat.atlassian.net/browse/INTEROP-9285)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined environment snapshot/leftover checks to better identify which PV/PVC resources to consider using CSI provisioner detection.
  * Improved filtering so StorageClass resources that are StorageClient-owned are excluded from leftover comparisons.
* **Tests**
  * Improved StorageClass teardown reliability by removing only StorageClient-related owner references, tolerating already-deleted resources, and surfacing unexpected teardown failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->