### PR TITLE
use stable tag for ODF 5.0

### DIFF
--- a/ocs_ci/framework/conf/ocs_version/ocs-5.0.yaml
+++ b/ocs_ci/framework/conf/ocs_version/ocs-5.0.yaml
@@ -1,8 +1,7 @@
 ---
 DEPLOYMENT:
-  # TODO: Change to latest-stable-5.0 once we have stable build
-  default_ocs_registry_image: "quay.io/rhceph-dev/ocs-registry:latest-5.0"
-  default_latest_tag: 'latest-5.0'
+  default_ocs_registry_image: "quay.io/rhceph-dev/ocs-registry:latest-stable-5.0"
+  default_latest_tag: 'latest-stable-5.0'
   ocs_csv_channel: "stable-5.0"
   default_ocp_version: '5.0'
   konflux_build: true
@@ -12,4 +11,4 @@ REPORTING:
   default_ocs_must_gather_latest_tag: 'v5.0'
   default_ocs_must_gather_image: "quay.io/rhceph-dev/odf4-odf-must-gather-rhel9"
 UPGRADE:
-  default_latest_stable_upgrade_tag: 'latest-upgrade-5.0'
+  default_latest_stable_upgrade_tag: 'latest-stable-upgrade-5.0'


### PR DESCRIPTION
Signed-off-by: vavuthu [vavuthu@redhat.com](mailto:vavuthu@redhat.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated deployment defaults to use the latest stable 5.0 release stream.
  * Updated the upgrade default tag to the latest stable 5.0 upgrade stream.
  * Removed an outdated TODO related to switching to stable release defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->