### PR TITLE
Use filtered quay API queries in get_latest_ds_olm_tag to avoid timeouts - cherry-pick

### DIFF
--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -3162,8 +3162,6 @@ def get_latest_ds_olm_tag(upgrade=False, latest_tag=None):
 
     """
     latest_tag = latest_tag or config.DEPLOYMENT.get("default_latest_tag", "latest")
-    tags = get_ocs_olm_operator_tags()
-    latest_image = None
     ocs_version = config.ENV_DATA["ocs_version"]
     upgrade_ocs_version = config.UPGRADE.get("upgrade_ocs_version")
     use_rc_build = config.UPGRADE.get("use_rc_build")
@@ -3173,12 +3171,24 @@ def get_latest_ds_olm_tag(upgrade=False, latest_tag=None):
         latest_tag = previous_rc_build
     if upgrade_version_change:
         upgrade = False
+    tags = get_ocs_olm_operator_tags(filter_tag_name=f"like:{ocs_version}")
+    latest_image = None
     for tag in tags:
         if tag["name"] == latest_tag:
             latest_image = tag["manifest_digest"]
             break
     if not latest_image:
-        raise TagNotFoundException("Couldn't find latest tag!")
+        log.warning(
+            f"Tag '{latest_tag}' not found in version-filtered results, "
+            "fetching all tags"
+        )
+        tags = get_ocs_olm_operator_tags()
+        for tag in tags:
+            if tag["name"] == latest_tag:
+                latest_image = tag["manifest_digest"]
+                break
+        if not latest_image:
+            raise TagNotFoundException("Couldn't find latest tag!")
     latest_tag_found = False
     for tag in tags:
         if not upgrade:
@@ -3268,7 +3278,7 @@ def load_auth_config():
         return {}
 
 
-def get_ocs_olm_operator_tags(limit=100):
+def get_ocs_olm_operator_tags(limit=100, filter_tag_name=""):
     """
     Query the OCS OLM Operator repo and retrieve a list of tags. Since we are limited
     to 100 tags per page, we end up making several API calls and combining the results
@@ -3276,6 +3286,7 @@ def get_ocs_olm_operator_tags(limit=100):
 
     Args:
         limit: the number of tags to limit the request to
+        filter_tag_name (str): Optional tag name filter (e.g. "like:4.22")
 
     Raises:
         KeyError: if the auth config isn't setup properly
@@ -3306,18 +3317,9 @@ def get_ocs_olm_operator_tags(limit=100):
     all_tags = []
     page = 1
     while True:
-        log.info(f"Retrieving OCS OLM Operator tags (limit {limit}, page {page})")
-        resp = requests.get(
-            constants.OPERATOR_CS_QUAY_API_QUERY.format(
-                tag_limit=limit,
-                image=image,
-                page=page,
-            ),
-            headers=headers,
+        tags = query_quay_for_operator_tags(
+            image, headers, limit, page, filter_tag_name=filter_tag_name
         )
-        if not resp.ok:
-            raise requests.RequestException(resp.json())
-        tags = resp.json()["tags"]
         if len(tags) == 0:
             log.info("No more tags to retrieve")
             break
@@ -3325,6 +3327,48 @@ def get_ocs_olm_operator_tags(limit=100):
         all_tags.extend(tags)
         page += 1
     return all_tags
+
+
+@retry(requests.RequestException, 20, 30, 1)
+def query_quay_for_operator_tags(
+    image: str, headers: dict, limit: int, page: int, filter_tag_name: str = ""
+) -> list:
+    """
+    Query quay tags for the specified image.
+
+    Args:
+        image (str): Image to query tags for
+        headers (dict): Request headers
+        limit (int): Maximum number of tags to query
+        page (int): Which page of results to return
+        filter_tag_name (str): Optional tag name filter (e.g. "like:4.22")
+
+    Raises:
+        requests.RequestException: If we do not receive an ok response from quay after several retries.
+
+    Returns:
+        list: list of tags queried from quay
+
+    """
+    log.info(f"Retrieving OCS OLM Operator tags (limit {limit}, page {page})")
+    url = constants.OPERATOR_CS_QUAY_API_QUERY.format(
+        tag_limit=limit,
+        image=image,
+        page=page,
+    )
+    if filter_tag_name:
+        url += f"&filter_tag_name={filter_tag_name}"
+    resp = requests.get(
+        url,
+        headers=headers,
+        timeout=120,
+    )
+    if not resp.ok:
+        raise requests.RequestException(
+            f"Quay API returned {resp.status_code}: {resp.text[:200]}"
+        )
+    tags = resp.json()["tags"]
+    return tags
 
 
 def check_if_executable_in_path(exec_name):


### PR DESCRIPTION
`get_latest_ds_olm_tag` fetched all tags from the quay registry by paginating through every page, which caused timeouts and `TagNotFoundException` failures. Now it uses the quay `filter_tag_name` parameter to fetch only version-relevant tags. Falls back to unfiltered fetch if the latest tag isn't found in filtered results.

This is a cherry-pick of https://github.com/red-hat-storage/ocs-ci/pull/15838