### PR TITLE
MDR deployment on HCP clusters

### DIFF
--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -87,6 +87,7 @@ from ocs_ci.ocs.exceptions import (
     ACMClusterConfigurationException,
     ACMObservabilityNotEnabled,
     WrongVersionExpression,
+    UnexpectedBehaviour,
 )
 from ocs_ci.deployment.cert_manager import deploy_cert_manager
 from ocs_ci.deployment.zones import create_dummy_zone_labels
@@ -4637,6 +4638,95 @@ class MultiClusterDROperatorsDeploy(object):
         logger.info("Applying changes to Ramen Hub configmap")
         self.update_config_map_commit(dict(dr_ramen_hub_configmap_data_get))
 
+    def check_mco_presence_and_version(self):
+        """
+        Verify whether the multicluster orchestrator deployment exists and available. This might be already present if
+        the ACM hub cluster is already prepared for DR with another set of managed clusters. If present, ensure that the
+        version of MCO and DR Hub Operator is as required.
+
+        Returns:
+            bool: True if the MCO deployment exists and version is matching, False if MCO deployment is not present
+
+        Raises:
+            UnexpectedBehaviour: In case of version mismactch
+
+        """
+
+        orchestrator_controller = ocp.OCP(
+            kind=constants.DEPLOYMENT,
+            resource_name=constants.ODF_MULTICLUSTER_ORCHESTRATOR_CONTROLLER_MANAGER,
+            namespace=constants.OPENSHIFT_OPERATORS,
+        )
+        if orchestrator_controller.is_exist():
+            logger.info(
+                f"{constants.DEPLOYMENT} {constants.ODF_MULTICLUSTER_ORCHESTRATOR_CONTROLLER_MANAGER} "
+                f"already exists"
+            )
+            orchestrator_controller.wait_for_resource(
+                condition="1",
+                column="AVAILABLE",
+                resource_count=1,
+                timeout=300,
+            )
+
+            # --- Version check + DR hub operator check ------------------------
+            # Verify the installed orchestrator CSV matches the expected channel
+            # version, and that the DR hub operator CSV (deployed automatically
+            # by the orchestrator) has reached Succeeded phase.
+            # Both checks are opt-in — set ENV_DATA
+            # orchestrator_version_check: true to enable them.
+            # If the key is absent or false the checks are skipped silently.
+            if config.ENV_DATA.get("orchestrator_version_check", False):
+                orchestrator_sub = ocp.OCP(
+                    kind=constants.SUBSCRIPTION,
+                    resource_name=constants.ACM_ODF_MULTICLUSTER_ORCHESTRATOR_RESOURCE,
+                    namespace=constants.OPENSHIFT_OPERATORS,
+                )
+                installed_csv = orchestrator_sub.get()["status"]["currentCSV"]
+                expected_csv = packagemanifest.PackageManifest(
+                    resource_name=constants.ACM_ODF_MULTICLUSTER_ORCHESTRATOR_RESOURCE
+                ).get_current_csv(
+                    channel=self.channel,
+                    csv_pattern=constants.ACM_ODF_MULTICLUSTER_ORCHESTRATOR_RESOURCE,
+                )
+                logger.info(
+                    f"Orchestrator version check — installed CSV: {installed_csv} | "
+                    f"expected CSV for channel '{self.channel}': {expected_csv}"
+                )
+                if installed_csv != expected_csv:
+                    raise UnexpectedBehaviour(
+                        f"Installed orchestrator CSV '{installed_csv}' does not match "
+                        f"expected '{expected_csv}' for channel '{self.channel}'. "
+                        f"Re-deploy or upgrade the multicluster orchestrator."
+                    )
+
+                logger.info(
+                    "Verifying DR hub operator CSV is in Succeeded phase "
+                    f"(namespace: {constants.OPENSHIFT_DR_SYSTEM_NAMESPACE})"
+                )
+                dr_hub_csvs = get_csvs_start_with_prefix(
+                    constants.ACM_ODR_HUB_OPERATOR_RESOURCE,
+                    constants.OPENSHIFT_DR_SYSTEM_NAMESPACE,
+                )
+                if not dr_hub_csvs:
+                    raise UnexpectedBehaviour(
+                        f"No CSV starting with '{constants.ACM_ODR_HUB_OPERATOR_RESOURCE}' "
+                        f"found in {constants.OPENSHIFT_DR_SYSTEM_NAMESPACE}. "
+                        f"The DR hub operator may not have been deployed yet."
+                    )
+                dr_hub_csv = CSV(
+                    resource_name=dr_hub_csvs[0]["metadata"]["name"],
+                    namespace=constants.OPENSHIFT_DR_SYSTEM_NAMESPACE,
+                )
+                dr_hub_csv.wait_for_phase("Succeeded", timeout=300)
+                logger.info(
+                    f"DR hub operator CSV '{dr_hub_csvs[0]['metadata']['name']}' "
+                    f"is Succeeded"
+                )
+            return True
+        else:
+            return False
+
     class s3_meta_obj_store:
         """
         Internal class to handle aws s3 metadata obj store
@@ -5158,10 +5248,15 @@ class MDRMultiClusterDROperatorsDeploy(MultiClusterDROperatorsDeploy):
         acm_indexes = get_all_acm_indexes()
         for i in acm_indexes:
             config.switch_ctx(i)
+            if self.check_mco_presence_and_version:
+                continue
+            if config.ENV_DATA.get("setup_fdf_catsrc_for_hub"):
+                setup_fdf_catsrc_for_hub()
             self.deploy_dr_multicluster_orchestrator()
             # Enable MCO console plugin
             enable_mco_console_plugin()
         # Configure mirror peer
+        config.switch_acm_ctx()
         self.configure_mirror_peer()
         self.apply_custom_ramen_image()
         # Deploy dr policy

--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -2231,11 +2231,24 @@ def get_managed_cluster_node_ips():
     """
     restore_index = config.cur_index
     primary_index = get_primary_cluster_config().MULTICLUSTER["multicluster_index"]
-    secondary_index = [
-        s.MULTICLUSTER["multicluster_index"]
-        for s in get_non_acm_cluster_config()
-        if s.MULTICLUSTER["multicluster_index"] != primary_index
-    ][0]
+    dr_cluster_relations = config.MULTICLUSTER.get("dr_cluster_relations", [])
+    if dr_cluster_relations:
+        # dr_cluster_relations is a list containing cluster pairs list with the index 0 pair as current pair under test
+        dr_cluster_names = dr_cluster_relations[0]
+        primary_name = config.get_cluster_name_by_index(primary_index)
+        secondary_index = config.get_cluster_index_by_name(
+            [
+                cluster_name
+                for cluster_name in dr_cluster_names
+                if cluster_name != primary_name
+            ][0]
+        )
+    else:
+        secondary_index = [
+            s.MULTICLUSTER["multicluster_index"]
+            for s in get_non_acm_cluster_config()
+            if s.MULTICLUSTER["multicluster_index"] != primary_index
+        ][0]
     cluster_name_primary = config.clusters[primary_index].ENV_DATA["cluster_name"]
     cluster_name_secondary = config.clusters[secondary_index].ENV_DATA["cluster_name"]
     cluster_data = [
@@ -2532,8 +2545,7 @@ def verify_drpolicy_cli(switch_ctx=None):
 
     restore_index = config.cur_index
     config.switch_ctx(switch_ctx) if switch_ctx else config.switch_acm_ctx()
-    drpolicy_obj = ocp.OCP(kind=constants.DRPOLICY)
-    drpolicy_items = drpolicy_obj.get().get("items") or []
+    drpolicy_items = get_all_drpolicy()
     if not drpolicy_items:
         config.switch_ctx(restore_index)
         raise UnexpectedBehaviour("No DRPolicy resources found on hub")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Metro-DR deployments now detect and reuse an available, correctly configured Multicluster Orchestrator instead of redeploying it.
  * Optional version validation provides clear failures when orchestrator or DR hub components do not match expectations.

* **Bug Fixes**
  * Improved selection of the correct secondary cluster for fencing operations.
  * DR policy verification now focuses on policies associated with the relevant managed clusters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->