### PR TITLE
use default_latest_tag: 'latest-stable-5.0' in ocs-5.0.yaml config

### DIFF
--- a/ocs_ci/framework/conf/ocs_version/ocs-5.0.yaml
+++ b/ocs_ci/framework/conf/ocs_version/ocs-5.0.yaml
@@ -2,7 +2,7 @@
 DEPLOYMENT:
   # TODO: Change to latest-stable-5.0 once we have stable build
   default_ocs_registry_image: "quay.io/rhceph-dev/ocs-registry:latest-5.0"
-  default_latest_tag: 'latest-5.0'
+  default_latest_tag: 'latest-stable-5.0'
   ocs_csv_channel: "stable-5.0"
   default_ocp_version: '5.0'
   konflux_build: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default deployment tag to use the stable 5.0 release channel, improving release consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->