### PR TITLE
[RDR] Fix duplicate OCP import in regional-dr conftest

### DIFF
--- a/tests/functional/disaster-recovery/regional-dr/conftest.py
+++ b/tests/functional/disaster-recovery/regional-dr/conftest.py
@@ -3,7 +3,6 @@ import platform
 import os
 import tempfile
 from ocs_ci.deployment.ocp import download_pull_secret
-from ocs_ci.ocs.ocp import OCP
 from ocs_ci.utility import templating
 import pytest
 


### PR DESCRIPTION
Remove the redundant import that caused flake8 failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed a redundant internal import with no user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->