### PR TITLE
fix test_corrupt_pg_alerts for many OSDs

### DIFF
--- a/ocs_ci/ocs/rados_utils.py
+++ b/ocs_ci/ocs/rados_utils.py
@@ -8,6 +8,7 @@ import tempfile
 
 from ocs_ci.ocs.resources import pod
 from ocs_ci.utility.utils import exec_cmd, run_cmd
+from ocs_ci.utility.utils import TimeoutSampler
 from ocs_ci.ocs import constants, ocp
 from ocs_ci.framework import config
 from ocs_ci.ocs.exceptions import CommandFailed
@@ -541,25 +542,43 @@ def corrupt_pg(osd_deployment, pool_name, pool_object):
         f'"runAsUser": 0}}, "volumeMounts": [{{"mountPath": "/var/lib/ceph/osd/ceph-{osd_id}", '
         f'"name": "{bridge_name}", "subPath": "ceph-{osd_id}"}}]}}}}]'
     )
-    osd_deployment.ocp.patch(
+    # Record the current pod UID so we can detect when the old pod is replaced
+    old_pod_uid = osd_pod.get()["metadata"]["uid"]
+
+    patched = osd_deployment.ocp.patch(
         resource_name=osd_deployment.name, params=patch_change, format_type="json"
     )
+    assert patched, f"Failed to patch deployment {osd_deployment.name}"
 
-    # Wait for the OSD pod to restart with corrupted data before issuing
-    # deep-scrub. If deep-scrub runs while the corrupted OSD is down, it only
-    # checks healthy replicas and finds no inconsistency.
+    # Wait for the old pod to terminate and a new one to reach Running.
+    # If deep-scrub runs while the corrupted OSD is down, it only checks
+    # healthy replicas and finds no inconsistency.
     logger.info(
-        f"Waiting for OSD pod {osd_deployment.name} to restart after corruption"
+        f"Waiting for OSD pod {osd_deployment.name} to be replaced "
+        f"(old pod UID: {old_pod_uid})"
     )
     ocp_pod = ocp.OCP(
         kind=constants.POD, namespace=config.ENV_DATA["cluster_namespace"]
     )
-    ocp_pod.wait_for_resource(
-        condition=constants.STATUS_RUNNING,
-        selector=f"ceph-osd-id={osd_id}",
-        resource_count=1,
+    for sample in TimeoutSampler(
         timeout=300,
-    )
+        sleep=10,
+        func=ocp_pod.get,
+        selector=f"ceph-osd-id={osd_id}",
+    ):
+        pods = sample.get("items", [])
+        running = [
+            p
+            for p in pods
+            if p["metadata"]["uid"] != old_pod_uid
+            and p["status"].get("phase") == "Running"
+            and all(
+                cs.get("ready", False)
+                for cs in p["status"].get("containerStatuses", [])
+            )
+        ]
+        if running:
+            break
     logger.info(f"OSD pod osd.{osd_id} is running, issuing deep-scrub on {pgid}")
     ct_pod.exec_ceph_cmd(f"ceph pg deep-scrub {pgid}")
 

--- a/ocs_ci/ocs/rados_utils.py
+++ b/ocs_ci/ocs/rados_utils.py
@@ -538,12 +538,29 @@ def corrupt_pg(osd_deployment, pool_name, pool_object):
         f'"{pgid}", "{pool_object}", "set-bytes", "/etc/shadow", "--no-mon-config"], '
         f'"command": [ "ceph-objectstore-tool" ], "image": "{ceph_image}", "imagePullPolicy": '
         '"IfNotPresent", "name": "corrupt-pg", "securityContext": {"privileged": true, '
-        f'"runAsUser": 0}}, "volumeMounts": [{{"mountPath": "/var/lib/ceph/osd/ceph-0", '
-        f'"name": "{bridge_name}", "subPath": "ceph-0"}}]}}}}]'
+        f'"runAsUser": 0}}, "volumeMounts": [{{"mountPath": "/var/lib/ceph/osd/ceph-{osd_id}", '
+        f'"name": "{bridge_name}", "subPath": "ceph-{osd_id}"}}]}}}}]'
     )
     osd_deployment.ocp.patch(
         resource_name=osd_deployment.name, params=patch_change, format_type="json"
     )
+
+    # Wait for the OSD pod to restart with corrupted data before issuing
+    # deep-scrub. If deep-scrub runs while the corrupted OSD is down, it only
+    # checks healthy replicas and finds no inconsistency.
+    logger.info(
+        f"Waiting for OSD pod {osd_deployment.name} to restart after corruption"
+    )
+    ocp_pod = ocp.OCP(
+        kind=constants.POD, namespace=config.ENV_DATA["cluster_namespace"]
+    )
+    ocp_pod.wait_for_resource(
+        condition=constants.STATUS_RUNNING,
+        selector=f"ceph-osd-id={osd_id}",
+        resource_count=1,
+        timeout=300,
+    )
+    logger.info(f"OSD pod osd.{osd_id} is running, issuing deep-scrub on {pgid}")
     ct_pod.exec_ceph_cmd(f"ceph pg deep-scrub {pgid}")
 
 

--- a/tests/functional/monitoring/conftest.py
+++ b/tests/functional/monitoring/conftest.py
@@ -307,12 +307,32 @@ def measure_corrupt_pg(request, measurement_dir, threading_lock):
         dict: Contains information about `start` and `stop` time for
             corrupting Ceph Placement Group
     """
-    osd_deployment = deployment.get_osd_deployments()[0]
-    original_deployment_revision = osd_deployment.revision
     ct_pod = pod.get_ceph_tools_pod()
     pool_name = helpers.create_unique_resource_name("corrupted", "pool")
     ct_pod.exec_ceph_cmd(f"ceph osd pool create {pool_name} 1 1")
     ct_pod.exec_ceph_cmd(f"ceph osd pool application enable {pool_name} rbd")
+
+    pool_object = "test_object"
+    ct_pod.exec_ceph_cmd(f"rados -p {pool_name} put {pool_object} /etc/passwd")
+
+    # Find the primary OSD for this PG and use its deployment for corruption.
+    # On clusters with many OSDs the PG may not reside on osd.0, so we must
+    # pick the OSD that actually holds the data.
+    pg_info = ct_pod.exec_ceph_cmd(f"ceph osd map {pool_name} {pool_object}")
+    target_osd_id = pg_info["up"][0]
+    logger.info(
+        f"PG {pg_info['pgid']} primary is osd.{target_osd_id}, "
+        f"selecting its deployment for corruption"
+    )
+    osd_deployments = deployment.get_osd_deployments()
+    osd_deployment = None
+    for d in osd_deployments:
+        osd_pod_data = d.pods[0].get()
+        if osd_pod_data["metadata"]["labels"]["ceph-osd-id"] == str(target_osd_id):
+            osd_deployment = d
+            break
+    assert osd_deployment, f"Could not find OSD deployment for osd.{target_osd_id}"
+    original_deployment_revision = osd_deployment.revision
 
     def teardown():
         """
@@ -348,9 +368,6 @@ def measure_corrupt_pg(request, measurement_dir, threading_lock):
     request.addfinalizer(teardown)
     logger.info("Setting osd noout flag")
     ct_pod.exec_ceph_cmd("ceph osd set noout")
-    logger.info(f"Put object into {pool_name}")
-    pool_object = "test_object"
-    ct_pod.exec_ceph_cmd(f"rados -p {pool_name} put {pool_object} /etc/passwd")
     logger.info(f"Corrupting pool {pool_name} on {osd_deployment.name}")
     rados_utils.corrupt_pg(osd_deployment, pool_name, pool_object)
 

--- a/tests/functional/monitoring/conftest.py
+++ b/tests/functional/monitoring/conftest.py
@@ -311,28 +311,8 @@ def measure_corrupt_pg(request, measurement_dir, threading_lock):
     pool_name = helpers.create_unique_resource_name("corrupted", "pool")
     ct_pod.exec_ceph_cmd(f"ceph osd pool create {pool_name} 1 1")
     ct_pod.exec_ceph_cmd(f"ceph osd pool application enable {pool_name} rbd")
-
-    pool_object = "test_object"
-    ct_pod.exec_ceph_cmd(f"rados -p {pool_name} put {pool_object} /etc/passwd")
-
-    # Find the primary OSD for this PG and use its deployment for corruption.
-    # On clusters with many OSDs the PG may not reside on osd.0, so we must
-    # pick the OSD that actually holds the data.
-    pg_info = ct_pod.exec_ceph_cmd(f"ceph osd map {pool_name} {pool_object}")
-    target_osd_id = pg_info["up"][0]
-    logger.info(
-        f"PG {pg_info['pgid']} primary is osd.{target_osd_id}, "
-        f"selecting its deployment for corruption"
-    )
-    osd_deployments = deployment.get_osd_deployments()
     osd_deployment = None
-    for d in osd_deployments:
-        osd_pod_data = d.pods[0].get()
-        if osd_pod_data["metadata"]["labels"]["ceph-osd-id"] == str(target_osd_id):
-            osd_deployment = d
-            break
-    assert osd_deployment, f"Could not find OSD deployment for osd.{target_osd_id}"
-    original_deployment_revision = osd_deployment.revision
+    original_deployment_revision = None
 
     def teardown():
         """
@@ -353,11 +333,11 @@ def measure_corrupt_pg(request, measurement_dir, threading_lock):
         logger.info("Unsetting osd nodeep-scrub flag")
         ct_pod.exec_ceph_cmd("ceph osd unset nodeep-scrub")
         logger.info(f"Checking that pool {pool_name} is deleted")
-        logger.info(
-            f"Restoring deployment {osd_deployment.name} "
-            f"to its original revision: {original_deployment_revision}"
-        )
-        if original_deployment_revision:
+        if osd_deployment and original_deployment_revision:
+            logger.info(
+                f"Restoring deployment {osd_deployment.name} "
+                f"to its original revision: {original_deployment_revision}"
+            )
             osd_deployment.set_revision(original_deployment_revision)
             # unset original_deployment_revision because revision number is deleted when used
             original_deployment_revision = False
@@ -366,6 +346,27 @@ def measure_corrupt_pg(request, measurement_dir, threading_lock):
         ceph_health_check(tries=20, delay=15)
 
     request.addfinalizer(teardown)
+
+    pool_object = "test_object"
+    ct_pod.exec_ceph_cmd(f"rados -p {pool_name} put {pool_object} /etc/passwd")
+
+    # Find the primary OSD for this PG and use its deployment for corruption.
+    # On clusters with many OSDs the PG may not reside on osd.0, so we must
+    # pick the OSD that actually holds the data.
+    pg_info = ct_pod.exec_ceph_cmd(f"ceph osd map {pool_name} {pool_object}")
+    target_osd_id = pg_info["up"][0]
+    logger.info(
+        f"PG {pg_info['pgid']} primary is osd.{target_osd_id}, "
+        f"selecting its deployment for corruption"
+    )
+    osd_deployments = deployment.get_osd_deployments()
+    for d in osd_deployments:
+        osd_pod_data = d.pods[0].get()
+        if osd_pod_data["metadata"]["labels"]["ceph-osd-id"] == str(target_osd_id):
+            osd_deployment = d
+            break
+    assert osd_deployment, f"Could not find OSD deployment for osd.{target_osd_id}"
+    original_deployment_revision = osd_deployment.revision
     logger.info("Setting osd noout flag")
     ct_pod.exec_ceph_cmd("ceph osd set noout")
     logger.info(f"Corrupting pool {pool_name} on {osd_deployment.name}")


### PR DESCRIPTION
  Body:                                                                                                                                                                                                   
  ## Summary                                                                                                                                                                                              
  - Fix PG corruption targeting wrong OSD on clusters with >3 OSDs (e.g. 6-node EC HCI)                                                                                                                   
  - The test blindly used `get_osd_deployments()[0]` (osd.0), but on large clusters the test pool's PG may not reside on osd.0, so the corruption silently failed
  - Now creates the pool first, uses `ceph osd map` to find the primary OSD, and targets that OSD's deployment
  - Wait for the corrupted OSD pod to restart before issuing `deep-scrub`, otherwise the scrub runs on healthy replicas and finds no inconsistency
  - Fix hardcoded `ceph-0` subPath in the corrupt-pg init container volumeMount to use the actual OSD ID

  ## Test plan
  - [x] Reproduced failure on 6-node/18-OSD EC HCI cluster (dosypenk-bm6)
  - [x] Verified fix passes on the same cluster

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved placement group corruption testing by selecting the correct OSD for each test object based on the PG’s actual primary OSD.
  * Updated corruption handling to generate the corruption payload using the targeted OSD details rather than a fixed path.
  * Enhanced reliability by waiting for the replacement OSD pod to return to a fully ready running state before initiating the deep-scrub.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->