### PR TITLE
RHSTOR-9207 - baseline testcases

### DIFF
--- a/tests/functional/pv/conftest.py
+++ b/tests/functional/pv/conftest.py
@@ -1,10 +1,55 @@
 import logging
 
+import pytest
+
 from ocs_ci.ocs import constants
 from ocs_ci.framework import config
+from ocs_ci.ocs.exceptions import CommandFailed, TimeoutExpiredError
 from ocs_ci.utility import version
 
 log = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def test_resources_cleanup(request):
+    """
+    Track dynamically created pods, PVCs, and snapshots and delete them during
+    teardown. If any resource fails to delete (leaving leftovers on the cluster),
+    the teardown fails loudly instead of silently passing.
+
+    Returns:
+        dict: buckets ``{"pods": [], "pvcs": [], "snapshots": []}`` for the test
+            to append the resource objects it creates.
+
+    """
+    resources = {"pods": [], "pvcs": [], "snapshots": []}
+
+    def resource_teardown():
+        log.info("Cleaning up test pods, PVCs, and snapshots")
+        cleanup_errors = (CommandFailed, TimeoutError, TimeoutExpiredError)
+        leftovers = []
+
+        # Delete in dependency order: pods first (they hold the PVCs), then PVCs,
+        # then snapshots.
+        for kind in ("pods", "pvcs", "snapshots"):
+            for obj in resources[kind]:
+                name = getattr(obj, "name", "unknown")
+                try:
+                    obj.delete()
+                except cleanup_errors as ex:
+                    log.error(f"Failed to delete {kind[:-1]} {name}: {ex}")
+                    leftovers.append(f"{kind[:-1]}/{name}")
+                except Exception as ex:
+                    log.exception(f"Unexpected error deleting {kind[:-1]} {name}: {ex}")
+                    leftovers.append(f"{kind[:-1]}/{name}")
+
+        assert not leftovers, (
+            "Teardown failed to delete resources; cluster may have leftovers: "
+            f"{', '.join(leftovers)}"
+        )
+
+    request.addfinalizer(resource_teardown)
+    return resources
 
 
 def pytest_collection_modifyitems(items):

--- a/tests/functional/pv/test_qos_limits.py
+++ b/tests/functional/pv/test_qos_limits.py
@@ -1,41 +1,43 @@
-import logging
-import pytest
-import time
 import json
+import logging
 import os
+import tempfile
+import pytest
 
 from ocs_ci.framework.pytest_customization.marks import (
     orange_squad,
-    tier1,
     skipif_ocs_version,
+    tier1,
 )
 from ocs_ci.framework.testlib import ManageTest
-from ocs_ci.ocs import constants
 from ocs_ci.helpers import helpers
-from ocs_ci.utility.utils import exec_cmd
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.exceptions import CommandFailed
 from ocs_ci.ocs.resources.pod import Pod
+from ocs_ci.utility.utils import exec_cmd
 
 log = logging.getLogger(__name__)
 
 
 @orange_squad
 @tier1
-@skipif_ocs_version("<4.21")
+@skipif_ocs_version("<4.23")
 class TestVolumeAttributesClassQoS(ManageTest):
 
-    @pytest.fixture(autouse=True)
+    @pytest.fixture(autouse=True, scope="class")
     def setup_qos_classes(self, request):
-        """Directly provisions Silver and Gold VolumeAttributesClass resources in the cluster."""
-        self.silver_vac_name = "silver-qos-tier"
-        self.gold_vac_name = "gold-qos-tier"
+        """Provisions Silver and Gold VolumeAttributesClass resources once for the test class."""
+        # Attach variables to request.cls so all test instances can access them via 'self'
+        request.cls.silver_vac_name = "silver-qos-tier"
+        request.cls.gold_vac_name = "gold-qos-tier"
 
-        self.silver_limits = {
+        request.cls.silver_limits = {
             "rbps": "1048576",
             "wbps": "1048576",
             "riops": "500",
             "wiops": "500",
         }
-        self.gold_limits = {
+        request.cls.gold_limits = {
             "rbps": "52428800",
             "wbps": "52428800",
             "riops": "2000",
@@ -45,37 +47,39 @@ class TestVolumeAttributesClassQoS(ManageTest):
         silver_manifest = {
             "apiVersion": "storage.k8s.io/v1",
             "kind": "VolumeAttributesClass",
-            "metadata": {"name": self.silver_vac_name},
+            "metadata": {"name": request.cls.silver_vac_name},
             "driverName": "openshift-storage.rbd.csi.ceph.com",
             "parameters": {
-                "maxReadBps": self.silver_limits["rbps"],
-                "maxWriteBps": self.silver_limits["wbps"],
-                "maxReadIops": self.silver_limits["riops"],
-                "maxWriteIops": self.silver_limits["wiops"],
+                "maxReadBps": request.cls.silver_limits["rbps"],
+                "maxWriteBps": request.cls.silver_limits["wbps"],
+                "maxReadIops": request.cls.silver_limits["riops"],
+                "maxWriteIops": request.cls.silver_limits["wiops"],
             },
         }
 
         gold_manifest = {
             "apiVersion": "storage.k8s.io/v1",
             "kind": "VolumeAttributesClass",
-            "metadata": {"name": self.gold_vac_name},
+            "metadata": {"name": request.cls.gold_vac_name},
             "driverName": "openshift-storage.rbd.csi.ceph.com",
             "parameters": {
-                "maxReadBps": self.gold_limits["rbps"],
-                "maxWriteBps": self.gold_limits["wbps"],
-                "maxReadIops": self.gold_limits["riops"],
-                "maxWriteIops": self.gold_limits["wiops"],
+                "maxReadBps": request.cls.gold_limits["rbps"],
+                "maxWriteBps": request.cls.gold_limits["wbps"],
+                "maxReadIops": request.cls.gold_limits["riops"],
+                "maxWriteIops": request.cls.gold_limits["wiops"],
             },
         }
 
-        log.info("Writing clean VolumeAttributesClass payload manifests...")
-        tmp_silver = f"/tmp/{self.silver_vac_name}.json"
-        tmp_gold = f"/tmp/{self.gold_vac_name}.json"
+        log.info(
+            "Writing clean VolumeAttributesClass payload manifests via tempfile..."
+        )
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as sf:
+            json.dump(silver_manifest, sf)
+            tmp_silver = sf.name
 
-        with open(tmp_silver, "w") as f:
-            json.dump(silver_manifest, f)
-        with open(tmp_gold, "w") as f:
-            json.dump(gold_manifest, f)
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as gf:
+            json.dump(gold_manifest, gf)
+            tmp_gold = gf.name
 
         log.info("Injecting class structures into cluster context...")
         exec_cmd(f"oc apply -f {tmp_silver}")
@@ -84,10 +88,10 @@ class TestVolumeAttributesClassQoS(ManageTest):
         def cleanup():
             log.info("Scrubbing VolumeAttributesClass operational configurations...")
             exec_cmd(
-                f"oc delete volumeattributesclass {self.silver_vac_name} --ignore-not-found"
+                f"oc delete volumeattributesclass {request.cls.silver_vac_name} --ignore-not-found"
             )
             exec_cmd(
-                f"oc delete volumeattributesclass {self.gold_vac_name} --ignore-not-found"
+                f"oc delete volumeattributesclass {request.cls.gold_vac_name} --ignore-not-found"
             )
             for tmp_file in [tmp_silver, tmp_gold]:
                 if os.path.exists(tmp_file):
@@ -97,28 +101,43 @@ class TestVolumeAttributesClassQoS(ManageTest):
 
     @pytest.fixture
     def test_resources_cleanup(self, request):
-        """Maintains low-impact cleanup handles for dynamically generated pods and claims."""
+        """Maintains cleanup handles for dynamically generated pods and claims."""
         resources = {"pods": [], "pvcs": []}
 
         def resource_teardown():
             log.info("Cleaning up remaining test case allocations...")
+            cleanup_errors = (CommandFailed, TimeoutError)
+
             for pod in resources["pods"]:
                 try:
                     pod.delete()
-                except Exception:
-                    pass
+                except cleanup_errors as ex:
+                    log.warning(
+                        f"Handled expected deletion failure for pod {getattr(pod, 'name', 'unknown')}: {ex}"
+                    )
+                except Exception as ex:
+                    log.error(
+                        f"Unexpected error deleting pod {getattr(pod, 'name', 'unknown')}: {ex}",
+                        exc_info=True,
+                    )
+
             for pvc in resources["pvcs"]:
                 try:
                     pvc.delete()
-                except Exception:
-                    pass
+                except cleanup_errors as ex:
+                    log.warning(
+                        f"Handled expected deletion failure for PVC {getattr(pvc, 'name', 'unknown')}: {ex}"
+                    )
+                except Exception as ex:
+                    log.error(
+                        f"Unexpected error deleting PVC {getattr(pvc, 'name', 'unknown')}: {ex}",
+                        exc_info=True,
+                    )
 
         request.addfinalizer(resource_teardown)
         return resources
 
-    def verify_node_cgroup_throttling(
-        self, pod_obj, pvc_obj, qos_slice, expected_limits
-    ):
+    def verify_node_cgroup_throttling(self, pod_obj, expected_limits):
         """Scrapes active kernel cgroup mappings dynamically and verifies io.max contents."""
         pod_data = pod_obj.get()
         node_name = pod_data["spec"]["nodeName"]
@@ -127,7 +146,6 @@ class TestVolumeAttributesClassQoS(ManageTest):
 
         log.info(f"Target Pod is active on worker node: {node_name}")
 
-        # Corrected find syntax: Uses -path to select the pod directory and -name to locate io.max
         find_cmd = (
             f"oc debug node/{node_name} -n default -- chroot /host "
             f'sh -c \'find /sys/fs/cgroup/kubepods.slice/ -path "*pod{pod_cgroup_uid}*" '
@@ -145,40 +163,19 @@ class TestVolumeAttributesClassQoS(ManageTest):
             ), f"Missing target threshold: {key}={val} in io.max output:\n{io_max_output}"
 
     # =========================================================================
-    # TC-01: Guaranteed Pod + Fresh Filesystem RWO Baseline
+    # PARAMETRIZED TEST MATRIX (QOS-TC-01 through QOS-TC-06)
     # =========================================================================
-    def test_qos_01_guaranteed_filesystem_rwo(
-        self, project_factory, test_resources_cleanup
-    ):
-        """TC-01: Low I/O Footprint Guaranteed Pod Base Check"""
-        proj = project_factory()
-
-        pvc_obj = helpers.create_pvc(
-            sc_name=constants.DEFAULT_STORAGECLASS_RBD,
-            size="10Gi",
-            namespace=proj.namespace,
-            access_mode=constants.ACCESS_MODE_RWO,
-            volume_mode=constants.VOLUME_MODE_FILESYSTEM,
-        )
-        test_resources_cleanup["pvcs"].append(pvc_obj)
-
-        log.info(f"Waiting for PVC {pvc_obj.name} to transition to Bound phase...")
-        helpers.wait_for_resource_state(pvc_obj, constants.STATUS_BOUND, timeout=180)
-
-        log.info(
-            f"Patching PVC {pvc_obj.name} with VolumeAttributesClass: {self.silver_vac_name}"
-        )
-        exec_cmd(
-            f"oc patch pvc {pvc_obj.name} -n {proj.namespace} -p "
-            f'\'{{"spec":{{"volumeAttributesClassName":"{self.silver_vac_name}"}}}}\''
-        )
-
-        pod_dict = {
-            "apiVersion": "v1",
-            "kind": "Pod",
-            "metadata": {"name": "guaranteed-qos-pod", "namespace": proj.namespace},
-            "spec": {
-                "containers": [
+    @pytest.mark.parametrize(
+        "test_id, access_mode, volume_mode, is_gold_vac, pod_name, containers_spec, expected_qos_class, is_read_only",
+        [
+            # QOS-TC-01: Guaranteed Pod + Fresh Filesystem RWO Baseline
+            (
+                "QOS-TC-01",
+                constants.ACCESS_MODE_RWO,
+                constants.VOLUME_MODE_FILESYSTEM,
+                False,
+                "guaranteed-qos-pod",
+                [
                     {
                         "name": "worker",
                         "image": "quay.io/centos/centos:stream9",
@@ -188,65 +185,21 @@ class TestVolumeAttributesClassQoS(ManageTest):
                             "limits": {"cpu": "200m", "memory": "256Mi"},
                         },
                         "volumeMounts": [
-                            {"name": "voldata", "mountPath": "/mnt/storage"}
+                            {"name": "vol-data", "mountPath": "/mnt/storage"}
                         ],
                     }
                 ],
-                "volumes": [
-                    {
-                        "name": "voldata",
-                        "persistentVolumeClaim": {"claimName": pvc_obj.name},
-                    }
-                ],
-            },
-        }
-        pod_obj = Pod(**pod_dict)
-        pod_obj.create()
-        test_resources_cleanup["pods"].append(pod_obj)
-
-        time.sleep(15)
-        helpers.wait_for_resource_state(pod_obj, constants.STATUS_RUNNING, timeout=420)
-
-        assert pod_obj.get()["status"]["qosClass"] == "Guaranteed"
-        self.verify_node_cgroup_throttling(
-            pod_obj, pvc_obj, "kubepods-pod.slice", self.silver_limits
-        )
-
-    # =========================================================================
-    # TC-02: Burstable Pod + Fresh Filesystem RWOP Validation
-    # =========================================================================
-    def test_qos_02_burstable_filesystem_rwop(
-        self, project_factory, test_resources_cleanup
-    ):
-        """TC-02: Burstable Pod + Fresh Filesystem RWOP Validation"""
-        proj = project_factory()
-
-        pvc_obj = helpers.create_pvc(
-            sc_name=constants.DEFAULT_STORAGECLASS_RBD,
-            size="10Gi",
-            namespace=proj.namespace,
-            access_mode=constants.ACCESS_MODE_RWOP,
-            volume_mode=constants.VOLUME_MODE_FILESYSTEM,
-        )
-        test_resources_cleanup["pvcs"].append(pvc_obj)
-
-        log.info(f"Waiting for PVC {pvc_obj.name} to transition to Bound phase...")
-        helpers.wait_for_resource_state(pvc_obj, constants.STATUS_BOUND, timeout=180)
-
-        log.info(
-            f"Patching PVC {pvc_obj.name} with VolumeAttributesClass: {self.silver_vac_name}"
-        )
-        exec_cmd(
-            f"oc patch pvc {pvc_obj.name} -n {proj.namespace} -p "
-            f'\'{{"spec":{{"volumeAttributesClassName":"{self.silver_vac_name}"}}}}\''
-        )
-
-        pod_dict = {
-            "apiVersion": "v1",
-            "kind": "Pod",
-            "metadata": {"name": "burstable-qos-pod", "namespace": proj.namespace},
-            "spec": {
-                "containers": [
+                "Guaranteed",
+                False,
+            ),
+            # QOS-TC-02: Burstable Pod + Fresh Filesystem RWOP Validation
+            (
+                "QOS-TC-02",
+                constants.ACCESS_MODE_RWOP,
+                constants.VOLUME_MODE_FILESYSTEM,
+                False,
+                "burstable-qos-pod",
+                [
                     {
                         "name": "worker",
                         "image": "quay.io/centos/centos:stream9",
@@ -256,71 +209,27 @@ class TestVolumeAttributesClassQoS(ManageTest):
                             "limits": {"cpu": "500m", "memory": "512Mi"},
                         },
                         "volumeMounts": [
-                            {"name": "voldata", "mountPath": "/mnt/storage"}
+                            {"name": "vol-data", "mountPath": "/mnt/storage"}
                         ],
                     }
                 ],
-                "volumes": [
-                    {
-                        "name": "voldata",
-                        "persistentVolumeClaim": {"claimName": pvc_obj.name},
-                    }
-                ],
-            },
-        }
-        pod_obj = Pod(**pod_dict)
-        pod_obj.create()
-        test_resources_cleanup["pods"].append(pod_obj)
-
-        time.sleep(15)
-        helpers.wait_for_resource_state(pod_obj, constants.STATUS_RUNNING, timeout=420)
-
-        assert pod_obj.get()["status"]["qosClass"] == "Burstable"
-        self.verify_node_cgroup_throttling(
-            pod_obj, pvc_obj, "kubepods-burstable.slice", self.silver_limits
-        )
-
-    # =========================================================================
-    # TC-03: BestEffort Pod + Fresh Block RWX Multi-Volume Isolation
-    # =========================================================================
-    def test_qos_03_besteffort_block_rwx_multicontainer(
-        self, project_factory, test_resources_cleanup
-    ):
-        """TC-03: BestEffort Pod + Fresh Block RWX Multi-Volume Isolation"""
-        proj = project_factory()
-
-        pvc_obj = helpers.create_pvc(
-            sc_name=constants.DEFAULT_STORAGECLASS_RBD,
-            size="10Gi",
-            namespace=proj.namespace,
-            access_mode=constants.ACCESS_MODE_RWX,
-            volume_mode=constants.VOLUME_MODE_BLOCK,
-        )
-        test_resources_cleanup["pvcs"].append(pvc_obj)
-
-        log.info(f"Waiting for PVC {pvc_obj.name} to transition to Bound phase...")
-        helpers.wait_for_resource_state(pvc_obj, constants.STATUS_BOUND, timeout=180)
-
-        log.info(
-            f"Patching PVC {pvc_obj.name} with VolumeAttributesClass: {self.silver_vac_name}"
-        )
-        exec_cmd(
-            f"oc patch pvc {pvc_obj.name} -n {proj.namespace} -p "
-            f'\'{{"spec":{{"volumeAttributesClassName":"{self.silver_vac_name}"}}}}\''
-        )
-
-        pod_dict = {
-            "apiVersion": "v1",
-            "kind": "Pod",
-            "metadata": {"name": "besteffort-qos-pod", "namespace": proj.namespace},
-            "spec": {
-                "containers": [
+                "Burstable",
+                False,
+            ),
+            # QOS-TC-03: BestEffort Pod + Fresh Block RWX Multi-Volume Isolation
+            (
+                "QOS-TC-03",
+                constants.ACCESS_MODE_RWX,
+                constants.VOLUME_MODE_BLOCK,
+                False,
+                "besteffort-qos-pod",
+                [
                     {
                         "name": "container-1",
                         "image": "quay.io/centos/centos:stream9",
                         "command": ["sleep", "3600"],
                         "volumeDevices": [
-                            {"name": "blockvol", "devicePath": "/dev/rbdblock"}
+                            {"name": "vol-data", "devicePath": "/dev/rbdblock"}
                         ],
                     },
                     {
@@ -328,63 +237,21 @@ class TestVolumeAttributesClassQoS(ManageTest):
                         "image": "quay.io/centos/centos:stream9",
                         "command": ["sleep", "3600"],
                         "volumeDevices": [
-                            {"name": "blockvol", "devicePath": "/dev/rbdblock"}
+                            {"name": "vol-data", "devicePath": "/dev/rbdblock"}
                         ],
                     },
                 ],
-                "volumes": [
-                    {
-                        "name": "blockvol",
-                        "persistentVolumeClaim": {"claimName": pvc_obj.name},
-                    }
-                ],
-            },
-        }
-        pod_obj = Pod(**pod_dict)
-        pod_obj.create()
-        test_resources_cleanup["pods"].append(pod_obj)
-
-        time.sleep(15)
-        helpers.wait_for_resource_state(pod_obj, constants.STATUS_RUNNING, timeout=420)
-
-        assert pod_obj.get()["status"]["qosClass"] == "BestEffort"
-        self.verify_node_cgroup_throttling(
-            pod_obj, pvc_obj, "kubepods-besteffort.slice", self.silver_limits
-        )
-
-    # =========================================================================
-    # TC-04: Guaranteed Class + Fresh Block RWO Mapping
-    # =========================================================================
-    def test_qos_04_guaranteed_block_rwo(self, project_factory, test_resources_cleanup):
-        """TC-04: Guaranteed Class + Fresh Block RWO Mapping"""
-        proj = project_factory()
-
-        pvc_obj = helpers.create_pvc(
-            sc_name=constants.DEFAULT_STORAGECLASS_RBD,
-            size="10Gi",
-            namespace=proj.namespace,
-            access_mode=constants.ACCESS_MODE_RWO,
-            volume_mode=constants.VOLUME_MODE_BLOCK,
-        )
-        test_resources_cleanup["pvcs"].append(pvc_obj)
-
-        log.info(f"Waiting for PVC {pvc_obj.name} to transition to Bound phase...")
-        helpers.wait_for_resource_state(pvc_obj, constants.STATUS_BOUND, timeout=180)
-
-        log.info(
-            f"Patching PVC {pvc_obj.name} with VolumeAttributesClass: {self.silver_vac_name}"
-        )
-        exec_cmd(
-            f"oc patch pvc {pvc_obj.name} -n {proj.namespace} -p "
-            f'\'{{"spec":{{"volumeAttributesClassName":"{self.silver_vac_name}"}}}}\''
-        )
-
-        pod_dict = {
-            "apiVersion": "v1",
-            "kind": "Pod",
-            "metadata": {"name": "guaranteed-block-pod", "namespace": proj.namespace},
-            "spec": {
-                "containers": [
+                "BestEffort",
+                False,
+            ),
+            # QOS-TC-04: Guaranteed Class + Fresh Block RWO Mapping
+            (
+                "QOS-TC-04",
+                constants.ACCESS_MODE_RWO,
+                constants.VOLUME_MODE_BLOCK,
+                False,
+                "guaranteed-block-pod",
+                [
                     {
                         "name": "worker",
                         "image": "quay.io/centos/centos:stream9",
@@ -394,63 +261,21 @@ class TestVolumeAttributesClassQoS(ManageTest):
                             "limits": {"cpu": "200m", "memory": "256Mi"},
                         },
                         "volumeDevices": [
-                            {"name": "blockvol", "devicePath": "/dev/rbdblock"}
+                            {"name": "vol-data", "devicePath": "/dev/rbdblock"}
                         ],
                     }
                 ],
-                "volumes": [
-                    {
-                        "name": "blockvol",
-                        "persistentVolumeClaim": {"claimName": pvc_obj.name},
-                    }
-                ],
-            },
-        }
-        pod_obj = Pod(**pod_dict)
-        pod_obj.create()
-        test_resources_cleanup["pods"].append(pod_obj)
-
-        time.sleep(15)
-        helpers.wait_for_resource_state(pod_obj, constants.STATUS_RUNNING, timeout=420)
-
-        assert pod_obj.get()["status"]["qosClass"] == "Guaranteed"
-        self.verify_node_cgroup_throttling(
-            pod_obj, pvc_obj, "kubepods-pod.slice", self.silver_limits
-        )
-
-    # =========================================================================
-    # TC-05: Burstable Class + Fresh Block RWOP Mapping
-    # =========================================================================
-    def test_qos_05_burstable_block_rwop(self, project_factory, test_resources_cleanup):
-        """TC-05: Burstable Class + Fresh Block RWOP Mapping"""
-        proj = project_factory()
-
-        pvc_obj = helpers.create_pvc(
-            sc_name=constants.DEFAULT_STORAGECLASS_RBD,
-            size="10Gi",
-            namespace=proj.namespace,
-            access_mode=constants.ACCESS_MODE_RWOP,
-            volume_mode=constants.VOLUME_MODE_BLOCK,
-        )
-        test_resources_cleanup["pvcs"].append(pvc_obj)
-
-        log.info(f"Waiting for PVC {pvc_obj.name} to transition to Bound phase...")
-        helpers.wait_for_resource_state(pvc_obj, constants.STATUS_BOUND, timeout=180)
-
-        log.info(
-            f"Patching PVC {pvc_obj.name} with VolumeAttributesClass: {self.silver_vac_name}"
-        )
-        exec_cmd(
-            f"oc patch pvc {pvc_obj.name} -n {proj.namespace} -p "
-            f'\'{{"spec":{{"volumeAttributesClassName":"{self.silver_vac_name}"}}}}\''
-        )
-
-        pod_dict = {
-            "apiVersion": "v1",
-            "kind": "Pod",
-            "metadata": {"name": "burstable-block-pod", "namespace": proj.namespace},
-            "spec": {
-                "containers": [
+                "Guaranteed",
+                False,
+            ),
+            # QOS-TC-05: Burstable Class + Fresh Block RWOP Mapping
+            (
+                "QOS-TC-05",
+                constants.ACCESS_MODE_RWOP,
+                constants.VOLUME_MODE_BLOCK,
+                False,
+                "burstable-block-pod",
+                [
                     {
                         "name": "worker",
                         "image": "quay.io/centos/centos:stream9",
@@ -460,62 +285,21 @@ class TestVolumeAttributesClassQoS(ManageTest):
                             "limits": {"cpu": "500m", "memory": "512Mi"},
                         },
                         "volumeDevices": [
-                            {"name": "blockvol", "devicePath": "/dev/rbdblock"}
+                            {"name": "vol-data", "devicePath": "/dev/rbdblock"}
                         ],
                     }
                 ],
-                "volumes": [
-                    {
-                        "name": "blockvol",
-                        "persistentVolumeClaim": {"claimName": pvc_obj.name},
-                    }
-                ],
-            },
-        }
-        pod_obj = Pod(**pod_dict)
-        pod_obj.create()
-        test_resources_cleanup["pods"].append(pod_obj)
-
-        time.sleep(15)
-        helpers.wait_for_resource_state(pod_obj, constants.STATUS_RUNNING, timeout=420)
-
-        assert pod_obj.get()["status"]["qosClass"] == "Burstable"
-        self.verify_node_cgroup_throttling(
-            pod_obj, pvc_obj, "kubepods-burstable.slice", self.silver_limits
-        )
-
-    # =========================================================================
-    # TC-06: Read-Only (ROX) Block Mode Evaluation
-    # =========================================================================
-    def test_qos_06_guaranteed_block_rox(self, project_factory, test_resources_cleanup):
-        """TC-06: Read-Only (ROX) Block Mode Evaluation"""
-        proj = project_factory()
-
-        # Provision claim as RWO to pass Ceph CSI validation, then enforce readOnly in the Pod spec
-        pvc_obj = helpers.create_pvc(
-            sc_name=constants.DEFAULT_STORAGECLASS_RBD,
-            size="10Gi",
-            namespace=proj.namespace,
-            access_mode=constants.ACCESS_MODE_RWO,
-            volume_mode=constants.VOLUME_MODE_BLOCK,
-        )
-        test_resources_cleanup["pvcs"].append(pvc_obj)
-
-        log.info(f"Waiting for PVC {pvc_obj.name} to transition to Bound phase...")
-        helpers.wait_for_resource_state(pvc_obj, constants.STATUS_BOUND, timeout=180)
-
-        log.info(f"Patching PVC {pvc_obj.name} with Gold VAC: {self.gold_vac_name}")
-        exec_cmd(
-            f"oc patch pvc {pvc_obj.name} -n {proj.namespace} -p "
-            f'\'{{"spec":{{"volumeAttributesClassName":"{self.gold_vac_name}"}}}}\''
-        )
-
-        pod_dict = {
-            "apiVersion": "v1",
-            "kind": "Pod",
-            "metadata": {"name": "rox-block-pod", "namespace": proj.namespace},
-            "spec": {
-                "containers": [
+                "Burstable",
+                False,
+            ),
+            # QOS-TC-06: Read-Only (ROX) Block Mode Evaluation
+            (
+                "QOS-TC-06",
+                constants.ACCESS_MODE_RWO,
+                constants.VOLUME_MODE_BLOCK,
+                True,  # Gold VAC Tier
+                "rox-block-pod",
+                [
                     {
                         "name": "worker",
                         "image": "quay.io/centos/centos:stream9",
@@ -525,44 +309,106 @@ class TestVolumeAttributesClassQoS(ManageTest):
                             "limits": {"cpu": "200m", "memory": "256Mi"},
                         },
                         "volumeDevices": [
-                            {"name": "blockvol", "devicePath": "/dev/rbdblock"}
+                            {"name": "vol-data", "devicePath": "/dev/rbdblock"}
                         ],
                     }
                 ],
-                "volumes": [
-                    {
-                        "name": "blockvol",
-                        "persistentVolumeClaim": {
-                            "claimName": pvc_obj.name,
-                            "readOnly": True,
-                        },
-                    }
-                ],
+                "Guaranteed",
+                True,  # Read-Only Spec Flag
+            ),
+        ],
+        ids=[
+            "QOS-TC-01",
+            "QOS-TC-02",
+            "QOS-TC-03",
+            "QOS-TC-04",
+            "QOS-TC-05",
+            "QOS-TC-06",
+        ],
+    )
+    def test_volume_attributes_class_qos(
+        self,
+        project_factory,
+        test_resources_cleanup,
+        test_id,
+        access_mode,
+        volume_mode,
+        is_gold_vac,
+        pod_name,
+        containers_spec,
+        expected_qos_class,
+        is_read_only,
+    ):
+        """Executes QoS limit validation across access modes, volume modes, and pod QoS classes."""
+        vac_name = self.gold_vac_name if is_gold_vac else self.silver_vac_name
+        expected_limits = self.gold_limits if is_gold_vac else self.silver_limits
+
+        proj = project_factory()
+
+        # 1. Provision PVC
+        pvc_obj = helpers.create_pvc(
+            sc_name=constants.DEFAULT_STORAGECLASS_RBD,
+            size="10Gi",
+            namespace=proj.namespace,
+            access_mode=access_mode,
+            volume_mode=volume_mode,
+        )
+        test_resources_cleanup["pvcs"].append(pvc_obj)
+
+        log.info(
+            f"[{test_id}] Waiting for PVC {pvc_obj.name} to transition to Bound phase..."
+        )
+        helpers.wait_for_resource_state(pvc_obj, constants.STATUS_BOUND, timeout=180)
+
+        # 2. Patch PVC with target VolumeAttributesClass via OCP API
+        log.info(
+            f"[{test_id}] Patching PVC {pvc_obj.name} with VolumeAttributesClass: {vac_name}"
+        )
+        patch_payload = json.dumps({"spec": {"volumeAttributesClassName": vac_name}})
+        pvc_obj.ocp.patch(
+            resource_name=pvc_obj.name, params=patch_payload, format_type="merge"
+        )
+
+        # 3. Create Pod
+        pvc_spec = {"claimName": pvc_obj.name}
+        if is_read_only:
+            pvc_spec["readOnly"] = True
+
+        pod_dict = {
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": {"name": pod_name, "namespace": proj.namespace},
+            "spec": {
+                "containers": containers_spec,
+                "volumes": [{"name": "vol-data", "persistentVolumeClaim": pvc_spec}],
             },
         }
+
         pod_obj = Pod(**pod_dict)
         pod_obj.create()
         test_resources_cleanup["pods"].append(pod_obj)
 
-        time.sleep(15)
         helpers.wait_for_resource_state(pod_obj, constants.STATUS_RUNNING, timeout=420)
 
-        # 1. Verify cgroup throttle boundaries map to Gold tier
-        self.verify_node_cgroup_throttling(
-            pod_obj, pvc_obj, "kubepods-pod.slice", self.gold_limits
-        )
-
-        # 2. Verify write operation fails inside the read-only volume container via direct exec_cmd
-        log.info("Verifying write protection on ROX block volume...")
-        dd_cmd = f"oc exec {pod_obj.name} -n {proj.namespace} -- dd if=/dev/zero of=/dev/rbdblock bs=1M count=1"
-        res = exec_cmd(dd_cmd, shell=True, ignore_error=True)
-        write_output = res.stderr.decode() if res.stderr else res.stdout.decode()
-
+        # 4. Verify Pod QoS Class
+        actual_qos = pod_obj.get()["status"]["qosClass"]
         assert (
-            res.returncode != 0
-            or "Operation not permitted" in write_output
-            or "Read-only" in write_output
-        ), (
-            f"Expected write operation to fail on read-only block device, "
-            f"but got exit code {res.returncode}: {write_output}"
-        )
+            actual_qos == expected_qos_class
+        ), f"[{test_id}] Pod {pod_name} QoS mismatch: expected {expected_qos_class}, got {actual_qos}"
+
+        # 5. Verify Node Kernel cgroup Throttling
+        self.verify_node_cgroup_throttling(pod_obj, expected_limits)
+
+        # 6. Additional Read-Only assertion for QOS-TC-06
+        if is_read_only:
+            log.info(f"[{test_id}] Verifying write protection on ROX block volume...")
+            dd_cmd = f"oc exec {pod_obj.name} -n {proj.namespace} -- dd if=/dev/zero of=/dev/rbdblock bs=1M count=1"
+            res = exec_cmd(dd_cmd, shell=True, ignore_error=True)
+            write_output = res.stderr.decode() if res.stderr else res.stdout.decode()
+
+            assert res.returncode != 0 and (
+                "Operation not permitted" in write_output or "Read-only" in write_output
+            ), (
+                f"[{test_id}] Expected write to fail with a read-only error on block device, "
+                f"but got exit code {res.returncode}: {write_output}"
+            )

--- a/tests/functional/pv/test_qos_limits.py
+++ b/tests/functional/pv/test_qos_limits.py
@@ -481,8 +481,10 @@ class TestVolumeAttributesClassQoS(ManageTest):
             )
 
             # Verify Read Path Workload
-            read_dd = (f"oc exec {pod_obj.name} -n {proj.namespace} -- "
-                       f"dd if=/dev/rbdblock of=/dev/null bs=1M count=10 status=progress")
+            read_dd = (
+                f"oc exec {pod_obj.name} -n {proj.namespace} -- "
+                f"dd if=/dev/rbdblock of=/dev/null bs=1M count=10 status=progress"
+            )
             read_res = exec_cmd(read_dd, shell=True, ignore_error=True)
             assert (
                 read_res.returncode == 0
@@ -497,16 +499,20 @@ class TestVolumeAttributesClassQoS(ManageTest):
                 io_target = "/dev/rbdblock"
 
             # Execute sequential write I/O through Ceph-CSI mounted volume path
-            write_dd = (f"oc exec {pod_obj.name} -n {proj.namespace} -- "
-                        f"dd if=/dev/zero of={io_target} bs=1M count=20 conv=fsync status=progress")
+            write_dd = (
+                f"oc exec {pod_obj.name} -n {proj.namespace} -- "
+                f"dd if=/dev/zero of={io_target} bs=1M count=20 conv=fsync status=progress"
+            )
             write_res = exec_cmd(write_dd, shell=True, ignore_error=True)
             assert (
                 write_res.returncode == 0
             ), f"[{test_id}] Write I/O workload failed on target {io_target}: {write_res.stderr}"
 
             # Execute sequential read I/O through Ceph-CSI mounted volume path
-            read_dd = (f"oc exec {pod_obj.name} -n {proj.namespace} -- "
-                       f"dd if={io_target} of=/dev/null bs=1M count=20 status=progress")
+            read_dd = (
+                f"oc exec {pod_obj.name} -n {proj.namespace} -- "
+                f"dd if={io_target} of=/dev/null bs=1M count=20 status=progress"
+            )
             read_res = exec_cmd(read_dd, shell=True, ignore_error=True)
             assert (
                 read_res.returncode == 0

--- a/tests/functional/pv/test_qos_limits.py
+++ b/tests/functional/pv/test_qos_limits.py
@@ -12,24 +12,24 @@ from ocs_ci.framework.pytest_customization.marks import (
 from ocs_ci.framework.testlib import ManageTest
 from ocs_ci.helpers import helpers
 from ocs_ci.ocs import constants
-from ocs_ci.ocs.exceptions import CommandFailed
+from ocs_ci.ocs.exceptions import CommandFailed, TimeoutExpiredError
 from ocs_ci.ocs.resources.pod import Pod
-from ocs_ci.utility.utils import exec_cmd
+from ocs_ci.utility.utils import exec_cmd, TimeoutSampler
 
 log = logging.getLogger(__name__)
 
 
 @orange_squad
 @tier1
-@skipif_ocs_version("<4.23")
+@skipif_ocs_version("<4.21")
 class TestVolumeAttributesClassQoS(ManageTest):
 
     @pytest.fixture(autouse=True, scope="class")
     def setup_qos_classes(self, request):
-        """Provisions Silver and Gold VolumeAttributesClass resources once for the test class."""
-        # Attach variables to request.cls so all test instances can access them via 'self'
+        """Provisions Silver, Gold, and Unthrottled VolumeAttributesClass resources once for the test class."""
         request.cls.silver_vac_name = "silver-qos-tier"
         request.cls.gold_vac_name = "gold-qos-tier"
+        request.cls.unthrottled_vac_name = "unthrottled-qos-tier"
 
         request.cls.silver_limits = {
             "rbps": "1048576",
@@ -43,6 +43,35 @@ class TestVolumeAttributesClassQoS(ManageTest):
             "riops": "2000",
             "wiops": "2000",
         }
+
+        tmp_silver = None
+        tmp_gold = None
+        tmp_unthrottled = None
+
+        def cleanup():
+            log.info("Scrubbing VolumeAttributesClass operational configurations...")
+            for vac_name in (
+                request.cls.silver_vac_name,
+                request.cls.gold_vac_name,
+                request.cls.unthrottled_vac_name,
+            ):
+                try:
+                    exec_cmd(
+                        f"oc delete volumeattributesclass {vac_name} --ignore-not-found",
+                        ignore_error=True,
+                    )
+                except Exception as ex:
+                    log.warning(f"Failed to delete VAC {vac_name}: {ex}")
+
+            for tmp_file in (tmp_silver, tmp_gold, tmp_unthrottled):
+                if tmp_file and os.path.exists(tmp_file):
+                    try:
+                        os.remove(tmp_file)
+                    except OSError as ex:
+                        log.warning(f"Failed to remove {tmp_file}: {ex}")
+
+        # Register finalizer immediately before any manifest file creation or apply operations
+        request.addfinalizer(cleanup)
 
         silver_manifest = {
             "apiVersion": "storage.k8s.io/v1",
@@ -70,6 +99,19 @@ class TestVolumeAttributesClassQoS(ManageTest):
             },
         }
 
+        unthrottled_manifest = {
+            "apiVersion": "storage.k8s.io/v1",
+            "kind": "VolumeAttributesClass",
+            "metadata": {"name": request.cls.unthrottled_vac_name},
+            "driverName": "openshift-storage.rbd.csi.ceph.com",
+            "parameters": {
+                "maxReadBps": request.cls.unthrottled_limits["rbps"],
+                "maxWriteBps": request.cls.unthrottled_limits["wbps"],
+                "maxReadIops": request.cls.unthrottled_limits["riops"],
+                "maxWriteIops": request.cls.unthrottled_limits["wiops"],
+            },
+        }
+
         log.info(
             "Writing clean VolumeAttributesClass payload manifests via tempfile..."
         )
@@ -81,33 +123,23 @@ class TestVolumeAttributesClassQoS(ManageTest):
             json.dump(gold_manifest, gf)
             tmp_gold = gf.name
 
-        def cleanup():
-            log.info("Scrubbing VolumeAttributesClass operational configurations...")
-            exec_cmd(
-                f"oc delete volumeattributesclass {request.cls.silver_vac_name} --ignore-not-found"
-            )
-            exec_cmd(
-                f"oc delete volumeattributesclass {request.cls.gold_vac_name} --ignore-not-found"
-            )
-            for tmp_file in [tmp_silver, tmp_gold]:
-                if os.path.exists(tmp_file):
-                    os.remove(tmp_file)
-
-        # Register finalizer immediately after definition to guarantee execution if apply fails
-        request.addfinalizer(cleanup)
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as uf:
+            json.dump(unthrottled_manifest, uf)
+            tmp_unthrottled = uf.name
 
         log.info("Injecting class structures into cluster context...")
         exec_cmd(f"oc apply -f {tmp_silver}")
         exec_cmd(f"oc apply -f {tmp_gold}")
+        exec_cmd(f"oc apply -f {tmp_unthrottled}")
 
     @pytest.fixture
     def test_resources_cleanup(self, request):
-        """Maintains cleanup handles for dynamically generated pods and claims."""
-        resources = {"pods": [], "pvcs": []}
+        """Maintains cleanup handles for dynamically generated pods, claims, and snapshots."""
+        resources = {"pods": [], "pvcs": [], "snapshots": []}
 
         def resource_teardown():
             log.info("Cleaning up remaining test case allocations...")
-            cleanup_errors = (CommandFailed, TimeoutError)
+            cleanup_errors = (CommandFailed, TimeoutError, TimeoutExpiredError)
 
             for pod in resources["pods"]:
                 try:
@@ -135,37 +167,87 @@ class TestVolumeAttributesClassQoS(ManageTest):
                         exc_info=True,
                     )
 
+            for snap in resources["snapshots"]:
+                try:
+                    snap.delete()
+                except cleanup_errors as ex:
+                    log.warning(
+                        f"Handled expected deletion failure for snapshot {getattr(snap, 'name', 'unknown')}: {ex}"
+                    )
+                except Exception as ex:
+                    log.error(
+                        f"Unexpected error deleting snapshot {getattr(snap, 'name', 'unknown')}: {ex}",
+                        exc_info=True,
+                    )
+
         request.addfinalizer(resource_teardown)
         return resources
 
-    def verify_node_cgroup_throttling(self, pod_obj, expected_limits):
-        """Scrapes active kernel cgroup mappings dynamically and verifies io.max contents."""
+    def verify_node_cgroup_throttling(
+        self, pod_obj, expected_limits, timeout=60, sleep=5
+    ):
+        """Scrapes active kernel cgroup mappings dynamically with polling retry logic until expected limits appear."""
         pod_data = pod_obj.get()
         node_name = pod_data["spec"]["nodeName"]
         pod_uid = pod_data["metadata"]["uid"]
         pod_cgroup_uid = pod_uid.replace("-", "_")
 
-        log.info(f"Target Pod is active on worker node: {node_name}")
+        log.info(
+            f"Target Pod is active on worker node: {node_name}. Polling cgroup io.max for limits..."
+        )
 
         find_cmd = (
             f"oc debug node/{node_name} -n default -- chroot /host "
             f'sh -c \'find /sys/fs/cgroup/kubepods.slice/ -path "*pod{pod_cgroup_uid}*" '
-            f'-name "io.max" -type f -exec cat {{}} \\;\''
+            f'-name "io.max" -type f -exec echo "===FILE: {{}}===" \\; -exec cat {{}} \\;\''
         )
 
-        res = exec_cmd(find_cmd, shell=True, ignore_error=True)
-        io_max_output = res.stdout.decode() if res.stdout else ""
+        def _check_cgroup_limits():
+            res = exec_cmd(find_cmd, shell=True, ignore_error=True)
+            output = res.stdout.decode() if res.stdout else ""
+            if not output.strip():
+                return False
 
-        log.info(f"Retrieved active io.max cgroup configurations:\n{io_max_output}")
+            # Check if all expected limit strings (e.g. 'rbps=52428800') exist in the CGroup output
+            for key, val in expected_limits.items():
+                expected_str = f"{key}={val}"
+                if expected_str not in output:
+                    log.debug(
+                        f"Threshold '{expected_str}' not yet visible in CGroup output. Retrying..."
+                    )
+                    return False
+            return output
 
-        for key, val in expected_limits.items():
-            assert (
-                f"{key}={val}" in io_max_output
-            ), f"Missing target threshold: {key}={val} in io.max output:\n{io_max_output}"
+        # Iterate over TimeoutSampler generator directly
+        matched_output = None
+        sample = TimeoutSampler(
+            timeout=timeout,
+            sleep=sleep,
+            func=_check_cgroup_limits,
+        )
 
-    # =========================================================================
-    # PARAMETRIZED TEST MATRIX (QOS-TC-01 through QOS-TC-06)
-    # =========================================================================
+        try:
+            for result in sample:
+                if result:
+                    matched_output = result
+                    break
+        except TimeoutExpiredError:
+            res = exec_cmd(find_cmd, shell=True, ignore_error=True)
+            final_output = res.stdout.decode() if res.stdout else ""
+            raise AssertionError(
+                f"Timed out after {timeout}s waiting for expected limits {expected_limits} "
+                f"in cgroup io.max for pod {pod_uid} on node {node_name}.\n"
+                f"Final CGroup Output:\n{final_output}"
+            )
+
+        log.info(
+            f"Successfully verified active io.max cgroup configurations:\n{matched_output}"
+        )
+
+        # =========================================================================
+        # PARAMETRIZED TEST MATRIX (QOS-TC-01 through QOS-TC-06)
+        # =========================================================================
+
     @pytest.mark.parametrize(
         "test_id, access_mode, volume_mode, is_gold_vac, pod_name, containers_spec, expected_qos_class, is_read_only",
         [
@@ -400,9 +482,12 @@ class TestVolumeAttributesClassQoS(ManageTest):
         # 5. Verify Node Kernel cgroup Throttling
         self.verify_node_cgroup_throttling(pod_obj, expected_limits)
 
-        # 6. Additional Read-Only assertion for QOS-TC-06
+        # 6. Perform Active I/O Path Validation
         if is_read_only:
-            log.info(f"[{test_id}] Verifying write protection on ROX block volume...")
+            log.info(
+                f"[{test_id}] Verifying write protection and read access on ROX block volume..."
+            )
+            # Verify Write Protection (Must fail)
             dd_cmd = f"oc exec {pod_obj.name} -n {proj.namespace} -- dd if=/dev/zero of=/dev/rbdblock bs=1M count=1"
             res = exec_cmd(dd_cmd, shell=True, ignore_error=True)
             write_output = res.stderr.decode() if res.stderr else res.stdout.decode()
@@ -413,3 +498,35 @@ class TestVolumeAttributesClassQoS(ManageTest):
                 f"[{test_id}] Expected write to fail with a read-only error on block device, "
                 f"but got exit code {res.returncode}: {write_output}"
             )
+
+            # Verify Read Path Workload
+            read_dd = (f"oc exec {pod_obj.name} -n {proj.namespace} -- "
+                       f"dd if=/dev/rbdblock of=/dev/null bs=1M count=10 status=progress")
+            read_res = exec_cmd(read_dd, shell=True, ignore_error=True)
+            assert (
+                read_res.returncode == 0
+            ), f"[{test_id}] Read I/O workload failed on read-only volume: {read_res.stderr}"
+        else:
+            log.info(
+                f"[{test_id}] Executing active write & read I/O workload on volume..."
+            )
+            if volume_mode == constants.VOLUME_MODE_FILESYSTEM:
+                io_target = "/mnt/storage/test_io.img"
+            else:
+                io_target = "/dev/rbdblock"
+
+            # Execute sequential write I/O through Ceph-CSI mounted volume path
+            write_dd = (f"oc exec {pod_obj.name} -n {proj.namespace} -- "
+                        f"dd if=/dev/zero of={io_target} bs=1M count=20 conv=fsync status=progress")
+            write_res = exec_cmd(write_dd, shell=True, ignore_error=True)
+            assert (
+                write_res.returncode == 0
+            ), f"[{test_id}] Write I/O workload failed on target {io_target}: {write_res.stderr}"
+
+            # Execute sequential read I/O through Ceph-CSI mounted volume path
+            read_dd = (f"oc exec {pod_obj.name} -n {proj.namespace} -- "
+                       f"dd if={io_target} of=/dev/null bs=1M count=20 status=progress")
+            read_res = exec_cmd(read_dd, shell=True, ignore_error=True)
+            assert (
+                read_res.returncode == 0
+            ), f"[{test_id}] Read I/O workload failed on target {io_target}: {read_res.stderr}"

--- a/tests/functional/pv/test_qos_limits.py
+++ b/tests/functional/pv/test_qos_limits.py
@@ -16,7 +16,7 @@ from ocs_ci.ocs.exceptions import CommandFailed, TimeoutExpiredError
 from ocs_ci.ocs.resources.pod import Pod
 from ocs_ci.utility.utils import exec_cmd, TimeoutSampler
 
-log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 @orange_squad
@@ -45,14 +45,12 @@ class TestVolumeAttributesClassQoS(ManageTest):
 
         tmp_silver = None
         tmp_gold = None
-        tmp_unthrottled = None
 
         def cleanup():
-            log.info("Scrubbing VolumeAttributesClass operational configurations...")
+            logger.info("Deleting VolumeAttributesClass resources")
             for vac_name in (
                 request.cls.silver_vac_name,
                 request.cls.gold_vac_name,
-                request.cls.unthrottled_vac_name,
             ):
                 try:
                     exec_cmd(
@@ -60,14 +58,14 @@ class TestVolumeAttributesClassQoS(ManageTest):
                         ignore_error=True,
                     )
                 except Exception as ex:
-                    log.warning(f"Failed to delete VAC {vac_name}: {ex}")
+                    logger.warning(f"Failed to delete VAC {vac_name}: {ex}")
 
-            for tmp_file in (tmp_silver, tmp_gold, tmp_unthrottled):
+            for tmp_file in (tmp_silver, tmp_gold):
                 if tmp_file and os.path.exists(tmp_file):
                     try:
                         os.remove(tmp_file)
                     except OSError as ex:
-                        log.warning(f"Failed to remove {tmp_file}: {ex}")
+                        logger.warning(f"Failed to remove {tmp_file}: {ex}")
 
         # Register finalizer immediately before any manifest file creation or apply operations
         request.addfinalizer(cleanup)
@@ -98,9 +96,7 @@ class TestVolumeAttributesClassQoS(ManageTest):
             },
         }
 
-        log.info(
-            "Writing clean VolumeAttributesClass payload manifests via tempfile..."
-        )
+        logger.info("Writing VolumeAttributesClass manifests to temp files")
         with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as sf:
             json.dump(silver_manifest, sf)
             tmp_silver = sf.name
@@ -109,7 +105,6 @@ class TestVolumeAttributesClassQoS(ManageTest):
             json.dump(gold_manifest, gf)
             tmp_gold = gf.name
 
-        log.info("Injecting class structures into cluster context...")
         exec_cmd(f"oc apply -f {tmp_silver}")
         exec_cmd(f"oc apply -f {tmp_gold}")
 
@@ -119,46 +114,43 @@ class TestVolumeAttributesClassQoS(ManageTest):
         resources = {"pods": [], "pvcs": [], "snapshots": []}
 
         def resource_teardown():
-            log.info("Cleaning up remaining test case allocations...")
+            logger.info("Cleaning up test pods, PVCs, and snapshots")
             cleanup_errors = (CommandFailed, TimeoutError, TimeoutExpiredError)
 
             for pod in resources["pods"]:
                 try:
                     pod.delete()
                 except cleanup_errors as ex:
-                    log.warning(
+                    logger.warning(
                         f"Handled expected deletion failure for pod {getattr(pod, 'name', 'unknown')}: {ex}"
                     )
                 except Exception as ex:
-                    log.error(
-                        f"Unexpected error deleting pod {getattr(pod, 'name', 'unknown')}: {ex}",
-                        exc_info=True,
+                    logger.exception(
+                        f"Unexpected error deleting pod {getattr(pod, 'name', 'unknown')}: {ex}"
                     )
 
             for pvc in resources["pvcs"]:
                 try:
                     pvc.delete()
                 except cleanup_errors as ex:
-                    log.warning(
+                    logger.warning(
                         f"Handled expected deletion failure for PVC {getattr(pvc, 'name', 'unknown')}: {ex}"
                     )
                 except Exception as ex:
-                    log.error(
-                        f"Unexpected error deleting PVC {getattr(pvc, 'name', 'unknown')}: {ex}",
-                        exc_info=True,
+                    logger.exception(
+                        f"Unexpected error deleting PVC {getattr(pvc, 'name', 'unknown')}: {ex}"
                     )
 
             for snap in resources["snapshots"]:
                 try:
                     snap.delete()
                 except cleanup_errors as ex:
-                    log.warning(
+                    logger.warning(
                         f"Handled expected deletion failure for snapshot {getattr(snap, 'name', 'unknown')}: {ex}"
                     )
                 except Exception as ex:
-                    log.error(
-                        f"Unexpected error deleting snapshot {getattr(snap, 'name', 'unknown')}: {ex}",
-                        exc_info=True,
+                    logger.exception(
+                        f"Unexpected error deleting snapshot {getattr(snap, 'name', 'unknown')}: {ex}"
                     )
 
         request.addfinalizer(resource_teardown)
@@ -173,8 +165,8 @@ class TestVolumeAttributesClassQoS(ManageTest):
         pod_uid = pod_data["metadata"]["uid"]
         pod_cgroup_uid = pod_uid.replace("-", "_")
 
-        log.info(
-            f"Target Pod is active on worker node: {node_name}. Polling cgroup io.max for limits..."
+        logger.info(
+            f"Pod {pod_obj.name} scheduled on node {node_name}; polling cgroup io.max for limits"
         )
 
         find_cmd = (
@@ -186,20 +178,19 @@ class TestVolumeAttributesClassQoS(ManageTest):
         def _check_cgroup_limits():
             res = exec_cmd(find_cmd, shell=True, ignore_error=True)
             output = res.stdout.decode() if res.stdout else ""
+
             if not output.strip():
                 return False
 
-            # Check if all expected limit strings (e.g. 'rbps=52428800') exist in the CGroup output
             for key, val in expected_limits.items():
                 expected_str = f"{key}={val}"
                 if expected_str not in output:
-                    log.debug(
+                    logger.debug(
                         f"Threshold '{expected_str}' not yet visible in CGroup output. Retrying..."
                     )
                     return False
             return output
 
-        # Iterate over TimeoutSampler generator directly
         matched_output = None
         sample = TimeoutSampler(
             timeout=timeout,
@@ -221,10 +212,10 @@ class TestVolumeAttributesClassQoS(ManageTest):
                 f"Final CGroup Output:\n{final_output}"
             )
 
-        log.info(
-            f"Successfully verified active io.max cgroup configurations:\n{matched_output}"
+        logger.info(
+            "Verified active io.max cgroup configurations match expected limits"
         )
-
+        logger.debug(f"Matched cgroup io.max output:\n{matched_output}")
         # =========================================================================
         # PARAMETRIZED TEST MATRIX (QOS-TC-01 through QOS-TC-06)
         # =========================================================================
@@ -409,7 +400,7 @@ class TestVolumeAttributesClassQoS(ManageTest):
 
         proj = project_factory()
 
-        # 1. Provision PVC
+        logger.test_step(f"[{test_id}] Provision {access_mode}/{volume_mode} PVC")
         pvc_obj = helpers.create_pvc(
             sc_name=constants.DEFAULT_STORAGECLASS_RBD,
             size="10Gi",
@@ -418,26 +409,25 @@ class TestVolumeAttributesClassQoS(ManageTest):
             volume_mode=volume_mode,
         )
         test_resources_cleanup["pvcs"].append(pvc_obj)
-
-        log.info(
-            f"[{test_id}] Waiting for PVC {pvc_obj.name} to transition to Bound phase..."
-        )
         helpers.wait_for_resource_state(pvc_obj, constants.STATUS_BOUND, timeout=180)
 
-        # 2. Patch PVC with target VolumeAttributesClass via OCP API
-        log.info(
-            f"[{test_id}] Patching PVC {pvc_obj.name} with VolumeAttributesClass: {vac_name}"
+        logger.test_step(
+            f"[{test_id}] Patch PVC {pvc_obj.name} with VolumeAttributesClass {vac_name}"
         )
         patch_payload = json.dumps({"spec": {"volumeAttributesClassName": vac_name}})
         pvc_obj.ocp.patch(
             resource_name=pvc_obj.name, params=patch_payload, format_type="merge"
         )
 
-        # 3. Create Pod
+        logger.test_step(f"[{test_id}] Create pod {pod_name} and wait for Running")
         pvc_spec = {"claimName": pvc_obj.name}
         if is_read_only:
             pvc_spec["readOnly"] = True
 
+        # Pods are built explicitly (not via pod_factory/helpers.create_pod) because
+        # these tests need precise control over per-container resources to force a
+        # specific QoS class (Guaranteed/Burstable/BestEffort), multi-container specs,
+        # and raw block volumeDevices — none of which the factory path can express.
         pod_dict = {
             "apiVersion": "v1",
             "kind": "Pod",
@@ -454,66 +444,73 @@ class TestVolumeAttributesClassQoS(ManageTest):
 
         helpers.wait_for_resource_state(pod_obj, constants.STATUS_RUNNING, timeout=420)
 
-        # 4. Verify Pod QoS Class
+        logger.test_step(f"[{test_id}] Verify pod QoS class")
         actual_qos = pod_obj.get()["status"]["qosClass"]
+        logger.assertion(
+            f"[{test_id}] Pod QoS class: expected={expected_qos_class}, actual={actual_qos}"
+        )
         assert (
             actual_qos == expected_qos_class
         ), f"[{test_id}] Pod {pod_name} QoS mismatch: expected {expected_qos_class}, got {actual_qos}"
 
-        # 5. Verify Node Kernel cgroup Throttling
+        logger.test_step(f"[{test_id}] Verify node cgroup io.max throttling")
         self.verify_node_cgroup_throttling(pod_obj, expected_limits)
 
-        # 6. Perform Active I/O Path Validation
+        logger.test_step(f"[{test_id}] Validate active I/O path on volume")
         if is_read_only:
-            log.info(
-                f"[{test_id}] Verifying write protection and read access on ROX block volume..."
-            )
-            # Verify Write Protection (Must fail)
-            dd_cmd = f"oc exec {pod_obj.name} -n {proj.namespace} -- dd if=/dev/zero of=/dev/rbdblock bs=1M count=1"
-            res = exec_cmd(dd_cmd, shell=True, ignore_error=True)
-            write_output = res.stderr.decode() if res.stderr else res.stdout.decode()
+            # Write must be rejected on a read-only block device. exec_cmd_on_pod
+            # raises CommandFailed on non-zero exit, so a successful call here means
+            # the write was (wrongly) allowed.
+            write_rejected = False
+            write_output = ""
+            try:
+                pod_obj.exec_cmd_on_pod(
+                    "dd if=/dev/zero of=/dev/rbdblock bs=1M count=1",
+                    out_yaml_format=False,
+                )
+            except CommandFailed as ex:
+                write_rejected = True
+                write_output = str(ex)
 
-            assert res.returncode != 0 and (
+            logger.assertion(
+                f"[{test_id}] Write to read-only block device rejected: {write_rejected}"
+            )
+            assert write_rejected and (
                 "Operation not permitted" in write_output or "Read-only" in write_output
             ), (
-                f"[{test_id}] Expected write to fail with a read-only error on block device, "
-                f"but got exit code {res.returncode}: {write_output}"
+                f"[{test_id}] Expected write to fail with a read-only error on block "
+                f"device: {write_output}"
             )
 
-            # Verify Read Path Workload
-            read_dd = (
-                f"oc exec {pod_obj.name} -n {proj.namespace} -- "
-                f"dd if=/dev/rbdblock of=/dev/null bs=1M count=10 status=progress"
+            # Read path must succeed on the read-only volume.
+            logger.assertion(
+                f"[{test_id}] Read from read-only volume expected to succeed"
             )
-            read_res = exec_cmd(read_dd, shell=True, ignore_error=True)
-            assert (
-                read_res.returncode == 0
-            ), f"[{test_id}] Read I/O workload failed on read-only volume: {read_res.stderr}"
+            pod_obj.exec_cmd_on_pod(
+                "dd if=/dev/rbdblock of=/dev/null bs=1M count=10 status=progress",
+                out_yaml_format=False,
+            )
         else:
-            log.info(
-                f"[{test_id}] Executing active write & read I/O workload on volume..."
-            )
             if volume_mode == constants.VOLUME_MODE_FILESYSTEM:
                 io_target = "/mnt/storage/test_io.img"
             else:
                 io_target = "/dev/rbdblock"
 
-            # Execute sequential write I/O through Ceph-CSI mounted volume path
-            write_dd = (
-                f"oc exec {pod_obj.name} -n {proj.namespace} -- "
-                f"dd if=/dev/zero of={io_target} bs=1M count=20 conv=fsync status=progress"
+            # Sequential write I/O through the Ceph-CSI mounted volume path.
+            # exec_cmd_on_pod raises CommandFailed on non-zero exit, failing the test.
+            logger.assertion(
+                f"[{test_id}] Write I/O to {io_target} expected to succeed"
             )
-            write_res = exec_cmd(write_dd, shell=True, ignore_error=True)
-            assert (
-                write_res.returncode == 0
-            ), f"[{test_id}] Write I/O workload failed on target {io_target}: {write_res.stderr}"
+            pod_obj.exec_cmd_on_pod(
+                f"dd if=/dev/zero of={io_target} bs=1M count=20 conv=fsync status=progress",
+                out_yaml_format=False,
+            )
 
-            # Execute sequential read I/O through Ceph-CSI mounted volume path
-            read_dd = (
-                f"oc exec {pod_obj.name} -n {proj.namespace} -- "
-                f"dd if={io_target} of=/dev/null bs=1M count=20 status=progress"
+            # Sequential read I/O through the Ceph-CSI mounted volume path.
+            logger.assertion(
+                f"[{test_id}] Read I/O from {io_target} expected to succeed"
             )
-            read_res = exec_cmd(read_dd, shell=True, ignore_error=True)
-            assert (
-                read_res.returncode == 0
-            ), f"[{test_id}] Read I/O workload failed on target {io_target}: {read_res.stderr}"
+            pod_obj.exec_cmd_on_pod(
+                f"dd if={io_target} of=/dev/null bs=1M count=20 status=progress",
+                out_yaml_format=False,
+            )

--- a/tests/functional/pv/test_qos_limits.py
+++ b/tests/functional/pv/test_qos_limits.py
@@ -81,10 +81,6 @@ class TestVolumeAttributesClassQoS(ManageTest):
             json.dump(gold_manifest, gf)
             tmp_gold = gf.name
 
-        log.info("Injecting class structures into cluster context...")
-        exec_cmd(f"oc apply -f {tmp_silver}")
-        exec_cmd(f"oc apply -f {tmp_gold}")
-
         def cleanup():
             log.info("Scrubbing VolumeAttributesClass operational configurations...")
             exec_cmd(
@@ -97,7 +93,12 @@ class TestVolumeAttributesClassQoS(ManageTest):
                 if os.path.exists(tmp_file):
                     os.remove(tmp_file)
 
+        # Register finalizer immediately after definition to guarantee execution if apply fails
         request.addfinalizer(cleanup)
+
+        log.info("Injecting class structures into cluster context...")
+        exec_cmd(f"oc apply -f {tmp_silver}")
+        exec_cmd(f"oc apply -f {tmp_gold}")
 
     @pytest.fixture
     def test_resources_cleanup(self, request):

--- a/tests/functional/pv/test_qos_limits.py
+++ b/tests/functional/pv/test_qos_limits.py
@@ -1,0 +1,568 @@
+import logging
+import pytest
+import time
+import json
+import os
+
+from ocs_ci.framework.pytest_customization.marks import (
+    orange_squad,
+    tier1,
+    skipif_ocs_version,
+)
+from ocs_ci.framework.testlib import ManageTest
+from ocs_ci.ocs import constants
+from ocs_ci.helpers import helpers
+from ocs_ci.utility.utils import exec_cmd
+from ocs_ci.ocs.resources.pod import Pod
+
+log = logging.getLogger(__name__)
+
+
+@orange_squad
+@tier1
+@skipif_ocs_version("<4.21")
+class TestVolumeAttributesClassQoS(ManageTest):
+
+    @pytest.fixture(autouse=True)
+    def setup_qos_classes(self, request):
+        """Directly provisions Silver and Gold VolumeAttributesClass resources in the cluster."""
+        self.silver_vac_name = "silver-qos-tier"
+        self.gold_vac_name = "gold-qos-tier"
+
+        self.silver_limits = {
+            "rbps": "1048576",
+            "wbps": "1048576",
+            "riops": "500",
+            "wiops": "500",
+        }
+        self.gold_limits = {
+            "rbps": "52428800",
+            "wbps": "52428800",
+            "riops": "2000",
+            "wiops": "2000",
+        }
+
+        silver_manifest = {
+            "apiVersion": "storage.k8s.io/v1",
+            "kind": "VolumeAttributesClass",
+            "metadata": {"name": self.silver_vac_name},
+            "driverName": "openshift-storage.rbd.csi.ceph.com",
+            "parameters": {
+                "maxReadBps": self.silver_limits["rbps"],
+                "maxWriteBps": self.silver_limits["wbps"],
+                "maxReadIops": self.silver_limits["riops"],
+                "maxWriteIops": self.silver_limits["wiops"],
+            },
+        }
+
+        gold_manifest = {
+            "apiVersion": "storage.k8s.io/v1",
+            "kind": "VolumeAttributesClass",
+            "metadata": {"name": self.gold_vac_name},
+            "driverName": "openshift-storage.rbd.csi.ceph.com",
+            "parameters": {
+                "maxReadBps": self.gold_limits["rbps"],
+                "maxWriteBps": self.gold_limits["wbps"],
+                "maxReadIops": self.gold_limits["riops"],
+                "maxWriteIops": self.gold_limits["wiops"],
+            },
+        }
+
+        log.info("Writing clean VolumeAttributesClass payload manifests...")
+        tmp_silver = f"/tmp/{self.silver_vac_name}.json"
+        tmp_gold = f"/tmp/{self.gold_vac_name}.json"
+
+        with open(tmp_silver, "w") as f:
+            json.dump(silver_manifest, f)
+        with open(tmp_gold, "w") as f:
+            json.dump(gold_manifest, f)
+
+        log.info("Injecting class structures into cluster context...")
+        exec_cmd(f"oc apply -f {tmp_silver}")
+        exec_cmd(f"oc apply -f {tmp_gold}")
+
+        def cleanup():
+            log.info("Scrubbing VolumeAttributesClass operational configurations...")
+            exec_cmd(
+                f"oc delete volumeattributesclass {self.silver_vac_name} --ignore-not-found"
+            )
+            exec_cmd(
+                f"oc delete volumeattributesclass {self.gold_vac_name} --ignore-not-found"
+            )
+            for tmp_file in [tmp_silver, tmp_gold]:
+                if os.path.exists(tmp_file):
+                    os.remove(tmp_file)
+
+        request.addfinalizer(cleanup)
+
+    @pytest.fixture
+    def test_resources_cleanup(self, request):
+        """Maintains low-impact cleanup handles for dynamically generated pods and claims."""
+        resources = {"pods": [], "pvcs": []}
+
+        def resource_teardown():
+            log.info("Cleaning up remaining test case allocations...")
+            for pod in resources["pods"]:
+                try:
+                    pod.delete()
+                except Exception:
+                    pass
+            for pvc in resources["pvcs"]:
+                try:
+                    pvc.delete()
+                except Exception:
+                    pass
+
+        request.addfinalizer(resource_teardown)
+        return resources
+
+    def verify_node_cgroup_throttling(
+        self, pod_obj, pvc_obj, qos_slice, expected_limits
+    ):
+        """Scrapes active kernel cgroup mappings dynamically and verifies io.max contents."""
+        pod_data = pod_obj.get()
+        node_name = pod_data["spec"]["nodeName"]
+        pod_uid = pod_data["metadata"]["uid"]
+        pod_cgroup_uid = pod_uid.replace("-", "_")
+
+        log.info(f"Target Pod is active on worker node: {node_name}")
+
+        # Corrected find syntax: Uses -path to select the pod directory and -name to locate io.max
+        find_cmd = (
+            f"oc debug node/{node_name} -n default -- chroot /host "
+            f'sh -c \'find /sys/fs/cgroup/kubepods.slice/ -path "*pod{pod_cgroup_uid}*" '
+            f'-name "io.max" -type f -exec cat {{}} \\;\''
+        )
+
+        res = exec_cmd(find_cmd, shell=True, ignore_error=True)
+        io_max_output = res.stdout.decode() if res.stdout else ""
+
+        log.info(f"Retrieved active io.max cgroup configurations:\n{io_max_output}")
+
+        for key, val in expected_limits.items():
+            assert (
+                f"{key}={val}" in io_max_output
+            ), f"Missing target threshold: {key}={val} in io.max output:\n{io_max_output}"
+
+    # =========================================================================
+    # TC-01: Guaranteed Pod + Fresh Filesystem RWO Baseline
+    # =========================================================================
+    def test_qos_01_guaranteed_filesystem_rwo(
+        self, project_factory, test_resources_cleanup
+    ):
+        """TC-01: Low I/O Footprint Guaranteed Pod Base Check"""
+        proj = project_factory()
+
+        pvc_obj = helpers.create_pvc(
+            sc_name=constants.DEFAULT_STORAGECLASS_RBD,
+            size="10Gi",
+            namespace=proj.namespace,
+            access_mode=constants.ACCESS_MODE_RWO,
+            volume_mode=constants.VOLUME_MODE_FILESYSTEM,
+        )
+        test_resources_cleanup["pvcs"].append(pvc_obj)
+
+        log.info(f"Waiting for PVC {pvc_obj.name} to transition to Bound phase...")
+        helpers.wait_for_resource_state(pvc_obj, constants.STATUS_BOUND, timeout=180)
+
+        log.info(
+            f"Patching PVC {pvc_obj.name} with VolumeAttributesClass: {self.silver_vac_name}"
+        )
+        exec_cmd(
+            f"oc patch pvc {pvc_obj.name} -n {proj.namespace} -p "
+            f'\'{{"spec":{{"volumeAttributesClassName":"{self.silver_vac_name}"}}}}\''
+        )
+
+        pod_dict = {
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": {"name": "guaranteed-qos-pod", "namespace": proj.namespace},
+            "spec": {
+                "containers": [
+                    {
+                        "name": "worker",
+                        "image": "quay.io/centos/centos:stream9",
+                        "command": ["sleep", "3600"],
+                        "resources": {
+                            "requests": {"cpu": "200m", "memory": "256Mi"},
+                            "limits": {"cpu": "200m", "memory": "256Mi"},
+                        },
+                        "volumeMounts": [
+                            {"name": "voldata", "mountPath": "/mnt/storage"}
+                        ],
+                    }
+                ],
+                "volumes": [
+                    {
+                        "name": "voldata",
+                        "persistentVolumeClaim": {"claimName": pvc_obj.name},
+                    }
+                ],
+            },
+        }
+        pod_obj = Pod(**pod_dict)
+        pod_obj.create()
+        test_resources_cleanup["pods"].append(pod_obj)
+
+        time.sleep(15)
+        helpers.wait_for_resource_state(pod_obj, constants.STATUS_RUNNING, timeout=420)
+
+        assert pod_obj.get()["status"]["qosClass"] == "Guaranteed"
+        self.verify_node_cgroup_throttling(
+            pod_obj, pvc_obj, "kubepods-pod.slice", self.silver_limits
+        )
+
+    # =========================================================================
+    # TC-02: Burstable Pod + Fresh Filesystem RWOP Validation
+    # =========================================================================
+    def test_qos_02_burstable_filesystem_rwop(
+        self, project_factory, test_resources_cleanup
+    ):
+        """TC-02: Burstable Pod + Fresh Filesystem RWOP Validation"""
+        proj = project_factory()
+
+        pvc_obj = helpers.create_pvc(
+            sc_name=constants.DEFAULT_STORAGECLASS_RBD,
+            size="10Gi",
+            namespace=proj.namespace,
+            access_mode=constants.ACCESS_MODE_RWOP,
+            volume_mode=constants.VOLUME_MODE_FILESYSTEM,
+        )
+        test_resources_cleanup["pvcs"].append(pvc_obj)
+
+        log.info(f"Waiting for PVC {pvc_obj.name} to transition to Bound phase...")
+        helpers.wait_for_resource_state(pvc_obj, constants.STATUS_BOUND, timeout=180)
+
+        log.info(
+            f"Patching PVC {pvc_obj.name} with VolumeAttributesClass: {self.silver_vac_name}"
+        )
+        exec_cmd(
+            f"oc patch pvc {pvc_obj.name} -n {proj.namespace} -p "
+            f'\'{{"spec":{{"volumeAttributesClassName":"{self.silver_vac_name}"}}}}\''
+        )
+
+        pod_dict = {
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": {"name": "burstable-qos-pod", "namespace": proj.namespace},
+            "spec": {
+                "containers": [
+                    {
+                        "name": "worker",
+                        "image": "quay.io/centos/centos:stream9",
+                        "command": ["sleep", "3600"],
+                        "resources": {
+                            "requests": {"cpu": "100m", "memory": "128Mi"},
+                            "limits": {"cpu": "500m", "memory": "512Mi"},
+                        },
+                        "volumeMounts": [
+                            {"name": "voldata", "mountPath": "/mnt/storage"}
+                        ],
+                    }
+                ],
+                "volumes": [
+                    {
+                        "name": "voldata",
+                        "persistentVolumeClaim": {"claimName": pvc_obj.name},
+                    }
+                ],
+            },
+        }
+        pod_obj = Pod(**pod_dict)
+        pod_obj.create()
+        test_resources_cleanup["pods"].append(pod_obj)
+
+        time.sleep(15)
+        helpers.wait_for_resource_state(pod_obj, constants.STATUS_RUNNING, timeout=420)
+
+        assert pod_obj.get()["status"]["qosClass"] == "Burstable"
+        self.verify_node_cgroup_throttling(
+            pod_obj, pvc_obj, "kubepods-burstable.slice", self.silver_limits
+        )
+
+    # =========================================================================
+    # TC-03: BestEffort Pod + Fresh Block RWX Multi-Volume Isolation
+    # =========================================================================
+    def test_qos_03_besteffort_block_rwx_multicontainer(
+        self, project_factory, test_resources_cleanup
+    ):
+        """TC-03: BestEffort Pod + Fresh Block RWX Multi-Volume Isolation"""
+        proj = project_factory()
+
+        pvc_obj = helpers.create_pvc(
+            sc_name=constants.DEFAULT_STORAGECLASS_RBD,
+            size="10Gi",
+            namespace=proj.namespace,
+            access_mode=constants.ACCESS_MODE_RWX,
+            volume_mode=constants.VOLUME_MODE_BLOCK,
+        )
+        test_resources_cleanup["pvcs"].append(pvc_obj)
+
+        log.info(f"Waiting for PVC {pvc_obj.name} to transition to Bound phase...")
+        helpers.wait_for_resource_state(pvc_obj, constants.STATUS_BOUND, timeout=180)
+
+        log.info(
+            f"Patching PVC {pvc_obj.name} with VolumeAttributesClass: {self.silver_vac_name}"
+        )
+        exec_cmd(
+            f"oc patch pvc {pvc_obj.name} -n {proj.namespace} -p "
+            f'\'{{"spec":{{"volumeAttributesClassName":"{self.silver_vac_name}"}}}}\''
+        )
+
+        pod_dict = {
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": {"name": "besteffort-qos-pod", "namespace": proj.namespace},
+            "spec": {
+                "containers": [
+                    {
+                        "name": "container-1",
+                        "image": "quay.io/centos/centos:stream9",
+                        "command": ["sleep", "3600"],
+                        "volumeDevices": [
+                            {"name": "blockvol", "devicePath": "/dev/rbdblock"}
+                        ],
+                    },
+                    {
+                        "name": "container-2",
+                        "image": "quay.io/centos/centos:stream9",
+                        "command": ["sleep", "3600"],
+                        "volumeDevices": [
+                            {"name": "blockvol", "devicePath": "/dev/rbdblock"}
+                        ],
+                    },
+                ],
+                "volumes": [
+                    {
+                        "name": "blockvol",
+                        "persistentVolumeClaim": {"claimName": pvc_obj.name},
+                    }
+                ],
+            },
+        }
+        pod_obj = Pod(**pod_dict)
+        pod_obj.create()
+        test_resources_cleanup["pods"].append(pod_obj)
+
+        time.sleep(15)
+        helpers.wait_for_resource_state(pod_obj, constants.STATUS_RUNNING, timeout=420)
+
+        assert pod_obj.get()["status"]["qosClass"] == "BestEffort"
+        self.verify_node_cgroup_throttling(
+            pod_obj, pvc_obj, "kubepods-besteffort.slice", self.silver_limits
+        )
+
+    # =========================================================================
+    # TC-04: Guaranteed Class + Fresh Block RWO Mapping
+    # =========================================================================
+    def test_qos_04_guaranteed_block_rwo(self, project_factory, test_resources_cleanup):
+        """TC-04: Guaranteed Class + Fresh Block RWO Mapping"""
+        proj = project_factory()
+
+        pvc_obj = helpers.create_pvc(
+            sc_name=constants.DEFAULT_STORAGECLASS_RBD,
+            size="10Gi",
+            namespace=proj.namespace,
+            access_mode=constants.ACCESS_MODE_RWO,
+            volume_mode=constants.VOLUME_MODE_BLOCK,
+        )
+        test_resources_cleanup["pvcs"].append(pvc_obj)
+
+        log.info(f"Waiting for PVC {pvc_obj.name} to transition to Bound phase...")
+        helpers.wait_for_resource_state(pvc_obj, constants.STATUS_BOUND, timeout=180)
+
+        log.info(
+            f"Patching PVC {pvc_obj.name} with VolumeAttributesClass: {self.silver_vac_name}"
+        )
+        exec_cmd(
+            f"oc patch pvc {pvc_obj.name} -n {proj.namespace} -p "
+            f'\'{{"spec":{{"volumeAttributesClassName":"{self.silver_vac_name}"}}}}\''
+        )
+
+        pod_dict = {
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": {"name": "guaranteed-block-pod", "namespace": proj.namespace},
+            "spec": {
+                "containers": [
+                    {
+                        "name": "worker",
+                        "image": "quay.io/centos/centos:stream9",
+                        "command": ["sleep", "3600"],
+                        "resources": {
+                            "requests": {"cpu": "200m", "memory": "256Mi"},
+                            "limits": {"cpu": "200m", "memory": "256Mi"},
+                        },
+                        "volumeDevices": [
+                            {"name": "blockvol", "devicePath": "/dev/rbdblock"}
+                        ],
+                    }
+                ],
+                "volumes": [
+                    {
+                        "name": "blockvol",
+                        "persistentVolumeClaim": {"claimName": pvc_obj.name},
+                    }
+                ],
+            },
+        }
+        pod_obj = Pod(**pod_dict)
+        pod_obj.create()
+        test_resources_cleanup["pods"].append(pod_obj)
+
+        time.sleep(15)
+        helpers.wait_for_resource_state(pod_obj, constants.STATUS_RUNNING, timeout=420)
+
+        assert pod_obj.get()["status"]["qosClass"] == "Guaranteed"
+        self.verify_node_cgroup_throttling(
+            pod_obj, pvc_obj, "kubepods-pod.slice", self.silver_limits
+        )
+
+    # =========================================================================
+    # TC-05: Burstable Class + Fresh Block RWOP Mapping
+    # =========================================================================
+    def test_qos_05_burstable_block_rwop(self, project_factory, test_resources_cleanup):
+        """TC-05: Burstable Class + Fresh Block RWOP Mapping"""
+        proj = project_factory()
+
+        pvc_obj = helpers.create_pvc(
+            sc_name=constants.DEFAULT_STORAGECLASS_RBD,
+            size="10Gi",
+            namespace=proj.namespace,
+            access_mode=constants.ACCESS_MODE_RWOP,
+            volume_mode=constants.VOLUME_MODE_BLOCK,
+        )
+        test_resources_cleanup["pvcs"].append(pvc_obj)
+
+        log.info(f"Waiting for PVC {pvc_obj.name} to transition to Bound phase...")
+        helpers.wait_for_resource_state(pvc_obj, constants.STATUS_BOUND, timeout=180)
+
+        log.info(
+            f"Patching PVC {pvc_obj.name} with VolumeAttributesClass: {self.silver_vac_name}"
+        )
+        exec_cmd(
+            f"oc patch pvc {pvc_obj.name} -n {proj.namespace} -p "
+            f'\'{{"spec":{{"volumeAttributesClassName":"{self.silver_vac_name}"}}}}\''
+        )
+
+        pod_dict = {
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": {"name": "burstable-block-pod", "namespace": proj.namespace},
+            "spec": {
+                "containers": [
+                    {
+                        "name": "worker",
+                        "image": "quay.io/centos/centos:stream9",
+                        "command": ["sleep", "3600"],
+                        "resources": {
+                            "requests": {"cpu": "100m", "memory": "128Mi"},
+                            "limits": {"cpu": "500m", "memory": "512Mi"},
+                        },
+                        "volumeDevices": [
+                            {"name": "blockvol", "devicePath": "/dev/rbdblock"}
+                        ],
+                    }
+                ],
+                "volumes": [
+                    {
+                        "name": "blockvol",
+                        "persistentVolumeClaim": {"claimName": pvc_obj.name},
+                    }
+                ],
+            },
+        }
+        pod_obj = Pod(**pod_dict)
+        pod_obj.create()
+        test_resources_cleanup["pods"].append(pod_obj)
+
+        time.sleep(15)
+        helpers.wait_for_resource_state(pod_obj, constants.STATUS_RUNNING, timeout=420)
+
+        assert pod_obj.get()["status"]["qosClass"] == "Burstable"
+        self.verify_node_cgroup_throttling(
+            pod_obj, pvc_obj, "kubepods-burstable.slice", self.silver_limits
+        )
+
+    # =========================================================================
+    # TC-06: Read-Only (ROX) Block Mode Evaluation
+    # =========================================================================
+    def test_qos_06_guaranteed_block_rox(self, project_factory, test_resources_cleanup):
+        """TC-06: Read-Only (ROX) Block Mode Evaluation"""
+        proj = project_factory()
+
+        # Provision claim as RWO to pass Ceph CSI validation, then enforce readOnly in the Pod spec
+        pvc_obj = helpers.create_pvc(
+            sc_name=constants.DEFAULT_STORAGECLASS_RBD,
+            size="10Gi",
+            namespace=proj.namespace,
+            access_mode=constants.ACCESS_MODE_RWO,
+            volume_mode=constants.VOLUME_MODE_BLOCK,
+        )
+        test_resources_cleanup["pvcs"].append(pvc_obj)
+
+        log.info(f"Waiting for PVC {pvc_obj.name} to transition to Bound phase...")
+        helpers.wait_for_resource_state(pvc_obj, constants.STATUS_BOUND, timeout=180)
+
+        log.info(f"Patching PVC {pvc_obj.name} with Gold VAC: {self.gold_vac_name}")
+        exec_cmd(
+            f"oc patch pvc {pvc_obj.name} -n {proj.namespace} -p "
+            f'\'{{"spec":{{"volumeAttributesClassName":"{self.gold_vac_name}"}}}}\''
+        )
+
+        pod_dict = {
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": {"name": "rox-block-pod", "namespace": proj.namespace},
+            "spec": {
+                "containers": [
+                    {
+                        "name": "worker",
+                        "image": "quay.io/centos/centos:stream9",
+                        "command": ["sleep", "3600"],
+                        "resources": {
+                            "requests": {"cpu": "200m", "memory": "256Mi"},
+                            "limits": {"cpu": "200m", "memory": "256Mi"},
+                        },
+                        "volumeDevices": [
+                            {"name": "blockvol", "devicePath": "/dev/rbdblock"}
+                        ],
+                    }
+                ],
+                "volumes": [
+                    {
+                        "name": "blockvol",
+                        "persistentVolumeClaim": {
+                            "claimName": pvc_obj.name,
+                            "readOnly": True,
+                        },
+                    }
+                ],
+            },
+        }
+        pod_obj = Pod(**pod_dict)
+        pod_obj.create()
+        test_resources_cleanup["pods"].append(pod_obj)
+
+        time.sleep(15)
+        helpers.wait_for_resource_state(pod_obj, constants.STATUS_RUNNING, timeout=420)
+
+        # 1. Verify cgroup throttle boundaries map to Gold tier
+        self.verify_node_cgroup_throttling(
+            pod_obj, pvc_obj, "kubepods-pod.slice", self.gold_limits
+        )
+
+        # 2. Verify write operation fails inside the read-only volume container via direct exec_cmd
+        log.info("Verifying write protection on ROX block volume...")
+        dd_cmd = f"oc exec {pod_obj.name} -n {proj.namespace} -- dd if=/dev/zero of=/dev/rbdblock bs=1M count=1"
+        res = exec_cmd(dd_cmd, shell=True, ignore_error=True)
+        write_output = res.stderr.decode() if res.stderr else res.stdout.decode()
+
+        assert (
+            res.returncode != 0
+            or "Operation not permitted" in write_output
+            or "Read-only" in write_output
+        ), (
+            f"Expected write operation to fail on read-only block device, "
+            f"but got exit code {res.returncode}: {write_output}"
+        )

--- a/tests/functional/pv/test_qos_limits.py
+++ b/tests/functional/pv/test_qos_limits.py
@@ -26,10 +26,9 @@ class TestVolumeAttributesClassQoS(ManageTest):
 
     @pytest.fixture(autouse=True, scope="class")
     def setup_qos_classes(self, request):
-        """Provisions Silver, Gold, and Unthrottled VolumeAttributesClass resources once for the test class."""
+        """Provisions Silver, Gold VolumeAttributesClass resources once for the test class."""
         request.cls.silver_vac_name = "silver-qos-tier"
         request.cls.gold_vac_name = "gold-qos-tier"
-        request.cls.unthrottled_vac_name = "unthrottled-qos-tier"
 
         request.cls.silver_limits = {
             "rbps": "1048576",
@@ -99,19 +98,6 @@ class TestVolumeAttributesClassQoS(ManageTest):
             },
         }
 
-        unthrottled_manifest = {
-            "apiVersion": "storage.k8s.io/v1",
-            "kind": "VolumeAttributesClass",
-            "metadata": {"name": request.cls.unthrottled_vac_name},
-            "driverName": "openshift-storage.rbd.csi.ceph.com",
-            "parameters": {
-                "maxReadBps": request.cls.unthrottled_limits["rbps"],
-                "maxWriteBps": request.cls.unthrottled_limits["wbps"],
-                "maxReadIops": request.cls.unthrottled_limits["riops"],
-                "maxWriteIops": request.cls.unthrottled_limits["wiops"],
-            },
-        }
-
         log.info(
             "Writing clean VolumeAttributesClass payload manifests via tempfile..."
         )
@@ -123,14 +109,9 @@ class TestVolumeAttributesClassQoS(ManageTest):
             json.dump(gold_manifest, gf)
             tmp_gold = gf.name
 
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as uf:
-            json.dump(unthrottled_manifest, uf)
-            tmp_unthrottled = uf.name
-
         log.info("Injecting class structures into cluster context...")
         exec_cmd(f"oc apply -f {tmp_silver}")
         exec_cmd(f"oc apply -f {tmp_gold}")
-        exec_cmd(f"oc apply -f {tmp_unthrottled}")
 
     @pytest.fixture
     def test_resources_cleanup(self, request):

--- a/tests/functional/pv/test_qos_limits.py
+++ b/tests/functional/pv/test_qos_limits.py
@@ -18,6 +18,72 @@ from ocs_ci.utility.utils import exec_cmd, TimeoutSampler
 
 logger = logging.getLogger(__name__)
 
+# Container image and resource presets shared across the QoS test matrix.
+QOS_TEST_IMAGE = "quay.io/centos/centos:stream9"
+QOS_SLEEP_CMD = ["sleep", "3600"]
+GUARANTEED_RESOURCES = {
+    "requests": {"cpu": "200m", "memory": "256Mi"},
+    "limits": {"cpu": "200m", "memory": "256Mi"},
+}
+BURSTABLE_RESOURCES = {
+    "requests": {"cpu": "100m", "memory": "128Mi"},
+    "limits": {"cpu": "500m", "memory": "512Mi"},
+}
+FS_VOLUME_MOUNTS = [{"name": "vol-data", "mountPath": "/mnt/storage"}]
+BLOCK_VOLUME_DEVICES = [{"name": "vol-data", "devicePath": "/dev/rbdblock"}]
+
+# Per-scenario container specs referenced by the parametrized test matrix below.
+GUARANTEED_FS_CONTAINERS = [
+    {
+        "name": "worker",
+        "image": QOS_TEST_IMAGE,
+        "command": QOS_SLEEP_CMD,
+        "resources": GUARANTEED_RESOURCES,
+        "volumeMounts": FS_VOLUME_MOUNTS,
+    }
+]
+BURSTABLE_FS_CONTAINERS = [
+    {
+        "name": "worker",
+        "image": QOS_TEST_IMAGE,
+        "command": QOS_SLEEP_CMD,
+        "resources": BURSTABLE_RESOURCES,
+        "volumeMounts": FS_VOLUME_MOUNTS,
+    }
+]
+BESTEFFORT_BLOCK_CONTAINERS = [
+    {
+        "name": "container-1",
+        "image": QOS_TEST_IMAGE,
+        "command": QOS_SLEEP_CMD,
+        "volumeDevices": BLOCK_VOLUME_DEVICES,
+    },
+    {
+        "name": "container-2",
+        "image": QOS_TEST_IMAGE,
+        "command": QOS_SLEEP_CMD,
+        "volumeDevices": BLOCK_VOLUME_DEVICES,
+    },
+]
+GUARANTEED_BLOCK_CONTAINERS = [
+    {
+        "name": "worker",
+        "image": QOS_TEST_IMAGE,
+        "command": QOS_SLEEP_CMD,
+        "resources": GUARANTEED_RESOURCES,
+        "volumeDevices": BLOCK_VOLUME_DEVICES,
+    }
+]
+BURSTABLE_BLOCK_CONTAINERS = [
+    {
+        "name": "worker",
+        "image": QOS_TEST_IMAGE,
+        "command": QOS_SLEEP_CMD,
+        "resources": BURSTABLE_RESOURCES,
+        "volumeDevices": BLOCK_VOLUME_DEVICES,
+    }
+]
+
 
 @orange_squad
 @tier1
@@ -108,54 +174,6 @@ class TestVolumeAttributesClassQoS(ManageTest):
         exec_cmd(f"oc apply -f {tmp_silver}")
         exec_cmd(f"oc apply -f {tmp_gold}")
 
-    @pytest.fixture
-    def test_resources_cleanup(self, request):
-        """Maintains cleanup handles for dynamically generated pods, claims, and snapshots."""
-        resources = {"pods": [], "pvcs": [], "snapshots": []}
-
-        def resource_teardown():
-            logger.info("Cleaning up test pods, PVCs, and snapshots")
-            cleanup_errors = (CommandFailed, TimeoutError, TimeoutExpiredError)
-
-            for pod in resources["pods"]:
-                try:
-                    pod.delete()
-                except cleanup_errors as ex:
-                    logger.warning(
-                        f"Handled expected deletion failure for pod {getattr(pod, 'name', 'unknown')}: {ex}"
-                    )
-                except Exception as ex:
-                    logger.exception(
-                        f"Unexpected error deleting pod {getattr(pod, 'name', 'unknown')}: {ex}"
-                    )
-
-            for pvc in resources["pvcs"]:
-                try:
-                    pvc.delete()
-                except cleanup_errors as ex:
-                    logger.warning(
-                        f"Handled expected deletion failure for PVC {getattr(pvc, 'name', 'unknown')}: {ex}"
-                    )
-                except Exception as ex:
-                    logger.exception(
-                        f"Unexpected error deleting PVC {getattr(pvc, 'name', 'unknown')}: {ex}"
-                    )
-
-            for snap in resources["snapshots"]:
-                try:
-                    snap.delete()
-                except cleanup_errors as ex:
-                    logger.warning(
-                        f"Handled expected deletion failure for snapshot {getattr(snap, 'name', 'unknown')}: {ex}"
-                    )
-                except Exception as ex:
-                    logger.exception(
-                        f"Unexpected error deleting snapshot {getattr(snap, 'name', 'unknown')}: {ex}"
-                    )
-
-        request.addfinalizer(resource_teardown)
-        return resources
-
     def verify_node_cgroup_throttling(
         self, pod_obj, expected_limits, timeout=60, sleep=5
     ):
@@ -230,20 +248,7 @@ class TestVolumeAttributesClassQoS(ManageTest):
                 constants.VOLUME_MODE_FILESYSTEM,
                 False,
                 "guaranteed-qos-pod",
-                [
-                    {
-                        "name": "worker",
-                        "image": "quay.io/centos/centos:stream9",
-                        "command": ["sleep", "3600"],
-                        "resources": {
-                            "requests": {"cpu": "200m", "memory": "256Mi"},
-                            "limits": {"cpu": "200m", "memory": "256Mi"},
-                        },
-                        "volumeMounts": [
-                            {"name": "vol-data", "mountPath": "/mnt/storage"}
-                        ],
-                    }
-                ],
+                GUARANTEED_FS_CONTAINERS,
                 "Guaranteed",
                 False,
             ),
@@ -254,20 +259,7 @@ class TestVolumeAttributesClassQoS(ManageTest):
                 constants.VOLUME_MODE_FILESYSTEM,
                 False,
                 "burstable-qos-pod",
-                [
-                    {
-                        "name": "worker",
-                        "image": "quay.io/centos/centos:stream9",
-                        "command": ["sleep", "3600"],
-                        "resources": {
-                            "requests": {"cpu": "100m", "memory": "128Mi"},
-                            "limits": {"cpu": "500m", "memory": "512Mi"},
-                        },
-                        "volumeMounts": [
-                            {"name": "vol-data", "mountPath": "/mnt/storage"}
-                        ],
-                    }
-                ],
+                BURSTABLE_FS_CONTAINERS,
                 "Burstable",
                 False,
             ),
@@ -278,24 +270,7 @@ class TestVolumeAttributesClassQoS(ManageTest):
                 constants.VOLUME_MODE_BLOCK,
                 False,
                 "besteffort-qos-pod",
-                [
-                    {
-                        "name": "container-1",
-                        "image": "quay.io/centos/centos:stream9",
-                        "command": ["sleep", "3600"],
-                        "volumeDevices": [
-                            {"name": "vol-data", "devicePath": "/dev/rbdblock"}
-                        ],
-                    },
-                    {
-                        "name": "container-2",
-                        "image": "quay.io/centos/centos:stream9",
-                        "command": ["sleep", "3600"],
-                        "volumeDevices": [
-                            {"name": "vol-data", "devicePath": "/dev/rbdblock"}
-                        ],
-                    },
-                ],
+                BESTEFFORT_BLOCK_CONTAINERS,
                 "BestEffort",
                 False,
             ),
@@ -306,20 +281,7 @@ class TestVolumeAttributesClassQoS(ManageTest):
                 constants.VOLUME_MODE_BLOCK,
                 False,
                 "guaranteed-block-pod",
-                [
-                    {
-                        "name": "worker",
-                        "image": "quay.io/centos/centos:stream9",
-                        "command": ["sleep", "3600"],
-                        "resources": {
-                            "requests": {"cpu": "200m", "memory": "256Mi"},
-                            "limits": {"cpu": "200m", "memory": "256Mi"},
-                        },
-                        "volumeDevices": [
-                            {"name": "vol-data", "devicePath": "/dev/rbdblock"}
-                        ],
-                    }
-                ],
+                GUARANTEED_BLOCK_CONTAINERS,
                 "Guaranteed",
                 False,
             ),
@@ -330,20 +292,7 @@ class TestVolumeAttributesClassQoS(ManageTest):
                 constants.VOLUME_MODE_BLOCK,
                 False,
                 "burstable-block-pod",
-                [
-                    {
-                        "name": "worker",
-                        "image": "quay.io/centos/centos:stream9",
-                        "command": ["sleep", "3600"],
-                        "resources": {
-                            "requests": {"cpu": "100m", "memory": "128Mi"},
-                            "limits": {"cpu": "500m", "memory": "512Mi"},
-                        },
-                        "volumeDevices": [
-                            {"name": "vol-data", "devicePath": "/dev/rbdblock"}
-                        ],
-                    }
-                ],
+                BURSTABLE_BLOCK_CONTAINERS,
                 "Burstable",
                 False,
             ),
@@ -354,20 +303,7 @@ class TestVolumeAttributesClassQoS(ManageTest):
                 constants.VOLUME_MODE_BLOCK,
                 True,  # Gold VAC Tier
                 "rox-block-pod",
-                [
-                    {
-                        "name": "worker",
-                        "image": "quay.io/centos/centos:stream9",
-                        "command": ["sleep", "3600"],
-                        "resources": {
-                            "requests": {"cpu": "200m", "memory": "256Mi"},
-                            "limits": {"cpu": "200m", "memory": "256Mi"},
-                        },
-                        "volumeDevices": [
-                            {"name": "vol-data", "devicePath": "/dev/rbdblock"}
-                        ],
-                    }
-                ],
+                GUARANTEED_BLOCK_CONTAINERS,
                 "Guaranteed",
                 True,  # Read-Only Spec Flag
             ),

--- a/tests/functional/pv/test_qos_limits.py
+++ b/tests/functional/pv/test_qos_limits.py
@@ -194,7 +194,9 @@ class TestVolumeAttributesClassQoS(ManageTest):
         )
 
         def _check_cgroup_limits():
-            res = exec_cmd(find_cmd, shell=True, ignore_error=True)
+            # Bound each oc debug invocation to the sampler deadline so a single
+            # unavailable node cannot block on exec_cmd's 600s default timeout.
+            res = exec_cmd(find_cmd, shell=True, ignore_error=True, timeout=timeout)
             output = res.stdout.decode() if res.stdout else ""
 
             if not output.strip():
@@ -222,7 +224,7 @@ class TestVolumeAttributesClassQoS(ManageTest):
                     matched_output = result
                     break
         except TimeoutExpiredError:
-            res = exec_cmd(find_cmd, shell=True, ignore_error=True)
+            res = exec_cmd(find_cmd, shell=True, ignore_error=True, timeout=timeout)
             final_output = res.stdout.decode() if res.stdout else ""
             raise AssertionError(
                 f"Timed out after {timeout}s waiting for expected limits {expected_limits} "
@@ -432,21 +434,32 @@ class TestVolumeAttributesClassQoS(ManageTest):
             else:
                 io_target = "/dev/rbdblock"
 
-            # Sequential write I/O through the Ceph-CSI mounted volume path.
-            # exec_cmd_on_pod raises CommandFailed on non-zero exit, failing the test.
-            logger.assertion(
-                f"[{test_id}] Write I/O to {io_target} expected to succeed"
-            )
-            pod_obj.exec_cmd_on_pod(
-                f"dd if=/dev/zero of={io_target} bs=1M count=20 conv=fsync status=progress",
-                out_yaml_format=False,
-            )
+            # Exercise the I/O path in every container so multi-container pods
+            # (e.g. TC-03's shared RWX block volume) are validated end to end and
+            # not just in the default container. Single-container pods loop once.
+            for container in containers_spec:
+                container_name = container["name"]
 
-            # Sequential read I/O through the Ceph-CSI mounted volume path.
-            logger.assertion(
-                f"[{test_id}] Read I/O from {io_target} expected to succeed"
-            )
-            pod_obj.exec_cmd_on_pod(
-                f"dd if={io_target} of=/dev/null bs=1M count=20 status=progress",
-                out_yaml_format=False,
-            )
+                # Sequential write I/O through the Ceph-CSI mounted volume path.
+                # exec_cmd_on_pod raises CommandFailed on non-zero exit, failing
+                # the test.
+                logger.assertion(
+                    f"[{test_id}] Write I/O to {io_target} in container "
+                    f"{container_name} expected to succeed"
+                )
+                pod_obj.exec_cmd_on_pod(
+                    f"dd if=/dev/zero of={io_target} bs=1M count=20 conv=fsync status=progress",
+                    out_yaml_format=False,
+                    container_name=container_name,
+                )
+
+                # Sequential read I/O through the Ceph-CSI mounted volume path.
+                logger.assertion(
+                    f"[{test_id}] Read I/O from {io_target} in container "
+                    f"{container_name} expected to succeed"
+                )
+                pod_obj.exec_cmd_on_pod(
+                    f"dd if={io_target} of=/dev/null bs=1M count=20 status=progress",
+                    out_yaml_format=False,
+                    container_name=container_name,
+                )


### PR DESCRIPTION
This PR introduces the automated test suite for verifying OpenShift Data Foundation (ODF) VolumeAttributesClass (VAC) Quality of Service (QoS) throttling limits on the storage layer.

The implementation covers the first six core test scenarios ([TC-01](https://redhat.atlassian.net/browse/TC-01) through [TC-06](https://redhat.atlassian.net/browse/TC-06)) from the QoS validation specification sheet ([RHSTOR-9207](https://redhat.atlassian.net/browse/RHSTOR-9207)).

**Covered Test Scenarios**
QOS-TC-01: Baseline verification for Guaranteed Pod class + Filesystem volume mode (RWO).

QOS-TC-02: Throttling verification for Burstable Pod class + Filesystem volume mode (RWOP).

QOS-TC-03: Multi-container isolation for BestEffort Pod class + Block volume mode (RWX).

QOS-TC-04: Direct raw device block cgroup mapping for Guaranteed Pod class + Block volume mode (RWO).

QOS-TC-05: Direct raw device block cgroup mapping for Burstable Pod class + Block volume mode (RWOP).

QOS-TC-06: Enforcement and write-protection evaluation for Read-Only Block mode volumes using Gold tier limits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for volume QoS limits on OCS 4.21 and later.
  * Validated Silver and Gold QoS configurations across filesystem and block volumes.
  * Added scenarios covering multiple access modes, volume modes, and read-only volumes.
  * Verified pod QoS classifications and node-level I/O throttling behavior.
  * Added checks for filesystem and block I/O performance under configured limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->