### PR TITLE
Defaulting ocs-ci to ODF 5.0

### DIFF
--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -23,7 +23,7 @@ RUN:
   cli_params: {} # this will be filled with CLI parameters data
   # If the client version ends with .nightly, the version will be exposed
   # to the latest accepted OCP nightly build version
-  client_version: "4.23.0-0.nightly"
+  client_version: "5.0.0-0.nightly"
   bin_dir: "./bin"
   google_api_secret: "~/.ocs-ci/google_api_secret.json"
   # Following chrome params are for openshift console UI testing
@@ -56,18 +56,18 @@ DEPLOYMENT:
   # if the installer version ends with .nightly, the version will be exposed
   # to the latest accepted OCP nightly build version. You can also use the
   # specific build version like: "4.2.0-0.nightly-2019-08-06-195545"
-  installer_version: "4.23.0-0.nightly"
+  installer_version: "5.0.0-0.nightly"
   force_download_installer: True
   force_download_client: True
   skip_download_client: False
-  default_latest_tag: "latest-stable-4.23"
+  default_latest_tag: "latest-stable-5.0"
   # define if ceph is setup as external mode, default is false
   external_mode: False
   # You can overwrite csv channel version by following parameter
-  ocs_csv_channel: "stable-4.23"
+  ocs_csv_channel: "stable-5.0"
   # you can overwrite the image for ocs operator catalog source by following parameter:
   # ocs_registry_image: "quay.io/rhceph-dev/ocs-olm-operator:4.2-32.9b6c93e.master"
-  default_ocs_registry_image: "quay.io/rhceph-dev/ocs-registry:latest-4.23"
+  default_ocs_registry_image: "quay.io/rhceph-dev/ocs-registry:latest-5.0"
   ocs_operator_nodes_to_label: 3
   # This is described as a WA for minimal configuration 3/3 worker/master
   # nodes. See: https://github.com/openshift/ocs-operator
@@ -159,7 +159,7 @@ REPORTING:
   ocp_must_gather_image: ""
   default_ocs_must_gather_image: "quay.io/rhceph-dev/odf4-odf-must-gather-rhel9"
   odf_live_must_gather_image: "registry.redhat.io/odf4/odf-must-gather-rhel9"
-  default_ocs_must_gather_latest_tag: "v4.23"
+  default_ocs_must_gather_latest_tag: "v5.0"
   gather_on_deploy_failure: true
   collect_logs_on_success_run: False
   rp_client_log_level: "ERROR"
@@ -192,7 +192,7 @@ ENV_DATA:
   worker_replicas: 3
   skip_ocp_deployment: false
   skip_ocs_deployment: false
-  ocs_version: "4.23"
+  ocs_version: "5.0"
   prometheus_version: "4.10.0"
   # uncomment to use custom directory for storing measurement data related to
   # monitoring tests, otherwise generate temporary directory for each test run
@@ -321,10 +321,10 @@ ENV_DATA:
 # This section is related to upgrade
 UPGRADE:
   upgrade_to_latest: true
-  ocp_channel: "stable-4.23"
+  ocp_channel: "stable-5.0"
   ocp_upgrade_path: "quay.io/openshift-release-dev/ocp-release"
   ocp_arch: "x86_64"
-  upgrade_logging_channel: "4.23"
+  upgrade_logging_channel: "5.0"
   # None value means that value in Rook operator config is used.
   # Otherwise it is changed to the provided value before ODF upgrade.
   csi_rbd_plugin_update_strategy_max_unavailable: null

--- a/ocs_ci/utility/version.py
+++ b/ocs_ci/utility/version.py
@@ -74,6 +74,7 @@ VERSION_4_19 = get_semantic_version("4.19", True)
 VERSION_4_20 = get_semantic_version("4.20", True)
 VERSION_4_21 = get_semantic_version("4.21", True)
 VERSION_4_22 = get_semantic_version("4.22", True)
+VERSION_4_23 = get_semantic_version("4.23", True)
 VERSION_5_0 = get_semantic_version("5.0", True)
 
 # Fusion version constants


### PR DESCRIPTION
Signed-off-by: vavuthu [vavuthu@redhat.com](mailto:vavuthu@redhat.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated default deployment, installer, upgrade, and must-gather configurations to use the 5.0 release channels and versions.
  - Added a new semantic version constant for 4.23 to improve compatibility with environments still using that release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->