### PR TITLE
Update RDR workload images to use release-4.22 tag

### DIFF
--- a/conf/ocsci/dr_workload.yaml
+++ b/conf/ocsci/dr_workload.yaml
@@ -2,7 +2,7 @@ ENV_DATA:
   deploy_via_cli: True
   cg_enabled: True
   dr_workload_repo_url: "https://github.com/red-hat-storage/ocs-workloads.git"
-  dr_workload_repo_branch: "master"
+  dr_workload_repo_branch: "release-4.22"
   dr_workload_subscription_rbd: [
     {name: "busybox-1", workload_dir: "rdr/busybox/rbd/subscription_with_placementrule/app-busybox-1",
      pod_count: 10, pvc_count: 10


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the disaster recovery workload configuration to use the `release-4.22` branch instead of `master`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->