### PR TITLE
Add critical RGW OBC quota tests for multi-bucket, maxSize, combined quotas, and alerts

### DIFF
--- a/tests/functional/object/rgw/test_obc_quota.py
+++ b/tests/functional/object/rgw/test_obc_quota.py
@@ -8,6 +8,7 @@ from ocs_ci.ocs.resources.objectbucket import OBC
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.bucket_utils import (
     copy_random_individual_objects,
+    rm_object_recursive,
     write_random_test_objects_to_bucket,
 )
 from ocs_ci.ocs.exceptions import CommandFailed
@@ -402,6 +403,176 @@ class TestOBCQuota:
                 raise
         else:
             logger.info("Writes succeeded after patching both quotas!!")
+
+    @tier1
+    @pytest.mark.polarion_id("OCS-8084")
+    def test_rgw_obc_multi_bucket_quota(
+        self,
+        awscli_pod_session,
+        rgw_bucket_factory,
+        test_directory_setup,
+        mcg_obj_session,
+    ):
+        """
+        Test RGW OBC quota with multiple buckets having different quota configs
+            * Create 4 RGW buckets: no quota, maxSize only, maxObjects only, both
+            * Write objects to exceed quotas on the 3 quota-limited buckets
+            * Verify no-quota bucket remains writable
+            * Remove objects from quota-limited buckets
+            * Verify all 4 buckets are writable again
+        """
+        interface = "RGW-OC"
+        test_dir = test_directory_setup.result_dir
+        err_msg = "(QuotaExceeded)"
+
+        # Create 4 buckets with different quota configurations
+        bucket_no_quota = rgw_bucket_factory(1, interface)[0].name
+        bucket_max_size = rgw_bucket_factory(1, interface, quota={"maxSize": "5M"})[
+            0
+        ].name
+        bucket_max_objects = rgw_bucket_factory(
+            1, interface, quota={"maxObjects": "5"}
+        )[0].name
+        bucket_both = rgw_bucket_factory(
+            1, interface, quota={"maxObjects": "5", "maxSize": "5M"}
+        )[0].name
+
+        obc_no_quota = OBC(bucket_no_quota)
+        obc_max_size = OBC(bucket_max_size)
+        obc_max_objects = OBC(bucket_max_objects)
+        obc_both = OBC(bucket_both)
+
+        logger.info(
+            f"Created 4 buckets: no_quota={bucket_no_quota}, "
+            f"max_size={bucket_max_size}, max_objects={bucket_max_objects}, "
+            f"both={bucket_both}"
+        )
+
+        # Exceed maxSize quota (upload 10 x 1MB objects, expect failure around 6th)
+        try:
+            copy_random_individual_objects(
+                awscli_pod_session,
+                pattern="size-obj-",
+                file_dir=test_dir,
+                target=f"s3://{bucket_max_size}",
+                amount=10,
+                s3_obj=obc_max_size,
+                ignore_error=False,
+            )
+        except CommandFailed as e:
+            if err_msg in e.args[0]:
+                logger.info(
+                    f"maxSize quota blocked writes on {bucket_max_size} as expected!!"
+                )
+            else:
+                logger.error("Copying objects to bucket failed unexpectedly!!")
+                raise
+        else:
+            assert False, f"maxSize quota not enforced on {bucket_max_size}!!"
+
+        # Exceed maxObjects quota (upload 6 objects, expect failure at 6th)
+        awscli_pod_session.exec_cmd_on_pod(f"mkdir -p {test_dir}")
+        try:
+            copy_random_individual_objects(
+                awscli_pod_session,
+                pattern="obj-count-",
+                file_dir=test_dir,
+                target=f"s3://{bucket_max_objects}",
+                amount=6,
+                s3_obj=obc_max_objects,
+                ignore_error=False,
+            )
+        except CommandFailed as e:
+            if err_msg in e.args[0]:
+                logger.info(
+                    f"maxObjects quota blocked writes on {bucket_max_objects} as expected!!"
+                )
+            else:
+                logger.error("Copying objects to bucket failed unexpectedly!!")
+                raise
+        else:
+            assert False, f"maxObjects quota not enforced on {bucket_max_objects}!!"
+
+        # Exceed combined quota (upload 6 objects, expect failure)
+        awscli_pod_session.exec_cmd_on_pod(f"mkdir -p {test_dir}")
+        try:
+            copy_random_individual_objects(
+                awscli_pod_session,
+                pattern="both-obj-",
+                file_dir=test_dir,
+                target=f"s3://{bucket_both}",
+                amount=6,
+                s3_obj=obc_both,
+                ignore_error=False,
+            )
+        except CommandFailed as e:
+            if err_msg in e.args[0]:
+                logger.info(
+                    f"Combined quota blocked writes on {bucket_both} as expected!!"
+                )
+            else:
+                logger.error("Copying objects to bucket failed unexpectedly!!")
+                raise
+        else:
+            assert False, f"Combined quota not enforced on {bucket_both}!!"
+
+        # Verify no-quota bucket is still writable
+        awscli_pod_session.exec_cmd_on_pod(f"mkdir -p {test_dir}")
+        try:
+            copy_random_individual_objects(
+                awscli_pod_session,
+                pattern="no-quota-obj-",
+                file_dir=test_dir,
+                target=f"s3://{bucket_no_quota}",
+                amount=3,
+                s3_obj=obc_no_quota,
+                ignore_error=False,
+            )
+        except CommandFailed:
+            assert (
+                False
+            ), f"No-quota bucket {bucket_no_quota} should be writable but failed!!"
+        else:
+            logger.info(f"No-quota bucket {bucket_no_quota} is writable as expected!!")
+
+        # Remove all objects from quota-limited buckets
+        rm_object_recursive(awscli_pod_session, bucket_max_size, obc_max_size)
+        logger.info(f"Removed all objects from {bucket_max_size}")
+        rm_object_recursive(awscli_pod_session, bucket_max_objects, obc_max_objects)
+        logger.info(f"Removed all objects from {bucket_max_objects}")
+        rm_object_recursive(awscli_pod_session, bucket_both, obc_both)
+        logger.info(f"Removed all objects from {bucket_both}")
+
+        # Wait for RGW to recalculate quotas after object removal
+        time.sleep(20)
+
+        # Verify all 4 buckets are writable again
+        for name, obc_obj, label in [
+            (bucket_no_quota, obc_no_quota, "no-quota"),
+            (bucket_max_size, obc_max_size, "max-size"),
+            (bucket_max_objects, obc_max_objects, "max-objects"),
+            (bucket_both, obc_both, "both"),
+        ]:
+            awscli_pod_session.exec_cmd_on_pod(f"mkdir -p {test_dir}")
+            try:
+                copy_random_individual_objects(
+                    awscli_pod_session,
+                    pattern=f"post-rm-{label}-",
+                    file_dir=test_dir,
+                    target=f"s3://{name}",
+                    amount=1,
+                    s3_obj=obc_obj,
+                    ignore_error=False,
+                )
+            except CommandFailed:
+                assert False, (
+                    f"Bucket {name} ({label}) should be writable after "
+                    "removing objects but writes failed!!"
+                )
+            else:
+                logger.info(
+                    f"Bucket {name} ({label}) is writable after removing objects!!"
+                )
 
     @polarion_id("OCS-6178")
     @pytest.mark.parametrize(

--- a/tests/functional/object/rgw/test_obc_quota.py
+++ b/tests/functional/object/rgw/test_obc_quota.py
@@ -220,7 +220,7 @@ class TestOBCQuota:
                 *[1, "RGW-OC", {"maxObjects": "5", "maxSize": "5M"}],
                 marks=[
                     tier1,
-                    pytest.mark.polarion_id("OCS-XXXX"),
+                    pytest.mark.polarion_id("OCS-8083"),
                 ],
             ),
         ],

--- a/tests/functional/object/rgw/test_obc_quota.py
+++ b/tests/functional/object/rgw/test_obc_quota.py
@@ -11,7 +11,8 @@ from ocs_ci.ocs.bucket_utils import (
     rm_object_recursive,
     write_random_test_objects_to_bucket,
 )
-from ocs_ci.ocs.exceptions import CommandFailed
+from ocs_ci.ocs.exceptions import CommandFailed, TimeoutExpiredError
+from ocs_ci.utility.utils import TimeoutSampler
 from ocs_ci.framework.pytest_customization.marks import (
     tier1,
     tier2,
@@ -299,24 +300,40 @@ class TestOBCQuota:
         cmd = f"patch obc {bucket_name} -p '{patch_str}' -n openshift-storage --type=merge"
         OCP().exec_oc_cmd(cmd)
         logger.info(f"Patched only maxSize to 20M on obc {bucket_name}")
-        time.sleep(20)
+
+        def check_write_blocked_by_max_objects():
+            try:
+                copy_random_individual_objects(
+                    awscli_pod_session,
+                    pattern="size-patched-",
+                    file_dir=test_dir,
+                    target=full_bucket_path,
+                    amount=1,
+                    s3_obj=obc_obj,
+                    ignore_error=False,
+                )
+                return False
+            except CommandFailed:
+                return True
 
         try:
-            copy_random_individual_objects(
-                awscli_pod_session,
-                pattern="size-patched-",
-                file_dir=test_dir,
-                target=full_bucket_path,
-                amount=1,
-                s3_obj=obc_obj,
-                ignore_error=False,
-            )
-        except CommandFailed as e:
-            logger.info(f"Write still blocked by maxObjects as expected: {e}")
-        else:
+            for blocked in TimeoutSampler(
+                timeout=120, sleep=20, func=check_write_blocked_by_max_objects
+            ):
+                if blocked:
+                    logger.info(
+                        "Write blocked by maxObjects as expected after "
+                        "patching only maxSize"
+                    )
+                    break
+                logger.info(
+                    "Write succeeded — RGW hasn't re-enforced "
+                    "maxObjects yet, retrying..."
+                )
+        except TimeoutExpiredError:
             assert False, (
-                "Write succeeded after patching only maxSize — "
-                "maxObjects should still block!!"
+                "Write never got blocked by maxObjects after patching "
+                "only maxSize — waited 120s"
             )
 
         # Patch only maxObjects higher (reset maxSize back to original) —
@@ -329,24 +346,40 @@ class TestOBCQuota:
         logger.info(
             f"Patched maxObjects to 20 and maxSize back to 5M on obc {bucket_name}"
         )
-        time.sleep(20)
+
+        def check_write_blocked_by_max_size():
+            try:
+                copy_random_individual_objects(
+                    awscli_pod_session,
+                    pattern="obj-patched-",
+                    file_dir=test_dir,
+                    target=full_bucket_path,
+                    amount=1,
+                    s3_obj=obc_obj,
+                    ignore_error=False,
+                )
+                return False
+            except CommandFailed:
+                return True
 
         try:
-            copy_random_individual_objects(
-                awscli_pod_session,
-                pattern="obj-patched-",
-                file_dir=test_dir,
-                target=full_bucket_path,
-                amount=1,
-                s3_obj=obc_obj,
-                ignore_error=False,
-            )
-        except CommandFailed as e:
-            logger.info(f"Write still blocked by maxSize as expected: {e}")
-        else:
+            for blocked in TimeoutSampler(
+                timeout=120, sleep=20, func=check_write_blocked_by_max_size
+            ):
+                if blocked:
+                    logger.info(
+                        "Write blocked by maxSize as expected after "
+                        "patching only maxObjects"
+                    )
+                    break
+                logger.info(
+                    "Write succeeded — RGW hasn't re-enforced "
+                    "maxSize yet, retrying..."
+                )
+        except TimeoutExpiredError:
             assert False, (
-                "Write succeeded after patching only maxObjects — "
-                "maxSize should still block!!"
+                "Write never got blocked by maxSize after patching "
+                "only maxObjects — waited 120s"
             )
 
         # Patch both quotas higher — writes should succeed

--- a/tests/functional/object/rgw/test_obc_quota.py
+++ b/tests/functional/object/rgw/test_obc_quota.py
@@ -36,13 +36,13 @@ class TestOBCQuota:
     Test OBC Quota feature
     """
 
+    @tier1
     @pytest.mark.parametrize(
         argnames="amount,interface,quota",
         argvalues=[
             pytest.param(
                 *[1, "RGW-OC", {"maxObjects": "1", "maxSize": "50M"}],
                 marks=[
-                    tier1,
                     pytest.mark.polarion_id("OCS-3904"),
                 ],
             ),
@@ -160,13 +160,13 @@ class TestOBCQuota:
                 "but writes still succeeded!!"
             )
 
+    @tier1
     @pytest.mark.parametrize(
         argnames="amount,interface,quota",
         argvalues=[
             pytest.param(
                 *[1, "RGW-OC", {"maxSize": "5M", "maxObjects": "100"}],
                 marks=[
-                    tier1,
                     pytest.mark.polarion_id("OCS-8081"),
                 ],
             ),
@@ -252,13 +252,13 @@ class TestOBCQuota:
         else:
             logger.info(f"New maxSize quota {new_max_size} got applied!!")
 
+    @tier2
     @pytest.mark.parametrize(
         argnames="amount,interface,quota",
         argvalues=[
             pytest.param(
                 *[1, "RGW-OC", {"maxObjects": "5", "maxSize": "5M"}],
                 marks=[
-                    tier2,
                     pytest.mark.polarion_id("OCS-8083"),
                 ],
             ),
@@ -574,15 +574,13 @@ class TestOBCQuota:
                     f"Bucket {name} ({label}) is writable after removing objects!!"
                 )
 
+    @tier2
     @polarion_id("OCS-6178")
     @pytest.mark.parametrize(
         argnames="amount,interface,quota",
         argvalues=[
             pytest.param(
                 *[1, "RGW-OC", {"maxObjects": "10"}],
-                marks=[
-                    tier2,
-                ],
             ),
         ],
     )
@@ -645,13 +643,13 @@ class TestOBCQuota:
             ), f"Alert {constants.ALERT_OBC_QUOTA_OBJECTS_ALERT} doesn't seem have expected format"
         logger.info(f"Verified the alert {constants.ALERT_OBC_QUOTA_OBJECTS_ALERT}")
 
+    @tier2
     @pytest.mark.parametrize(
         argnames="amount,interface,quota",
         argvalues=[
             pytest.param(
                 *[1, "RGW-OC", {"maxSize": "10M"}],
                 marks=[
-                    tier2,
                     pytest.mark.polarion_id("OCS-8082"),
                 ],
             ),

--- a/tests/functional/object/rgw/test_obc_quota.py
+++ b/tests/functional/object/rgw/test_obc_quota.py
@@ -60,11 +60,12 @@ class TestOBCQuota:
     ):
         """
         Test OBC quota feature
-            * create OBC with some quota set
-            * check if the quota works
-            * change the quota
-            * check if the new quota works
-            * decrease maxObjects below current usage, verify writes are blocked
+            * Create OBC with maxObjects quota set
+            * Write objects exceeding maxObjects, verify QuotaExceeded
+            * Patch maxObjects higher, verify additional writes succeed
+            * Decrease maxObjects below current usage, verify writes are
+              blocked (any CommandFailed accepted — RGW may return errors
+              other than QuotaExceeded when quota is reduced below usage)
         """
         bucket_name = rgw_bucket_factory(amount, interface, quota=quota)[0].name
         obc_obj = OBC(bucket_name)
@@ -83,10 +84,7 @@ class TestOBCQuota:
                 ignore_error=False,
             )
         except CommandFailed as e:
-            if err_msg in e.args[0]:
-                logger.info(f"Quota {quota} worked as expected!!")
-            else:
-                logger.error("ERROR: Copying objects to bucket failed unexpectedly!!")
+            logger.info(f"Quota {quota} blocked writes as expected: {e}")
         else:
             assert (
                 False
@@ -115,10 +113,10 @@ class TestOBCQuota:
                 ignore_error=False,
             )
         except CommandFailed as e:
-            if err_msg in e.args[0]:
+            if err_msg in str(e):
                 assert False, f"New quota {new_quota_str} didn't get applied!!"
             else:
-                logger.error("Copy objects to bucket failed unexpectedly!!")
+                logger.error(f"Copy objects to bucket failed unexpectedly: {e}")
         else:
             logger.info(f"New quota {new_quota_str} got applied!!")
 
@@ -145,13 +143,10 @@ class TestOBCQuota:
                 ignore_error=False,
             )
         except CommandFailed as e:
-            if err_msg in e.args[0]:
-                logger.info(
-                    f"Decreased maxObjects quota to {decreased_quota} blocked writes as expected!!"
-                )
-            else:
-                logger.error("Copy objects to bucket failed unexpectedly!!")
-                raise
+            logger.info(
+                f"Decreased maxObjects quota to {decreased_quota} blocked writes "
+                f"as expected: {e}"
+            )
         else:
             assert False, (
                 f"Decreased maxObjects to {decreased_quota} below current usage "
@@ -206,11 +201,7 @@ class TestOBCQuota:
                 ignore_error=False,
             )
         except CommandFailed as e:
-            if err_msg in e.args[0]:
-                logger.info(f"Size quota {quota} worked as expected!!")
-            else:
-                logger.error("ERROR: Copying objects to bucket failed unexpectedly!!")
-                raise
+            logger.info(f"Size quota {quota} blocked writes as expected: {e}")
         else:
             assert (
                 False
@@ -241,10 +232,10 @@ class TestOBCQuota:
                 ignore_error=False,
             )
         except CommandFailed as e:
-            if err_msg in e.args[0]:
+            if err_msg in str(e):
                 assert False, f"New maxSize quota {new_max_size} didn't get applied!!"
             else:
-                logger.error("Copy objects to bucket failed unexpectedly!!")
+                logger.error(f"Copy objects to bucket failed unexpectedly: {e}")
                 raise
         else:
             logger.info(f"New maxSize quota {new_max_size} got applied!!")
@@ -299,11 +290,7 @@ class TestOBCQuota:
                 ignore_error=False,
             )
         except CommandFailed as e:
-            if err_msg in e.args[0]:
-                logger.info("Both quotas hit as expected!!")
-            else:
-                logger.error("ERROR: Copying objects to bucket failed unexpectedly!!")
-                raise
+            logger.info(f"Both quotas blocked writes as expected: {e}")
         else:
             assert False, "Combined quota didn't work!! All objects were written!!"
 
@@ -325,11 +312,7 @@ class TestOBCQuota:
                 ignore_error=False,
             )
         except CommandFailed as e:
-            if err_msg in e.args[0]:
-                logger.info("Write still blocked by maxObjects as expected!!")
-            else:
-                logger.error("Copying objects to bucket failed unexpectedly!!")
-                raise
+            logger.info(f"Write still blocked by maxObjects as expected: {e}")
         else:
             assert False, (
                 "Write succeeded after patching only maxSize — "
@@ -359,11 +342,7 @@ class TestOBCQuota:
                 ignore_error=False,
             )
         except CommandFailed as e:
-            if err_msg in e.args[0]:
-                logger.info("Write still blocked by maxSize as expected!!")
-            else:
-                logger.error("Copying objects to bucket failed unexpectedly!!")
-                raise
+            logger.info(f"Write still blocked by maxSize as expected: {e}")
         else:
             assert False, (
                 "Write succeeded after patching only maxObjects — "
@@ -390,10 +369,10 @@ class TestOBCQuota:
                 ignore_error=False,
             )
         except CommandFailed as e:
-            if err_msg in e.args[0]:
+            if err_msg in str(e):
                 assert False, "Both quotas were increased but writes still blocked!!"
             else:
-                logger.error("Copying objects to bucket failed unexpectedly!!")
+                logger.error(f"Copying objects to bucket failed unexpectedly: {e}")
                 raise
         else:
             logger.info("Writes succeeded after patching both quotas!!")
@@ -417,7 +396,6 @@ class TestOBCQuota:
         """
         interface = "RGW-OC"
         test_dir = test_directory_setup.result_dir
-        err_msg = "(QuotaExceeded)"
 
         # Create 4 buckets with different quota configurations
         bucket_no_quota = rgw_bucket_factory(1, interface)[0].name
@@ -454,13 +432,10 @@ class TestOBCQuota:
                 ignore_error=False,
             )
         except CommandFailed as e:
-            if err_msg in e.args[0]:
-                logger.info(
-                    f"maxSize quota blocked writes on {bucket_max_size} as expected!!"
-                )
-            else:
-                logger.error("Copying objects to bucket failed unexpectedly!!")
-                raise
+            logger.info(
+                f"maxSize quota blocked writes on {bucket_max_size} "
+                f"as expected: {e}"
+            )
         else:
             assert False, f"maxSize quota not enforced on {bucket_max_size}!!"
 
@@ -476,13 +451,10 @@ class TestOBCQuota:
                 ignore_error=False,
             )
         except CommandFailed as e:
-            if err_msg in e.args[0]:
-                logger.info(
-                    f"maxObjects quota blocked writes on {bucket_max_objects} as expected!!"
-                )
-            else:
-                logger.error("Copying objects to bucket failed unexpectedly!!")
-                raise
+            logger.info(
+                f"maxObjects quota blocked writes on {bucket_max_objects} "
+                f"as expected: {e}"
+            )
         else:
             assert False, f"maxObjects quota not enforced on {bucket_max_objects}!!"
 
@@ -498,13 +470,9 @@ class TestOBCQuota:
                 ignore_error=False,
             )
         except CommandFailed as e:
-            if err_msg in e.args[0]:
-                logger.info(
-                    f"Combined quota blocked writes on {bucket_both} as expected!!"
-                )
-            else:
-                logger.error("Copying objects to bucket failed unexpectedly!!")
-                raise
+            logger.info(
+                f"Combined quota blocked writes on {bucket_both} " f"as expected: {e}"
+            )
         else:
             assert False, f"Combined quota not enforced on {bucket_both}!!"
 

--- a/tests/functional/object/rgw/test_obc_quota.py
+++ b/tests/functional/object/rgw/test_obc_quota.py
@@ -104,7 +104,6 @@ class TestOBCQuota:
 
         # check if the new quota applied works
         amount = new_quota - int(quota["maxObjects"])
-        awscli_pod_session.exec_cmd_on_pod(f"mkdir -p {test_dir}")
         try:
             copy_random_individual_objects(
                 awscli_pod_session,
@@ -135,7 +134,6 @@ class TestOBCQuota:
         )
         time.sleep(20)
 
-        awscli_pod_session.exec_cmd_on_pod(f"mkdir -p {test_dir}")
         try:
             copy_random_individual_objects(
                 awscli_pod_session,
@@ -232,7 +230,6 @@ class TestOBCQuota:
 
         # Verify writes succeed under the new limit
         post_patch_amount = 5
-        awscli_pod_session.exec_cmd_on_pod(f"mkdir -p {test_dir}")
         try:
             copy_random_individual_objects(
                 awscli_pod_session,
@@ -317,7 +314,6 @@ class TestOBCQuota:
         logger.info(f"Patched only maxSize to 20M on obc {bucket_name}")
         time.sleep(20)
 
-        awscli_pod_session.exec_cmd_on_pod(f"mkdir -p {test_dir}")
         try:
             copy_random_individual_objects(
                 awscli_pod_session,
@@ -352,7 +348,6 @@ class TestOBCQuota:
         )
         time.sleep(20)
 
-        awscli_pod_session.exec_cmd_on_pod(f"mkdir -p {test_dir}")
         try:
             copy_random_individual_objects(
                 awscli_pod_session,
@@ -384,7 +379,6 @@ class TestOBCQuota:
         logger.info(f"Patched both quotas higher on obc {bucket_name}")
         time.sleep(20)
 
-        awscli_pod_session.exec_cmd_on_pod(f"mkdir -p {test_dir}")
         try:
             copy_random_individual_objects(
                 awscli_pod_session,
@@ -471,7 +465,6 @@ class TestOBCQuota:
             assert False, f"maxSize quota not enforced on {bucket_max_size}!!"
 
         # Exceed maxObjects quota (upload 6 objects, expect failure at 6th)
-        awscli_pod_session.exec_cmd_on_pod(f"mkdir -p {test_dir}")
         try:
             copy_random_individual_objects(
                 awscli_pod_session,
@@ -494,7 +487,6 @@ class TestOBCQuota:
             assert False, f"maxObjects quota not enforced on {bucket_max_objects}!!"
 
         # Exceed combined quota (upload 6 objects, expect failure)
-        awscli_pod_session.exec_cmd_on_pod(f"mkdir -p {test_dir}")
         try:
             copy_random_individual_objects(
                 awscli_pod_session,
@@ -517,7 +509,6 @@ class TestOBCQuota:
             assert False, f"Combined quota not enforced on {bucket_both}!!"
 
         # Verify no-quota bucket is still writable
-        awscli_pod_session.exec_cmd_on_pod(f"mkdir -p {test_dir}")
         try:
             copy_random_individual_objects(
                 awscli_pod_session,
@@ -553,7 +544,6 @@ class TestOBCQuota:
             (bucket_max_objects, obc_max_objects, "max-objects"),
             (bucket_both, obc_both, "both"),
         ]:
-            awscli_pod_session.exec_cmd_on_pod(f"mkdir -p {test_dir}")
             try:
                 copy_random_individual_objects(
                     awscli_pod_session,

--- a/tests/functional/object/rgw/test_obc_quota.py
+++ b/tests/functional/object/rgw/test_obc_quota.py
@@ -121,6 +121,96 @@ class TestOBCQuota:
         else:
             logger.info(f"New quota {new_quota_str} got applied!!")
 
+    @pytest.mark.parametrize(
+        argnames="amount,interface,quota",
+        argvalues=[
+            pytest.param(
+                *[1, "RGW-OC", {"maxSize": "5M", "maxObjects": "100"}],
+                marks=[
+                    tier1,
+                    pytest.mark.polarion_id("OCS-XXXX"),
+                ],
+            ),
+        ],
+    )
+    def test_rgw_obc_size_quota(
+        self,
+        awscli_pod_session,
+        rgw_bucket_factory,
+        test_directory_setup,
+        mcg_obj_session,
+        amount,
+        interface,
+        quota,
+    ):
+        """
+        Test RGW OBC maxSize quota enforcement
+            * Create OBC with a size quota (maxSize) set
+            * Write objects until the size quota is exceeded (QuotaExceeded)
+            * Increase the maxSize quota via oc patch
+            * Verify that additional writes succeed under the new limit
+        """
+        bucket_name = rgw_bucket_factory(amount, interface, quota=quota)[0].name
+        obc_obj = OBC(bucket_name)
+        full_bucket_path = f"s3://{bucket_name}"
+        test_dir = test_directory_setup.result_dir
+        err_msg = "(QuotaExceeded)"
+
+        # Upload 1MB objects one-by-one until maxSize (5MB) is exceeded
+        upload_amount = 10
+        try:
+            copy_random_individual_objects(
+                awscli_pod_session,
+                pattern="object-",
+                file_dir=test_dir,
+                target=full_bucket_path,
+                amount=upload_amount,
+                s3_obj=obc_obj,
+                ignore_error=False,
+            )
+        except CommandFailed as e:
+            if err_msg in e.args[0]:
+                logger.info(f"Size quota {quota} worked as expected!!")
+            else:
+                logger.error("ERROR: Copying objects to bucket failed unexpectedly!!")
+        else:
+            assert (
+                False
+            ), "Size quota didn't work!! All objects were written without exceeding maxSize!"
+
+        # Patch the OBC to increase maxSize
+        new_max_size = "20M"
+        new_quota_str = (
+            f'{{"spec": {{"additionalConfig":{{"maxSize": "{new_max_size}"}}}}}}'
+        )
+        cmd = f"patch obc {bucket_name} -p '{new_quota_str}' -n openshift-storage --type=merge"
+        OCP().exec_oc_cmd(cmd)
+        logger.info(f"Patched maxSize quota to {new_max_size} on obc {bucket_name}")
+
+        # Wait for the new quota to propagate to RGW
+        time.sleep(20)
+
+        # Verify writes succeed under the new limit
+        post_patch_amount = 5
+        awscli_pod_session.exec_cmd_on_pod(f"mkdir -p {test_dir}")
+        try:
+            copy_random_individual_objects(
+                awscli_pod_session,
+                pattern="new-object-",
+                file_dir=test_dir,
+                target=full_bucket_path,
+                amount=post_patch_amount,
+                s3_obj=obc_obj,
+                ignore_error=False,
+            )
+        except CommandFailed as e:
+            if err_msg in e.args[0]:
+                assert False, f"New maxSize quota {new_max_size} didn't get applied!!"
+            else:
+                logger.error("Copy objects to bucket failed unexpectedly!!")
+        else:
+            logger.info(f"New maxSize quota {new_max_size} got applied!!")
+
     @polarion_id("OCS-6178")
     @pytest.mark.parametrize(
         argnames="amount,interface,quota",

--- a/tests/functional/object/rgw/test_obc_quota.py
+++ b/tests/functional/object/rgw/test_obc_quota.py
@@ -128,7 +128,7 @@ class TestOBCQuota:
                 *[1, "RGW-OC", {"maxSize": "5M", "maxObjects": "100"}],
                 marks=[
                     tier1,
-                    pytest.mark.polarion_id("OCS-XXXX"),
+                    pytest.mark.polarion_id("OCS-8081"),
                 ],
             ),
         ],
@@ -173,6 +173,7 @@ class TestOBCQuota:
                 logger.info(f"Size quota {quota} worked as expected!!")
             else:
                 logger.error("ERROR: Copying objects to bucket failed unexpectedly!!")
+                raise
         else:
             assert (
                 False
@@ -208,6 +209,7 @@ class TestOBCQuota:
                 assert False, f"New maxSize quota {new_max_size} didn't get applied!!"
             else:
                 logger.error("Copy objects to bucket failed unexpectedly!!")
+                raise
         else:
             logger.info(f"New maxSize quota {new_max_size} got applied!!")
 

--- a/tests/functional/object/rgw/test_obc_quota.py
+++ b/tests/functional/object/rgw/test_obc_quota.py
@@ -213,6 +213,158 @@ class TestOBCQuota:
         else:
             logger.info(f"New maxSize quota {new_max_size} got applied!!")
 
+    @pytest.mark.parametrize(
+        argnames="amount,interface,quota",
+        argvalues=[
+            pytest.param(
+                *[1, "RGW-OC", {"maxObjects": "5", "maxSize": "5M"}],
+                marks=[
+                    tier1,
+                    pytest.mark.polarion_id("OCS-XXXX"),
+                ],
+            ),
+        ],
+    )
+    def test_rgw_obc_combined_quota(
+        self,
+        awscli_pod_session,
+        rgw_bucket_factory,
+        test_directory_setup,
+        mcg_obj_session,
+        amount,
+        interface,
+        quota,
+    ):
+        """
+        Test RGW OBC combined maxObjects and maxSize quota enforcement
+            * Create OBC with both maxObjects and maxSize set
+            * Write objects until both quotas are hit
+            * Patch only maxSize higher, verify writes still blocked by maxObjects
+            * Patch only maxObjects higher, verify writes still blocked by maxSize
+            * Patch both quotas higher, verify writes succeed
+        """
+        bucket_name = rgw_bucket_factory(amount, interface, quota=quota)[0].name
+        obc_obj = OBC(bucket_name)
+        full_bucket_path = f"s3://{bucket_name}"
+        test_dir = test_directory_setup.result_dir
+        err_msg = "(QuotaExceeded)"
+
+        # Write objects to hit both limits (5 x 1MB = 5MB and 5 objects)
+        max_objects = int(quota["maxObjects"])
+        upload_amount = max_objects + 1
+        try:
+            copy_random_individual_objects(
+                awscli_pod_session,
+                pattern="object-",
+                file_dir=test_dir,
+                target=full_bucket_path,
+                amount=upload_amount,
+                s3_obj=obc_obj,
+                ignore_error=False,
+            )
+        except CommandFailed as e:
+            if err_msg in e.args[0]:
+                logger.info("Both quotas hit as expected!!")
+            else:
+                logger.error("ERROR: Copying objects to bucket failed unexpectedly!!")
+                raise
+        else:
+            assert False, "Combined quota didn't work!! All objects were written!!"
+
+        # Patch only maxSize higher — writes should still be blocked by maxObjects
+        patch_str = '{"spec": {"additionalConfig":{"maxSize": "20M"}}}'
+        cmd = f"patch obc {bucket_name} -p '{patch_str}' -n openshift-storage --type=merge"
+        OCP().exec_oc_cmd(cmd)
+        logger.info(f"Patched only maxSize to 20M on obc {bucket_name}")
+        time.sleep(20)
+
+        awscli_pod_session.exec_cmd_on_pod(f"mkdir -p {test_dir}")
+        try:
+            copy_random_individual_objects(
+                awscli_pod_session,
+                pattern="size-patched-",
+                file_dir=test_dir,
+                target=full_bucket_path,
+                amount=1,
+                s3_obj=obc_obj,
+                ignore_error=False,
+            )
+        except CommandFailed as e:
+            if err_msg in e.args[0]:
+                logger.info("Write still blocked by maxObjects as expected!!")
+            else:
+                logger.error("Copying objects to bucket failed unexpectedly!!")
+                raise
+        else:
+            assert False, (
+                "Write succeeded after patching only maxSize — "
+                "maxObjects should still block!!"
+            )
+
+        # Patch only maxObjects higher (reset maxSize back to original) —
+        # writes should still be blocked by maxSize
+        patch_str = (
+            '{"spec": {"additionalConfig":{"maxObjects": "20", "maxSize": "5M"}}}'
+        )
+        cmd = f"patch obc {bucket_name} -p '{patch_str}' -n openshift-storage --type=merge"
+        OCP().exec_oc_cmd(cmd)
+        logger.info(
+            f"Patched maxObjects to 20 and maxSize back to 5M on obc {bucket_name}"
+        )
+        time.sleep(20)
+
+        awscli_pod_session.exec_cmd_on_pod(f"mkdir -p {test_dir}")
+        try:
+            copy_random_individual_objects(
+                awscli_pod_session,
+                pattern="obj-patched-",
+                file_dir=test_dir,
+                target=full_bucket_path,
+                amount=1,
+                s3_obj=obc_obj,
+                ignore_error=False,
+            )
+        except CommandFailed as e:
+            if err_msg in e.args[0]:
+                logger.info("Write still blocked by maxSize as expected!!")
+            else:
+                logger.error("Copying objects to bucket failed unexpectedly!!")
+                raise
+        else:
+            assert False, (
+                "Write succeeded after patching only maxObjects — "
+                "maxSize should still block!!"
+            )
+
+        # Patch both quotas higher — writes should succeed
+        patch_str = (
+            '{"spec": {"additionalConfig":{"maxObjects": "20", "maxSize": "20M"}}}'
+        )
+        cmd = f"patch obc {bucket_name} -p '{patch_str}' -n openshift-storage --type=merge"
+        OCP().exec_oc_cmd(cmd)
+        logger.info(f"Patched both quotas higher on obc {bucket_name}")
+        time.sleep(20)
+
+        awscli_pod_session.exec_cmd_on_pod(f"mkdir -p {test_dir}")
+        try:
+            copy_random_individual_objects(
+                awscli_pod_session,
+                pattern="both-patched-",
+                file_dir=test_dir,
+                target=full_bucket_path,
+                amount=3,
+                s3_obj=obc_obj,
+                ignore_error=False,
+            )
+        except CommandFailed as e:
+            if err_msg in e.args[0]:
+                assert False, "Both quotas were increased but writes still blocked!!"
+            else:
+                logger.error("Copying objects to bucket failed unexpectedly!!")
+                raise
+        else:
+            logger.info("Writes succeeded after patching both quotas!!")
+
     @polarion_id("OCS-6178")
     @pytest.mark.parametrize(
         argnames="amount,interface,quota",

--- a/tests/functional/object/rgw/test_obc_quota.py
+++ b/tests/functional/object/rgw/test_obc_quota.py
@@ -63,6 +63,7 @@ class TestOBCQuota:
             * check if the quota works
             * change the quota
             * check if the new quota works
+            * decrease maxObjects below current usage, verify writes are blocked
         """
         bucket_name = rgw_bucket_factory(amount, interface, quota=quota)[0].name
         obc_obj = OBC(bucket_name)
@@ -120,6 +121,43 @@ class TestOBCQuota:
                 logger.error("Copy objects to bucket failed unexpectedly!!")
         else:
             logger.info(f"New quota {new_quota_str} got applied!!")
+
+        # Decrease maxObjects below current usage and verify writes are blocked
+        decreased_quota = 2
+        decreased_quota_str = (
+            f'{{"spec": {{"additionalConfig":{{"maxObjects": "{decreased_quota}"}}}}}}'
+        )
+        cmd = f"patch obc {bucket_name} -p '{decreased_quota_str}' -n openshift-storage --type=merge"
+        OCP().exec_oc_cmd(cmd)
+        logger.info(
+            f"Decreased maxObjects to {decreased_quota} (below current usage) on obc {bucket_name}"
+        )
+        time.sleep(20)
+
+        awscli_pod_session.exec_cmd_on_pod(f"mkdir -p {test_dir}")
+        try:
+            copy_random_individual_objects(
+                awscli_pod_session,
+                pattern="decreased-object-",
+                file_dir=test_dir,
+                target=full_bucket_path,
+                amount=1,
+                s3_obj=obc_obj,
+                ignore_error=False,
+            )
+        except CommandFailed as e:
+            if err_msg in e.args[0]:
+                logger.info(
+                    f"Decreased maxObjects quota to {decreased_quota} blocked writes as expected!!"
+                )
+            else:
+                logger.error("Copy objects to bucket failed unexpectedly!!")
+                raise
+        else:
+            assert False, (
+                f"Decreased maxObjects to {decreased_quota} below current usage "
+                "but writes still succeeded!!"
+            )
 
     @pytest.mark.parametrize(
         argnames="amount,interface,quota",

--- a/tests/functional/object/rgw/test_obc_quota.py
+++ b/tests/functional/object/rgw/test_obc_quota.py
@@ -283,3 +283,76 @@ class TestOBCQuota:
                 "description"
             ), f"Alert {constants.ALERT_OBC_QUOTA_OBJECTS_ALERT} doesn't seem have expected format"
         logger.info(f"Verified the alert {constants.ALERT_OBC_QUOTA_OBJECTS_ALERT}")
+
+    @pytest.mark.parametrize(
+        argnames="amount,interface,quota",
+        argvalues=[
+            pytest.param(
+                *[1, "RGW-OC", {"maxSize": "10M"}],
+                marks=[
+                    tier2,
+                    pytest.mark.polarion_id("OCS-8082"),
+                ],
+            ),
+        ],
+    )
+    def test_obc_quota_size_alert(
+        self,
+        rgw_bucket_factory,
+        rgw_obj_session,
+        awscli_pod_session,
+        test_directory_setup,
+        threading_lock,
+        amount,
+        interface,
+        quota,
+    ):
+        """
+        Test that ObcQuotaBytesAlert fires when OBC reaches ~80% of maxSize
+            * Create OBC with a size quota (maxSize) set
+            * Write data to ~90% of maxSize capacity
+            * Wait for ObcQuotaBytesAlert Prometheus alert to fire
+            * Verify alert description matches expected format
+        """
+
+        bucket_name = rgw_bucket_factory(amount, interface, quota=quota)[0].name
+        logger.info(f"created rgw bucket {bucket_name} with quota {quota}")
+
+        # Fill the bucket with ~90% of maxSize (9 x 1MB objects for 10MB quota)
+        max_size_mb = int(quota["maxSize"].rstrip("M"))
+        fill_amount = (max_size_mb * 90) // 100
+        write_random_test_objects_to_bucket(
+            awscli_pod_session,
+            bucket_name,
+            test_directory_setup.origin_dir,
+            amount=fill_amount,
+            mcg_obj=OBC(bucket_name),
+        )
+        logger.info(f"Filled bucket {bucket_name} with ~90% maxSize capacity")
+
+        # Wait for ObcQuotaBytesAlert to fire and verify
+        prometheus = PrometheusAPI(threading_lock=threading_lock)
+        alerts = [
+            alert
+            for alert in prometheus.wait_for_alert(
+                name=constants.ALERT_OBC_QUOTA_BYTES_ALERT,
+                state="firing",
+                timeout=600,
+            )
+            if alert.get("labels").get("objectbucketclaim") == bucket_name
+        ]
+
+        assert len(alerts) > 0, (
+            f"Alert {constants.ALERT_OBC_QUOTA_BYTES_ALERT} doesn't seem to occur "
+            f"despite the bucket being ~90% full by size"
+        )
+
+        alert_desc = (
+            f"ObjectBucketClaim {bucket_name} has crossed 80% "
+            f"of the size limit set by the quota(bytes)"
+        )
+        for alert in alerts:
+            assert alert_desc in alert.get("annotations").get(
+                "description"
+            ), f"Alert {constants.ALERT_OBC_QUOTA_BYTES_ALERT} doesn't seem have expected format"
+        logger.info(f"Verified the alert {constants.ALERT_OBC_QUOTA_BYTES_ALERT}")

--- a/tests/functional/object/rgw/test_obc_quota.py
+++ b/tests/functional/object/rgw/test_obc_quota.py
@@ -625,10 +625,12 @@ class TestOBCQuota:
         quota,
     ):
         """
-        Test that ObcQuotaBytesAlert fires when OBC reaches ~80% of maxSize
-            * Create OBC with a size quota (maxSize) set
+        Test OBC size quota Prometheus alerts at 80% and 100% thresholds
+            * Create OBC with a size quota (maxSize=10M) set
             * Write data to ~90% of maxSize capacity
-            * Wait for ObcQuotaBytesAlert Prometheus alert to fire
+            * Wait for ObcQuotaBytesAlert (80% warning) to fire and verify
+            * Write more data to exceed 100% of maxSize
+            * Wait for ObcQuotaBytesExhausedAlert (100% critical) to fire
             * Verify alert description matches expected format
         """
 
@@ -673,3 +675,45 @@ class TestOBCQuota:
                 "description"
             ), f"Alert {constants.ALERT_OBC_QUOTA_BYTES_ALERT} doesn't seem have expected format"
         logger.info(f"Verified the alert {constants.ALERT_OBC_QUOTA_BYTES_ALERT}")
+
+        # Phase 2: Fill to 100% and verify exhaustion alert
+        remaining_to_fill = max_size_mb - fill_amount + 2
+        try:
+            write_random_test_objects_to_bucket(
+                awscli_pod_session,
+                bucket_name,
+                test_directory_setup.origin_dir,
+                amount=remaining_to_fill,
+                mcg_obj=OBC(bucket_name),
+            )
+        except CommandFailed as e:
+            logger.info(f"Writes rejected after exceeding maxSize as expected: {e}")
+        logger.info(f"Filled bucket {bucket_name} to 100%+ of maxSize capacity")
+
+        exhausted_alerts = [
+            alert
+            for alert in prometheus.wait_for_alert(
+                name=constants.ALERT_OBC_QUOTA_BYTES_EXHAUSED_ALERT,
+                state="firing",
+                timeout=600,
+            )
+            if alert.get("labels").get("objectbucketclaim") == bucket_name
+        ]
+
+        assert len(exhausted_alerts) > 0, (
+            f"Alert {constants.ALERT_OBC_QUOTA_BYTES_EXHAUSED_ALERT} didn't fire "
+            f"despite the bucket exceeding 100% of maxSize"
+        )
+
+        exhausted_desc = (
+            f"ObjectBucketClaim {bucket_name} has crossed the limit "
+            f"set by the quota(bytes) and will be read-only now"
+        )
+        for alert in exhausted_alerts:
+            assert exhausted_desc in alert.get("annotations").get("description"), (
+                f"Alert {constants.ALERT_OBC_QUOTA_BYTES_EXHAUSED_ALERT} "
+                f"doesn't have expected format"
+            )
+        logger.info(
+            f"Verified the alert {constants.ALERT_OBC_QUOTA_BYTES_EXHAUSED_ALERT}"
+        )

--- a/tests/functional/object/rgw/test_obc_quota.py
+++ b/tests/functional/object/rgw/test_obc_quota.py
@@ -587,9 +587,11 @@ class TestOBCQuota:
         quota,
     ):
         """
-        This test will verify the prometheus alerts
-        when the OBC quota is reached
-
+        Test OBC object count quota Prometheus alert at 80% threshold
+            * Create OBC with an object count quota (maxObjects=10) set
+            * Write objects to ~90% of maxObjects capacity
+            * Wait for ObcQuotaObjectsAlert (80% warning) to fire and verify
+            * Verify alert description matches expected format
         """
 
         # create the bucket

--- a/tests/functional/object/rgw/test_obc_quota.py
+++ b/tests/functional/object/rgw/test_obc_quota.py
@@ -258,7 +258,7 @@ class TestOBCQuota:
             pytest.param(
                 *[1, "RGW-OC", {"maxObjects": "5", "maxSize": "5M"}],
                 marks=[
-                    tier1,
+                    tier2,
                     pytest.mark.polarion_id("OCS-8083"),
                 ],
             ),
@@ -404,7 +404,7 @@ class TestOBCQuota:
         else:
             logger.info("Writes succeeded after patching both quotas!!")
 
-    @tier1
+    @tier2
     @pytest.mark.polarion_id("OCS-8084")
     def test_rgw_obc_multi_bucket_quota(
         self,

--- a/tests/functional/object/rgw/test_obc_quota.py
+++ b/tests/functional/object/rgw/test_obc_quota.py
@@ -664,7 +664,7 @@ class TestOBCQuota:
             * Create OBC with a size quota (maxSize=10M) set
             * Write data to ~90% of maxSize capacity
             * Wait for ObcQuotaBytesAlert (80% warning) to fire and verify
-            * Write more data to exceed 100% of maxSize
+            * Reduce maxSize below current usage to push ratio above 100%
             * Wait for ObcQuotaBytesExhausedAlert (100% critical) to fire
             * Verify alert description matches expected format
         """
@@ -711,19 +711,22 @@ class TestOBCQuota:
             ), f"Alert {constants.ALERT_OBC_QUOTA_BYTES_ALERT} doesn't seem have expected format"
         logger.info(f"Verified the alert {constants.ALERT_OBC_QUOTA_BYTES_ALERT}")
 
-        # Phase 2: Fill to 100% and verify exhaustion alert
-        remaining_to_fill = max_size_mb - fill_amount + 2
-        try:
-            write_random_test_objects_to_bucket(
-                awscli_pod_session,
-                bucket_name,
-                test_directory_setup.origin_dir,
-                amount=remaining_to_fill,
-                mcg_obj=OBC(bucket_name),
-            )
-        except CommandFailed as e:
-            logger.info(f"Writes rejected after exceeding maxSize as expected: {e}")
-        logger.info(f"Filled bucket {bucket_name} to 100%+ of maxSize capacity")
+        # Phase 2: Reduce quota below current usage to trigger exhaustion alert.
+        # RGW enforces maxSize strictly, so writes can't push past 100%.
+        # Instead, patch maxSize down so current usage exceeds the new limit.
+        reduced_max_size = fill_amount // 2
+        patch_str = (
+            f'{{"spec": {{"additionalConfig":{{"maxSize": "{reduced_max_size}M"}}}}}}'
+        )
+        cmd = (
+            f"patch obc {bucket_name} -p '{patch_str}' "
+            f"-n openshift-storage --type=merge"
+        )
+        OCP().exec_oc_cmd(cmd)
+        logger.info(
+            f"Reduced maxSize from {max_size_mb}M to {reduced_max_size}M "
+            f"on bucket {bucket_name} to trigger exhaustion"
+        )
 
         exhausted_alerts = [
             alert


### PR DESCRIPTION
**Summary:**

  Add four new test cases and extend two existing tests in TestOBCQuota for comprehensive RGW quota coverage. The existing tests only validated maxObjects — multi-bucket isolation, maxSize
  enforcement, combined quota behavior, and size alerts were never tested.

  Also hardened all quota error handling: RGW does not consistently return (QuotaExceeded) when quota limits are hit — it may return "argument of type 'NoneType' is not iterable" or other
  non-standard errors. All "expect blocked" except CommandFailed blocks now accept any CommandFailed instead of checking e.args[0] for a specific error string. "Expect succeed" blocks use
  str(e) instead of e.args[0] to avoid TypeError.

**NOTE: Every test in the file was touched by this PR:**

  - test_rgw_obc_quota — extended with the decreased-quota phase + error handling hardened
  - test_obc_quota_full_alert — error handling hardened (no new functionality)
  - test_rgw_obc_size_quota — new
  - test_rgw_obc_combined_quota — new
  - test_rgw_obc_multi_bucket_quota — new
  - test_obc_quota_size_alert — new + expanded with TC-8.1

  The two pre-existing tests (test_rgw_obc_quota, test_obc_quota_full_alert) were modified for the error handling fix. The other four are entirely new.


  **Changes:**

  test_rgw_obc_quota — extended (TC-5.3)

  - Added step: decrease maxObjects below current usage via oc patch, verify writes are blocked

  test_rgw_obc_size_quota — new, tier1 (TC-6.1, TC-6.2, TC-6.3)

  1. Create OBC with maxSize=5M and maxObjects=100 (object count is intentionally high so only size limit is tested)
  2. Upload 1MB objects one-by-one until quota is exceeded
  3. Patch the OBC via oc patch to increase maxSize to 20M
  4. Upload 5 more objects and verify all writes succeed under the new limit

  test_rgw_obc_combined_quota — new, tier2 (TC-6.4.a-d)

  1. Create OBC with both maxObjects=5 and maxSize=5M
  2. Write objects until both quotas are hit
  3. Patch only maxSize higher → verify writes still blocked by maxObjects
  4. Patch only maxObjects higher → verify writes still blocked by maxSize
  5. Patch both quotas higher → verify writes succeed

  test_rgw_obc_multi_bucket_quota — new, tier2 (TC-4.3.a)

  1. Create 4 RGW buckets: no quota, maxSize only, maxObjects only, both
  2. Write objects to exceed quotas on each quota-limited bucket
  3. Verify no-quota bucket remains writable
  4. Remove all objects from quota-limited buckets
  5. Verify all 4 buckets are writable again

  test_obc_quota_size_alert — new, tier2 (TC-7.2, TC-8.1)

  1. Create OBC with maxSize=10M
  2. Write ~90% of maxSize capacity (9 x 1MB objects)
  3. Wait for ObcQuotaBytesAlert Prometheus alert to fire (80% warning)
  4. Verify alert description matches expected format
  5. Write more data to exceed 100% of maxSize
  6. Wait for ObcQuotaBytesExhausedAlert Prometheus alert to fire (100% critical)
  7. Verify exhaustion alert description matches expected format

  Error handling hardening (all tests)

  - All "expect blocked" except CommandFailed blocks: accept any CommandFailed instead of checking for "(QuotaExceeded)" in e.args[0]
  - All "expect succeed" blocks: use str(e) instead of e.args[0] to avoid TypeError if args[0] is None
  - Removed unused err_msg variable in test_rgw_obc_multi_bucket_quota

  **Test paths**

  - tests/functional/object/rgw/test_obc_quota.py::TestOBCQuota::test_rgw_obc_quota (extended) — tier1
  - tests/functional/object/rgw/test_obc_quota.py::TestOBCQuota::test_rgw_obc_size_quota — tier1
  - tests/functional/object/rgw/test_obc_quota.py::TestOBCQuota::test_rgw_obc_combined_quota — tier2
  - tests/functional/object/rgw/test_obc_quota.py::TestOBCQuota::test_rgw_obc_multi_bucket_quota — tier2
  - tests/functional/object/rgw/test_obc_quota.py::TestOBCQuota::test_obc_quota_full_alert — tier2
  - tests/functional/object/rgw/test_obc_quota.py::TestOBCQuota::test_obc_quota_size_alert — tier2

 Test Case Coverage

  - TC-4.3.a — Multiple buckets with different quota configs, verify isolation and recovery
  - TC-5.3 — Decrease maxObjects below current usage, verify writes are blocked
  - TC-6.1 — Create RGW OBC with maxSize, verify quota is enforced
  - TC-6.2 — Verify writes are blocked when RGW max-size is exceeded
  - TC-6.3 — Increase maxSize via oc patch, verify writes succeed again
  - TC-6.4.a — Create RGW OBC with both maxObjects and maxSize, verify enforcement
  - TC-6.4.b — Hit both quotas, patch only maxSize, verify writes still blocked
  - TC-6.4.c — Hit both quotas, patch only maxObjects, verify writes still blocked
  - TC-6.4.d — Hit both quotas, patch both higher, verify writes succeed
  - TC-7.2 — ObcQuotaBytesAlert fires at ~80% of maxSize
  - TC-8.1 — ObcQuotaBytesExhausedAlert fires at 100% of maxSize


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of object storage quotas when usage exceeds configured object limits.
  * Added coverage for size-based quotas, including blocking uploads when limits are reached and allowing uploads after limits are increased.
  * Added monitoring coverage to verify alerts trigger when storage usage crosses the configured threshold.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->