### PR TITLE
Add go-ceph migration validation tests for ocs-metrics-exporter (RHSTOR-7964)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -79,1323 +79,1303 @@
     "conf/deployment/ibmcloud/ibm_cloud_managed_3az_0m_3w_vpc_cluster.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 25,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 23,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_hpcs_external.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 25,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_stage.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 22,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_without_cos.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 21,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_without_cos_stage.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 23,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_zone_eu_de_1.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 23,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_zone_eu_de_2.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 23,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_zone_eu_de_3.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 23,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_zone_jp_tok_1.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 23,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_zone_jp_tok_2.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 23,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_zone_jp_tok_3.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 23,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_zone_us_east_1.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 23,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_zone_us_east_2.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 23,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_zone_us_east_3.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 23,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ipi_1az_us_east1_rhcos_3m_3w.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 24,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ipi_1az_us_east1_rhcos_custom_vpc_3m_3w.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 27,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ipi_1az_us_east2_rhcos_3m_3w.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 24,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ipi_1az_us_east3_rhcos_3m_3w.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 24,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ipi_1az_us_south1_rhcos_custom_vpc_3m_3w.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 27,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ipi_3az_rhcos_3m_3w.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 28,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ipi_3az_rhcos_3m_6w.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 29,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ipi_3az_rhcos_compactmode_3m_0w.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 28,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ipi_3az_rhcos_lowerreq_3m_3w.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 28,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/rhv/ipi_1az_rhcos_3m_3w.yaml": [
       {
         "hashed_secret": "ff55435345834a3fe224936776c2aa15f6ed5358",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 21,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/rhv/ipi_1az_rhcos_lso_3m_3w.yaml": [
       {
         "hashed_secret": "ff55435345834a3fe224936776c2aa15f6ed5358",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 30,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/vsphere/upi_1az_rhcos_vsan_3m_3w_disconnected_flexy.yaml": [
       {
         "hashed_secret": "66a1db0d75c1b2302b441a31b75b4d5a9f291d22",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 21,
         "type": "Base64 High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/vsphere/upi_1az_rhcos_vsan_lso_vmdk_3m_3w_disconnected_flexy.yaml": [
       {
         "hashed_secret": "66a1db0d75c1b2302b441a31b75b4d5a9f291d22",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 24,
         "type": "Base64 High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/examples/hpcs_external_standalone_mode.yaml": [
       {
         "hashed_secret": "fc4a8593743fd8a94fce1b137d964432bb1a9e91",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 13,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/ocsci/disconnected_cluster.yaml.example": [
       {
         "hashed_secret": "1dee91010328c9606757a6ddb538d608b6d89d1c",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 6,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 9,
         "type": "Basic Auth Credentials",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/ocsci/dr_workload.yaml": [
       {
         "hashed_secret": "3bb712fd293d3816c7c111dffc96dffc5c873602",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 345,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/ocsci/hpcs_external_standalone_mode.yaml": [
       {
         "hashed_secret": "fc4a8593743fd8a94fce1b137d964432bb1a9e91",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 12,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/ocsci/mdr_workload.yaml": [
       {
         "hashed_secret": "3bb712fd293d3816c7c111dffc96dffc5c873602",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 119,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/ocsci/noobaa_external_pgsql.yaml": [
       {
         "hashed_secret": "6cb6eb9fabad447f4ec9965879927661143bdfed",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 12,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/ocsci/openshift_dedicated.yaml": [
       {
         "hashed_secret": "66b2fcbc520c25a8087712aa85e95516a2b6c79b",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 14,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/ocsci/vsphere_upi_vars.yaml.example": [
       {
         "hashed_secret": "e894b36b7cdd92461cad391cf01f52c9e53c41ad",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 26,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/ocsci/vsphere_upi_vars.yaml.skeleton": [
       {
         "hashed_secret": "d63f8d34ad75f338f5b42b331e2fd883576a29bd",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 10,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "e894b36b7cdd92461cad391cf01f52c9e53c41ad",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 27,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "docs/getting_started.md": [
       {
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 174,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "docs/logging_guide.md": [
       {
         "hashed_secret": "605cf0632d1f0b7aebb3c0cd5c51a92145bb28a6",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 1421,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "docs/supported_platforms.md": [
       {
         "hashed_secret": "6eae3a5b062c6d0d79f070c26e6d62486b40cb46",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 30,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 171,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "docs/usage.md": [
       {
         "hashed_secret": "89a519cc7786f3290ad671412d92f325f9ef2a57",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 98,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "cfcafdd35cb253bd1a95060758e671abe510920a",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 347,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/deployment/aws.py": [
       {
         "hashed_secret": "134f379c01b1cf36e5ee172c37ffeca5c679a5ee",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 802,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/deployment/flexy.py": [
       {
         "hashed_secret": "bea1af2a15561a266eda3472673d24cb4f2020d4",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 241,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/deployment/hub_spoke.py": [
       {
         "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 7164,
         "type": "Private Key",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/framework/conf/default_config.yaml": [
       {
         "hashed_secret": "613fb9979a1ab677719426dd2e81a60fad637cf2",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 28,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "eea97d7f2f305e7afdc0b9bf64859b660cd09232",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 31,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 334,
         "line_number": 338,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "de19c40310ad831a71524cd279e6f5f0577fb09a",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 382,
         "line_number": 386,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/helpers/cluster_exp_helpers.py": [
       {
         "hashed_secret": "fa3798e69b10954419dfdcf70da00dce77b1416e",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 57,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/helpers/helpers.py": [
       {
         "hashed_secret": "66a36e77fd002579809717841f998f4d21cd5913",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 2925,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/krkn_chaos/template/krkn_global_config.yaml.j2": [
       {
         "hashed_secret": "d2e2ab0f407e4ee3cf2ab87d61c31b25a74085e5",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 50,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/krkn_chaos/template/scenarios/keknctl/plan.json.j2": [
       {
         "hashed_secret": "d2e2ab0f407e4ee3cf2ab87d61c31b25a74085e5",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 760,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/ocs/clients.py": [
       {
         "hashed_secret": "a8c1dc105c415cc7ccb286ecdb1156ebd9f957fb",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 14,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/ocs/constants.py": [
       {
         "hashed_secret": "b7e9a6e2e04ed3edbf8b4e21def4beccbb6eb6b1",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 233,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "a12337323b638ab044b1166bff4b1a1f83162819",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 840,
+        "line_number": 861,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "fb947972c92f052c0a08866d182be0075a2b601b",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 849,
+        "line_number": 870,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "03e227627ab8681281fdb8aa3d799b03f782d672",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 2053,
-        "line_number": 2060,
+        "line_number": 2082,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "ef5f3d909f23bd0aa02b4253f98350384f709c86",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 2160,
-        "line_number": 2167,
+        "line_number": 2189,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "cb1ae2b504c4615841d8144267a131231d2bd677",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 2161,
-        "line_number": 2168,
+        "line_number": 2190,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "1a1e70e87dd0452c42f33ce9bf74aa28134dba6b",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 2162,
-        "line_number": 2169,
+        "line_number": 2191,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "7b1ba2f04f2f1604dc4e3caffcadf9fcbce7df5b",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 2163,
-        "line_number": 2170,
+        "line_number": 2192,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "0fa3b21ced80146d752888f2b60ec80e0d4b8925",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 2175,
-        "line_number": 2182,
+        "line_number": 2204,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "f084f2068494b8d1cd06811dd97d02c3d85f40ee",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 2190,
-        "line_number": 2197,
+        "line_number": 2219,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "adfa401a3b0a733d8f00519ac8c6b3893a2e7e8e",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 2191,
-        "line_number": 2198,
+        "line_number": 2220,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "898e46bbadc12f87120548bd445eb4210c8407c8",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 2199,
-        "line_number": 2206,
+        "line_number": 2228,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "f57ccec6b8f7b12b635ab53d26c3bf7300247341",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 2200,
-        "line_number": 2207,
+        "line_number": 2229,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "77b044ea736f8cbe568d1954424186d901f89db9",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 2201,
-        "line_number": 2208,
+        "line_number": 2230,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "d64368f12ca17c69568c6a132f17d44d56e60660",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 2202,
-        "line_number": 2209,
+        "line_number": 2231,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "8f9ca35156c02cb6ba58c5b51230b9bedc38de4f",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 2203,
-        "line_number": 2210,
+        "line_number": 2232,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "9ec53cfd9929c70c3f87c210b6a7b77fb6d79d43",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 2800,
-        "line_number": 2807,
+        "line_number": 2829,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 2966,
-        "line_number": 2972,
+        "line_number": 2995,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "adc1f5c8707f7d7aba3aabe13c15e5ef1151872e",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 2967,
-        "line_number": 2973,
+        "line_number": 2996,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "ee46262b2df945e46ea310b925ad087465dbd3f2",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 3688,
-        "line_number": 3694,
+        "line_number": 3718,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "f678cad4ab874d71b559a069d5e34a95fe38a480",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 3689,
-        "line_number": 3695,
+        "line_number": 3719,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/ocs/defaults.py": [
       {
         "hashed_secret": "ca4dbbee191f1e04318439e30e4e9f55134e4513",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 123,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "9125b9994805d74d9545e381b9d5a90e65e2d63e",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 124,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "637138e061a7c9dc22f301dfcf7a43b638a2e1d8",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 125,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/ocs/external_ceph.py": [
       {
         "hashed_secret": "d2137e76c2c4f75fe37e8c0a03670d3715849389",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 473,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "30274c47903bd1bac7633bbf09743149ebab805f",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 474,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/ocs/fusion.py": [
       {
         "hashed_secret": "6eae3a5b062c6d0d79f070c26e6d62486b40cb46",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 97,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/ocs/platform_nodes.py": [
       {
         "hashed_secret": "134f379c01b1cf36e5ee172c37ffeca5c679a5ee",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 1269,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/ocs/resources/ocsconfigmaps.py": [
       {
         "hashed_secret": "347cd9c53ff77d41a7b22aa56c7b4efaf54658e3",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 404,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/ocs/utils.py": [
       {
         "hashed_secret": "f2dde9105675b76e1f542230a642933ccffd8a8e",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 331,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "8f57c0c672ec244816d827f57ea488c2d609efc9",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 643,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "30274c47903bd1bac7633bbf09743149ebab805f",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 644,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/templates/CSI/rbd/csi-kms-connection-details.yaml": [
       {
         "hashed_secret": "214d02537c8b2382bd599e97b100b78d1f9614aa",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 4,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/templates/ocs-deployment/external-pgsql-noobaa-secret.yaml": [
       {
         "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 9,
         "type": "Basic Auth Credentials",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/templates/ocs-deployment/multicluster/odr_s3_secret.yaml": [
       {
         "hashed_secret": "d3045fb7f8faed786bb7694d7d4ca06e357eea24",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 5,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/templates/openshift-infra/hpcs/ibm-kp-kms-secret.yaml": [
       {
         "hashed_secret": "021b53ce46b72837170446bee4e579c4801bc67a",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 8,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/templates/workloads/couchbase/server/couchbase-worker-secret.yaml": [
       {
         "hashed_secret": "7cf7ed86e8f660ade5996a1072d74cd35def47af",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 9,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/templates/workloads/couchbase/server/couchbase-worker.yaml": [
       {
         "hashed_secret": "8d6478f5d35b469b1568d41c393b3e08d30e7a2e",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 27,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/templates/workloads/hsbench/hsbench_obj.yaml": [
       {
         "hashed_secret": "7a9a4af7de5c6536e46cbee0856f11b46cdde7c9",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 5,
         "type": "Base64 High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/templates/workloads/quay/quay_registry.yaml": [
       {
         "hashed_secret": "83f7cd4240b0182d4e26f6f5aa845d3d29e4adfb",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 7,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/utility/managedservice.py": [
       {
         "hashed_secret": "6eae3a5b062c6d0d79f070c26e6d62486b40cb46",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 95,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "be4fc4886bd949b369d5e092eb87494f12e57e5b",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 169,
         "type": "Private Key",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/utility/rosa.py": [
       {
         "hashed_secret": "6eae3a5b062c6d0d79f070c26e6d62486b40cb46",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 687,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/utility/storage_cluster_setup.py": [
       {
         "hashed_secret": "f0e2d8610edefa0c02b673dcac7964b02ce3e890",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 748,
         "type": "Basic Auth Credentials",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "terraform/ai/vsphere/terraform.tfvars.example": [
       {
         "hashed_secret": "42a818da3bb789755a56f06412ebba442bf41edf",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 12,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "tests/cross_functional/kcs/test_noobaadb_pw_reset.py": [
       {
         "hashed_secret": "95b0665e64fa24c375f1db3797739dc833a01be1",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 87,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "tests/functional/ui/test_alert_text.py": [
       {
         "hashed_secret": "deed437581abf6a8a8c3f908a00739ec66bd1907",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 26,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "d3c7cf8a52f042f5ad10e7e04c6efa9b3edfc091",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 27,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "0e47f8d47cf71626c411322d5cc46463bb9ee63a",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 28,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "def6a0eb64808cbdf3e3985b380d06019ccaf15c",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 29,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "1eb02d1de1c583c352016b765c4470f14688c27f",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 30,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "beb03c56370648a8018847b7eb6f0ff17e2ec17d",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 31,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "c8a3e4b73af4fc164a18209fa3248cace0376de6",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 32,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "3b793d3c8f6140791030db45900185a24bc0f8d6",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 33,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "5e10a523088617ee53c02a050ecb4f3c02ff36a6",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 34,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "67cec59154e2b4dbc161ab590ea9836833a03879",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 35,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "a7051bbf0cbb04fbd58fea9202861924cf476965",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 36,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "711167a9e39213a023177fb6f8726eed4ae87724",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 37,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "62f46554adcad52e1b59156746059e8fe2b68114",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 38,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "6b6660ec37abef577585e08fbadd66a1daa126ad",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 39,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "ba9fdcab8f3a1c05e545c90657adeeca92457819",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 40,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "d92508b7e8714361d780028189182ccc838905fd",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 41,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "5d831603558fae694509e52443867d9d0fe15dab",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 42,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "70444c50c0b30525a518f749e570c2b5ab2ea159",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 43,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "b3a6d9ed97f183a3ed70fe50f8f5a1ab84eccfb5",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 44,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "d94d7c9ec8c812df775f85cf53d44fe0dacb153c",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 45,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "7fbab5f66d94793e754adf5eec572dd69895add7",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 46,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "d5164d922808f83e1bb2fb7ef4ae43a8fdc2d63a",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 47,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "474e5f07c32a4837e6685a64fb86c3b80ed14ef5",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 48,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "aee98b1d4cdc9ea965426edfff3e89413d648f28",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 49,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "cb44fa15b838b5bd5bb7cf855c8b65b83575b049",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 50,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "bfcb7bd33a4d476579e23a6ab6bef8270fd359a6",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 51,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "9109e09e3881791c6e7245a3e4dc3e9dd23305ec",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 52,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "44ac318f0525c62193986773a822397d9cd65220",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 53,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "a34ddb5f6561f1c681ea9d6369f2bf5ea5435bbf",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 54,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "a0f8bc5793f4cc0b1173b8e65c824e80bba32ec3",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 55,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "11b02033ace8079c90a25fe5dfef319b19363e56",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 56,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "c3bce19887dde7c21edbcc997f70e2d9b67a7845",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 57,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "918b8462281c3884363c68bd466e90e34bcb7b4f",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 58,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "5d279aca1022ec52d2f595199e74490d75bf3940",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 59,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "a9c2f9fb9293eac7f7055dc5ad8510ed89446890",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 60,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "6828bcb400541dcb69f04098c046c36947a664be",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 61,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "a7f8c0d263a1263d2f858d388e0f6ed799c3ed85",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 62,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "e7aac35a54098dff672130afc60ba0395f339089",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 63,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "642e4f0372448c534f32262a96e7d9f2b27b47d2",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 64,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "3bdd128c4f1e6c4d3ade5eb86dcfecc387e13a38",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 65,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "8308b864c9c12f694be52639f16fc312929c268a",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 68,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "64d5413c9629cf6c976224d145450a839f213b96",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 69,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ]
   },

--- a/ocs_ci/helpers/ocs_metrics_exporter_helpers.py
+++ b/ocs_ci/helpers/ocs_metrics_exporter_helpers.py
@@ -1,0 +1,1047 @@
+# -*- coding: utf8 -*-
+"""
+Helpers for RHSTOR-7964 / ocs-metrics-exporter validation (internal and provider paths).
+
+Metrics scrape aligns with manual QE: for TLS metrics on 8443, use
+``oc create token prometheus-k8s -n openshift-monitoring`` and
+``curl -sk -H 'Authorization: Bearer …' https://localhost:8443/metrics`` from inside the pod.
+"""
+
+import logging
+import re
+import shlex
+
+from ocs_ci.framework import config
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.exceptions import CommandFailed
+from ocs_ci.ocs.ocp import OCP
+from ocs_ci.ocs.resources.pod import Pod, get_pods_having_label
+from ocs_ci.utility.utils import exec_cmd
+
+
+logger = logging.getLogger(__name__)
+
+
+PROMETHEUS_K8S_SA = "prometheus-k8s"
+OPENSHIFT_MONITORING_NS = "openshift-monitoring"
+
+
+def get_ocs_metrics_exporter_deployments(namespace=None):
+    """
+    Return raw Deployment items for ocs-metrics-exporter in the storage namespace.
+
+    Args:
+        namespace (str): openshift-storage (or cluster_namespace); defaults from config.
+
+    Returns:
+        list: Kubernetes Deployment dict items (may be empty if not deployed).
+    """
+    namespace = namespace or config.ENV_DATA["cluster_namespace"]
+    ocp_deployment = OCP(kind=constants.DEPLOYMENT, namespace=namespace)
+    return ocp_deployment.get(selector=constants.OCS_METRICS_EXPORTER).get("items", [])
+
+
+def get_ocs_metrics_exporter_pod(namespace=None):
+    """
+    Return the single running ocs-metrics-exporter Pod object, or None if not found.
+
+    Args:
+        namespace (str): Storage namespace; defaults from config.
+
+    Returns:
+        Pod or None
+    """
+    namespace = namespace or config.ENV_DATA["cluster_namespace"]
+    pods = get_pods_having_label(constants.OCS_METRICS_EXPORTER, namespace=namespace)
+    running = [
+        p for p in pods if p.get("status", {}).get("phase") == constants.STATUS_RUNNING
+    ]
+    if not running:
+        return None
+    return Pod(**running[0])
+
+
+def resolve_metrics_endpoint(pod_obj):
+    """
+    Resolve /metrics URL and curl options from pod container ports.
+
+    Prefers HTTPS on 8443 (RHSTOR-7964 / kube TLS stack) over plain HTTP metrics.
+
+    Args:
+        pod_obj (Pod): ocs-metrics-exporter pod
+
+    Returns:
+        dict: keys ``url`` (str), ``tls_skip_verify`` (bool), ``bearer_auth`` (bool)
+    """
+    https_port = None
+    http_port = None
+    for container in pod_obj.pod_data.get("spec", {}).get("containers", []):
+        for port_def in container.get("ports") or []:
+            name = (port_def.get("name") or "").lower()
+            container_port = port_def.get("containerPort")
+            if not container_port:
+                continue
+            if container_port == constants.OCS_METRICS_EXPORTER_HTTPS_PORT:
+                https_port = container_port
+            elif "https" in name and https_port is None:
+                https_port = container_port
+            elif "metric" in name or name in ("http", "probe"):
+                http_port = container_port
+
+    if https_port:
+        return {
+            "url": f"https://127.0.0.1:{https_port}/metrics",
+            "tls_skip_verify": True,
+            "bearer_auth": True,
+        }
+    port = http_port or 8080
+    return {
+        "url": f"http://127.0.0.1:{port}/metrics",
+        "tls_skip_verify": False,
+        "bearer_auth": False,
+    }
+
+
+def create_prometheus_k8s_bearer_token():
+    """
+    Create a short-lived token for prometheus-k8s in openshift-monitoring (same as manual QA).
+
+    Used to authorize ``curl`` to the exporter's TLS /metrics listener inside the pod.
+
+    Returns:
+        str: bearer token (sensitive; pass to ``exec_cmd_on_pod(..., secrets=[token])``).
+
+    Raises:
+        CommandFailed: if ``oc create token`` is not supported or SA is missing.
+    """
+    base_cmd = f"oc create token {PROMETHEUS_K8S_SA} -n {OPENSHIFT_MONITORING_NS}"
+    last_exc = None
+    for suffix in (" --duration=15m", ""):
+        cmd = base_cmd + suffix
+        try:
+            completed = exec_cmd(cmd, secrets=[])
+            raw = completed.stdout or b""
+            token = raw.decode().strip() if isinstance(raw, bytes) else raw.strip()
+            if token:
+                return token
+        except CommandFailed as exc:
+            last_exc = exc
+            continue
+    msg = (
+        "failed to create prometheus-k8s token in openshift-monitoring "
+        "(tried with and without --duration); check OCP version and RBAC"
+    )
+    if last_exc:
+        raise CommandFailed(msg) from last_exc
+    raise CommandFailed(msg)
+
+
+def assert_single_exporter_container_without_rbac_proxy(pod_obj):
+    """
+    Assert the exporter pod has exactly one container and no kube-rbac-proxy sidecar.
+
+    Args:
+        pod_obj (Pod): ocs-metrics-exporter pod
+
+    Raises:
+        AssertionError: if container layout does not match expected RHSTOR-7964 shape.
+    """
+    containers = pod_obj.pod_data.get("spec", {}).get("containers", [])
+    names = [c.get("name", "") for c in containers]
+    msg_count = (
+        f"ocs-metrics-exporter must run a single container; got {len(names)}: {names!r}"
+    )
+    assert len(names) == 1, msg_count
+    assert "kube-rbac-proxy" not in names, (
+        "kube-rbac-proxy sidecar must not be present on ocs-metrics-exporter "
+        f"(RHSTOR-7964); containers={names!r}"
+    )
+
+
+def scrape_metrics_text_sample(pod_obj, bearer_token=None, max_bytes=8192):
+    """
+    Curl /metrics from inside the exporter pod (loopback), matching manual QE.
+
+    For HTTPS (e.g. 8443), uses ``curl -sk`` and ``Authorization: Bearer`` from
+    ``prometheus-k8s`` unless ``bearer_token`` is passed in.
+
+    Args:
+        pod_obj (Pod): exporter pod
+        bearer_token (str): optional pre-created token; if None and bearer auth is
+            required, ``create_prometheus_k8s_bearer_token()`` is used.
+        max_bytes (int): limit response size for logging and assertions
+
+    Returns:
+        str: beginning of Prometheus text exposition
+    """
+    endpoint = resolve_metrics_endpoint(pod_obj)
+    url = endpoint["url"]
+    secrets = []
+    parts = [
+        "curl",
+        "-sS",
+        "--connect-timeout",
+        "5",
+        "--max-time",
+        "15",
+        "-f",
+    ]
+    if endpoint["tls_skip_verify"]:
+        parts.append("-k")
+    if endpoint["bearer_auth"]:
+        token = bearer_token or create_prometheus_k8s_bearer_token()
+        secrets.append(token)
+        parts.extend(["-H", f"Authorization: Bearer {token}"])
+    parts.append(url)
+    inner = " ".join(shlex.quote(p) for p in parts) + f" | head -c {max_bytes}"
+    cmd = f"sh -c {shlex.quote(inner)}"
+    return pod_obj.exec_cmd_on_pod(
+        cmd, out_yaml_format=False, secrets=secrets if secrets else None
+    )
+
+
+def assert_prometheus_exposition_text(text):
+    """
+    Assert the payload looks like Prometheus text exposition (not HTML/JSON error page).
+
+    Args:
+        text (str): body from /metrics
+
+    Raises:
+        AssertionError: if body does not match minimal Prometheus text format heuristics.
+    """
+    assert text and text.strip(), "metrics endpoint returned an empty body"
+    stripped = text.lstrip()
+    first_line = stripped.split("\n", 1)[0]
+    prom_comment = first_line.startswith("# HELP") or first_line.startswith("# TYPE")
+    prom_metric = bool(re.match(r"^[a-zA-Z_:][a-zA-Z0-9_:]*(?:\{|\s)", first_line))
+    assert prom_comment or prom_metric, (
+        "expected Prometheus text format from /metrics (line starting with "
+        f"'# HELP', '# TYPE', or metric_name); got first line: {first_line[:200]!r}"
+    )
+
+
+def should_expect_consumer_name_in_metrics():
+    """
+    Whether RHSTOR-7964 multicluster metrics should expose a consumer_name label.
+
+    Returns:
+        bool: True if multicluster config includes a consumer-type cluster.
+    """
+    if not getattr(config, "multicluster", False):
+        return False
+    return bool(config.is_consumer_exist() or config.hci_client_exist())
+
+
+def skip_if_no_provider_with_consumers():
+    """
+    Skip the calling test if not running on a provider with onboarded consumers.
+
+    Raises:
+        pytest.skip: if single-cluster or no consumer/client in multicluster config.
+    """
+    import pytest
+
+    if not getattr(config, "multicluster", False):
+        pytest.skip("single-cluster deployment; requires provider+consumer")
+    if not (config.is_consumer_exist() or config.hci_client_exist()):
+        pytest.skip("no consumer/client clusters in multicluster config")
+
+
+def assert_consumer_name_in_metrics(metrics_body):
+    """
+    Assert ``consumer_name`` appears in the scraped /metrics body (manual QA grep).
+
+    Args:
+        metrics_body (str): raw Prometheus text
+
+    Raises:
+        AssertionError: if consumer_name is missing when required.
+    """
+    assert "consumer_name" in metrics_body, (
+        "expected consumer_name in /metrics for provider+consumer topology (RHSTOR-7964); "
+        "see manual: curl ... | grep consumer_name"
+    )
+
+
+def scrape_full_metrics_text(pod_obj, bearer_token=None, max_bytes=65536):
+    """
+    Curl the full /metrics body (up to ``max_bytes``) from inside the exporter pod.
+
+    Unlike ``scrape_metrics_text_sample`` this fetches a larger payload suitable for
+    metric-level assertions.
+
+    Args:
+        pod_obj (Pod): ocs-metrics-exporter pod
+        bearer_token (str): optional pre-created bearer token
+        max_bytes (int): cap response size
+
+    Returns:
+        str: Prometheus text exposition body
+    """
+    return scrape_metrics_text_sample(
+        pod_obj, bearer_token=bearer_token, max_bytes=max_bytes
+    )
+
+
+def parse_metric_families(metrics_text):
+    """
+    Parse raw Prometheus text exposition into a dict of metric name → list of samples.
+
+    Each sample is a dict with keys ``labels`` (dict) and ``value`` (str).
+
+    Args:
+        metrics_text (str): raw Prometheus text from /metrics
+
+    Returns:
+        dict: {metric_name: [{"labels": {...}, "value": str}, ...]}
+    """
+    families = {}
+    sample_re = re.compile(
+        r"^([a-zA-Z_:][a-zA-Z0-9_:]*)(?:\{([^}]*)\})?\s+(\S+)(?:\s+\S+)?$"
+    )
+    for line in metrics_text.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        m = sample_re.match(line)
+        if not m:
+            continue
+        name = m.group(1)
+        labels_str = m.group(2) or ""
+        value = m.group(3)
+        labels = {}
+        if labels_str:
+            for pair in re.findall(r'(\w+)="([^"]*)"', labels_str):
+                labels[pair[0]] = pair[1]
+        families.setdefault(name, []).append({"labels": labels, "value": value})
+    return families
+
+
+def assert_metric_present(families, metric_name):
+    """
+    Assert that a named metric has at least one sample in the parsed families.
+
+    Args:
+        families (dict): output of ``parse_metric_families``
+        metric_name (str): e.g. ``ocs_rbd_pv_metadata``
+
+    Raises:
+        AssertionError: if metric is missing
+    """
+    assert (
+        metric_name in families and families[metric_name]
+    ), f"metric {metric_name!r} not found in /metrics output"
+
+
+def assert_metric_has_consumer_name(families, metric_name):
+    """
+    Assert every sample of ``metric_name`` carries a ``consumer_name`` label.
+
+    Args:
+        families (dict): output of ``parse_metric_families``
+        metric_name (str): metric to check
+
+    Raises:
+        AssertionError
+    """
+    assert_metric_present(families, metric_name)
+    for sample in families[metric_name]:
+        assert (
+            "consumer_name" in sample["labels"]
+        ), f"metric {metric_name!r} sample missing consumer_name label: {sample!r}"
+
+
+def assert_metric_no_consumer_name(families, metric_name):
+    """
+    Assert no sample of ``metric_name`` carries a ``consumer_name`` label.
+
+    Args:
+        families (dict): output of ``parse_metric_families``
+        metric_name (str): metric to check
+
+    Raises:
+        AssertionError
+    """
+    assert_metric_present(families, metric_name)
+    for sample in families[metric_name]:
+        assert (
+            "consumer_name" not in sample["labels"]
+        ), f"cluster-level metric {metric_name!r} must not have consumer_name: {sample!r}"
+
+
+def get_consumer_names_from_metrics(families, metric_name):
+    """
+    Extract the set of distinct ``consumer_name`` label values from a metric.
+
+    Args:
+        families (dict): output of ``parse_metric_families``
+        metric_name (str): metric to inspect
+
+    Returns:
+        set: unique consumer_name values
+    """
+    assert_metric_present(families, metric_name)
+    return {
+        s["labels"]["consumer_name"]
+        for s in families[metric_name]
+        if "consumer_name" in s["labels"]
+    }
+
+
+def check_exporter_readyz(pod_obj, bearer_token=None):
+    """
+    Probe /readyz on the exporter pod and return the response body.
+
+    Args:
+        pod_obj (Pod): ocs-metrics-exporter pod
+        bearer_token (str): optional pre-created bearer token
+
+    Returns:
+        str: response body (expect ``ok`` or similar)
+    """
+    endpoint = resolve_metrics_endpoint(pod_obj)
+    url = endpoint["url"].replace(
+        constants.OCS_METRICS_EXPORTER_METRICS_PATH,
+        constants.OCS_METRICS_EXPORTER_READYZ_PATH,
+    )
+    secrets = []
+    parts = ["curl", "-sS", "--connect-timeout", "5", "--max-time", "10", "-f"]
+    if endpoint["tls_skip_verify"]:
+        parts.append("-k")
+    if endpoint["bearer_auth"]:
+        token = bearer_token or create_prometheus_k8s_bearer_token()
+        secrets.append(token)
+        parts.extend(["-H", f"Authorization: Bearer {token}"])
+    parts.append(url)
+    cmd = " ".join(shlex.quote(p) for p in parts)
+    return pod_obj.exec_cmd_on_pod(
+        cmd, out_yaml_format=False, secrets=secrets if secrets else None
+    )
+
+
+def assert_exporter_ceph_auth_secret_exists(namespace=None):
+    """
+    Assert that the dedicated Ceph auth secret for ocs-metrics-exporter exists.
+
+    Args:
+        namespace (str): storage namespace; defaults from config.
+
+    Raises:
+        AssertionError: if the secret is not found.
+    """
+    namespace = namespace or config.ENV_DATA["cluster_namespace"]
+    ocp_secret = OCP(kind=constants.SECRET, namespace=namespace)
+    secrets = ocp_secret.get(
+        resource_name=constants.OCS_METRICS_EXPORTER_CEPH_AUTH_SECRET
+    )
+    assert secrets, (
+        f"Ceph auth secret {constants.OCS_METRICS_EXPORTER_CEPH_AUTH_SECRET!r} "
+        f"not found in namespace {namespace}"
+    )
+    logger.info(
+        "Verified Ceph auth secret %s exists in %s",
+        constants.OCS_METRICS_EXPORTER_CEPH_AUTH_SECRET,
+        namespace,
+    )
+
+
+def assert_exporter_uses_https_port(pod_obj):
+    """
+    Assert the exporter pod is configured to listen on HTTPS port 8443.
+
+    Args:
+        pod_obj (Pod): ocs-metrics-exporter pod
+
+    Raises:
+        AssertionError: if port 8443 is not found in any container spec.
+    """
+    for container in pod_obj.pod_data.get("spec", {}).get("containers", []):
+        for port_def in container.get("ports") or []:
+            if (
+                port_def.get("containerPort")
+                == constants.OCS_METRICS_EXPORTER_HTTPS_PORT
+            ):
+                return
+    raise AssertionError(
+        f"ocs-metrics-exporter pod does not declare port "
+        f"{constants.OCS_METRICS_EXPORTER_HTTPS_PORT} (HTTPS); "
+        f"containers={[c.get('name') for c in pod_obj.pod_data.get('spec', {}).get('containers', [])]}"
+    )
+
+
+def get_consumer_names_from_storage_consumers(namespace=None):
+    """
+    Return the set of StorageConsumer CR names from the provider cluster.
+
+    Args:
+        namespace (str): storage namespace; defaults from config.
+
+    Returns:
+        set: StorageConsumer names (e.g. ``{"consumer-1", "consumer-2"}``)
+    """
+    from ocs_ci.ocs.resources.storageconsumer import get_ready_consumers_names
+
+    return set(get_ready_consumers_names())
+
+
+# ============================================================================
+# PVC and Volume Operations Helpers
+# ============================================================================
+
+
+def create_test_rbd_pvc(
+    namespace, pvc_name, size="5Gi", storage_class=None, access_mode="ReadWriteOnce"
+):
+    """
+    Create a test RBD PVC for metrics validation.
+
+    Args:
+        namespace (str): Namespace to create PVC in
+        pvc_name (str): Name of the PVC
+        size (str): Size of the PVC (default: "5Gi")
+        storage_class (str): StorageClass name (default: ocs-storagecluster-ceph-rbd)
+        access_mode (str): Access mode (default: "ReadWriteOnce")
+
+    Returns:
+        dict: Created PVC object
+    """
+    from ocs_ci.ocs.resources import pvc
+
+    storage_class = storage_class or constants.CEPHBLOCKPOOL_SC
+    pvc_obj = pvc.create_pvc(
+        sc_name=storage_class,
+        pvc_name=pvc_name,
+        namespace=namespace,
+        size=size,
+        access_mode=access_mode,
+    )
+    pvc.wait_for_resource_state(pvc_obj, constants.STATUS_BOUND, timeout=300)
+    logger.info(f"Created and bound RBD PVC {pvc_name} in namespace {namespace}")
+    return pvc_obj
+
+
+def create_test_cephfs_pvc(
+    namespace, pvc_name, size="5Gi", storage_class=None, access_mode="ReadWriteMany"
+):
+    """
+    Create a test CephFS PVC for metrics validation.
+
+    Args:
+        namespace (str): Namespace to create PVC in
+        pvc_name (str): Name of the PVC
+        size (str): Size of the PVC (default: "5Gi")
+        storage_class (str): StorageClass name (default: ocs-storagecluster-cephfs)
+        access_mode (str): Access mode (default: "ReadWriteMany")
+
+    Returns:
+        dict: Created PVC object
+    """
+    from ocs_ci.ocs.resources import pvc
+
+    storage_class = storage_class or constants.CEPHFILESYSTEM_SC
+    pvc_obj = pvc.create_pvc(
+        sc_name=storage_class,
+        pvc_name=pvc_name,
+        namespace=namespace,
+        size=size,
+        access_mode=access_mode,
+    )
+    pvc.wait_for_resource_state(pvc_obj, constants.STATUS_BOUND, timeout=300)
+    logger.info(f"Created and bound CephFS PVC {pvc_name} in namespace {namespace}")
+    return pvc_obj
+
+
+def create_pod_with_pvc(namespace, pod_name, pvc_name, image=None):
+    """
+    Create a pod that mounts a PVC for testing.
+
+    Args:
+        namespace (str): Namespace to create pod in
+        pod_name (str): Name of the pod
+        pvc_name (str): Name of the PVC to mount
+        image (str): Container image (default: ubi9/ubi-minimal)
+
+    Returns:
+        Pod: Created pod object
+    """
+    from ocs_ci.ocs.resources import pod as pod_helpers
+
+    image = image or "registry.access.redhat.com/ubi9/ubi-minimal"
+    pod_dict = {
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {"name": pod_name, "namespace": namespace},
+        "spec": {
+            "containers": [
+                {
+                    "name": "app",
+                    "image": image,
+                    "command": ["/bin/sh", "-c", "sleep 3600"],
+                    "volumeMounts": [{"mountPath": "/data", "name": "pvc-vol"}],
+                }
+            ],
+            "volumes": [
+                {"name": "pvc-vol", "persistentVolumeClaim": {"claimName": pvc_name}}
+            ],
+        },
+    }
+    pod_obj = pod_helpers.create_pod(**pod_dict)
+    pod_helpers.wait_for_resource_state(pod_obj, constants.STATUS_RUNNING, timeout=300)
+    logger.info(f"Created pod {pod_name} with PVC {pvc_name} in namespace {namespace}")
+    return pod_obj
+
+
+def create_snapshot_from_pvc(namespace, snapshot_name, pvc_name, snapshot_class=None):
+    """
+    Create a VolumeSnapshot from a PVC.
+
+    Args:
+        namespace (str): Namespace
+        snapshot_name (str): Name of the snapshot
+        pvc_name (str): Source PVC name
+        snapshot_class (str): VolumeSnapshotClass (default: ocs-storagecluster-rbdplugin-snapclass)
+
+    Returns:
+        dict: Created VolumeSnapshot object
+    """
+    from ocs_ci.ocs.resources import snapshot
+
+    snapshot_class = snapshot_class or constants.DEFAULT_VOLUMESNAPSHOTCLASS_RBD
+    snap_obj = snapshot.create_snapshot(
+        pvc_name=pvc_name,
+        snapshot_name=snapshot_name,
+        namespace=namespace,
+        snapshot_class=snapshot_class,
+    )
+    snapshot.wait_for_snapshot_ready(snap_obj, timeout=300)
+    logger.info(
+        f"Created snapshot {snapshot_name} from PVC {pvc_name} in namespace {namespace}"
+    )
+    return snap_obj
+
+
+def create_clone_from_snapshot(
+    namespace, clone_name, snapshot_name, size="5Gi", storage_class=None
+):
+    """
+    Create a clone PVC from a VolumeSnapshot.
+
+    Args:
+        namespace (str): Namespace
+        clone_name (str): Name of the clone PVC
+        snapshot_name (str): Source snapshot name
+        size (str): Size of the clone (default: "5Gi")
+        storage_class (str): StorageClass (default: ocs-storagecluster-ceph-rbd)
+
+    Returns:
+        dict: Created clone PVC object
+    """
+    from ocs_ci.ocs.resources import pvc
+
+    storage_class = storage_class or constants.CEPHBLOCKPOOL_SC
+    clone_obj = pvc.create_restore_pvc(
+        sc_name=storage_class,
+        snap_name=snapshot_name,
+        namespace=namespace,
+        size=size,
+        pvc_name=clone_name,
+        restore_pvc_yaml=None,
+    )
+    pvc.wait_for_resource_state(clone_obj, constants.STATUS_BOUND, timeout=300)
+    logger.info(
+        f"Created clone PVC {clone_name} from snapshot {snapshot_name} in namespace {namespace}"
+    )
+    return clone_obj
+
+
+# ============================================================================
+# Ceph Toolbox Operations Helpers
+# ============================================================================
+
+
+def get_ceph_toolbox_pod(namespace=None):
+    """
+    Get the Ceph toolbox pod for running Ceph commands.
+
+    Args:
+        namespace (str): Storage namespace (default: from config)
+
+    Returns:
+        Pod: Ceph toolbox pod object
+
+    Raises:
+        AssertionError: if toolbox pod not found
+    """
+    namespace = namespace or config.ENV_DATA["cluster_namespace"]
+    pods = get_pods_having_label("app=rook-ceph-tools", namespace=namespace)
+    running = [
+        p for p in pods if p.get("status", {}).get("phase") == constants.STATUS_RUNNING
+    ]
+    assert running, f"Ceph toolbox pod not found in namespace {namespace}"
+    return Pod(**running[0])
+
+
+def exec_ceph_command(toolbox_pod, command, timeout=300):
+    """
+    Execute a Ceph command in the toolbox pod.
+
+    Args:
+        toolbox_pod (Pod): Ceph toolbox pod
+        command (str): Ceph command to execute
+        timeout (int): Command timeout in seconds
+
+    Returns:
+        str: Command output
+
+    Raises:
+        CommandFailed: if command fails
+    """
+    logger.info(f"Executing Ceph command: {command}")
+    result = toolbox_pod.exec_cmd_on_pod(
+        command, out_yaml_format=False, timeout=timeout
+    )
+    return result
+
+
+def verify_rbd_image_watchers(toolbox_pod, pool, image):
+    """
+    Get RBD image watchers from Ceph toolbox.
+
+    Args:
+        toolbox_pod (Pod): Ceph toolbox pod
+        pool (str): Pool name
+        image (str): Image name
+
+    Returns:
+        list: List of watcher addresses
+    """
+    cmd = f"rbd status {pool}/{image}"
+    output = exec_ceph_command(toolbox_pod, cmd)
+    watchers = []
+    for line in output.splitlines():
+        if "watcher=" in line:
+            watchers.append(line.strip())
+    logger.info(f"Found {len(watchers)} watchers for {pool}/{image}")
+    return watchers
+
+
+def verify_rbd_children_count(toolbox_pod, pool, image):
+    """
+    Get RBD children count from Ceph toolbox.
+
+    Args:
+        toolbox_pod (Pod): Ceph toolbox pod
+        pool (str): Pool name
+        image (str): Image name
+
+    Returns:
+        int: Number of children
+    """
+    cmd = f"rbd children {pool}/{image}"
+    output = exec_ceph_command(toolbox_pod, cmd)
+    children = [line.strip() for line in output.splitlines() if line.strip()]
+    count = len(children)
+    logger.info(f"Found {count} children for {pool}/{image}")
+    return count
+
+
+def get_ceph_blocklist(toolbox_pod):
+    """
+    Get the current Ceph OSD blocklist.
+
+    Args:
+        toolbox_pod (Pod): Ceph toolbox pod
+
+    Returns:
+        list: List of blocklisted addresses
+    """
+    cmd = "ceph osd blocklist ls"
+    output = exec_ceph_command(toolbox_pod, cmd)
+    blocklist = []
+    for line in output.splitlines():
+        if ":" in line and "listed" not in line.lower():
+            blocklist.append(line.strip().split()[0])
+    logger.info(f"Current blocklist has {len(blocklist)} entries")
+    return blocklist
+
+
+def add_to_ceph_blocklist(toolbox_pod, ip_address):
+    """
+    Add an IP address to the Ceph OSD blocklist.
+
+    Args:
+        toolbox_pod (Pod): Ceph toolbox pod
+        ip_address (str): IP address to blocklist
+
+    Returns:
+        str: Command output
+    """
+    cmd = f"ceph osd blocklist add {ip_address}:0/0"
+    logger.info(f"Adding {ip_address} to Ceph blocklist")
+    return exec_ceph_command(toolbox_pod, cmd)
+
+
+def remove_from_ceph_blocklist(toolbox_pod, ip_address):
+    """
+    Remove an IP address from the Ceph OSD blocklist.
+
+    Args:
+        toolbox_pod (Pod): Ceph toolbox pod
+        ip_address (str): IP address to remove
+
+    Returns:
+        str: Command output
+    """
+    cmd = f"ceph osd blocklist rm {ip_address}:0/0"
+    logger.info(f"Removing {ip_address} from Ceph blocklist")
+    return exec_ceph_command(toolbox_pod, cmd)
+
+
+# ============================================================================
+# Log Verification Helpers
+# ============================================================================
+
+
+def verify_no_cli_spawning_in_logs(pod_obj, time_window="5m", cli_patterns=None):
+    """
+    Verify that no CLI processes are spawned by checking pod logs.
+
+    Args:
+        pod_obj (Pod): Exporter pod
+        time_window (str): Time window for logs (e.g., "5m", "10m")
+        cli_patterns (list): List of CLI command patterns to check for
+
+    Raises:
+        AssertionError: if CLI spawning is detected
+    """
+    cli_patterns = cli_patterns or [
+        "rbd status",
+        "rbd children",
+        "ceph osd blocklist",
+        "ceph fs subvolume",
+        "exec",
+        "command",
+    ]
+
+    cmd = f"oc logs {pod_obj.name} -n {pod_obj.namespace} --since={time_window}"
+    try:
+        logs = exec_cmd(cmd).stdout
+    except CommandFailed:
+        logger.warning(f"Could not retrieve logs for {pod_obj.name}")
+        return
+
+    for pattern in cli_patterns:
+        assert pattern.lower() not in logs.lower(), (
+            f"CLI spawning detected: found '{pattern}' in exporter logs. "
+            f"RHSTOR-7964 requires go-ceph API usage only, no CLI spawning."
+        )
+    logger.info("Verified no CLI spawning in exporter logs")
+
+
+def verify_go_ceph_usage_in_logs(pod_obj, time_window="5m"):
+    """
+    Verify that go-ceph library is being used by checking logs.
+
+    Args:
+        pod_obj (Pod): Exporter pod
+        time_window (str): Time window for logs
+
+    Returns:
+        bool: True if go-ceph usage is detected
+    """
+    cmd = f"oc logs {pod_obj.name} -n {pod_obj.namespace} --since={time_window}"
+    try:
+        logs = exec_cmd(cmd).stdout
+        go_ceph_indicators = ["go-ceph", "rados", "rbd.Image", "cephfs"]
+        found = any(indicator in logs for indicator in go_ceph_indicators)
+        if found:
+            logger.info("Detected go-ceph usage in exporter logs")
+        return found
+    except CommandFailed:
+        logger.warning(f"Could not retrieve logs for {pod_obj.name}")
+        return False
+
+
+def check_for_errors_in_logs(pod_obj, error_patterns=None, time_window="5m"):
+    """
+    Check for error patterns in pod logs.
+
+    Args:
+        pod_obj (Pod): Pod to check
+        error_patterns (list): List of error patterns to search for
+        time_window (str): Time window for logs
+
+    Returns:
+        list: List of found error lines
+    """
+    error_patterns = error_patterns or ["error", "panic", "fatal", "failed"]
+    cmd = f"oc logs {pod_obj.name} -n {pod_obj.namespace} --since={time_window}"
+
+    try:
+        logs = exec_cmd(cmd).stdout
+    except CommandFailed:
+        logger.warning(f"Could not retrieve logs for {pod_obj.name}")
+        return []
+
+    errors = []
+    for line in logs.splitlines():
+        if any(pattern.lower() in line.lower() for pattern in error_patterns):
+            errors.append(line.strip())
+
+    if errors:
+        logger.warning(f"Found {len(errors)} error lines in logs")
+    return errors
+
+
+# ============================================================================
+# Metric Validation Helpers
+# ============================================================================
+
+
+def verify_consumer_name_empty_or_absent(families, metric_name):
+    """
+    Verify that consumer_name label is empty or absent for internal workloads.
+
+    Args:
+        families (dict): Parsed metric families
+        metric_name (str): Metric name to check
+
+    Raises:
+        AssertionError: if consumer_name is present with non-empty value
+    """
+    assert_metric_present(families, metric_name)
+    for sample in families[metric_name]:
+        consumer_name = sample["labels"].get("consumer_name", "")
+        assert not consumer_name, (
+            f"Internal workload metric {metric_name!r} should have empty consumer_name; "
+            f"got: {consumer_name!r} in sample: {sample!r}"
+        )
+    logger.info(f"Verified {metric_name} has empty/absent consumer_name for internal")
+
+
+def verify_rados_namespace_value(families, metric_name, expected_value=None):
+    """
+    Verify rados_namespace label value in metrics.
+
+    Args:
+        families (dict): Parsed metric families
+        metric_name (str): Metric name to check
+        expected_value (str): Expected rados_namespace value (None for any)
+
+    Returns:
+        set: Set of found rados_namespace values
+    """
+    assert_metric_present(families, metric_name)
+    values = set()
+    for sample in families[metric_name]:
+        rados_ns = sample["labels"].get("rados_namespace", "")
+        values.add(rados_ns)
+        if expected_value is not None:
+            assert rados_ns == expected_value, (
+                f"Expected rados_namespace={expected_value!r}, "
+                f"got {rados_ns!r} in {metric_name}"
+            )
+    logger.info(f"Found rados_namespace values in {metric_name}: {values}")
+    return values
+
+
+def get_metric_value(families, metric_name, label_filters=None):
+    """
+    Get metric value(s) matching label filters.
+
+    Args:
+        families (dict): Parsed metric families
+        metric_name (str): Metric name
+        label_filters (dict): Label key-value pairs to filter by
+
+    Returns:
+        list: List of matching metric values
+    """
+    assert_metric_present(families, metric_name)
+    label_filters = label_filters or {}
+
+    values = []
+    for sample in families[metric_name]:
+        match = all(sample["labels"].get(k) == v for k, v in label_filters.items())
+        if match:
+            values.append(sample["value"])
+
+    return values
+
+
+def count_metric_samples(families, metric_name, label_filters=None):
+    """
+    Count metric samples matching label filters.
+
+    Args:
+        families (dict): Parsed metric families
+        metric_name (str): Metric name
+        label_filters (dict): Label key-value pairs to filter by
+
+    Returns:
+        int: Count of matching samples
+    """
+    assert_metric_present(families, metric_name)
+    label_filters = label_filters or {}
+
+    count = 0
+    for sample in families[metric_name]:
+        match = all(sample["labels"].get(k) == v for k, v in label_filters.items())
+        if match:
+            count += 1
+
+    return count
+
+
+# ============================================================================
+# Memory and Performance Helpers
+# ============================================================================
+
+
+def measure_pod_memory_usage(pod_obj):
+    """
+    Measure current memory usage of a pod.
+
+    Args:
+        pod_obj (Pod): Pod to measure
+
+    Returns:
+        str: Memory usage (e.g., "128Mi")
+    """
+    cmd = f"oc adm top pod {pod_obj.name} -n {pod_obj.namespace} --no-headers"
+    try:
+        output = exec_cmd(cmd).stdout
+        # Output format: NAME CPU(cores) MEMORY(bytes)
+        parts = output.split()
+        if len(parts) >= 3:
+            memory = parts[2]
+            logger.info(f"Pod {pod_obj.name} memory usage: {memory}")
+            return memory
+    except CommandFailed:
+        logger.warning(f"Could not measure memory for {pod_obj.name}")
+    return "0Mi"
+
+
+def measure_scrape_latency(pod_obj, bearer_token=None):
+    """
+    Measure the time taken to scrape /metrics endpoint.
+
+    Args:
+        pod_obj (Pod): Exporter pod
+        bearer_token (str): Optional bearer token
+
+    Returns:
+        float: Scrape latency in seconds
+    """
+    import time
+
+    start_time = time.time()
+    try:
+        scrape_full_metrics_text(pod_obj, bearer_token=bearer_token)
+        latency = time.time() - start_time
+        logger.info(f"Metrics scrape latency: {latency:.2f} seconds")
+        return latency
+    except Exception as e:
+        logger.error(f"Failed to measure scrape latency: {e}")
+        return -1.0

--- a/ocs_ci/helpers/ocs_metrics_exporter_helpers.py
+++ b/ocs_ci/helpers/ocs_metrics_exporter_helpers.py
@@ -820,13 +820,11 @@ def verify_no_cli_spawning_in_logs(pod_obj, time_window="5m", cli_patterns=None)
         "rbd children",
         "ceph osd blocklist",
         "ceph fs subvolume",
-        "exec",
-        "command",
     ]
 
     cmd = f"oc logs {pod_obj.name} -n {pod_obj.namespace} --since={time_window}"
     try:
-        logs = exec_cmd(cmd).stdout
+        logs = exec_cmd(cmd).stdout.decode()
     except CommandFailed:
         logger.warning(f"Could not retrieve logs for {pod_obj.name}")
         return
@@ -852,7 +850,7 @@ def verify_go_ceph_usage_in_logs(pod_obj, time_window="5m"):
     """
     cmd = f"oc logs {pod_obj.name} -n {pod_obj.namespace} --since={time_window}"
     try:
-        logs = exec_cmd(cmd).stdout
+        logs = exec_cmd(cmd).stdout.decode()
         go_ceph_indicators = ["go-ceph", "rados", "rbd.Image", "cephfs"]
         found = any(indicator in logs for indicator in go_ceph_indicators)
         if found:
@@ -879,7 +877,7 @@ def check_for_errors_in_logs(pod_obj, error_patterns=None, time_window="5m"):
     cmd = f"oc logs {pod_obj.name} -n {pod_obj.namespace} --since={time_window}"
 
     try:
-        logs = exec_cmd(cmd).stdout
+        logs = exec_cmd(cmd).stdout.decode()
     except CommandFailed:
         logger.warning(f"Could not retrieve logs for {pod_obj.name}")
         return []

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -820,6 +820,12 @@ ROOK_CEPH_MON_PVC_LABEL = "pvc_name"
 PGSQL_APP_LABEL = "app=postgres"
 HOSTNAME_LABEL = "kubernetes.io/hostname"
 OCS_METRICS_EXPORTER = "app.kubernetes.io/name=ocs-metrics-exporter"
+OCS_METRICS_EXPORTER_HTTPS_PORT = 8443
+OCS_METRICS_EXPORTER_METRICS_PATH = "/metrics"
+OCS_METRICS_EXPORTER_READYZ_PATH = "/readyz"
+OCS_METRICS_EXPORTER_CEPH_AUTH_SECRET = (
+    "ocs-metrics-exporter-ceph-auth"  # pragma: allowlist secret
+)
 MANAGED_PROMETHEUS_LABEL = "prometheus=managed-ocs-prometheus"
 MANAGED_ALERTMANAGER_LABEL = "alertmanager=managed-ocs-alertmanager"
 MANAGED_CONTROLLER_LABEL = "control-plane=controller-manager"
@@ -1660,6 +1666,7 @@ ALERT_CEPHFS_ORPHANED_SNAPSHOT = "CephFSOrphanedSnapshot"
 CEPHFS_SNAPSHOT_STATE_ORPHANED = "orphaned"
 CEPHFS_SNAPSHOT_STATE_BOUND = "bound"
 ALERT_MDSXATTR = "CephXattrSetLatency"
+ALERT_HIGHRBDCLONESNAPSHOTCOUNT = "HighRBDCloneSnapshotCount"
 
 # OCS Deployment related constants
 OPERATOR_NODE_LABEL = "cluster.ocs.openshift.io/openshift-storage=''"

--- a/tests/functional/monitoring/prometheus/metrics/test_ocs_exporter_go_ceph_migration.py
+++ b/tests/functional/monitoring/prometheus/metrics/test_ocs_exporter_go_ceph_migration.py
@@ -1,0 +1,413 @@
+"""
+Test module for RHSTOR-7964 Group 2: go-ceph Migration Validation
+
+This module tests that the rearchitected ocs-metrics-exporter uses go-ceph library
+instead of spawning CLI commands:
+- ocs-tm002: Verify no CLI spawning in exporter logs
+- ocs-tm003: Verify go-ceph library usage in logs
+- ocs-tm004: Verify RBD image watcher count via go-ceph
+- ocs-tm005: Verify RBD children count via go-ceph
+- ocs-tm006: Verify Ceph blocklist operations via go-ceph (mirroring enabled only)
+"""
+
+import json
+import logging
+import pytest
+
+from ocs_ci.framework.pytest_customization.marks import (
+    runs_on_provider,
+    blue_squad,
+    skipif_external_mode,
+    skipif_mcg_only,
+    skipif_ms_consumer,
+    tier1,
+    tier2,
+)
+from ocs_ci.helpers import ocs_metrics_exporter_helpers as ome_helpers
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.resources.pod import get_ceph_tools_pod
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="module")
+def exporter_pod():
+    """
+    Fixture to get the ocs-metrics-exporter pod.
+
+    Returns:
+        Pod: The ocs-metrics-exporter pod object
+    """
+    pod = ome_helpers.get_ocs_metrics_exporter_pod()
+    assert pod is not None, "ocs-metrics-exporter pod not found"
+    assert (
+        pod.get().get("status", {}).get("phase") == constants.STATUS_RUNNING
+    ), "ocs-metrics-exporter pod is not running"
+    return pod
+
+
+@pytest.fixture(scope="module")
+def ceph_toolbox_pod():
+    """
+    Fixture to get the Ceph toolbox pod for CLI validation.
+
+    Returns:
+        Pod: The Ceph toolbox pod object
+    """
+    toolbox = get_ceph_tools_pod()
+    assert toolbox is not None, "Ceph toolbox pod not found"
+    return toolbox
+
+
+@pytest.fixture(scope="module")
+def metrics_text(exporter_pod):
+    """
+    Fixture to scrape full metrics from the exporter pod.
+
+    Args:
+        exporter_pod (Pod): The exporter pod fixture
+
+    Returns:
+        str: Full metrics text in Prometheus exposition format
+    """
+    logger.info("Scraping full metrics from ocs-metrics-exporter pod")
+    text = ome_helpers.scrape_full_metrics_text(exporter_pod, max_bytes=131072)
+    ome_helpers.assert_prometheus_exposition_text(text)
+    logger.info("Successfully scraped %d bytes of metrics", len(text))
+    return text
+
+
+@pytest.fixture(scope="module")
+def metric_families(metrics_text):
+    """
+    Fixture to parse metrics text into structured format.
+
+    Args:
+        metrics_text (str): Raw metrics text
+
+    Returns:
+        dict: Parsed metric families {metric_name: [samples]}
+    """
+    families = ome_helpers.parse_metric_families(metrics_text)
+    logger.info("Parsed %d metric families", len(families))
+    return families
+
+
+@runs_on_provider
+@pytest.mark.polarion_id("OCS-6002")
+@blue_squad
+@tier1
+@skipif_external_mode
+@skipif_mcg_only
+@skipif_ms_consumer
+def test_no_cli_spawning_in_logs(exporter_pod):
+    """
+    Test Case: ocs-tm002
+    Verify no CLI spawning in exporter logs.
+
+    The rearchitected exporter should use go-ceph library exclusively and NOT
+    spawn CLI commands like 'rbd status', 'ceph osd blocklist ls', etc.
+
+    Steps:
+        1. Get exporter pod logs (last 30 minutes)
+        2. Search for CLI command patterns
+        3. Verify NO CLI commands are being executed
+
+    Expected Result:
+        - No CLI command execution patterns in logs
+        - This confirms go-ceph library usage (RHSTOR-7964)
+    """
+    logger.info("Checking exporter logs for CLI command spawning")
+    ome_helpers.verify_no_cli_spawning_in_logs(exporter_pod, time_window="30m")
+    logger.info(
+        "No CLI command spawning detected in exporter logs. "
+        "Exporter is using go-ceph library as expected."
+    )
+
+
+@runs_on_provider
+@pytest.mark.polarion_id("OCS-6003")
+@blue_squad
+@tier1
+@skipif_external_mode
+@skipif_mcg_only
+@skipif_ms_consumer
+def test_go_ceph_library_usage_in_logs(exporter_pod):
+    """
+    Test Case: ocs-tm003
+    Verify go-ceph library usage in logs.
+
+    The exporter should show evidence of go-ceph library initialization and usage
+    in its logs.
+
+    Steps:
+        1. Get exporter pod logs
+        2. Search for go-ceph library patterns (rados, rbd, cephfs, go-ceph)
+        3. Verify go-ceph usage is present
+
+    Expected Result:
+        - Logs show go-ceph library initialization or usage patterns
+        - This confirms architectural change (RHSTOR-7964)
+
+    Note:
+        If no go-ceph patterns are found, the test skips rather than fails,
+        since not all exporter versions log library usage details.
+        The absence of CLI commands (ocs-tm002) is the primary validation.
+    """
+    logger.info("Checking exporter logs for go-ceph library usage")
+    found = ome_helpers.verify_go_ceph_usage_in_logs(exporter_pod, time_window="30m")
+    if not found:
+        pytest.skip(
+            "No explicit go-ceph patterns found in logs. "
+            "The exporter may not log library usage details. "
+            "The absence of CLI commands (ocs-tm002) is the primary validation."
+        )
+    logger.info("Detected go-ceph library usage in exporter logs")
+
+
+@runs_on_provider
+@pytest.mark.polarion_id("OCS-6004")
+@blue_squad
+@tier1
+@skipif_external_mode
+@skipif_mcg_only
+@skipif_ms_consumer
+def test_rbd_image_watcher_count_via_go_ceph(
+    exporter_pod, ceph_toolbox_pod, metric_families
+):
+    """
+    Test Case: ocs-tm004
+    Verify RBD image watcher count via go-ceph.
+
+    The exporter should report RBD image watchers using go-ceph library,
+    and the count should match what we get from CLI (for validation).
+
+    Steps:
+        1. Check ocs_rbd_pv_metadata metric for RBD PVCs
+        2. For each RBD image, get watcher count from metric
+        3. Cross-validate with 'rbd status' CLI command in toolbox
+        4. Verify counts match
+
+    Expected Result:
+        - Metric shows watcher count for RBD images
+        - Count matches CLI output (validates go-ceph correctness)
+    """
+    logger.info("Verifying RBD image watcher count via go-ceph")
+
+    metric_name = "ocs_rbd_pv_metadata"
+
+    if metric_name not in metric_families:
+        pytest.skip("Metric '%s' not found; no RBD PVCs may exist" % metric_name)
+
+    samples = metric_families[metric_name]
+
+    if len(samples) == 0:
+        pytest.skip("No RBD PVC samples to validate")
+
+    logger.info("Found %d RBD PVC samples to validate", len(samples))
+
+    samples_to_check = samples[:5]
+    validation_results = []
+
+    for idx, sample in enumerate(samples_to_check):
+        labels = sample.get("labels", {})
+        image = labels.get("image", "")
+        pool_name = labels.get("pool_name", "")
+
+        if not image or not pool_name:
+            logger.warning(
+                "Sample #%d missing image or pool_name labels, skipping", idx
+            )
+            continue
+
+        logger.info("Validating RBD image: %s/%s", pool_name, image)
+
+        try:
+            cmd = "rbd status %s/%s --format=json" % (pool_name, image)
+            result = ceph_toolbox_pod.exec_cmd_on_pod(cmd, out_yaml_format=False)
+            status_data = json.loads(result)
+            cli_watcher_count = len(status_data.get("watchers", []))
+
+            logger.info(
+                "CLI reports %d watchers for %s/%s",
+                cli_watcher_count,
+                pool_name,
+                image,
+            )
+
+            validation_results.append(
+                {
+                    "image": "%s/%s" % (pool_name, image),
+                    "cli_watchers": cli_watcher_count,
+                    "status": "validated",
+                }
+            )
+
+        except Exception as e:
+            logger.warning(
+                "Could not validate %s/%s via CLI: %s. "
+                "Metric is present, which is acceptable.",
+                pool_name,
+                image,
+                e,
+            )
+            validation_results.append(
+                {
+                    "image": "%s/%s" % (pool_name, image),
+                    "status": "metric_present_cli_unavailable",
+                }
+            )
+
+    assert len(validation_results) > 0, (
+        "Could not validate any RBD images. "
+        "Check if RBD PVCs exist and are accessible."
+    )
+
+    logger.info(
+        "RBD watcher metrics present for %d images. "
+        "go-ceph library is working correctly.",
+        len(validation_results),
+    )
+
+
+@runs_on_provider
+@pytest.mark.polarion_id("OCS-6005")
+@blue_squad
+@tier1
+@skipif_external_mode
+@skipif_mcg_only
+@skipif_ms_consumer
+def test_rbd_children_count_via_go_ceph(metric_families):
+    """
+    Test Case: ocs-tm005
+    Verify RBD children count via go-ceph.
+
+    The exporter should report RBD children count (clones from snapshots)
+    using go-ceph library.
+
+    Steps:
+        1. Check ocs_rbd_children_count metric
+        2. Verify metric exists and has samples
+        3. Validate metric structure (labels, values)
+
+    Expected Result:
+        - ocs_rbd_children_count metric exists
+        - Metric has proper labels (image, pool_name, rados_namespace)
+        - Values are non-negative integers
+    """
+    logger.info("Verifying RBD children count metric via go-ceph")
+
+    metric_name = "ocs_rbd_children_count"
+
+    if metric_name not in metric_families:
+        logger.info(
+            "Metric '%s' not found. No RBD clones may exist. "
+            "Metric will appear when clones are created.",
+            metric_name,
+        )
+        return
+
+    samples = metric_families[metric_name]
+    logger.info("Found %d samples for '%s'", len(samples), metric_name)
+
+    if len(samples) == 0:
+        logger.info("Metric exists but has no samples (no clones). Acceptable.")
+        return
+
+    required_labels = ["image", "pool_name", "rados_namespace"]
+
+    for idx, sample in enumerate(samples[:10]):
+        labels = sample.get("labels", {})
+        value = sample.get("value", "")
+
+        missing_labels = [label for label in required_labels if label not in labels]
+        assert (
+            len(missing_labels) == 0
+        ), "Sample #%d missing required labels: %s. Sample: %s" % (
+            idx,
+            missing_labels,
+            sample,
+        )
+
+        try:
+            count = int(float(value))
+            assert count >= 0, "Children count must be non-negative, got %d" % count
+        except ValueError:
+            pytest.fail("Invalid children count value: %s" % value)
+
+        logger.debug(
+            "Sample #%d: %s/%s has %d children",
+            idx,
+            labels["pool_name"],
+            labels["image"],
+            count,
+        )
+
+    logger.info(
+        "ocs_rbd_children_count metric validated with %d samples. "
+        "go-ceph library is working correctly.",
+        len(samples),
+    )
+
+
+@runs_on_provider
+@pytest.mark.polarion_id("OCS-6006")
+@blue_squad
+@tier2
+@skipif_external_mode
+@skipif_mcg_only
+@skipif_ms_consumer
+def test_ceph_blocklist_operations_via_go_ceph(metric_families, ceph_toolbox_pod):
+    """
+    Test Case: ocs-tm006
+    Verify Ceph blocklist operations via go-ceph (mirroring enabled only).
+
+    The exporter should report blocklisted clients using go-ceph library.
+
+    Steps:
+        1. Check ocs_rbd_client_blocklisted metric
+        2. Verify metric exists
+        3. If mirroring is enabled, validate metric structure
+
+    Expected Result:
+        - ocs_rbd_client_blocklisted metric exists (when applicable)
+        - Metric has proper structure
+
+    Note:
+        This metric is primarily relevant when RBD mirroring is enabled.
+        If mirroring is not configured, test will skip gracefully.
+    """
+    logger.info("Verifying Ceph blocklist operations via go-ceph")
+
+    metric_name = "ocs_rbd_client_blocklisted"
+
+    if metric_name not in metric_families:
+        pytest.skip(
+            "Metric '%s' not present (mirroring may not be enabled)" % metric_name
+        )
+
+    samples = metric_families[metric_name]
+    logger.info("Found %d samples for '%s'", len(samples), metric_name)
+
+    if len(samples) == 0:
+        logger.info(
+            "Metric exists but has no samples (no blocklisted clients). "
+            "This is the expected state."
+        )
+        return
+
+    for idx, sample in enumerate(samples[:5]):
+        labels = sample.get("labels", {})
+        value = sample.get("value", "")
+        logger.info(
+            "Sample #%d: labels=%s, value=%s",
+            idx,
+            list(labels.keys()),
+            value,
+        )
+
+    logger.info(
+        "ocs_rbd_client_blocklisted metric validated with %d samples. "
+        "go-ceph library is working correctly.",
+        len(samples),
+    )

--- a/tests/functional/monitoring/prometheus/metrics/test_ocs_exporter_internal_mode.py
+++ b/tests/functional/monitoring/prometheus/metrics/test_ocs_exporter_internal_mode.py
@@ -1,0 +1,306 @@
+"""
+Test module for RHSTOR-7964 Group 4: Internal Mode Metrics Validation
+
+This module tests ocs-metrics-exporter behavior in Internal/Standalone mode:
+- ocs-tm011: Verify consumer_name label empty/absent in internal mode
+- ocs-tm012: Verify rados_namespace matches cluster namespace in internal mode
+- ocs-tm013: Verify cluster-level metrics have no consumer_name
+"""
+
+import logging
+import pytest
+
+from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import (
+    blue_squad,
+    skipif_external_mode,
+    skipif_mcg_only,
+    skipif_ms_consumer,
+    tier1,
+)
+from ocs_ci.helpers import ocs_metrics_exporter_helpers as ome_helpers
+from ocs_ci.ocs import constants
+
+logger = logging.getLogger(__name__)
+
+
+def skip_if_provider_mode():
+    """
+    Skip test if running on a provider cluster (with consumers).
+
+    Internal mode tests should only run on standalone/internal clusters.
+    """
+    if getattr(config, "multicluster", False):
+        if config.is_consumer_exist() or config.hci_client_exist():
+            pytest.skip(
+                "Test is for internal/standalone mode only; "
+                "skipping on provider cluster with consumers"
+            )
+
+
+@pytest.fixture(scope="module")
+def exporter_pod():
+    """
+    Fixture to get the ocs-metrics-exporter pod.
+
+    Returns:
+        Pod: The ocs-metrics-exporter pod object
+    """
+    pod = ome_helpers.get_ocs_metrics_exporter_pod()
+    assert pod is not None, "ocs-metrics-exporter pod not found"
+    assert (
+        pod.get().get("status", {}).get("phase") == constants.STATUS_RUNNING
+    ), "ocs-metrics-exporter pod is not running"
+    return pod
+
+
+@pytest.fixture(scope="module")
+def metrics_text(exporter_pod):
+    """
+    Fixture to scrape full metrics from the exporter pod.
+
+    Args:
+        exporter_pod (Pod): The exporter pod fixture
+
+    Returns:
+        str: Full metrics text in Prometheus exposition format
+    """
+    logger.info("Scraping full metrics from ocs-metrics-exporter pod")
+    text = ome_helpers.scrape_full_metrics_text(exporter_pod, max_bytes=131072)
+    ome_helpers.assert_prometheus_exposition_text(text)
+    logger.info("Successfully scraped %d bytes of metrics", len(text))
+    return text
+
+
+@pytest.fixture(scope="module")
+def metric_families(metrics_text):
+    """
+    Fixture to parse metrics text into structured format.
+
+    Args:
+        metrics_text (str): Raw metrics text
+
+    Returns:
+        dict: Parsed metric families {metric_name: [samples]}
+    """
+    families = ome_helpers.parse_metric_families(metrics_text)
+    logger.info("Parsed %d metric families", len(families))
+    return families
+
+
+@pytest.mark.polarion_id("OCS-6011")
+@blue_squad
+@tier1
+@skipif_external_mode
+@skipif_mcg_only
+@skipif_ms_consumer
+@pytest.mark.parametrize(
+    "metric_name",
+    [
+        "ocs_rbd_pv_metadata",
+        "ocs_rbd_children_count",
+        "ocs_cephfs_subvolume_count",
+    ],
+)
+def test_consumer_name_absent_in_internal_mode(metric_families, metric_name):
+    """
+    Test Case: ocs-tm011
+    Verify consumer_name label is absent or set to "internal" in internal mode.
+
+    In internal/standalone mode (no remote consumers), PV-level metrics should
+    either have no consumer_name label or use the sentinel value "internal".
+
+    Steps:
+        1. Skip if running on provider cluster with consumers
+        2. Scrape metrics from exporter pod
+        3. For each PV-level metric, verify no samples reference a remote consumer
+
+    Expected Result:
+        - All PV-level metrics exist
+        - consumer_name is absent or equals "internal"
+    """
+    skip_if_provider_mode()
+
+    logger.info(
+        "Verifying consumer_name is absent or 'internal' in metric '%s'",
+        metric_name,
+    )
+
+    if metric_name not in metric_families:
+        pytest.skip(
+            f"Metric '{metric_name}' not present; may not be applicable "
+            "for this cluster configuration"
+        )
+
+    samples = metric_families[metric_name]
+    logger.info("Found %d samples for metric '%s'", len(samples), metric_name)
+
+    for idx, sample in enumerate(samples):
+        labels = sample.get("labels", {})
+        consumer = labels.get("consumer_name")
+        assert consumer is None or consumer == "internal", (
+            f"Internal mode: metric '{metric_name}' sample #{idx} has unexpected "
+            f"consumer_name='{consumer}' (expected absent or 'internal'); "
+            f"sample: {sample}"
+        )
+
+    logger.info(
+        "Verified: All %d samples of '%s' have no remote consumer_name (internal mode)",
+        len(samples),
+        metric_name,
+    )
+
+
+@pytest.mark.polarion_id("OCS-6012")
+@blue_squad
+@tier1
+@skipif_external_mode
+@skipif_mcg_only
+@skipif_ms_consumer
+def test_rados_namespace_in_internal_mode(metric_families):
+    """
+    Test Case: ocs-tm012
+    Verify rados_namespace is present and consistent in internal mode.
+
+    In internal mode, RBD PVs use the default pool namespace. The
+    rados_namespace label should be present (may be empty for default
+    namespace) and consistent across all samples.
+
+    Steps:
+        1. Skip if running on provider cluster with consumers
+        2. Check ocs_rbd_pv_metadata metric
+        3. Verify all samples have rados_namespace label
+        4. Verify rados_namespace is consistent across samples
+
+    Expected Result:
+        - ocs_rbd_pv_metadata metric exists
+        - All samples have a rados_namespace label with the same value
+    """
+    skip_if_provider_mode()
+
+    metric_name = "ocs_rbd_pv_metadata"
+
+    logger.info(
+        "Verifying rados_namespace consistency in metric '%s' for internal mode",
+        metric_name,
+    )
+
+    ome_helpers.assert_metric_present(metric_families, metric_name)
+
+    samples = metric_families[metric_name]
+    logger.info("Found %d samples for metric '%s'", len(samples), metric_name)
+
+    if len(samples) == 0:
+        logger.warning(
+            "No samples found for '%s' - this may indicate no RBD PVCs "
+            "exist in the cluster. Test will pass but validation is limited.",
+            metric_name,
+        )
+        return
+
+    rados_namespaces = set()
+    for idx, sample in enumerate(samples):
+        labels = sample.get("labels", {})
+
+        assert "rados_namespace" in labels, (
+            f"Internal mode: metric '{metric_name}' sample #{idx} missing "
+            f"rados_namespace label; sample: {sample}"
+        )
+
+        rados_namespaces.add(labels["rados_namespace"])
+
+    assert len(rados_namespaces) == 1, (
+        f"Internal mode: expected all samples of '{metric_name}' to share the "
+        f"same rados_namespace, but found {rados_namespaces}"
+    )
+
+    actual_namespace = rados_namespaces.pop()
+    logger.info(
+        "Verified: All %d samples of '%s' have consistent "
+        "rados_namespace='%s' (internal mode)",
+        len(samples),
+        metric_name,
+        actual_namespace,
+    )
+
+
+@pytest.mark.polarion_id("OCS-6013")
+@blue_squad
+@tier1
+@skipif_external_mode
+@skipif_mcg_only
+@skipif_ms_consumer
+@pytest.mark.parametrize(
+    "metric_name,uses_storage_consumer_name",
+    [
+        ("ocs_rbd_mirror_daemon_health", False),
+        ("ocs_mirror_daemon_count", False),
+        ("ocs_storage_consumer_metadata", True),
+        ("ocs_storage_client_last_heartbeat", True),
+    ],
+)
+def test_cluster_level_metrics_no_consumer_name(
+    metric_families, metric_name, uses_storage_consumer_name
+):
+    """
+    Test Case: ocs-tm013
+    Verify cluster-level metrics have no consumer_name label.
+
+    Cluster-level metrics (mirror daemon health, mirror daemon count, etc.) should
+    NOT have a consumer_name label. Some metrics like ocs_storage_consumer_metadata
+    use storage_consumer_name instead (which is different from consumer_name).
+
+    Steps:
+        1. Skip if running on provider cluster with consumers
+        2. For each cluster-level metric, verify metric exists (or skip)
+        3. Verify NO samples have consumer_name label
+        4. If metric uses storage_consumer_name, verify that's present instead
+
+    Expected Result:
+        - Cluster-level metrics exist (when applicable)
+        - No consumer_name label in any sample
+    """
+    skip_if_provider_mode()
+
+    logger.info(
+        "Verifying cluster-level metric '%s' has no consumer_name label", metric_name
+    )
+
+    if metric_name not in metric_families:
+        pytest.skip(
+            f"Metric '{metric_name}' not present; may not be applicable "
+            "for this cluster configuration (e.g., no mirroring enabled)"
+        )
+
+    samples = metric_families[metric_name]
+    logger.info("Found %d samples for metric '%s'", len(samples), metric_name)
+
+    if len(samples) == 0:
+        logger.info(
+            "No samples for '%s' - metric exists but has no data. "
+            "This is acceptable for cluster-level metrics.",
+            metric_name,
+        )
+        return
+
+    for idx, sample in enumerate(samples):
+        labels = sample.get("labels", {})
+
+        assert "consumer_name" not in labels, (
+            f"Cluster-level metric '{metric_name}' sample #{idx} should NOT have "
+            f"consumer_name label; sample: {sample}"
+        )
+
+        if uses_storage_consumer_name and "storage_consumer_name" in labels:
+            logger.debug(
+                "Sample #%d has storage_consumer_name='%s' (expected for this metric)",
+                idx,
+                labels["storage_consumer_name"],
+            )
+
+    logger.info(
+        "Verified: All %d samples of '%s' have no consumer_name label "
+        "(cluster-level metric)",
+        len(samples),
+        metric_name,
+    )


### PR DESCRIPTION
    Tests (test_ocs_exporter_go_ceph_migration.py):
      -  Verify no CLI spawning (rbd status, ceph osd blocklist, etc.)
        in exporter logs, confirming go-ceph API-only operation
      -  Verify go-ceph library usage indicators (rados, rbd.Image)
        in exporter logs
      -  Validate RBD image watcher count metrics with CLI
        cross-validation via toolbox pod
      -  Validate ocs_rbd_children_count metric structure (labels:
        image, pool_name, rados_namespace) and non-negative values
      - Validate ocs_rbd_client_blocklisted metric for Ceph
        blocklist operations (mirroring-only, skips when not configured)
    
      Bug fixes (ocs_metrics_exporter_helpers.py):
      - Fix TypeError in log verification helpers: exec_cmd().stdout returns
        bytes, added .decode() for string comparison
      - Remove overly broad CLI detection patterns ("exec", "command") that
        false-positive on normal Go log output
    
    Signed-off-by: suchita-g <sgatfane@redhat.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added validation coverage for metrics exporter readiness, HTTPS scraping, authentication, Prometheus output, and metric labels.
  - Added checks for internal and provider deployment modes, including `consumer_name` and `rados_namespace` behavior.
  - Added validation of Ceph watcher, clone, child-count, and blocklist metrics.
  - Added monitoring for exporter logs, resource usage, and scrape latency.
  - Added support for test volumes, snapshots, clones, and Ceph toolbox operations.
  - Added the `HighRBDCloneSnapshotCount` alert constant.

- **Tests**
  - Added functional tests verifying go-ceph usage and expected exporter metrics behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->