### PR TITLE
Fix OCP release image URL for OCP 5.0+

### DIFF
--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -1070,6 +1070,22 @@ class Deployment(object):
         )
         if ibmcloud_ipi:
             ibmcloud.label_nodes_region()
+        vsphere_upi = (
+            config.ENV_DATA["platform"] == constants.VSPHERE_PLATFORM
+            and config.ENV_DATA["deployment_type"] == "upi"
+        )
+        # Workaround for OCPBUGS-100052: vSphere UPI nodes are missing the
+        # platform-type label after OCP 4.22+. Revert once the bug is fixed.
+        if (
+            vsphere_upi
+            and version.get_semantic_ocp_version_from_config() >= version.VERSION_4_22
+        ):
+            logger.info("Labeling all nodes with platform-type=vsphere for vSphere UPI")
+            ocp = OCP()
+            ocp.exec_oc_cmd(
+                "label node --all node.openshift.io/platform-type=vsphere"
+                " --overwrite"
+            )
         # configure Ingress Node Firewall and restrict SSH access to nodes
         if config.ENV_DATA.get("restrict_ssh_access_to_nodes", False):
             try:

--- a/ocs_ci/deployment/disconnected.py
+++ b/ocs_ci/deployment/disconnected.py
@@ -24,6 +24,7 @@ from ocs_ci.utility.utils import (
     create_directory_path,
     exec_cmd,
     get_latest_ds_olm_tag,
+    get_ocp_release_mirror_path,
     get_ocp_version,
     login_to_mirror_registry,
     prepare_customized_pull_secret,
@@ -611,10 +612,15 @@ def mirror_ocp_release_images(ocp_image_path, ocp_version):
             - imageContentSources (for install-config.yaml)
             - ImageDigestMirrorSet (for running cluster)
     """
-    dest_image_repo = (
-        f"{config.DEPLOYMENT['mirror_registry']}/"
-        f"{constants.OCP_RELEASE_IMAGE_MIRROR_PATH}"
-    )
+    if ocp_version.startswith("sha256"):
+        mirror_path = (
+            constants.OCP_RELEASE_IMAGE_MIRROR_PATH_V5
+            if "release-5" in ocp_image_path
+            else constants.OCP_RELEASE_IMAGE_MIRROR_PATH
+        )
+    else:
+        mirror_path = get_ocp_release_mirror_path(ocp_version)
+    dest_image_repo = f"{config.DEPLOYMENT['mirror_registry']}/{mirror_path}"
     if ocp_version.startswith("sha256"):
         ocp_image = f"{ocp_image_path}@{ocp_version}"
         dest_ocp_image = f"{dest_image_repo}@{ocp_version}"
@@ -667,7 +673,7 @@ def mirror_ocp_release_images(ocp_image_path, ocp_version):
     config.DEPLOYMENT["haproxy_router_image"] = haproxy_router_line.split()[1]
 
     return (
-        f"{config.DEPLOYMENT['mirror_registry']}/{constants.OCP_RELEASE_IMAGE_MIRROR_PATH}",
+        f"{config.DEPLOYMENT['mirror_registry']}/{mirror_path}",
         ocp_version,
         ics,
         idms,

--- a/ocs_ci/framework/conf/ocp_version/ocp-5.0-upgrade.yaml
+++ b/ocs_ci/framework/conf/ocp_version/ocp-5.0-upgrade.yaml
@@ -2,5 +2,5 @@
 # Use this config for upgrading of OCP 4.22/4.23 to 5.0 cluster
 UPGRADE:
   ocp_upgrade_version: "5.0.0-0.nightly"
-  ocp_upgrade_path: "registry.ci.openshift.org/ocp/release"
+  ocp_upgrade_path: "registry.ci.openshift.org/ocp/release-5"
   ocp_channel: "stable-5.0"

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -2562,10 +2562,12 @@ FLEXY_ENV_FILE_UPDATED_PATH = os.path.join(
     FLEXY_HOST_DIR_PATH, FLEXY_ENV_FILE_UPDATED_NAME
 )
 REGISTRY_SVC = "registry.ci.openshift.org/ocp/release"
+REGISTRY_SVC_V5 = "registry.ci.openshift.org/ocp/release-5"
 QUAY_REGISTRY_SVC = "quay.io/openshift-release-dev/ocp-release"
 FLEXY_USER_LOCAL_UID = 101000
 
 OCP_RELEASE_IMAGE_MIRROR_PATH = "ocp/release"
+OCP_RELEASE_IMAGE_MIRROR_PATH_V5 = "ocp/release-5"
 FLEXY_OCP_RELEASE_IMAGE_MIRROR_PATH = "ocp/release"
 
 # domains required to be accessible through proxy on disconnected cluster

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -1330,9 +1330,29 @@ def get_registry_svc(version):
 
     """
     major = version.split(".")[0]
-    if int(major) >= 5:
-        return "registry.ci.openshift.org/ocp/release-5"
+    if int(major) == 5:
+        return constants.REGISTRY_SVC_V5
     return constants.REGISTRY_SVC
+
+
+def get_ocp_release_mirror_path(version):
+    """
+    Get the OCP release image mirror path for the given OCP version.
+
+    OCP 5.x release images are published under ocp/release-5
+    instead of ocp/release.
+
+    Args:
+        version (str): OCP version string (e.g. "5.0.0-0.nightly-2026-06-18-000016")
+
+    Returns:
+        str: Mirror path (e.g. "ocp/release-5")
+
+    """
+    major = version.split(".")[0]
+    if int(major) == 5:
+        return constants.OCP_RELEASE_IMAGE_MIRROR_PATH_V5
+    return constants.OCP_RELEASE_IMAGE_MIRROR_PATH
 
 
 @retry(CommandFailed, tries=2, delay=5, backoff=2)


### PR DESCRIPTION
OCP 5.x release images are published under ocp/release-5 instead of ocp/release. Update the upgrade config, add a version-aware mirror path helper, and use it in disconnected mirroring so both standard and disconnected upgrades resolve the correct image repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced disconnected image mirroring to use version-specific OpenShift release mirror subpaths.
  * OpenShift 5 references now mirror from the `release-5` location when applicable, including digest-based scenarios.
* **Bug Fixes**
  * Added a vSphere UPI workaround to restore missing `platform-type` node labels after deployment for OCP 4.22+.
* **Configuration**
  * Updated the OCP 5.0 upgrade configuration to use the dedicated `release-5` release image path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->