### PR TITLE
fix active mgr pod issue

### DIFF
--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -1787,6 +1787,29 @@ def get_mgr_pods(mgr_label=constants.MGR_APP_LABEL, namespace=None):
     return mgr_pods
 
 
+def get_active_mgr_pod():
+    """
+    Get the active MGR pod using ceph mgr stat
+
+    Returns:
+        Pod: The active MGR pod object
+
+    Raises:
+        ValueError: If the active MGR pod is not found
+
+    """
+    toolbox = get_ceph_tools_pod()
+    active_mgr_pod_output = toolbox.exec_cmd_on_pod("ceph mgr stat")
+    active_mgr_pod_suffix = active_mgr_pod_output.get("active_name")
+    logger.info(f"The active MGR pod suffix is {active_mgr_pod_suffix}")
+
+    for mgr_pod in get_mgr_pods():
+        if active_mgr_pod_suffix in mgr_pod.name:
+            logger.info(f"Active MGR pod: {mgr_pod.name}")
+            return mgr_pod
+    raise ValueError(f"Active MGR pod with suffix '{active_mgr_pod_suffix}' not found")
+
+
 def get_osd_pods(osd_label=constants.OSD_APP_LABEL, namespace=None):
     """
     Fetches info about osd pods in the cluster

--- a/tests/functional/workloads/ocp/monitoring/test_monitoring_on_negative_scenarios.py
+++ b/tests/functional/workloads/ocp/monitoring/test_monitoring_on_negative_scenarios.py
@@ -479,7 +479,6 @@ class TestMonitoringBackedByOCS(E2ETest):
         active_mgr_pod_obj = pod.get_active_mgr_pod()
         logger.info(f"The active MGR pod name is {active_mgr_pod_obj.name}")
 
-
         # Get the node where the mgr pod is hosted
         mgr_node_obj = pod.get_pod_node(active_mgr_pod_obj)
 

--- a/tests/functional/workloads/ocp/monitoring/test_monitoring_on_negative_scenarios.py
+++ b/tests/functional/workloads/ocp/monitoring/test_monitoring_on_negative_scenarios.py
@@ -55,15 +55,9 @@ def wait_to_update_mgrpod_info_prometheus_pod(threading_lock):
     logger.info(
         "Verifying ceph health status metrics is updated after rebooting the node"
     )
-    ocp_obj = ocp.OCP(
-        kind=constants.POD, namespace=config.ENV_DATA["cluster_namespace"]
-    )
-    mgr_pod = (
-        ocp_obj.get(selector=constants.MGR_APP_LABEL)
-        .get("items")[0]
-        .get("metadata")
-        .get("name")
-    )
+    mgr_pod = pod.get_active_mgr_pod().name
+    logger.info(f"Checking metrics for active MGR pod: {mgr_pod}")
+
     assert check_ceph_health_status_metrics_on_prometheus(
         mgr_pod=mgr_pod, threading_lock=threading_lock
     ), "Ceph health status metrics are not updated after the rebooting node where the mgr running"
@@ -481,18 +475,10 @@ class TestMonitoringBackedByOCS(E2ETest):
 
         """
 
-        # Get the mgr pod obj
-        mgr_pod_obj = pod.get_mgr_pods()
-
         # Get active mgr pod
-        toolbox = pod.get_ceph_tools_pod()
-        active_mgr_pod_output = toolbox.exec_cmd_on_pod("ceph mgr stat")
-        active_mgr_pod_suffix = active_mgr_pod_output.get("active_name")
-        logger.info(f"The active MGR pod is {active_mgr_pod_suffix}")
-        for obj in mgr_pod_obj:
-            if active_mgr_pod_suffix in obj.name:
-                active_mgr_pod_obj = obj
-        logger.info(f"The active MGR pod name is  {active_mgr_pod_obj.name}")
+        active_mgr_pod_obj = pod.get_active_mgr_pod()
+        logger.info(f"The active MGR pod name is {active_mgr_pod_obj.name}")
+
 
         # Get the node where the mgr pod is hosted
         mgr_node_obj = pod.get_pod_node(active_mgr_pod_obj)


### PR DESCRIPTION
Fixes https://github.com/red-hat-storage/ocs-ci/issues/15802

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of the active Ceph manager pod.
  * Monitoring workflows now reliably target the correct active manager pod after node reboots and in negative scenarios.
  * Increased reliability of Prometheus/metric validation tied to Ceph health status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->