### PR TITLE
[RDR] Add option to skip mirroring status check

### DIFF
--- a/conf/ocsci/skip_mirroring_check.yaml
+++ b/conf/ocsci/skip_mirroring_check.yaml
@@ -1,0 +1,3 @@
+---
+ENV_DATA:
+  skip_mirroring_status_check: true

--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -603,6 +603,11 @@ def wait_for_mirroring_status_ok(
         TimeoutExpiredError: In case of unexpected mirroring status
 
     """
+    if config.ENV_DATA.get("skip_mirroring_status_check"):
+        logger.warning(
+            "Skipping mirroring status check (skip_mirroring_status_check is set)"
+        )
+        return True
     restore_index = config.cur_index
     dr_cluster_relations = config.MULTICLUSTER.get("dr_cluster_relations", [])
     if dr_cluster_relations:


### PR DESCRIPTION
Allow skipping mirroring status check when skip_mirroring_status_check is set in ENV_DATA
Useful for clusters/conditions where mirroring health check should be intentionally skipped.

Usage: pass conf/ocsci/skip_mirroring_check.yaml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an environment-driven configuration to optionally bypass mirroring status checks.
  * When enabled, mirroring validation no longer waits for per-cluster status polling.
* **Bug Fixes**
  * Default behavior remains unchanged: mirroring status polling and timeout enforcement still apply when the bypass option is not set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->