### PR TITLE
Update exteranal mode template for CephX changes

### DIFF
--- a/ocs_ci/ocs/utils.py
+++ b/ocs_ci/ocs/utils.py
@@ -832,7 +832,6 @@ def setup_ceph_toolbox(force_setup=False, storage_cluster=None):
                     "image"
                 ] = get_rook_version()
                 toolbox["metadata"]["name"] += "-external"
-                keyring_dict = ocsci_config.EXTERNAL_MODE.get("admin_keyring")
                 if ocs_version >= version.VERSION_4_10:
                     toolbox["spec"]["template"]["spec"]["containers"][0]["command"] = [
                         "/bin/bash"
@@ -844,11 +843,6 @@ def setup_ceph_toolbox(force_setup=False, storage_cluster=None):
                         1
                     ] = "-c"
                     toolbox["spec"]["template"]["spec"]["containers"][0]["tty"] = True
-                env = toolbox["spec"]["template"]["spec"]["containers"][0]["env"]
-                # replace secret
-                env = [item for item in env if not (item["name"] == "ROOK_CEPH_SECRET")]
-                env.append({"name": "ROOK_CEPH_SECRET", "value": keyring_dict["key"]})
-                toolbox["spec"]["template"]["spec"]["containers"][0]["env"] = env
                 # add ceph volumeMounts
                 ceph_volume_mount_path = {
                     "mountPath": "/etc/ceph",

--- a/ocs_ci/templates/ocs-deployment/toolbox_pod.yaml
+++ b/ocs_ci/templates/ocs-deployment/toolbox_pod.yaml
@@ -25,12 +25,17 @@ spec:
         imagePullPolicy: IfNotPresent
         env:
           - name: ROOK_CEPH_USERNAME
-            value: client.admin
+            valueFrom:
+              secretKeyRef:
+                name: rook-ceph-operator-creds
+                key: userID
           - name: ROOK_CEPH_SECRET
             valueFrom:
               secretKeyRef:
-                name: rook-ceph-mon
-                key: ceph-secret
+                name: rook-ceph-operator-creds
+                key: userKey
+          - name: CEPH_ARGS
+            value: "--name $(ROOK_CEPH_USERNAME)"
         securityContext:
           privileged: true
         volumeMounts:
@@ -42,6 +47,9 @@ spec:
             name: libmodules
           - name: mon-endpoint-volume
             mountPath: /etc/rook
+          - mountPath: /var/lib/rook-ceph-mon
+            name: operator-creds
+            readOnly: true
       # if hostNetwork: false, the "rbd map" command hangs, see https://github.com/rook/rook/issues/2021
       hostNetwork: true
       volumes:
@@ -60,3 +68,9 @@ spec:
             items:
             - key: data
               path: mon-endpoints
+        - name: operator-creds
+          secret:
+            secretName: rook-ceph-operator-creds
+            items:
+            - key: userKey
+              path: secret.keyring


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Ceph toolbox authentication by using the correct operator credentials.
  - Updated toolbox configuration to identify the appropriate Ceph user automatically.
  - Improved access to external-mode Ceph environments by mounting required credentials securely and read-only.
  - Preserved compatibility with newer OCS versions while applying the updated toolbox configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->