### PR TITLE
Add CSI OMAP metadata and PV caching removal tests for ocs-metrics-exporter

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -79,1323 +79,1303 @@
     "conf/deployment/ibmcloud/ibm_cloud_managed_3az_0m_3w_vpc_cluster.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 25,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 23,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_hpcs_external.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 25,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_stage.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 22,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_without_cos.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 21,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_without_cos_stage.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 23,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_zone_eu_de_1.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 23,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_zone_eu_de_2.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 23,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_zone_eu_de_3.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 23,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_zone_jp_tok_1.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 23,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_zone_jp_tok_2.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 23,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_zone_jp_tok_3.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 23,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_zone_us_east_1.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 23,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_zone_us_east_2.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 23,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_zone_us_east_3.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 23,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ipi_1az_us_east1_rhcos_3m_3w.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 24,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ipi_1az_us_east1_rhcos_custom_vpc_3m_3w.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 27,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ipi_1az_us_east2_rhcos_3m_3w.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 24,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ipi_1az_us_east3_rhcos_3m_3w.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 24,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ipi_1az_us_south1_rhcos_custom_vpc_3m_3w.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 27,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ipi_3az_rhcos_3m_3w.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 28,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ipi_3az_rhcos_3m_6w.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 29,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ipi_3az_rhcos_compactmode_3m_0w.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 28,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/ibmcloud/ipi_3az_rhcos_lowerreq_3m_3w.yaml": [
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 28,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/rhv/ipi_1az_rhcos_3m_3w.yaml": [
       {
         "hashed_secret": "ff55435345834a3fe224936776c2aa15f6ed5358",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 21,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/rhv/ipi_1az_rhcos_lso_3m_3w.yaml": [
       {
         "hashed_secret": "ff55435345834a3fe224936776c2aa15f6ed5358",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 30,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/vsphere/upi_1az_rhcos_vsan_3m_3w_disconnected_flexy.yaml": [
       {
         "hashed_secret": "66a1db0d75c1b2302b441a31b75b4d5a9f291d22",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 21,
         "type": "Base64 High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/deployment/vsphere/upi_1az_rhcos_vsan_lso_vmdk_3m_3w_disconnected_flexy.yaml": [
       {
         "hashed_secret": "66a1db0d75c1b2302b441a31b75b4d5a9f291d22",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 24,
         "type": "Base64 High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/examples/hpcs_external_standalone_mode.yaml": [
       {
         "hashed_secret": "fc4a8593743fd8a94fce1b137d964432bb1a9e91",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 13,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/ocsci/disconnected_cluster.yaml.example": [
       {
         "hashed_secret": "1dee91010328c9606757a6ddb538d608b6d89d1c",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 6,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 9,
         "type": "Basic Auth Credentials",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/ocsci/dr_workload.yaml": [
       {
         "hashed_secret": "3bb712fd293d3816c7c111dffc96dffc5c873602",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 345,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/ocsci/hpcs_external_standalone_mode.yaml": [
       {
         "hashed_secret": "fc4a8593743fd8a94fce1b137d964432bb1a9e91",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 12,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/ocsci/mdr_workload.yaml": [
       {
         "hashed_secret": "3bb712fd293d3816c7c111dffc96dffc5c873602",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 119,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/ocsci/noobaa_external_pgsql.yaml": [
       {
         "hashed_secret": "6cb6eb9fabad447f4ec9965879927661143bdfed",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 12,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/ocsci/openshift_dedicated.yaml": [
       {
         "hashed_secret": "66b2fcbc520c25a8087712aa85e95516a2b6c79b",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 14,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/ocsci/vsphere_upi_vars.yaml.example": [
       {
         "hashed_secret": "e894b36b7cdd92461cad391cf01f52c9e53c41ad",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 26,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "conf/ocsci/vsphere_upi_vars.yaml.skeleton": [
       {
         "hashed_secret": "d63f8d34ad75f338f5b42b331e2fd883576a29bd",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 10,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "e894b36b7cdd92461cad391cf01f52c9e53c41ad",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 27,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "docs/getting_started.md": [
       {
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 174,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "docs/logging_guide.md": [
       {
         "hashed_secret": "605cf0632d1f0b7aebb3c0cd5c51a92145bb28a6",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 1421,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "docs/supported_platforms.md": [
       {
         "hashed_secret": "6eae3a5b062c6d0d79f070c26e6d62486b40cb46",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 30,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 171,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "docs/usage.md": [
       {
         "hashed_secret": "89a519cc7786f3290ad671412d92f325f9ef2a57",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 98,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "cfcafdd35cb253bd1a95060758e671abe510920a",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 347,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/deployment/aws.py": [
       {
         "hashed_secret": "134f379c01b1cf36e5ee172c37ffeca5c679a5ee",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 802,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/deployment/flexy.py": [
       {
         "hashed_secret": "bea1af2a15561a266eda3472673d24cb4f2020d4",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 241,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/deployment/hub_spoke.py": [
       {
         "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 7164,
         "type": "Private Key",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/framework/conf/default_config.yaml": [
       {
         "hashed_secret": "613fb9979a1ab677719426dd2e81a60fad637cf2",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 28,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "eea97d7f2f305e7afdc0b9bf64859b660cd09232",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 31,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 334,
         "line_number": 338,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "de19c40310ad831a71524cd279e6f5f0577fb09a",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 382,
         "line_number": 386,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/helpers/cluster_exp_helpers.py": [
       {
         "hashed_secret": "fa3798e69b10954419dfdcf70da00dce77b1416e",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 57,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/helpers/helpers.py": [
       {
         "hashed_secret": "66a36e77fd002579809717841f998f4d21cd5913",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 2925,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/krkn_chaos/template/krkn_global_config.yaml.j2": [
       {
         "hashed_secret": "d2e2ab0f407e4ee3cf2ab87d61c31b25a74085e5",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 50,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/krkn_chaos/template/scenarios/keknctl/plan.json.j2": [
       {
         "hashed_secret": "d2e2ab0f407e4ee3cf2ab87d61c31b25a74085e5",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 760,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/ocs/clients.py": [
       {
         "hashed_secret": "a8c1dc105c415cc7ccb286ecdb1156ebd9f957fb",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 14,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/ocs/constants.py": [
       {
         "hashed_secret": "b7e9a6e2e04ed3edbf8b4e21def4beccbb6eb6b1",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 233,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "a12337323b638ab044b1166bff4b1a1f83162819",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 840,
+        "line_number": 856,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "fb947972c92f052c0a08866d182be0075a2b601b",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 849,
+        "line_number": 865,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "03e227627ab8681281fdb8aa3d799b03f782d672",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 2053,
-        "line_number": 2060,
+        "line_number": 2076,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "ef5f3d909f23bd0aa02b4253f98350384f709c86",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 2160,
-        "line_number": 2167,
+        "line_number": 2183,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "cb1ae2b504c4615841d8144267a131231d2bd677",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 2161,
-        "line_number": 2168,
+        "line_number": 2184,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "1a1e70e87dd0452c42f33ce9bf74aa28134dba6b",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 2162,
-        "line_number": 2169,
+        "line_number": 2185,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "7b1ba2f04f2f1604dc4e3caffcadf9fcbce7df5b",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 2163,
-        "line_number": 2170,
+        "line_number": 2186,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "0fa3b21ced80146d752888f2b60ec80e0d4b8925",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 2175,
-        "line_number": 2182,
+        "line_number": 2198,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "f084f2068494b8d1cd06811dd97d02c3d85f40ee",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 2190,
-        "line_number": 2197,
+        "line_number": 2213,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "adfa401a3b0a733d8f00519ac8c6b3893a2e7e8e",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 2191,
-        "line_number": 2198,
+        "line_number": 2214,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "898e46bbadc12f87120548bd445eb4210c8407c8",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 2199,
-        "line_number": 2206,
+        "line_number": 2222,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "f57ccec6b8f7b12b635ab53d26c3bf7300247341",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 2200,
-        "line_number": 2207,
+        "line_number": 2223,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "77b044ea736f8cbe568d1954424186d901f89db9",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 2201,
-        "line_number": 2208,
+        "line_number": 2224,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "d64368f12ca17c69568c6a132f17d44d56e60660",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 2202,
-        "line_number": 2209,
+        "line_number": 2225,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "8f9ca35156c02cb6ba58c5b51230b9bedc38de4f",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 2203,
-        "line_number": 2210,
+        "line_number": 2226,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "9ec53cfd9929c70c3f87c210b6a7b77fb6d79d43",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 2800,
-        "line_number": 2807,
+        "line_number": 2823,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 2966,
-        "line_number": 2972,
+        "line_number": 2989,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "adc1f5c8707f7d7aba3aabe13c15e5ef1151872e",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 2967,
-        "line_number": 2973,
+        "line_number": 2990,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "ee46262b2df945e46ea310b925ad087465dbd3f2",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 3688,
-        "line_number": 3694,
+        "line_number": 3712,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "f678cad4ab874d71b559a069d5e34a95fe38a480",
+        "is_secret": false,
         "is_verified": false,
-        "line_number": 3689,
-        "line_number": 3695,
+        "line_number": 3713,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/ocs/defaults.py": [
       {
         "hashed_secret": "ca4dbbee191f1e04318439e30e4e9f55134e4513",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 123,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "9125b9994805d74d9545e381b9d5a90e65e2d63e",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 124,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "637138e061a7c9dc22f301dfcf7a43b638a2e1d8",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 125,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/ocs/external_ceph.py": [
       {
         "hashed_secret": "d2137e76c2c4f75fe37e8c0a03670d3715849389",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 473,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "30274c47903bd1bac7633bbf09743149ebab805f",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 474,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/ocs/fusion.py": [
       {
         "hashed_secret": "6eae3a5b062c6d0d79f070c26e6d62486b40cb46",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 97,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/ocs/platform_nodes.py": [
       {
         "hashed_secret": "134f379c01b1cf36e5ee172c37ffeca5c679a5ee",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 1269,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/ocs/resources/ocsconfigmaps.py": [
       {
         "hashed_secret": "347cd9c53ff77d41a7b22aa56c7b4efaf54658e3",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 404,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/ocs/utils.py": [
       {
         "hashed_secret": "f2dde9105675b76e1f542230a642933ccffd8a8e",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 331,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "8f57c0c672ec244816d827f57ea488c2d609efc9",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 643,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "30274c47903bd1bac7633bbf09743149ebab805f",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 644,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/templates/CSI/rbd/csi-kms-connection-details.yaml": [
       {
         "hashed_secret": "214d02537c8b2382bd599e97b100b78d1f9614aa",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 4,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/templates/ocs-deployment/external-pgsql-noobaa-secret.yaml": [
       {
         "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 9,
         "type": "Basic Auth Credentials",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/templates/ocs-deployment/multicluster/odr_s3_secret.yaml": [
       {
         "hashed_secret": "d3045fb7f8faed786bb7694d7d4ca06e357eea24",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 5,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/templates/openshift-infra/hpcs/ibm-kp-kms-secret.yaml": [
       {
         "hashed_secret": "021b53ce46b72837170446bee4e579c4801bc67a",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 8,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/templates/workloads/couchbase/server/couchbase-worker-secret.yaml": [
       {
         "hashed_secret": "7cf7ed86e8f660ade5996a1072d74cd35def47af",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 9,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/templates/workloads/couchbase/server/couchbase-worker.yaml": [
       {
         "hashed_secret": "8d6478f5d35b469b1568d41c393b3e08d30e7a2e",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 27,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/templates/workloads/hsbench/hsbench_obj.yaml": [
       {
         "hashed_secret": "7a9a4af7de5c6536e46cbee0856f11b46cdde7c9",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 5,
         "type": "Base64 High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/templates/workloads/quay/quay_registry.yaml": [
       {
         "hashed_secret": "83f7cd4240b0182d4e26f6f5aa845d3d29e4adfb",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 7,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/utility/managedservice.py": [
       {
         "hashed_secret": "6eae3a5b062c6d0d79f070c26e6d62486b40cb46",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 95,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "be4fc4886bd949b369d5e092eb87494f12e57e5b",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 169,
         "type": "Private Key",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/utility/rosa.py": [
       {
         "hashed_secret": "6eae3a5b062c6d0d79f070c26e6d62486b40cb46",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 687,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "ocs_ci/utility/storage_cluster_setup.py": [
       {
         "hashed_secret": "f0e2d8610edefa0c02b673dcac7964b02ce3e890",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 748,
         "type": "Basic Auth Credentials",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "terraform/ai/vsphere/terraform.tfvars.example": [
       {
         "hashed_secret": "42a818da3bb789755a56f06412ebba442bf41edf",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 12,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "tests/cross_functional/kcs/test_noobaadb_pw_reset.py": [
       {
         "hashed_secret": "95b0665e64fa24c375f1db3797739dc833a01be1",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 87,
         "type": "Secret Keyword",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ],
     "tests/functional/ui/test_alert_text.py": [
       {
         "hashed_secret": "deed437581abf6a8a8c3f908a00739ec66bd1907",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 26,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "d3c7cf8a52f042f5ad10e7e04c6efa9b3edfc091",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 27,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "0e47f8d47cf71626c411322d5cc46463bb9ee63a",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 28,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "def6a0eb64808cbdf3e3985b380d06019ccaf15c",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 29,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "1eb02d1de1c583c352016b765c4470f14688c27f",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 30,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "beb03c56370648a8018847b7eb6f0ff17e2ec17d",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 31,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "c8a3e4b73af4fc164a18209fa3248cace0376de6",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 32,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "3b793d3c8f6140791030db45900185a24bc0f8d6",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 33,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "5e10a523088617ee53c02a050ecb4f3c02ff36a6",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 34,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "67cec59154e2b4dbc161ab590ea9836833a03879",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 35,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "a7051bbf0cbb04fbd58fea9202861924cf476965",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 36,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "711167a9e39213a023177fb6f8726eed4ae87724",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 37,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "62f46554adcad52e1b59156746059e8fe2b68114",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 38,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "6b6660ec37abef577585e08fbadd66a1daa126ad",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 39,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "ba9fdcab8f3a1c05e545c90657adeeca92457819",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 40,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "d92508b7e8714361d780028189182ccc838905fd",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 41,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "5d831603558fae694509e52443867d9d0fe15dab",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 42,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "70444c50c0b30525a518f749e570c2b5ab2ea159",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 43,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "b3a6d9ed97f183a3ed70fe50f8f5a1ab84eccfb5",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 44,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "d94d7c9ec8c812df775f85cf53d44fe0dacb153c",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 45,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "7fbab5f66d94793e754adf5eec572dd69895add7",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 46,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "d5164d922808f83e1bb2fb7ef4ae43a8fdc2d63a",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 47,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "474e5f07c32a4837e6685a64fb86c3b80ed14ef5",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 48,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "aee98b1d4cdc9ea965426edfff3e89413d648f28",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 49,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "cb44fa15b838b5bd5bb7cf855c8b65b83575b049",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 50,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "bfcb7bd33a4d476579e23a6ab6bef8270fd359a6",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 51,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "9109e09e3881791c6e7245a3e4dc3e9dd23305ec",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 52,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "44ac318f0525c62193986773a822397d9cd65220",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 53,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "a34ddb5f6561f1c681ea9d6369f2bf5ea5435bbf",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 54,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "a0f8bc5793f4cc0b1173b8e65c824e80bba32ec3",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 55,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "11b02033ace8079c90a25fe5dfef319b19363e56",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 56,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "c3bce19887dde7c21edbcc997f70e2d9b67a7845",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 57,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "918b8462281c3884363c68bd466e90e34bcb7b4f",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 58,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "5d279aca1022ec52d2f595199e74490d75bf3940",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 59,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "a9c2f9fb9293eac7f7055dc5ad8510ed89446890",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 60,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "6828bcb400541dcb69f04098c046c36947a664be",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 61,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "a7f8c0d263a1263d2f858d388e0f6ed799c3ed85",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 62,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "e7aac35a54098dff672130afc60ba0395f339089",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 63,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "642e4f0372448c534f32262a96e7d9f2b27b47d2",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 64,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "3bdd128c4f1e6c4d3ade5eb86dcfecc387e13a38",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 65,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "8308b864c9c12f694be52639f16fc312929c268a",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 68,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       },
       {
         "hashed_secret": "64d5413c9629cf6c976224d145450a839f213b96",
+        "is_secret": false,
         "is_verified": false,
         "line_number": 69,
         "type": "Hex High Entropy String",
-        "verified_result": null,
-        "is_secret": false
+        "verified_result": null
       }
     ]
   },

--- a/ocs_ci/helpers/ocs_metrics_exporter_helpers.py
+++ b/ocs_ci/helpers/ocs_metrics_exporter_helpers.py
@@ -1,0 +1,245 @@
+# -*- coding: utf8 -*-
+"""
+Helpers for ocs-metrics-exporter validation (RHSTOR-7964).
+
+Metrics scrape aligns with manual QE: for TLS metrics on 8443, use
+``oc create token prometheus-k8s -n openshift-monitoring`` and
+``curl -sk -H 'Authorization: Bearer ...' https://localhost:8443/metrics``
+from inside the pod.
+"""
+
+import logging
+import re
+import shlex
+
+from ocs_ci.framework import config
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.exceptions import CommandFailed
+from ocs_ci.ocs.resources.pod import Pod, get_pods_having_label
+from ocs_ci.utility.utils import exec_cmd
+
+
+logger = logging.getLogger(__name__)
+
+PROMETHEUS_K8S_SA = "prometheus-k8s"
+OPENSHIFT_MONITORING_NS = "openshift-monitoring"
+
+
+def get_ocs_metrics_exporter_pod(namespace=None):
+    """
+    Return the single running ocs-metrics-exporter Pod object, or None.
+
+    Args:
+        namespace (str): Storage namespace; defaults from config.
+
+    Returns:
+        Pod or None
+    """
+    namespace = namespace or config.ENV_DATA["cluster_namespace"]
+    pods = get_pods_having_label(constants.OCS_METRICS_EXPORTER, namespace=namespace)
+    running = [
+        p for p in pods if p.get("status", {}).get("phase") == constants.STATUS_RUNNING
+    ]
+    if not running:
+        return None
+    return Pod(**running[0])
+
+
+def resolve_metrics_endpoint(pod_obj):
+    """
+    Resolve /metrics URL and curl options from pod container ports.
+
+    Prefers HTTPS on 8443 over plain HTTP metrics.
+
+    Args:
+        pod_obj (Pod): ocs-metrics-exporter pod
+
+    Returns:
+        dict: keys ``url``, ``tls_skip_verify``, ``bearer_auth``
+    """
+    https_port = None
+    http_port = None
+    for container in pod_obj.pod_data.get("spec", {}).get("containers", []):
+        for port_def in container.get("ports") or []:
+            name = (port_def.get("name") or "").lower()
+            container_port = port_def.get("containerPort")
+            if not container_port:
+                continue
+            if container_port == constants.OCS_METRICS_EXPORTER_HTTPS_PORT:
+                https_port = container_port
+            elif "https" in name and https_port is None:
+                https_port = container_port
+            elif "metric" in name or name in ("http", "probe"):
+                http_port = container_port
+
+    if https_port:
+        return {
+            "url": f"https://127.0.0.1:{https_port}/metrics",
+            "tls_skip_verify": True,
+            "bearer_auth": True,
+        }
+    port = http_port or 8080
+    return {
+        "url": f"http://127.0.0.1:{port}/metrics",
+        "tls_skip_verify": False,
+        "bearer_auth": False,
+    }
+
+
+def create_prometheus_k8s_bearer_token():
+    """
+    Create a short-lived token for prometheus-k8s in openshift-monitoring.
+
+    Returns:
+        str: bearer token
+
+    Raises:
+        CommandFailed: if ``oc create token`` fails.
+    """
+    base_cmd = f"oc create token {PROMETHEUS_K8S_SA} -n {OPENSHIFT_MONITORING_NS}"
+    last_exc = None
+    for suffix in (" --duration=15m", ""):
+        cmd = base_cmd + suffix
+        try:
+            completed = exec_cmd(cmd, secrets=[])
+            raw = completed.stdout or b""
+            token = raw.decode().strip() if isinstance(raw, bytes) else raw.strip()
+            if token:
+                return token
+        except CommandFailed as exc:
+            last_exc = exc
+            continue
+    msg = (
+        "failed to create prometheus-k8s token in openshift-monitoring "
+        "(tried with and without --duration); check OCP version and RBAC"
+    )
+    if last_exc:
+        raise CommandFailed(msg) from last_exc
+    raise CommandFailed(msg)
+
+
+def scrape_full_metrics_text(pod_obj, bearer_token=None, max_bytes=65536):
+    """
+    Curl the full /metrics body (up to ``max_bytes``) from inside the exporter pod.
+
+    Args:
+        pod_obj (Pod): ocs-metrics-exporter pod
+        bearer_token (str): optional pre-created bearer token
+        max_bytes (int): cap response size
+
+    Returns:
+        str: Prometheus text exposition body
+    """
+    endpoint = resolve_metrics_endpoint(pod_obj)
+    url = endpoint["url"]
+    secrets = []
+    parts = [
+        "curl",
+        "-sS",
+        "--connect-timeout",
+        "5",
+        "--max-time",
+        "15",
+        "-f",
+    ]
+    if endpoint["tls_skip_verify"]:
+        parts.append("-k")
+    if endpoint["bearer_auth"]:
+        token = bearer_token or create_prometheus_k8s_bearer_token()
+        secrets.append(token)
+        parts.extend(["-H", f"Authorization: Bearer {token}"])
+    parts.append(url)
+    inner = " ".join(shlex.quote(p) for p in parts) + f" | head -c {max_bytes}"
+    cmd = f"sh -c {shlex.quote(inner)}"
+    return pod_obj.exec_cmd_on_pod(
+        cmd, out_yaml_format=False, secrets=secrets if secrets else None
+    )
+
+
+def assert_prometheus_exposition_text(text):
+    """
+    Assert the payload looks like Prometheus text exposition format.
+
+    Args:
+        text (str): body from /metrics
+
+    Raises:
+        AssertionError: if body does not match minimal Prometheus text format.
+    """
+    assert text and text.strip(), "metrics endpoint returned an empty body"
+    stripped = text.lstrip()
+    first_line = stripped.split("\n", 1)[0]
+    prom_comment = first_line.startswith("# HELP") or first_line.startswith("# TYPE")
+    prom_metric = bool(re.match(r"^[a-zA-Z_:][a-zA-Z0-9_:]*(?:\{|\s)", first_line))
+    assert prom_comment or prom_metric, (
+        "expected Prometheus text format from /metrics (line starting with "
+        f"'# HELP', '# TYPE', or metric_name); got first line: {first_line[:200]!r}"
+    )
+
+
+def parse_metric_families(metrics_text):
+    """
+    Parse raw Prometheus text exposition into a dict of metric name -> list of samples.
+
+    Each sample is a dict with keys ``labels`` (dict) and ``value`` (str).
+
+    Args:
+        metrics_text (str): raw Prometheus text from /metrics
+
+    Returns:
+        dict: {metric_name: [{"labels": {...}, "value": str}, ...]}
+    """
+    families = {}
+    sample_re = re.compile(
+        r"^([a-zA-Z_:][a-zA-Z0-9_:]*)(?:\{([^}]*)\})?\s+(\S+)(?:\s+\S+)?$"
+    )
+    for line in metrics_text.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        m = sample_re.match(line)
+        if not m:
+            continue
+        name = m.group(1)
+        labels_str = m.group(2) or ""
+        value = m.group(3)
+        labels = {}
+        if labels_str:
+            for pair in re.findall(r'(\w+)="([^"]*)"', labels_str):
+                labels[pair[0]] = pair[1]
+        families.setdefault(name, []).append({"labels": labels, "value": value})
+    return families
+
+
+def verify_no_cli_spawning_in_logs(pod_obj, time_window="5m", cli_patterns=None):
+    """
+    Verify that specified patterns are absent in pod logs.
+
+    Args:
+        pod_obj (Pod): Exporter pod
+        time_window (str): Time window for logs (e.g., "5m", "30m")
+        cli_patterns (list): Patterns to check for
+
+    Raises:
+        AssertionError: if any pattern is detected
+    """
+    cli_patterns = cli_patterns or [
+        "rbd status",
+        "rbd children",
+        "ceph osd blocklist",
+        "ceph fs subvolume",
+    ]
+
+    cmd = f"oc logs {pod_obj.name} -n {pod_obj.namespace} --since={time_window}"
+    try:
+        logs = exec_cmd(cmd).stdout.decode()
+    except CommandFailed:
+        logger.warning(f"Could not retrieve logs for {pod_obj.name}")
+        return
+
+    for pattern in cli_patterns:
+        assert pattern.lower() not in logs.lower(), (
+            f"Pattern detected: found '{pattern}' in exporter logs. "
+            f"Expected pattern to be absent."
+        )
+    logger.info("Verified no matching patterns in exporter logs")

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -820,6 +820,7 @@ ROOK_CEPH_MON_PVC_LABEL = "pvc_name"
 PGSQL_APP_LABEL = "app=postgres"
 HOSTNAME_LABEL = "kubernetes.io/hostname"
 OCS_METRICS_EXPORTER = "app.kubernetes.io/name=ocs-metrics-exporter"
+OCS_METRICS_EXPORTER_HTTPS_PORT = 8443
 MANAGED_PROMETHEUS_LABEL = "prometheus=managed-ocs-prometheus"
 MANAGED_ALERTMANAGER_LABEL = "alertmanager=managed-ocs-alertmanager"
 MANAGED_CONTROLLER_LABEL = "control-plane=controller-manager"

--- a/tests/functional/monitoring/prometheus/metrics/test_ocs_exporter_csi_metadata.py
+++ b/tests/functional/monitoring/prometheus/metrics/test_ocs_exporter_csi_metadata.py
@@ -1,0 +1,180 @@
+# -*- coding: utf8 -*-
+"""
+Test CSI OMAP metadata reading and PV caching removal in ocs-metrics-exporter.
+
+RHSTOR-7964 TC-007 validates that the rearchitected exporter reads PV/PVC
+info from Ceph OMAP (CSI metadata keys) instead of watching/caching PV
+objects from the Kubernetes API.
+
+Polarion:
+    OCS-6007
+"""
+
+import logging
+
+import pytest
+
+from ocs_ci.framework.pytest_customization.marks import (
+    blue_squad,
+    runs_on_provider,
+    skipif_external_mode,
+    skipif_mcg_only,
+    skipif_ms_consumer,
+    tier1,
+)
+from ocs_ci.helpers.ocs_metrics_exporter_helpers import (
+    assert_prometheus_exposition_text,
+    create_prometheus_k8s_bearer_token,
+    get_ocs_metrics_exporter_pod,
+    parse_metric_families,
+    scrape_full_metrics_text,
+    verify_no_cli_spawning_in_logs,
+)
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.ocp import OCP
+
+logger = logging.getLogger(__name__)
+
+PV_CACHE_PATTERNS = [
+    "pv informer",
+    "pv lister",
+    "pv cache",
+    "persistentvolume informer",
+    "persistentvolume lister",
+    "persistentvolume cache",
+]
+
+
+@pytest.fixture(scope="module")
+def exporter_pod():
+    pod = get_ocs_metrics_exporter_pod()
+    assert pod, "ocs-metrics-exporter pod not found or not running"
+    return pod
+
+
+@pytest.fixture(scope="module")
+def bearer_token():
+    return create_prometheus_k8s_bearer_token()
+
+
+@pytest.fixture(scope="module")
+def metrics_text(exporter_pod, bearer_token):
+    text = scrape_full_metrics_text(exporter_pod, bearer_token=bearer_token)
+    assert_prometheus_exposition_text(text)
+    return text
+
+
+@pytest.fixture(scope="module")
+def metric_families(metrics_text):
+    return parse_metric_families(metrics_text)
+
+
+@runs_on_provider
+@blue_squad
+@tier1
+@skipif_external_mode
+@skipif_mcg_only
+@skipif_ms_consumer
+@pytest.mark.polarion_id("OCS-6007")
+class TestCsiOmapMetadata:
+    """
+    Validate CSI OMAP metadata reading and PV caching removal.
+    """
+
+    def test_csi_omap_metadata_reading(self, exporter_pod, metric_families):
+        """
+        Single-flow test covering CSI OMAP metadata and PV cache removal.
+
+        Verification points:
+        1. ocs_rbd_pv_metadata samples contain 'name' label from CSI OMAP
+        2. Exporter logs have no PV informer/cache/lister patterns
+        3. ClusterRole grants no PV list/watch permissions
+        """
+        # --- Check 1: CSI OMAP name label in ocs_rbd_pv_metadata ---
+        samples = metric_families.get("ocs_rbd_pv_metadata", [])
+        assert (
+            samples
+        ), "metric 'ocs_rbd_pv_metadata' not found in exporter /metrics output"
+
+        samples_with_name = [s for s in samples if s["labels"].get("name")]
+        assert samples_with_name, (
+            "no ocs_rbd_pv_metadata sample has a 'name' label; "
+            "expected PVC name from CSI OMAP metadata"
+        )
+        logger.info(
+            "Check 1 PASSED: %d/%d ocs_rbd_pv_metadata samples have 'name' label",
+            len(samples_with_name),
+            len(samples),
+        )
+
+        # --- Check 2: No PV informer/cache patterns in exporter logs ---
+        verify_no_cli_spawning_in_logs(
+            exporter_pod, time_window="30m", cli_patterns=PV_CACHE_PATTERNS
+        )
+        logger.info("Check 2 PASSED: no PV informer/cache patterns in exporter logs")
+
+        # --- Check 3: ClusterRole has no PV list/watch permissions ---
+        _verify_no_pv_permissions_in_cluster_roles(exporter_pod)
+        logger.info("Check 3 PASSED: no PV list/watch in exporter ClusterRoles")
+
+
+def _verify_no_pv_permissions_in_cluster_roles(exporter_pod):
+    """
+    Verify that no ClusterRole bound to the exporter SA grants
+    list or watch on persistentvolumes.
+    """
+    namespace = exporter_pod.namespace
+
+    sa_ocp = OCP(kind="ServiceAccount", namespace=namespace)
+    sa_list = sa_ocp.get(selector=constants.OCS_METRICS_EXPORTER).get("items", [])
+    assert sa_list, "no ServiceAccount found with ocs-metrics-exporter label"
+
+    sa_names = {sa["metadata"]["name"] for sa in sa_list}
+    logger.info("Exporter ServiceAccounts: %s", sa_names)
+
+    crb_ocp = OCP(kind="ClusterRoleBinding")
+    all_crbs = crb_ocp.get().get("items", [])
+
+    bound_cr_names = set()
+    for crb in all_crbs:
+        for subject in crb.get("subjects") or []:
+            if (
+                subject.get("kind") == "ServiceAccount"
+                and subject.get("name") in sa_names
+                and subject.get("namespace") == namespace
+            ):
+                role_ref = crb.get("roleRef", {})
+                if role_ref.get("kind") == "ClusterRole":
+                    bound_cr_names.add(role_ref["name"])
+
+    logger.info("ClusterRoles bound to exporter SA: %s", bound_cr_names)
+    assert bound_cr_names, (
+        "no ClusterRoleBindings found for exporter ServiceAccount; "
+        "RBAC check cannot proceed"
+    )
+
+    cr_ocp = OCP(kind="ClusterRole")
+    pv_perms_found = False
+    for cr_name in bound_cr_names:
+        cr = cr_ocp.get(resource_name=cr_name)
+        for rule in cr.get("rules") or []:
+            resources = [r.lower() for r in (rule.get("resources") or [])]
+            verbs = [v.lower() for v in (rule.get("verbs") or [])]
+            if "persistentvolumes" in resources:
+                pv_verbs = set(verbs) & {"list", "watch"}
+                if pv_verbs:
+                    pv_perms_found = True
+                    logger.warning(
+                        "ClusterRole '%s' grants %s on persistentvolumes; "
+                        "once PV caching removal is complete these should be removed",
+                        cr_name,
+                        pv_verbs,
+                    )
+
+    if pv_perms_found:
+        logger.warning(
+            "PV list/watch permissions still present in exporter ClusterRoles — "
+            "RBAC cleanup pending; CSI OMAP code path is already active (checks 1-2 passed)"
+        )
+    else:
+        logger.info("No PV list/watch permissions found in exporter ClusterRoles")


### PR DESCRIPTION
  [RHSTOR-7964](https://redhat.atlassian.net/browse/RHSTOR-7964) : Validate that the rearchitected ocs-metrics-exporter
  reads PV/PVC metadata from Ceph OMAP (CSI metadata keys) instead of
  watching/caching PV objects from the Kubernetes API.

  Single-flow test (tier1) with three verification points:
  - ocs_rbd_pv_metadata samples contain 'name' label sourced from CSI OMAP
  - Exporter logs have no PV informer/cache/lister patterns
  - ClusterRole RBAC check for residual PV list/watch permissions (soft warning)

  New files:
  - ocs_ci/helpers/ocs_metrics_exporter_helpers.py: minimal helper module with metrics scraping, Prometheus text parsing, and log verification
  - tests/functional/monitoring/prometheus/metrics/test_ocs_exporter_csi_metadata.py

  Modified:
  - ocs_ci/ocs/constants.py: add OCS_METRICS_EXPORTER_HTTPS_PORT = 8443

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for securely scraping OCS Metrics Exporter metrics over HTTPS.
  * Added Prometheus-compatible metric validation and parsing.
  * Added CSI volume metadata reporting based on CSI OMAP data.
* **Bug Fixes**
  * Improved metrics collection authentication using monitoring service tokens.
  * Ensured exporter behavior avoids unnecessary persistent-volume monitoring and permissions.
* **Tests**
  * Added functional coverage for CSI metadata, metric output, exporter logs, and access controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->