### PR TITLE
Add Support for Running RDR Test on Disconnected Env

### DIFF
--- a/conf/ocsci/dr_workloads_hci.yaml
+++ b/conf/ocsci/dr_workloads_hci.yaml
@@ -1,0 +1,4 @@
+ENV_DATA:
+  dr_workload_repo_url: "https://github.ibm.com/ProjectAbell/odf-qe-ocs-workloads.git"
+  dr_workload_repo_branch: "master"
+  dr_workload_repo_login: True

--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -4053,10 +4053,16 @@ def create_gitops_private_repo_secret():
     gitops_private_repo_secret_yaml = tempfile.NamedTemporaryFile(
         mode="w+", prefix="gitops_private", delete=False
     )
-    templating.dump_data_to_temp_yaml(
-        gitops_private_repo_secret, gitops_private_repo_secret_yaml.name
-    )
-    run_cmd(f"oc create -f {gitops_private_repo_secret_yaml.name}")  # IgnoreDeprecation
+    try:
+        gitops_private_repo_secret_yaml.close()
+        templating.dump_data_to_temp_yaml(
+            gitops_private_repo_secret, gitops_private_repo_secret_yaml.name
+        )
+        run_cmd(  # IgnoreDeprecation
+            f"oc create -f {gitops_private_repo_secret_yaml.name}"
+        )
+    finally:
+        os.unlink(gitops_private_repo_secret_yaml.name)
 
 
 def generate_rdr_mirror_images():

--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -4032,6 +4032,33 @@ def validate_protection_label(kind, namespace, protection_name=None):
     )
 
 
+def create_gitops_private_repo_secret():
+    """
+    Create Gitops Secret that are required to pull workloads from Private Git repo
+    """
+
+    gitops_private_repo_secret = templating.load_yaml(
+        constants.GITOPS_PRIVATE_REPO_SECRET_YAML
+    )
+    gitops_private_repo_secret["metadata"][
+        "name"
+    ] = constants.GITOPS_PRIVATE_REPO_SECRET
+
+    gitops_private_repo_secret["stringData"]["url"] = config.ENV_DATA.get(
+        "dr_workload_repo_url"
+    )
+    gitops_private_repo_secret["stringData"]["password"] = config.clusters[
+        get_active_acm_index()
+    ].AUTH["ibm_hci"]["github_token"]
+    gitops_private_repo_secret_yaml = tempfile.NamedTemporaryFile(
+        mode="w+", prefix="gitops_private", delete=False
+    )
+    templating.dump_data_to_temp_yaml(
+        gitops_private_repo_secret, gitops_private_repo_secret_yaml.name
+    )
+    run_cmd(f"oc create -f {gitops_private_repo_secret_yaml.name}")  # IgnoreDeprecation
+
+
 def generate_rdr_mirror_images():
     """
     Extract and return list of container images from RDR workload repository.
@@ -4247,8 +4274,7 @@ def get_cdi_registry_credentials():
     )
     auths = json.loads(base64.b64decode(raw_b64)).get("auths", {})
 
-    # Prefer an exact-hostname match (e.g. "r8-ru26-w-l.quay-service.fusion.tadn.ibm.com")
-    # over sub-repo entries (e.g. "r8-.../mirror-automation-.../hci/...").
+    # Prefer an exact-hostname match over sub-repo entries.
     entry = auths.get(mirror_host) or next(
         (v for k, v in auths.items() if k.startswith(mirror_host)),
         None,
@@ -4272,7 +4298,7 @@ def get_cdi_registry_credentials():
         username, password = auth_decoded.split(":", 1)
 
     logger.debug(
-        f"Extracted CDI registry credentials for '{mirror_host}': " f"user='{username}'"
+        f"Extracted CDI registry credentials for '{mirror_host}': user='{username}'"
     )
     return username, password
 
@@ -4291,9 +4317,6 @@ def create_cdi_pull_secret(namespace, secret_name="quayadmin"):
     The credentials are derived automatically from the cluster's existing
     ``secret/pull-secret`` in ``openshift-config`` — no manual credential
     management is required.
-
-    The secret name must match the ``secretRef`` value in the workload YAML
-    files (default: ``quayadmin``).
 
     This function is idempotent — it deletes an existing secret before
     re-creating it.
@@ -4339,10 +4362,7 @@ def fetch_mirror_registry_cert():
     Fetch the TLS certificate presented by ``config.DEPLOYMENT["mirror_registry"]``
     using ``openssl s_client``.
 
-    The mirror registry is stored as a bare hostname (and optional port), e.g.
-    ``r8-ru26-w-l.quay-service.fusion.tadn.ibm.com`` or
-    ``r8-ru26-w-l.quay-service.fusion.tadn.ibm.com:8443``.  Port 443 is
-    assumed when none is specified.
+    Port 443 is assumed when none is specified in the registry address.
 
     Returns:
         str: PEM-encoded certificate string (includes trailing newline).
@@ -4391,12 +4411,7 @@ def create_cdi_cert_configmap(namespace, configmap_name="user-ca-bundle"):
     TLS certificate when importing VM disk images in a disconnected environment.
 
     CDI's ``spec.source.registry.certConfigMap`` is namespace-scoped — it must
-    exist in the **same namespace** as the DataVolume / VolumeImportSource.
-    The certificate is fetched live from the registry endpoint via
-    ``openssl s_client``, so no manual cert management is required.
-
-    The ConfigMap name must match the ``certConfigMap`` value in the workload
-    YAML files (default: ``user-ca-bundle``).
+    exist in the same namespace as the DataVolume / VolumeImportSource.
 
     This function is idempotent — it deletes an existing ConfigMap before
     re-creating it.

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -3485,6 +3485,12 @@ GITOPS_SUBSCRIPTION_YAML = os.path.join(
 GITOPS_OPERATORGROUP_YAML = os.path.join(
     TEMPLATE_DIR, "gitops-deployment", "gitops_og.yaml"
 )
+GITOPS_PRIVATE_REPO_SECRET = "private-repo-git"
+GITOPS_PRIVATE_REPO_SECRET_YAML = os.path.join(
+    TEMPLATE_DIR, "gitops-deployment", "gitops_private_repo_secret.yaml"
+)
+PRIVATE_REPO_SUB_SECRET = "private-repo-git-sub"
+PRIVATE_REPO_SUB_SECRET_YAML = os.path.join(TEMPLATE_DIR, "DR", "secret.yaml")
 OADP_NAMESPACE = "openshift-adp"
 OADP_OPERATOR_NAME = "redhat-oadp-operator"
 OADP_SUBSCRIPTION_YAML = os.path.join(

--- a/ocs_ci/ocs/dr/dr_workload.py
+++ b/ocs_ci/ocs/dr/dr_workload.py
@@ -3,6 +3,7 @@ This module will have all DR related workload classes
 
 """
 
+import base64
 import logging
 import os
 import tempfile
@@ -39,11 +40,16 @@ from ocs_ci.ocs.resources.drpc import DRPC
 
 from ocs_ci.ocs.utils import (
     get_primary_cluster_config,
+    get_active_acm_index,
     get_non_acm_cluster_config,
     get_non_acm_cluster_and_non_provider_cluster_config,
 )
 from ocs_ci.utility import templating
-from ocs_ci.utility.utils import clone_repo, run_cmd, TimeoutSampler
+from ocs_ci.utility.utils import (
+    clone_repo,
+    run_cmd,
+    TimeoutSampler,
+)  # IgnoreDeprecation
 
 log = logging.getLogger(__name__)
 
@@ -55,11 +61,16 @@ class DRWorkload(object):
     """
 
     def __init__(
-        self, workload_name=None, workload_repo_url=None, workload_repo_branch=None
+        self,
+        workload_name=None,
+        workload_repo_url=None,
+        workload_repo_branch=None,
+        workload_repo_login=None,
     ):
         self.workload_name = workload_name
         self.workload_repo_url = workload_repo_url
         self.workload_repo_branch = workload_repo_branch
+        self.workload_repo_login = workload_repo_login
 
     def deploy_workload(self):
         raise NotImplementedError("Method not implemented")
@@ -81,8 +92,14 @@ class BusyBox(DRWorkload):
         workload_repo_url = config.ENV_DATA["dr_workload_repo_url"]
         log.info(f"Repo used: {workload_repo_url}")
         workload_repo_branch = config.ENV_DATA["dr_workload_repo_branch"]
-        super().__init__("busybox", workload_repo_url, workload_repo_branch)
-
+        workload_repo_login = config.ENV_DATA.get("dr_workload_repo_login")
+        if workload_repo_login:
+            workload_repo_login = config.clusters[get_active_acm_index()].AUTH[
+                "ibm_hci"
+            ]["github_token"]
+        super().__init__(
+            "busybox", workload_repo_url, workload_repo_branch, workload_repo_login
+        )
         self.workload_type = kwargs.get("workload_type", constants.SUBSCRIPTION)
         self.workload_namespace = kwargs.get("workload_namespace", None)
         self.pvc_interface = kwargs.get("pvc_interface", None)
@@ -285,8 +302,35 @@ class BusyBox(DRWorkload):
         channel_yaml_data["spec"]["pathname"] = self.workload_repo_url
         if config.ENV_DATA.get("deploy_via_cli"):
             channel_yaml_data["metadata"]["namespace"] = self.workload_namespace
-
+            if config.ENV_DATA.get("dr_workload_repo_login"):
+                channel_yaml_data["spec"].setdefault("secretRef", {})
+                channel_yaml_data["spec"]["secretRef"][
+                    "name"
+                ] = constants.PRIVATE_REPO_SUB_SECRET
         if config.ENV_DATA.get("deploy_via_cli"):
+            if config.ENV_DATA.get("dr_workload_repo_login"):
+                sub_app_private_repo_secret = templating.load_yaml(
+                    constants.PRIVATE_REPO_SUB_SECRET_YAML
+                )
+                sub_app_private_repo_secret["metadata"][
+                    "name"
+                ] = constants.PRIVATE_REPO_SUB_SECRET
+                sub_app_private_repo_secret["metadata"].setdefault("annotations", {})
+                sub_app_private_repo_secret["metadata"].setdefault("labels", {})
+                sub_app_private_repo_secret["metadata"]["annotations"][
+                    "apps.open-cluster-management.io/serving-channel"
+                ] = f"{self.workload_namespace}/ramen-gitops"
+                sub_app_private_repo_secret["metadata"][
+                    "namespace"
+                ] = self.workload_namespace
+                sub_app_private_repo_secret["metadata"]["labels"][
+                    "apps.open-cluster-management.io/serving-channel"
+                ] = "true"
+                sub_app_private_repo_secret["data"]["accessToken"] = base64.b64encode(
+                    config.clusters[get_active_acm_index()]
+                    .AUTH["ibm_hci"]["github_token"]
+                    .encode()
+                ).decode()
             subscription_app_yaml_data = templating.load_yaml(
                 self.subscription_app_file
             )
@@ -340,6 +384,11 @@ class BusyBox(DRWorkload):
                     placement_yaml_data,
                     managed_clusterset_binding_yaml_data,
                 ]
+                + (
+                    [sub_app_private_repo_secret]
+                    if config.ENV_DATA.get("dr_workload_repo_login")
+                    else []
+                )
             )
 
             self.deploy_subscription_workload_yaml_file = tempfile.NamedTemporaryFile(
@@ -559,6 +608,7 @@ class BusyBox(DRWorkload):
             url=self.workload_repo_url,
             location=self.target_clone_dir,
             branch=self.workload_repo_branch,
+            clone_token=self.workload_repo_login,
         )
 
     def _get_workload_namespace(self):
@@ -713,7 +763,14 @@ class BusyBox_AppSet(DRWorkload):
     def __init__(self, **kwargs):
         workload_repo_url = config.ENV_DATA["dr_workload_repo_url"]
         workload_repo_branch = config.ENV_DATA["dr_workload_repo_branch"]
-        super().__init__("busybox", workload_repo_url, workload_repo_branch)
+        workload_repo_login = config.ENV_DATA.get("dr_workload_repo_login")
+        if workload_repo_login:
+            workload_repo_login = config.clusters[get_active_acm_index()].AUTH[
+                "ibm_hci"
+            ]["github_token"]
+        super().__init__(
+            "busybox", workload_repo_url, workload_repo_branch, workload_repo_login
+        )
 
         self.workload_type = kwargs.get("workload_type", constants.APPLICATION_SET)
         self.workload_namespace = kwargs.get("workload_namespace", None)
@@ -885,10 +942,12 @@ class BusyBox_AppSet(DRWorkload):
 
         """
         # Clone workload repo
+
         clone_repo(
             url=self.workload_repo_url,
             location=self.target_clone_dir,
             branch=self.workload_repo_branch,
+            clone_token=self.workload_repo_login,
         )
 
     def add_annotation_to_placement(self):
@@ -1062,7 +1121,14 @@ class CnvWorkload(DRWorkload):
         """
         workload_repo_url = config.ENV_DATA["dr_workload_repo_url"]
         workload_repo_branch = config.ENV_DATA["dr_workload_repo_branch"]
-        super().__init__("cnv", workload_repo_url, workload_repo_branch)
+        workload_repo_login = config.ENV_DATA.get("dr_workload_repo_login")
+        if workload_repo_login:
+            workload_repo_login = config.clusters[get_active_acm_index()].AUTH[
+                "ibm_hci"
+            ]["github_token"]
+        super().__init__(
+            "cnv", workload_repo_url, workload_repo_branch, workload_repo_login
+        )
 
         self.workload_name = kwargs.get("workload_name")
         self.vm_name = kwargs.get("vm_name")
@@ -1149,9 +1215,38 @@ class CnvWorkload(DRWorkload):
                     self.channel_name = channel_yaml_data["metadata"]["name"]
                     channel_yaml_data["spec"]["pathname"] = self.workload_repo_url
                     channel_yaml_data["metadata"]["namespace"] = self.channel_namespace
-                templating.dump_data_to_temp_yaml(
-                    channel_yaml_data_load, self.channel_yaml_file
+                    if config.ENV_DATA.get("dr_workload_repo_login"):
+                        channel_yaml_data["spec"].setdefault("secretRef", {})
+                        channel_yaml_data["spec"]["secretRef"][
+                            "name"
+                        ] = constants.PRIVATE_REPO_SUB_SECRET
+            if config.ENV_DATA.get("dr_workload_repo_login"):
+                cnv_sub_private_repo_secret = templating.load_yaml(
+                    constants.PRIVATE_REPO_SUB_SECRET_YAML
                 )
+                cnv_sub_private_repo_secret["metadata"][
+                    "name"
+                ] = constants.PRIVATE_REPO_SUB_SECRET
+                cnv_sub_private_repo_secret["metadata"].setdefault("annotations", {})
+                cnv_sub_private_repo_secret["metadata"].setdefault("labels", {})
+                cnv_sub_private_repo_secret["metadata"]["annotations"][
+                    "apps.open-cluster-management.io/serving-channel"
+                ] = f"{self.channel_namespace}/{self.channel_name}"
+                cnv_sub_private_repo_secret["metadata"][
+                    "namespace"
+                ] = self.channel_namespace
+                cnv_sub_private_repo_secret["metadata"]["labels"][
+                    "apps.open-cluster-management.io/serving-channel"
+                ] = "true"
+                cnv_sub_private_repo_secret["data"]["accessToken"] = base64.b64encode(
+                    config.clusters[get_active_acm_index()]
+                    .AUTH["ibm_hci"]["github_token"]
+                    .encode()
+                ).decode()
+                channel_yaml_data_load.append(cnv_sub_private_repo_secret)
+            templating.dump_data_to_temp_yaml(
+                channel_yaml_data_load, self.channel_yaml_file
+            )
         for cnv_workload_yaml_data in cnv_workload_yaml_data_load:
             if self.workload_type == constants.SUBSCRIPTION:
                 if cnv_workload_yaml_data["kind"] == "Namespace":
@@ -1177,6 +1272,19 @@ class CnvWorkload(DRWorkload):
                 cnv_workload_yaml_data["spec"]["template"]["spec"]["destination"][
                     "namespace"
                 ] = self.workload_namespace
+
+                # Update repoURL and targetRevision to use the configured repo
+                # (internal mirror in disconnected environments).
+                template_spec = cnv_workload_yaml_data["spec"]["template"]["spec"]
+                if "source" in template_spec:
+                    template_spec["source"]["repoURL"] = self.workload_repo_url
+                    template_spec["source"][
+                        "targetRevision"
+                    ] = self.workload_repo_branch
+                if "sources" in template_spec:
+                    for src in template_spec["sources"]:
+                        src["repoURL"] = self.workload_repo_url
+                        src["targetRevision"] = self.workload_repo_branch
 
                 # Change the AppSet placement label
                 for generator in cnv_workload_yaml_data["spec"]["generators"]:
@@ -1253,6 +1361,7 @@ class CnvWorkload(DRWorkload):
                 url=self.workload_repo_url,
                 location=self.target_clone_dir,
                 branch=self.workload_repo_branch,
+                clone_token=self.workload_repo_login,
             )
 
     def add_annotation_to_placement(self):
@@ -1397,6 +1506,14 @@ class CnvWorkload(DRWorkload):
                 if "(AlreadyExists)" in str(ex):
                     log.warning("The namespace already exists!")
 
+            # In disconnected environments the workload YAML files reference
+            # an internal Quay registry via ``secretRef: quayadmin`` and
+            # ``certConfigMap: user-ca-bundle``.  Both resources must exist in
+            # the workload namespace before the subscription deploys the workload.
+            if config.DEPLOYMENT.get("disconnected"):
+                create_cdi_pull_secret(namespace=self.workload_namespace)
+                create_cdi_cert_configmap(namespace=self.workload_namespace)
+
             # Create or recreate the secret for ssh access
             try:
                 log.info(
@@ -1462,7 +1579,14 @@ class BusyboxDiscoveredApps(DRWorkload):
         workload_repo_url = config.ENV_DATA["dr_workload_repo_url"]
         log.info(f"Repo used: {workload_repo_url}")
         workload_repo_branch = config.ENV_DATA["dr_workload_repo_branch"]
-        super().__init__("busybox", workload_repo_url, workload_repo_branch)
+        workload_repo_login = config.ENV_DATA.get("dr_workload_repo_login")
+        if workload_repo_login:
+            workload_repo_login = config.clusters[get_active_acm_index()].AUTH[
+                "ibm_hci"
+            ]["github_token"]
+        super().__init__(
+            "busybox", workload_repo_url, workload_repo_branch, workload_repo_login
+        )
         self.workload_type = kwargs.get("workload_type", constants.DISCOVERED_APPS)
         self.workload_namespace = kwargs.get("workload_namespace", None)
         self.discovered_apps_placement_name = kwargs.get("workload_placement_name")
@@ -1593,6 +1717,7 @@ class BusyboxDiscoveredApps(DRWorkload):
             url=self.workload_repo_url,
             location=self.target_clone_dir,
             branch=self.workload_repo_branch,
+            clone_token=self.workload_repo_login,
         )
 
     def verify_workload_deployment(self, vrg_name=None):
@@ -1924,7 +2049,14 @@ class CnvWorkloadDiscoveredApps(DRWorkload):
         """
         workload_repo_url = config.ENV_DATA["dr_workload_repo_url"]
         workload_repo_branch = config.ENV_DATA["dr_workload_repo_branch"]
-        super().__init__("cnv", workload_repo_url, workload_repo_branch)
+        workload_repo_login = config.ENV_DATA.get("dr_workload_repo_login")
+        if workload_repo_login:
+            workload_repo_login = config.clusters[get_active_acm_index()].AUTH[
+                "ibm_hci"
+            ]["github_token"]
+        super().__init__(
+            "cnv", workload_repo_url, workload_repo_branch, workload_repo_login
+        )
         self.workload_name = kwargs.get("workload_name")
         self.vm_name = kwargs.get("vm_name")
         self.vm_secret_name = kwargs.get("vm_secret")
@@ -2015,6 +2147,7 @@ class CnvWorkloadDiscoveredApps(DRWorkload):
             url=self.workload_repo_url,
             location=self.target_clone_dir,
             branch=self.workload_repo_branch,
+            clone_token=self.workload_repo_login,
         )
 
     def create_namespace(self):

--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -91,7 +91,10 @@ class OCP(object):
         if (
             (not cluster_kubeconfig)
             and config.multicluster
-            and "hci_" in config.ENV_DATA["platform"]
+            and (
+                "hci_" in config.ENV_DATA["platform"]
+                or "ibm_hci" in config.ENV_DATA["platform"]
+            )
             and kind.lower() in constants.PROVIDER_CLUSTER_RESOURCE_KINDS
         ):
             provider_cluster_index = config.get_provider_index()

--- a/ocs_ci/ocs/platform_nodes.py
+++ b/ocs_ci/ocs/platform_nodes.py
@@ -143,7 +143,11 @@ class PlatformNodesFactory:
         if config.ENV_DATA["platform"] == constants.BAREMETAL_PLATFORM:
             if config.ENV_DATA["deployment_type"] == "ai":
                 platform += "_ai"
-        if config.ENV_DATA["platform"] == constants.IBM_HCI_PLATFORM:
+        if (
+            config.ENV_DATA["platform"] == constants.IBM_HCI_PLATFORM
+            and not get_client_type_by_name(cluster_name)
+            == constants.HOSTED_CLUSTER_KUBEVIRT
+        ):
             if config.ENV_DATA["deployment_type"] == "ipi":
                 platform += "_ipi"
 

--- a/ocs_ci/templates/DR/secret.yaml
+++ b/ocs_ci/templates/DR/secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: private-repo-git-sub
+  namespace: default
+data:
+  user: YWRtaW4K # gitleaks:allow
+  accessToken: PLACEHOLDER # gitleaks:allow

--- a/ocs_ci/templates/gitops-deployment/gitops_private_repo_secret.yaml
+++ b/ocs_ci/templates/gitops-deployment/gitops_private_repo_secret.yaml
@@ -1,0 +1,11 @@
+# gitleaks:allow
+apiVersion: v1
+kind: Secret
+metadata:
+  name: PLACEHOLDER
+  namespace: openshift-gitops
+  labels:
+    argocd.argoproj.io/secret-type: repository
+stringData:
+  url: PLACEHOLDER
+  password: PLACEHOLDER

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -4002,6 +4002,7 @@ def clone_repo(
     to_checkout=None,
     clone_type="shallow",
     force_checkout=False,
+    clone_token=None,
 ):
     """
     Clone a repository or checkout latest changes if it already exists at
@@ -4018,6 +4019,7 @@ def clone_repo(
             clone_type as "normal".
         force_checkout (bool): True for force checkout to branch.
             force checkout will ignore the unmerged entries.
+        clone_token (str): Token to clone repo
 
     Raises:
         UnknownCloneTypeException: In case of incorrect clone_type is used
@@ -4057,7 +4059,12 @@ def clone_repo(
 
     if not os.path.isdir(location) or (tmp_repo and os.path.isdir(location)):
         log.info("Cloning repository into %s", location)
-        run_cmd(f"git clone {git_params} {url} {location}")
+        if clone_token:
+            url = url.replace("https://", f"https://{clone_token}@")
+            clone_token = [clone_token]
+        run_cmd(  # IgnoreDeprecation
+            cmd=f"git clone {git_params} {url} {location}", secrets=clone_token
+        )
     else:
         log.info("Repository already cloned at %s, skipping clone", location)
         log.info("Fetching latest changes from repository")
@@ -7753,10 +7760,11 @@ def genereate_cred_file_rack():
     # Any rackIP corrections discovered are applied to rack_dict and persisted
     # back to the primary JSON file before the backup is written, so the backup
     # always reflects the final corrected rackIP values.
-    rack_dict = _verify_bmc_connectivity_rack(
-        rack_dict=rack_dict,
-        file_path=str(file_path),
-    )
+    if not config.ENV_DATA.get("skip_bmc_verification"):
+        rack_dict = _verify_bmc_connectivity_rack(
+            rack_dict=rack_dict,
+            file_path=str(file_path),
+        )
 
     # Save a timestamped backup copy in home directory — written after ping
     # verification so the backup contains any corrected rackIP values.

--- a/tests/functional/disaster-recovery/regional-dr/conftest.py
+++ b/tests/functional/disaster-recovery/regional-dr/conftest.py
@@ -3,6 +3,7 @@ import platform
 import os
 import tempfile
 from ocs_ci.deployment.ocp import download_pull_secret
+from ocs_ci.ocs.ocp import OCP
 from ocs_ci.utility import templating
 import pytest
 
@@ -18,6 +19,7 @@ from ocs_ci.utility.utils import (
 )
 from ocs_ci.helpers.dr_helpers import (
     apply_itms_to_managed_clusters,
+    create_gitops_private_repo_secret,
     generate_rdr_mirror_images,
 )
 from ocs_ci.ocs.exceptions import (
@@ -122,6 +124,24 @@ def rdr_health_check():
 def get_virtctl():
     with config.RunWithProviderConfigContextIfAvailable():
         get_virtctl_tool()
+
+
+@pytest.fixture(scope="session", autouse=True)
+def check_gitops_secret_offline_mode():
+    if config.MULTICLUSTER.get("multicluster_mode") != constants.RDR_MODE:
+        return
+    if config.ENV_DATA.get("dr_workload_repo_login"):
+        for cluster_index in range(config.nclusters):
+            config.switch_ctx(cluster_index)
+            try:
+                OCP(
+                    kind=constants.SECRET,
+                    namespace=constants.GITOPS_NAMESPACE,
+                    resource_name=constants.GITOPS_PRIVATE_REPO_SECRET,
+                ).get()
+            except (CommandFailed, FileNotFoundError):
+                log.info("Secret not found creating New one")
+                create_gitops_private_repo_secret()
 
 
 @pytest.fixture()
@@ -528,7 +548,7 @@ def scale_deployments(request):
     return _scale
 
 
-@pytest.fixture(scope="session", autouse=True)
+@pytest.fixture(scope="session", autouse=False)
 def mirror_rdr_images(request):
     """
     Mirror RDR images to disconnected registry and apply ITMS to managed clusters.

--- a/tests/functional/disaster-recovery/regional-dr/conftest.py
+++ b/tests/functional/disaster-recovery/regional-dr/conftest.py
@@ -131,17 +131,21 @@ def check_gitops_secret_offline_mode():
     if config.MULTICLUSTER.get("multicluster_mode") != constants.RDR_MODE:
         return
     if config.ENV_DATA.get("dr_workload_repo_login"):
-        for cluster_index in range(config.nclusters):
-            config.switch_ctx(cluster_index)
-            try:
-                OCP(
-                    kind=constants.SECRET,
-                    namespace=constants.GITOPS_NAMESPACE,
-                    resource_name=constants.GITOPS_PRIVATE_REPO_SECRET,
-                ).get()
-            except (CommandFailed, FileNotFoundError):
-                log.info("Secret not found creating New one")
-                create_gitops_private_repo_secret()
+        original_index = config.cur_index
+        try:
+            for cluster_index in range(config.nclusters):
+                config.switch_ctx(cluster_index)
+                try:
+                    OCP(
+                        kind=constants.SECRET,
+                        namespace=constants.GITOPS_NAMESPACE,
+                        resource_name=constants.GITOPS_PRIVATE_REPO_SECRET,
+                    ).get()
+                except (CommandFailed, FileNotFoundError):
+                    log.info("Secret not found creating New one")
+                    create_gitops_private_repo_secret()
+        finally:
+            config.switch_ctx(original_index)
 
 
 @pytest.fixture()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added private Git repository authentication for disaster-recovery workloads, including secure GitOps and subscription secret generation for offline/disconnected runs.
  * Enabled authenticated repository cloning with an optional token.
  * Extended CNV workload templates to update private repo references.
  * Added disconnected CDI prereqs for CNV deployments.
* **Bug Fixes**
  * Improved provider cluster kubeconfig selection and IBM HCI platform mapping for hosted KubeVirt.
* **Tests**
  * Adjusted RDR test setup for GitOps secret provisioning and made image mirroring opt-in.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->