### PR TITLE
[RDR] Use wait_for_mirroring_status_ok in RDR health check fixture

### DIFF
--- a/tests/functional/disaster-recovery/regional-dr/conftest.py
+++ b/tests/functional/disaster-recovery/regional-dr/conftest.py
@@ -26,12 +26,13 @@ from ocs_ci.ocs.exceptions import (
     CephHealthException,
     CephHealthNotRecoveredException,
     CephHealthRecoveredException,
+    TimeoutExpiredError,
     UnexpectedDeploymentConfiguration,
 )
 from ocs_ci.helpers import helpers
 from ocs_ci.helpers.dr_helpers import (
     check_rbd_mirror_running,
-    check_mirroring_status_ok,
+    wait_for_mirroring_status_ok,
 )
 
 log = logging.getLogger(__name__)
@@ -111,9 +112,11 @@ def rdr_health_check():
             except UnexpectedDeploymentConfiguration as e:
                 log.error(f"rbd-mirror daemon check failed on {cluster_name}: {e}")
                 pytest.skip(f"rbd-mirror daemon check failed on {cluster_name}")
-            if not check_mirroring_status_ok():
-                log.error(f"Mirroring health is not OK on {cluster_name}")
-                pytest.skip(f"Mirroring health is not OK on {cluster_name}")
+        try:
+            wait_for_mirroring_status_ok(timeout=120)
+        except TimeoutExpiredError:
+            log.error("Mirroring health is not OK on managed clusters")
+            pytest.skip("Mirroring health is not OK on managed clusters")
     finally:
         config.switch_ctx(restore_index)
 


### PR DESCRIPTION
The rdr_health_check fixture (added in #15050 ) uses check_mirroring_status_ok() which checks mirroring health once. If mirroring is temporarily unhealthy, the test is skipped unnecessarily.
Replace with wait_for_mirroring_status_ok(timeout=120s) which retries with TimeoutSampler, giving transient issues time to recover before skipping.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved disaster recovery health checks by waiting for mirroring to become healthy before evaluating test readiness.
  * Added timeout handling so checks are skipped only when mirroring health does not recover within the allowed period.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->