### PR TITLE
Add GCP WIF service account creation for NooBaa STS deployment

### DIFF
--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -238,7 +238,7 @@ class Deployment(object):
         self.sts_role_arn = None
         self.azure_noobaa_mi_client_id = None
         self.gcp_noobaa_sa_email = None
-        self._gcp_wif_params = None
+        self.gcp_wif_params = None
         storage_class.set_custom_storage_class_path()
         logger.info(
             f"Deployment platform {self.platform} initiated with storage class: {self.storage_class}"
@@ -1333,7 +1333,7 @@ class Deployment(object):
             else:
                 subscription_yaml_data["spec"]["config"]["env"].extend(azure_sub_data)
         elif gcp_sts_deployment:
-            if not self._gcp_wif_params or not self.gcp_noobaa_sa_email:
+            if not self.gcp_wif_params or not self.gcp_noobaa_sa_email:
                 raise ValueError(
                     "GCP WIF parameters or NooBaa SA email not initialized. "
                     "Ensure deploy_ocs_via_operator() ran the GCP STS block "
@@ -1344,12 +1344,12 @@ class Deployment(object):
             gcp_sub_data = [
                 {
                     "name": "PROJECT_NUMBER",
-                    "value": self._gcp_wif_params["project_number"],
+                    "value": self.gcp_wif_params["project_number"],
                 },
-                {"name": "POOL_ID", "value": self._gcp_wif_params["pool_id"]},
+                {"name": "POOL_ID", "value": self.gcp_wif_params["pool_id"]},
                 {
                     "name": "PROVIDER_ID",
-                    "value": self._gcp_wif_params["provider_id"],
+                    "value": self.gcp_wif_params["provider_id"],
                 },
                 {
                     "name": "SERVICE_ACCOUNT_EMAIL",
@@ -1502,14 +1502,14 @@ class Deployment(object):
             gcp_project_id = (
                 config.ENV_DATA.get("gcp_project_id") or sa_dict["project_id"]
             )
-            self._gcp_wif_params = get_wif_params_from_cluster()
+            self.gcp_wif_params = get_wif_params_from_cluster()
             cluster_path = config.ENV_DATA["cluster_path"]
             infra_id = get_infra_id(cluster_path)
             sa_name = build_noobaa_sa_name(infra_id)
             self.gcp_noobaa_sa_email = create_noobaa_gcp_service_account(
                 gcp_project_id=gcp_project_id,
-                project_number=self._gcp_wif_params["project_number"],
-                pool_id=self._gcp_wif_params["pool_id"],
+                project_number=self.gcp_wif_params["project_number"],
+                pool_id=self.gcp_wif_params["pool_id"],
                 sa_name=sa_name,
             )
         stage_testing = config.DEPLOYMENT.get("stage_rh_osbs")

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -20,6 +20,13 @@ from botocore.exceptions import BotoCoreError, ClientError, EndpointConnectionEr
 
 from ocs_ci.deployment.helpers import storage_class
 from ocs_ci.utility.azure_utils import AZURE as AzureUtil
+from ocs_ci.utility.gcp import (
+    build_noobaa_sa_name,
+    create_noobaa_gcp_service_account,
+    get_wif_params_from_cluster,
+    load_service_account_key_dict,
+    SERVICE_ACCOUNT_KEY_FILEPATH,
+)
 from ocs_ci.deployment.ocp import OCPDeployment as BaseOCPDeployment
 from ocs_ci.deployment.helpers.external_cluster_helpers import (
     ExternalCluster,
@@ -203,6 +210,7 @@ from ocs_ci.utility.utils import (
     ceph_health_check_multi_storagecluster_external,
     get_acm_version,
     get_acm_mce_build_tag,
+    get_infra_id,
     apply_oadp_workaround,
     mute_mon_netsplit,
 )
@@ -229,6 +237,8 @@ class Deployment(object):
     def __init__(self):
         self.sts_role_arn = None
         self.azure_noobaa_mi_client_id = None
+        self.gcp_noobaa_sa_email = None
+        self._gcp_wif_params = None
         storage_class.set_custom_storage_class_path()
         logger.info(
             f"Deployment platform {self.platform} initiated with storage class: {self.storage_class}"
@@ -1240,6 +1250,9 @@ class Deployment(object):
             config.DEPLOYMENT.get("sts_enabled")
             and platform == constants.AZURE_PLATFORM
         )
+        gcp_sts_deployment = (
+            config.DEPLOYMENT.get("sts_enabled") and platform == constants.GCP_PLATFORM
+        )
         managed_ibmcloud = (
             platform == constants.IBMCLOUD_PLATFORM
             and config.ENV_DATA["deployment_type"] == "managed"
@@ -1319,6 +1332,34 @@ class Deployment(object):
                 subscription_yaml_data["spec"]["config"]["env"] = azure_sub_data
             else:
                 subscription_yaml_data["spec"]["config"]["env"].extend(azure_sub_data)
+        elif gcp_sts_deployment:
+            if not self._gcp_wif_params or not self.gcp_noobaa_sa_email:
+                raise ValueError(
+                    "GCP WIF parameters or NooBaa SA email not initialized. "
+                    "Ensure deploy_ocs_via_operator() ran the GCP STS block "
+                    "before subscribe_ocs()."
+                )
+            if "config" not in subscription_yaml_data["spec"]:
+                subscription_yaml_data["spec"]["config"] = {}
+            gcp_sub_data = [
+                {
+                    "name": "PROJECT_NUMBER",
+                    "value": self._gcp_wif_params["project_number"],
+                },
+                {"name": "POOL_ID", "value": self._gcp_wif_params["pool_id"]},
+                {
+                    "name": "PROVIDER_ID",
+                    "value": self._gcp_wif_params["provider_id"],
+                },
+                {
+                    "name": "SERVICE_ACCOUNT_EMAIL",
+                    "value": self.gcp_noobaa_sa_email,
+                },
+            ]
+            if "env" not in subscription_yaml_data["spec"]["config"]:
+                subscription_yaml_data["spec"]["config"]["env"] = gcp_sub_data
+            else:
+                subscription_yaml_data["spec"]["config"]["env"].extend(gcp_sub_data)
 
         subscription_yaml_data["metadata"]["namespace"] = self.namespace
         subscription_manifest = tempfile.NamedTemporaryFile(
@@ -1450,6 +1491,26 @@ class Deployment(object):
                 cluster_name=config.ENV_DATA["cluster_name"],
                 resource_group=config.ENV_DATA["cluster_name"],
                 subscription_id=config.AUTH["azure_auth"]["subscription_id"],
+            )
+        gcp_sts_deployment = (
+            config.DEPLOYMENT.get("sts_enabled") and platform == constants.GCP_PLATFORM
+        )
+        if gcp_sts_deployment:
+            logger.test_step("Create GCP service account for NooBaa WIF")
+            os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = SERVICE_ACCOUNT_KEY_FILEPATH
+            sa_dict = load_service_account_key_dict()
+            gcp_project_id = (
+                config.ENV_DATA.get("gcp_project_id") or sa_dict["project_id"]
+            )
+            self._gcp_wif_params = get_wif_params_from_cluster()
+            cluster_path = config.ENV_DATA["cluster_path"]
+            infra_id = get_infra_id(cluster_path)
+            sa_name = build_noobaa_sa_name(infra_id)
+            self.gcp_noobaa_sa_email = create_noobaa_gcp_service_account(
+                gcp_project_id=gcp_project_id,
+                project_number=self._gcp_wif_params["project_number"],
+                pool_id=self._gcp_wif_params["pool_id"],
+                sa_name=sa_name,
             )
         stage_testing = config.DEPLOYMENT.get("stage_rh_osbs")
         konflux_build = config.DEPLOYMENT.get("konflux_build")

--- a/ocs_ci/deployment/gcp.py
+++ b/ocs_ci/deployment/gcp.py
@@ -226,7 +226,14 @@ class GCPIPI(GCPBase):
                 # 3. Delete NooBaa GCP service account
                 sa_name = build_noobaa_sa_name(infra_id)
                 sa_email = f"{sa_name}@{gcp_project}.iam.gserviceaccount.com"
-                delete_noobaa_gcp_service_account(gcp_project, sa_email)
+                try:
+                    delete_noobaa_gcp_service_account(gcp_project, sa_email)
+                except Exception:
+                    logger.warning(
+                        "Failed to delete NooBaa GCP service account. "
+                        "Proceeding with WIF resource cleanup.",
+                        exc_info=True,
+                    )
 
                 # 4. Run ccoctl gcp delete to remove WIF resources
                 cco.delete_gcp_sts_resources(

--- a/ocs_ci/deployment/gcp.py
+++ b/ocs_ci/deployment/gcp.py
@@ -17,6 +17,8 @@ from ocs_ci.utility import cco
 from ocs_ci.utility.deployment import get_ocp_release_image_from_installer
 from ocs_ci.utility.gcp import (
     GoogleCloudUtil,
+    build_noobaa_sa_name,
+    delete_noobaa_gcp_service_account,
     load_service_account_key_dict,
     SERVICE_ACCOUNT_KEY_FILEPATH,
 )
@@ -210,16 +212,23 @@ class GCPIPI(GCPBase):
             try:
                 # 1. Set GCP authentication
                 gcp_project = self._get_gcp_project()
+                cluster_path = config.ENV_DATA["cluster_path"]
+                infra_id = get_infra_id_from_openshift_install_state(cluster_path)
 
                 # 2. Ensure ccoctl binary and CredentialsRequest manifests
                 # are available (may be missing if teardown runs on a
-                # different agent than the one that deployed)
-                cluster_path = config.ENV_DATA["cluster_path"]
+                # different agent than the one that deployed).
+                # Done before SA deletion so a prep failure doesn't leave
+                # the SA deleted but WIF resources orphaned.
                 credentials_requests_dir = os.path.join(cluster_path, "creds_reqs")
                 self._ensure_ccoctl_and_credentials_requests(credentials_requests_dir)
 
-                # 3. Run ccoctl gcp delete to remove WIF resources
-                infra_id = get_infra_id_from_openshift_install_state(cluster_path)
+                # 3. Delete NooBaa GCP service account
+                sa_name = build_noobaa_sa_name(infra_id)
+                sa_email = f"{sa_name}@{gcp_project}.iam.gserviceaccount.com"
+                delete_noobaa_gcp_service_account(gcp_project, sa_email)
+
+                # 4. Run ccoctl gcp delete to remove WIF resources
                 cco.delete_gcp_sts_resources(
                     infra_id,
                     gcp_project,

--- a/ocs_ci/deployment/gcp.py
+++ b/ocs_ci/deployment/gcp.py
@@ -119,6 +119,11 @@ class GCPIPI(GCPBase):
         """
         cluster_path = config.ENV_DATA["cluster_path"]
         pull_secret_path = os.path.join(constants.DATA_DIR, "pull-secret")
+        if "installer_path" not in config.ENV_DATA:
+            bin_dir = os.path.abspath(os.path.expanduser(config.RUN.get("bin_dir", "")))
+            config.ENV_DATA["installer_path"] = os.path.join(
+                bin_dir, "openshift-install"
+            )
         release_image = get_ocp_release_image_from_installer()
         cco_image = cco.get_cco_container_image(release_image, pull_secret_path)
         cco.extract_ccoctl_binary(cco_image, pull_secret_path)
@@ -209,33 +214,27 @@ class GCPIPI(GCPBase):
 
         """
         if config.DEPLOYMENT.get("sts_enabled"):
-            try:
-                # 1. Set GCP authentication
-                gcp_project = self._get_gcp_project()
-                cluster_path = config.ENV_DATA["cluster_path"]
-                infra_id = get_infra_id_from_openshift_install_state(cluster_path)
+            gcp_project = self._get_gcp_project()
+            cluster_path = config.ENV_DATA["cluster_path"]
+            infra_id = get_infra_id_from_openshift_install_state(cluster_path)
 
-                # 2. Ensure ccoctl binary and CredentialsRequest manifests
-                # are available (may be missing if teardown runs on a
-                # different agent than the one that deployed).
-                # Done before SA deletion so a prep failure doesn't leave
-                # the SA deleted but WIF resources orphaned.
+            # 1. Delete NooBaa GCP service account (uses Google API
+            # directly, no ccoctl dependency)
+            sa_name = build_noobaa_sa_name(infra_id)
+            sa_email = f"{sa_name}@{gcp_project}.iam.gserviceaccount.com"
+            try:
+                delete_noobaa_gcp_service_account(gcp_project, sa_email)
+            except Exception:
+                logger.warning(
+                    "Failed to delete NooBaa GCP service account. "
+                    "Proceeding with WIF resource cleanup.",
+                    exc_info=True,
+                )
+
+            # 2. Delete WIF resources via ccoctl
+            try:
                 credentials_requests_dir = os.path.join(cluster_path, "creds_reqs")
                 self._ensure_ccoctl_and_credentials_requests(credentials_requests_dir)
-
-                # 3. Delete NooBaa GCP service account
-                sa_name = build_noobaa_sa_name(infra_id)
-                sa_email = f"{sa_name}@{gcp_project}.iam.gserviceaccount.com"
-                try:
-                    delete_noobaa_gcp_service_account(gcp_project, sa_email)
-                except Exception:
-                    logger.warning(
-                        "Failed to delete NooBaa GCP service account. "
-                        "Proceeding with WIF resource cleanup.",
-                        exc_info=True,
-                    )
-
-                # 4. Run ccoctl gcp delete to remove WIF resources
                 cco.delete_gcp_sts_resources(
                     infra_id,
                     gcp_project,
@@ -243,7 +242,7 @@ class GCPIPI(GCPBase):
                 )
             except Exception:
                 logger.warning(
-                    "Failed to delete GCP STS resources. "
+                    "Failed to delete GCP WIF resources via ccoctl. "
                     "Proceeding with cluster destroy.",
                     exc_info=True,
                 )

--- a/ocs_ci/utility/gcp.py
+++ b/ocs_ci/utility/gcp.py
@@ -150,31 +150,20 @@ def get_wif_params_from_cluster():
     return params
 
 
-def create_noobaa_gcp_service_account(gcp_project_id, project_number, pool_id, sa_name):
+def _get_or_create_gcp_sa(iam, gcp_project_id, sa_name):
     """
-    Create a GCP service account for NooBaa with WIF principal bindings.
+    Get an existing GCP service account or create a new one.
 
-    On GCP WIF clusters, NooBaa pods need a dedicated GCP service
-    account to authenticate to GCS without static credentials.
+    Uses a get-then-create pattern so the call is idempotent: if the
+    SA already exists (e.g. from a previous partial run), it is reused.
 
     Args:
-        gcp_project_id (str): GCP project ID (string, not number)
-        project_number (str): GCP project number (numeric), used to
-            construct the WIF principal URIs
-        pool_id (str): Workload Identity Pool ID created by ccoctl
-        sa_name (str): Service account ID (max 30 chars, typically
-            ``{infra_id}-noobaa``)
-
-    Returns:
-        str: The created service account's email address
+        iam: Google IAM v1 service client
+        gcp_project_id (str): GCP project ID
+        sa_name (str): Service account ID (max 30 chars)
 
     """
-    os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = SERVICE_ACCOUNT_KEY_FILEPATH
-    iam = build("iam", "v1", cache_discovery=False)
-    crm = build("cloudresourcemanager", "v1", cache_discovery=False)
     project_resource = f"projects/{gcp_project_id}"
-
-    # 1. Create the GCP service account (idempotent - reuse if it exists)
     sa_email = f"{sa_name}@{gcp_project_id}.iam.gserviceaccount.com"
     sa_resource = f"{project_resource}/serviceAccounts/{sa_email}"
     try:
@@ -197,18 +186,28 @@ def create_noobaa_gcp_service_account(gcp_project_id, project_number, pool_id, s
         ).execute()
         logger.info(f"Service account created: {sa_email}")
 
-    # 2. Grant roles/storage.admin on the project so NooBaa can create,
-    # read, write, list, and delete GCS buckets and objects.
-    # Newly created SAs may not be visible to IAM for up to 60s (GCP
-    # eventual consistency), so retry on 400 "does not exist".
-    logger.info(f"Granting roles/storage.admin to {sa_email}")
 
+def _grant_storage_admin_role_to_sa(crm, gcp_project_id, sa_email):
+    """
+    Grant roles/storage.admin on the GCP project for the given SA.
+
+    This role lets NooBaa create, read, write, list, and delete GCS
+    buckets and objects. Newly created SAs may not be visible to IAM
+    for up to 60s (GCP eventual consistency), so the setIamPolicy
+    call is retried via TimeoutSampler on 400 "does not exist".
+
+    Args:
+        crm: Google Cloud Resource Manager v1 service client
+        gcp_project_id (str): GCP project ID
+        sa_email (str): Service account email to grant the role to
+
+    """
+    logger.info(f"Granting roles/storage.admin to {sa_email}")
     member = f"serviceAccount:{sa_email}"
     role = "roles/storage.admin"
 
-    def _set_storage_admin_policy():
+    def _set_policy():
         policy = crm.projects().getIamPolicy(resource=gcp_project_id, body={}).execute()
-
         binding_found = False
         for binding in policy.get("bindings", []):
             if binding["role"] == role:
@@ -220,7 +219,6 @@ def create_noobaa_gcp_service_account(gcp_project_id, project_number, pool_id, s
             policy.setdefault("bindings", []).append(
                 {"role": role, "members": [member]}
             )
-
         try:
             crm.projects().setIamPolicy(
                 resource=gcp_project_id, body={"policy": policy}
@@ -232,23 +230,41 @@ def create_noobaa_gcp_service_account(gcp_project_id, project_number, pool_id, s
                 return False
             raise
 
-    for granted in TimeoutSampler(timeout=60, sleep=10, func=_set_storage_admin_policy):
+    for granted in TimeoutSampler(timeout=60, sleep=10, func=_set_policy):
         if granted:
             break
+    logger.info(f"roles/storage.admin granted to {sa_email}")
 
-    # 3. Add WIF principal bindings on the SA itself.
-    # Each NooBaa k8s SA gets roles/iam.workloadIdentityUser so it can
-    # impersonate this GCP SA via WIF.
+
+def _add_noobaa_wif_bindings_to_sa(
+    iam, gcp_project_id, sa_email, project_number, pool_id
+):
+    """
+    Add WIF principal bindings so NooBaa k8s SAs can impersonate this GCP SA.
+
+    Grants roles/iam.workloadIdentityUser on the SA to the three
+    NooBaa Kubernetes service accounts (noobaa, noobaa-core,
+    noobaa-endpoint), allowing them to obtain GCP tokens via
+    Workload Identity Federation.
+
+    Args:
+        iam: Google IAM v1 service client
+        gcp_project_id (str): GCP project ID
+        sa_email (str): Service account email to bind to
+        project_number (str): GCP project number (numeric)
+        pool_id (str): Workload Identity Pool ID
+
+    """
+    sa_resource = f"projects/{gcp_project_id}/serviceAccounts/{sa_email}"
     namespace = config.ENV_DATA.get(
         "cluster_namespace", constants.OPENSHIFT_STORAGE_NAMESPACE
     )
-    service_accounts = ["noobaa", "noobaa-core", "noobaa-endpoint"]
+    k8s_service_accounts = ["noobaa", "noobaa-core", "noobaa-endpoint"]
     sa_policy = (
         iam.projects().serviceAccounts().getIamPolicy(resource=sa_resource).execute()
     )
     wif_role = "roles/iam.workloadIdentityUser"
 
-    # Find or create a binding for the WIF role on the SA policy
     wif_binding = None
     for binding in sa_policy.get("bindings", []):
         if binding["role"] == wif_role:
@@ -258,8 +274,7 @@ def create_noobaa_gcp_service_account(gcp_project_id, project_number, pool_id, s
         wif_binding = {"role": wif_role, "members": []}
         sa_policy.setdefault("bindings", []).append(wif_binding)
 
-    # Add the fully qualified WIF principal for each NooBaa k8s SA to the binding
-    for k8s_sa in service_accounts:
+    for k8s_sa in k8s_service_accounts:
         principal = (
             f"principal://iam.googleapis.com/projects/{project_number}"
             f"/locations/global/workloadIdentityPools/{pool_id}"
@@ -272,6 +287,37 @@ def create_noobaa_gcp_service_account(gcp_project_id, project_number, pool_id, s
     iam.projects().serviceAccounts().setIamPolicy(
         resource=sa_resource, body={"policy": sa_policy}
     ).execute()
+
+
+def create_noobaa_gcp_service_account(gcp_project_id, project_number, pool_id, sa_name):
+    """
+    Create a GCP service account for NooBaa with WIF principal bindings.
+
+    On GCP WIF clusters, NooBaa pods need a dedicated GCP service
+    account to authenticate to GCS without static credentials.
+
+    Args:
+        gcp_project_id (str): GCP project ID (string, not number)
+        project_number (str): GCP project number (numeric), used to
+            construct the WIF principal URIs
+        pool_id (str): Workload Identity Pool ID created by ccoctl
+        sa_name (str): Service account ID (max 30 chars, typically
+            ``{infra_id}-noobaa``)
+
+    Returns:
+        str: The created service account's email address
+
+    """
+    os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = SERVICE_ACCOUNT_KEY_FILEPATH
+    iam = build("iam", "v1", cache_discovery=False)
+    crm = build("cloudresourcemanager", "v1", cache_discovery=False)
+    sa_email = f"{sa_name}@{gcp_project_id}.iam.gserviceaccount.com"
+
+    _get_or_create_gcp_sa(iam, gcp_project_id, sa_name)
+    _grant_storage_admin_role_to_sa(crm, gcp_project_id, sa_email)
+    _add_noobaa_wif_bindings_to_sa(
+        iam, gcp_project_id, sa_email, project_number, pool_id
+    )
 
     logger.info(f"NooBaa GCP service account {sa_email} configured for WIF")
     return sa_email

--- a/ocs_ci/utility/gcp.py
+++ b/ocs_ci/utility/gcp.py
@@ -358,6 +358,7 @@ def delete_noobaa_gcp_service_account(gcp_project_id, sa_email):
         crm.projects().setIamPolicy(
             resource=gcp_project_id, body={"policy": policy}
         ).execute()
+        logger.info(f"roles/storage.admin binding removed for {sa_email}")
     except Exception as e:
         logger.warning(f"Failed to remove IAM binding for {sa_email}: {e}")
 

--- a/ocs_ci/utility/gcp.py
+++ b/ocs_ci/utility/gcp.py
@@ -124,9 +124,14 @@ def get_wif_params_from_cluster():
 
     # The secret has a single data key containing the base64-encoded
     # JSON credential file (typically "service_account.json")
-    encoded_creds = list(secret_data.values())[0]
-    creds = json.loads(base64.b64decode(encoded_creds).decode())
-    audience = creds["audience"]
+    try:
+        encoded_creds = next(iter(secret_data.values()))
+        creds = json.loads(base64.b64decode(encoded_creds).decode())
+        audience = creds["audience"]
+    except (StopIteration, KeyError, json.JSONDecodeError) as e:
+        raise ValueError(
+            f"CCO secret gcp-ccm-cloud-credentials is missing or malformed: {e}"
+        ) from e
 
     # Parse project number, pool ID, and provider ID from the audience URL
     match = re.search(

--- a/ocs_ci/utility/gcp.py
+++ b/ocs_ci/utility/gcp.py
@@ -10,17 +10,20 @@ the case so far.
 .. _`Google Cloud python libraries`: https://cloud.google.com/python/docs/reference
 """
 
-
+import base64
 import json
 import logging
 import os
+import re
 import time
 
+from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
 from libcloud.compute.types import Provider
 from libcloud.compute.providers import get_driver
-from googleapiclient.discovery import build
 
 from ocs_ci.framework import config
+from ocs_ci.ocs import constants
 from ocs_ci.utility.utils import TimeoutSampler
 from ocs_ci.ocs.exceptions import (
     TimeoutExpiredError,
@@ -33,7 +36,6 @@ from ocs_ci.ocs.constants import (
     OPERATION_RESTART,
     OPERATION_TERMINATE,
 )
-
 
 logger = logging.getLogger(__name__)
 
@@ -73,6 +75,251 @@ def load_service_account_key_dict(filepath=SERVICE_ACCOUNT_KEY_FILEPATH):
         filepath,
     )
     return sa_dict
+
+
+def build_noobaa_sa_name(infra_id):
+    """
+    Build a GCP service account ID for NooBaa, truncating infra_id if
+    the result would exceed GCP's 30-character limit.
+
+    Args:
+        infra_id (str): Cluster infrastructure ID
+
+    Returns:
+        str: SA ID of the form ``{infra_id}-noobaa``, at most 30 chars
+
+    """
+    suffix = "-noobaa"
+    max_prefix_len = 30 - len(suffix)
+    return f"{infra_id[:max_prefix_len]}{suffix}"
+
+
+def get_wif_params_from_cluster():
+    """
+    Extract GCP Workload Identity Federation parameters from the cluster.
+
+    Returns:
+        dict: Keys ``project_number``, ``pool_id``, ``provider_id``
+
+    Raises:
+        ValueError: If the audience URL does not match the expected
+            WIF format
+
+    """
+    from ocs_ci.ocs.ocp import OCP
+
+    logger.info("Extracting WIF parameters from cluster CCO secret")
+
+    # The CCO creates per-component secrets with GCP WIF credentials.
+    # The audience field in each one contains the full WIF pool path:
+    #   //iam.googleapis.com/projects/<number>/locations/global/
+    #   workloadIdentityPools/<pool>/providers/<provider>
+    # We extract from gcp-ccm-cloud-credentials but any CCO secret works.
+    secret_ocp_obj = OCP(
+        kind=constants.SECRET,
+        namespace="openshift-cloud-controller-manager",
+        resource_name="gcp-ccm-cloud-credentials",
+    )
+    secret_data = secret_ocp_obj.get()["data"]
+
+    # The secret has a single data key containing the base64-encoded
+    # JSON credential file (typically "service_account.json")
+    encoded_creds = list(secret_data.values())[0]
+    creds = json.loads(base64.b64decode(encoded_creds).decode())
+    audience = creds["audience"]
+
+    # Parse project number, pool ID, and provider ID from the audience URL
+    match = re.search(
+        r"projects/(\d+)/locations/global/"
+        r"workloadIdentityPools/([^/]+)/providers/([^/]+)",
+        audience,
+    )
+    if not match:
+        raise ValueError(f"Failed to parse WIF audience URL: {audience}")
+    params = {
+        "project_number": match.group(1),
+        "pool_id": match.group(2),
+        "provider_id": match.group(3),
+    }
+    logger.info(f"Extracted WIF params: {params}")
+    return params
+
+
+def create_noobaa_gcp_service_account(gcp_project_id, project_number, pool_id, sa_name):
+    """
+    Create a GCP service account for NooBaa with WIF principal bindings.
+
+    On GCP WIF clusters, NooBaa pods need a dedicated GCP service
+    account to authenticate to GCS without static credentials.
+
+    Args:
+        gcp_project_id (str): GCP project ID (string, not number)
+        project_number (str): GCP project number (numeric), used to
+            construct the WIF principal URIs
+        pool_id (str): Workload Identity Pool ID created by ccoctl
+        sa_name (str): Service account ID (max 30 chars, typically
+            ``{infra_id}-noobaa``)
+
+    Returns:
+        str: The created service account's email address
+
+    """
+    os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = SERVICE_ACCOUNT_KEY_FILEPATH
+    iam = build("iam", "v1", cache_discovery=False)
+    crm = build("cloudresourcemanager", "v1", cache_discovery=False)
+    project_resource = f"projects/{gcp_project_id}"
+
+    # 1. Create the GCP service account (idempotent - reuse if it exists)
+    sa_email = f"{sa_name}@{gcp_project_id}.iam.gserviceaccount.com"
+    sa_resource = f"{project_resource}/serviceAccounts/{sa_email}"
+    try:
+        iam.projects().serviceAccounts().get(name=sa_resource).execute()
+        logger.info(f"Service account already exists: {sa_email}")
+    except HttpError as e:
+        if e.resp.status != 404:
+            raise
+        logger.info(
+            f"Creating GCP service account {sa_name} in project {gcp_project_id}"
+        )
+        iam.projects().serviceAccounts().create(
+            name=project_resource,
+            body={
+                "accountId": sa_name,
+                "serviceAccount": {
+                    "displayName": "NooBaa WIF Service Account",
+                },
+            },
+        ).execute()
+        logger.info(f"Service account created: {sa_email}")
+
+    # 2. Grant roles/storage.admin on the project so NooBaa can create,
+    # read, write, list, and delete GCS buckets and objects.
+    # Newly created SAs may not be visible to IAM for up to 60s (GCP
+    # eventual consistency), so retry on 400 "does not exist".
+    logger.info(f"Granting roles/storage.admin to {sa_email}")
+
+    member = f"serviceAccount:{sa_email}"
+    role = "roles/storage.admin"
+
+    def _set_storage_admin_policy():
+        policy = crm.projects().getIamPolicy(resource=gcp_project_id, body={}).execute()
+
+        binding_found = False
+        for binding in policy.get("bindings", []):
+            if binding["role"] == role:
+                if member not in binding["members"]:
+                    binding["members"].append(member)
+                binding_found = True
+                break
+        if not binding_found:
+            policy.setdefault("bindings", []).append(
+                {"role": role, "members": [member]}
+            )
+
+        try:
+            crm.projects().setIamPolicy(
+                resource=gcp_project_id, body={"policy": policy}
+            ).execute()
+            return True
+        except HttpError as e:
+            if e.resp.status == 400 and "does not exist" in str(e):
+                logger.warning("SA not yet visible to IAM, will retry")
+                return False
+            raise
+
+    for granted in TimeoutSampler(timeout=60, sleep=10, func=_set_storage_admin_policy):
+        if granted:
+            break
+
+    # 3. Add WIF principal bindings on the SA itself.
+    # Each NooBaa k8s SA gets roles/iam.workloadIdentityUser so it can
+    # impersonate this GCP SA via WIF.
+    namespace = config.ENV_DATA.get(
+        "cluster_namespace", constants.OPENSHIFT_STORAGE_NAMESPACE
+    )
+    service_accounts = ["noobaa", "noobaa-core", "noobaa-endpoint"]
+    sa_policy = (
+        iam.projects().serviceAccounts().getIamPolicy(resource=sa_resource).execute()
+    )
+    wif_role = "roles/iam.workloadIdentityUser"
+
+    # Find or create a binding for the WIF role on the SA policy
+    wif_binding = None
+    for binding in sa_policy.get("bindings", []):
+        if binding["role"] == wif_role:
+            wif_binding = binding
+            break
+    if not wif_binding:
+        wif_binding = {"role": wif_role, "members": []}
+        sa_policy.setdefault("bindings", []).append(wif_binding)
+
+    # Add the fully qualified WIF principal for each NooBaa k8s SA to the binding
+    for k8s_sa in service_accounts:
+        principal = (
+            f"principal://iam.googleapis.com/projects/{project_number}"
+            f"/locations/global/workloadIdentityPools/{pool_id}"
+            f"/subject/system:serviceaccount:{namespace}:{k8s_sa}"
+        )
+        if principal not in wif_binding["members"]:
+            wif_binding["members"].append(principal)
+            logger.info(f"Adding WIF binding for {k8s_sa}: {principal}")
+
+    iam.projects().serviceAccounts().setIamPolicy(
+        resource=sa_resource, body={"policy": sa_policy}
+    ).execute()
+
+    logger.info(f"NooBaa GCP service account {sa_email} configured for WIF")
+    return sa_email
+
+
+def delete_noobaa_gcp_service_account(gcp_project_id, sa_email):
+    """
+    Delete the NooBaa GCP service account created for WIF deployments.
+
+    Safe to call during cluster destroy even if the SA was never
+    fully created - each step is independently wrapped so partial
+    failures don't block teardown.
+
+    Args:
+        gcp_project_id (str): GCP project ID (string identifier)
+        sa_email (str): Full email of the service account to delete
+
+    """
+    os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = SERVICE_ACCOUNT_KEY_FILEPATH
+    crm = build("cloudresourcemanager", "v1", cache_discovery=False)
+    iam = build("iam", "v1", cache_discovery=False)
+    member = f"serviceAccount:{sa_email}"
+
+    # 1. Remove the project-level roles/storage.admin binding first,
+    # before deleting the SA, to avoid orphaned IAM references.
+    try:
+        logger.info(f"Removing roles/storage.admin binding for {sa_email}")
+        policy = crm.projects().getIamPolicy(resource=gcp_project_id, body={}).execute()
+        for binding in policy.get("bindings", []):
+            if (
+                binding["role"] == "roles/storage.admin"
+                and member in binding["members"]
+            ):
+                binding["members"].remove(member)
+                if not binding["members"]:
+                    policy["bindings"].remove(binding)
+                break
+        crm.projects().setIamPolicy(
+            resource=gcp_project_id, body={"policy": policy}
+        ).execute()
+    except Exception as e:
+        logger.warning(f"Failed to remove IAM binding for {sa_email}: {e}")
+
+    # 2. Delete the service account itself.
+    # WIF bindings on the SA are automatically cleaned up by GCP
+    # when the SA is deleted.
+    try:
+        logger.info(f"Deleting service account {sa_email}")
+        sa_resource = f"projects/{gcp_project_id}/serviceAccounts/{sa_email}"
+        iam.projects().serviceAccounts().delete(name=sa_resource).execute()
+        logger.info(f"Service account {sa_email} deleted")
+    except Exception as e:
+        logger.warning(f"Failed to delete service account {sa_email}: {e}")
 
 
 class GoogleCloudUtil:

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -6754,6 +6754,54 @@ def get_azure_sts_creds_from_sub():
     return creds
 
 
+def get_gcp_sts_creds_from_sub():
+    """
+    Get GCP WIF/STS credentials from the ODF Subscription.
+
+    GCP equivalent of ``get_azure_sts_creds_from_sub``.
+
+    Returns:
+        dict: Keys are ``project_number``, ``pool_id``,
+            ``provider_id``, and ``service_account_email``.
+
+    Raises:
+        ClusterNotInSTSModeException: If cluster is not in STS
+            mode or if any required env vars are missing
+
+    """
+    from ocs_ci.ocs.ocp import OCP
+
+    if not config.DEPLOYMENT.get("sts_enabled"):
+        raise ClusterNotInSTSModeException
+
+    # Maps ODF Subscription env var names to the dict keys returned.
+    # These env vars are injected by subscribe_ocs() during GCP STS
+    # deployment - see Deployment.subscribe_ocs() in deployment.py.
+    env_key_map = {
+        "PROJECT_NUMBER": "project_number",
+        "POOL_ID": "pool_id",
+        "PROVIDER_ID": "provider_id",
+        "SERVICE_ACCOUNT_EMAIL": "service_account_email",
+    }
+    odf_sub = OCP(
+        kind=constants.SUBSCRIPTION,
+        resource_name=constants.ODF_SUBSCRIPTION,
+        namespace=config.ENV_DATA["cluster_namespace"],
+    )
+    creds = {}
+    env_items = odf_sub.get().get("spec", {}).get("config", {}).get("env", [])
+    for item in env_items:
+        if item["name"] in env_key_map:
+            creds[env_key_map[item["name"]]] = item["value"]
+
+    # All four values are required for GCP WIF to function
+    required = {"project_number", "pool_id", "provider_id", "service_account_email"}
+    if not required.issubset(creds):
+        raise ClusterNotInSTSModeException
+
+    return creds
+
+
 def get_glibc_version():
     """
     Gets the GLIBC version.


### PR DESCRIPTION
## Summary

Follow-up to #15372 (OCP-side GCP STS/WIF automation via ccoctl). This PR adds the **ODF installation** half: creating a dedicated GCP service account for NooBaa with Workload Identity Federation bindings, injecting the WIF parameters into the ODF Subscription, and cleaning up the SA on cluster teardown.

This replicates what #15108 did for Azure STS (managed identity + Subscription env vars + teardown cleanup), adapted for GCP's WIF model.

Needed to cover [RHSTOR-8661](https://redhat.atlassian.net/browse/RHSTOR-8661) (GCP WIF/STS support for ODF) and [OCSQE-4967](https://redhat.atlassian.net/browse/OCSQE-4967).

## Changes

- **`ocs_ci/utility/gcp.py`** - Add `get_wif_params_from_cluster()`, `create_noobaa_gcp_service_account()`, and `delete_noobaa_gcp_service_account()` using the Google API Python client (IAM + Cloud Resource Manager APIs)
- **`ocs_ci/deployment/deployment.py`** - Wire GCP STS into `deploy_ocs_via_operator()` (SA creation) and `subscribe_ocs()` (inject `PROJECT_NUMBER`, `POOL_ID`, `PROVIDER_ID`, `SERVICE_ACCOUNT_EMAIL` env vars into ODF Subscription)
- **`ocs_ci/deployment/gcp.py`** - Add NooBaa SA deletion to `destroy_cluster()` before ccoctl cleanup
- **`ocs_ci/utility/utils.py`** - Add `get_gcp_sts_creds_from_sub()` for day-2 test automation to retrieve WIF params from the Subscription

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Google Cloud Workload Identity Federation (WIF) “NooBaa STS-style credentials” support to the OCS operator deployment flow.
  * When STS is enabled, ODF subscriptions are automatically enriched with required GCP identity environment variables (project/pool/provider and service account email).
  * Added automated retrieval and validation of STS/WIF settings from the ODF subscription.

* **Bug Fixes**
  * Improved teardown by creating and cleaning up a NooBaa-dedicated GCP service account and IAM bindings when destroying clusters with STS enabled.
  * STS/WIF cleanup now fails more gracefully while continuing standard cluster destruction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->