### PR TITLE
add happy path test for RHSTOR-8282

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -4077,3 +4077,5 @@ FUSION_ACCESS_OPERATOR_NAME = "openshift-fusion-access-operator"
 FUSION_ACCESS_CR_YAML = os.path.join(
     TEMPLATE_DEPLOYMENT_DIR_FUSION_ACCESS, "fusion-access-san.yaml"
 )
+
+CONFIRM_DELETION_ANNOTATION = "uninstall.ocs.openshift.io/confirm-deletion"

--- a/ocs_ci/ocs/uninstall.py
+++ b/ocs_ci/ocs/uninstall.py
@@ -8,7 +8,7 @@ from ocs_ci.ocs.ocp import switch_to_project
 from ocs_ci.ocs.resources.pod import get_all_pods
 from ocs_ci.ocs.resources.pvc import get_all_pvcs_in_storageclass, get_all_pvcs
 from ocs_ci.ocs.resources.storage_cluster import get_all_storageclass
-from ocs_ci.utility import rosa
+from ocs_ci.utility import rosa, version
 from ocs_ci.utility.localstorage import check_local_volume_local_volume_set
 from ocs_ci.utility.utils import TimeoutSampler
 
@@ -141,6 +141,32 @@ def uninstall_ocs():
     """
     ocp_obj = ocp.OCP()
 
+    if (
+        config.ENV_DATA["platform"].lower() != constants.ROSA_PLATFORM
+        and version.get_semantic_ocs_version_from_config() >= version.VERSION_4_23
+    ):
+        log.test_step("Annotating storageCluster to confirm deletion")
+        ns_name = config.ENV_DATA["cluster_namespace"]
+        storage_cluster = ocp.OCP(
+            kind=constants.STORAGECLUSTER,
+            resource_name=constants.DEFAULT_CLUSTERNAME,
+            namespace=ns_name,
+        )
+        confirm_annotation = (
+            f'{{"metadata":{{"annotations":'
+            f'{{"{constants.CONFIRM_DELETION_ANNOTATION}":"true"}}}}}}'
+        )
+        result = storage_cluster.patch(
+            resource_name=constants.DEFAULT_CLUSTERNAME,
+            params=confirm_annotation,
+            format_type="merge",
+        )
+        if not result:
+            raise CommandFailed(
+                f"StorageCluster '{constants.DEFAULT_CLUSTERNAME}' "
+                "confirm-deletion annotation failed; aborting uninstall"
+            )
+
     log.info("deleting volume snapshots")
     vs_ocp_obj = ocp.OCP(kind=constants.VOLUMESNAPSHOT)
     vs_list = vs_ocp_obj.get(all_namespaces=True)["items"]
@@ -185,17 +211,17 @@ def uninstall_ocs():
     except CommandFailed:
         log.info("No cluster logging found")
 
-    log.info("Deleting OCS PVCs")
-    for pvc in pvc_to_delete:
-        log.info(f"Deleting PVC: {pvc.name}")
-        pvc.delete()
-
     ns_name = config.ENV_DATA["cluster_namespace"]
     storage_cluster = ocp.OCP(
         kind=constants.STORAGECLUSTER,
         resource_name=constants.DEFAULT_CLUSTERNAME,
         namespace=ns_name,
     )
+
+    log.info("Deleting OCS PVCs")
+    for pvc in pvc_to_delete:
+        log.info(f"Deleting PVC: {pvc.name}")
+        pvc.delete()
 
     log.info("Checking for local storage")
     lso_sc = None

--- a/ocs_ci/ocs/uninstall.py
+++ b/ocs_ci/ocs/uninstall.py
@@ -8,7 +8,7 @@ from ocs_ci.ocs.ocp import switch_to_project
 from ocs_ci.ocs.resources.pod import get_all_pods
 from ocs_ci.ocs.resources.pvc import get_all_pvcs_in_storageclass, get_all_pvcs
 from ocs_ci.ocs.resources.storage_cluster import get_all_storageclass
-from ocs_ci.utility import rosa
+from ocs_ci.utility import rosa, version
 from ocs_ci.utility.localstorage import check_local_volume_local_volume_set
 from ocs_ci.utility.utils import TimeoutSampler
 
@@ -185,17 +185,34 @@ def uninstall_ocs():
     except CommandFailed:
         log.info("No cluster logging found")
 
-    log.info("Deleting OCS PVCs")
-    for pvc in pvc_to_delete:
-        log.info(f"Deleting PVC: {pvc.name}")
-        pvc.delete()
-
     ns_name = config.ENV_DATA["cluster_namespace"]
     storage_cluster = ocp.OCP(
         kind=constants.STORAGECLUSTER,
         resource_name=constants.DEFAULT_CLUSTERNAME,
         namespace=ns_name,
     )
+
+    if version.get_semantic_ocp_version_from_config() >= version.VERSION_5_0:
+        log.info("Annotating storageCluster to confirm deletion")
+        confirm_annotation = (
+            '[{"op": "add", "path": "/metadata/annotations/'
+            'uninstall.ocs.openshift.io~1confirm-deletion", "value": "true"}]'
+        )
+        result = storage_cluster.patch(
+            resource_name=constants.DEFAULT_CLUSTERNAME,
+            params=confirm_annotation,
+            format_type="json",
+        )
+        if not result:
+            raise CommandFailed(
+                f"StorageCluster '{constants.DEFAULT_CLUSTERNAME}' "
+                "confirm-deletion annotation failed; aborting uninstall"
+            )
+
+    log.info("Deleting OCS PVCs")
+    for pvc in pvc_to_delete:
+        log.info(f"Deleting PVC: {pvc.name}")
+        pvc.delete()
 
     log.info("Checking for local storage")
     lso_sc = None

--- a/tests/functional/deployment/test_storagecluster_deletion.py
+++ b/tests/functional/deployment/test_storagecluster_deletion.py
@@ -1,0 +1,91 @@
+import logging
+
+import pytest
+
+from ocs_ci.framework.testlib import (
+    ManageTest,
+    tier1,
+    brown_squad,
+    skipif_ocs_version,
+)
+from ocs_ci.ocs import constants, ocp
+from ocs_ci.ocs.exceptions import CommandFailed
+from ocs_ci.framework import config
+
+logger = logging.getLogger(__name__)
+
+
+@brown_squad
+class TestStorageClusterDeletionGuard(ManageTest):
+    """
+    Verify that a ValidatingAdmissionPolicy prevents StorageCluster
+    deletion unless the confirm-deletion annotation is set.
+    """
+
+    @tier1
+    @skipif_ocs_version("<4.23")
+    @pytest.mark.polarion_id("OCS-8218")
+    def test_storagecluster_delete_blocked_without_annotation(self, request):
+        """
+        Attempt to delete the StorageCluster without the
+        confirm-deletion annotation and verify the request
+        is rejected by the ValidatingAdmissionPolicy.
+        """
+        ns_name = config.ENV_DATA["cluster_namespace"]
+        sc_name = constants.DEFAULT_CLUSTERNAME
+
+        storage_cluster = ocp.OCP(
+            kind=constants.STORAGECLUSTER,
+            resource_name=sc_name,
+            namespace=ns_name,
+        )
+
+        annotations = storage_cluster.get().get("metadata", {}).get("annotations", {})
+        original_value = annotations.get(constants.CONFIRM_DELETION_ANNOTATION)
+
+        def restore_annotation():
+            if original_value is not None:
+                logger.info("Restoring confirm-deletion annotation")
+                patch = (
+                    f'{{"metadata":{{"annotations":'
+                    f'{{"{constants.CONFIRM_DELETION_ANNOTATION}":"{original_value}"}}}}}}'
+                )
+                storage_cluster.patch(
+                    resource_name=sc_name,
+                    params=patch,
+                    format_type="merge",
+                )
+            else:
+                logger.info("Removing confirm-deletion annotation")
+                storage_cluster.exec_oc_cmd(
+                    f"annotate storagecluster {sc_name} -n {ns_name} "
+                    f"{constants.CONFIRM_DELETION_ANNOTATION}-"
+                )
+
+        request.addfinalizer(restore_annotation)
+
+        if original_value == "true":
+            logger.test_step("Removing confirm-deletion annotation before test")
+            storage_cluster.exec_oc_cmd(
+                f"annotate storagecluster {sc_name} -n {ns_name} "
+                f"{constants.CONFIRM_DELETION_ANNOTATION}-"
+            )
+
+        logger.test_step(
+            "Attempting to delete StorageCluster without confirm-deletion annotation"
+        )
+        with pytest.raises(CommandFailed) as exc_info:
+            storage_cluster.delete(resource_name=sc_name)
+
+        error_msg = str(exc_info.value)
+        assert (
+            "StorageCluster deletion is IRREVERSIBLE" in error_msg
+        ), f"Expected deletion warning message, got: {error_msg}"
+        logger.test_step(
+            "StorageCluster deletion correctly blocked by ValidatingAdmissionPolicy"
+        )
+
+        # Verify StorageCluster still exists
+        assert storage_cluster.is_exist(
+            resource_name=sc_name
+        ), "StorageCluster should still exist after blocked deletion"

--- a/tests/functional/deployment/test_storagecluster_deletion.py
+++ b/tests/functional/deployment/test_storagecluster_deletion.py
@@ -1,0 +1,93 @@
+import logging
+
+import pytest
+
+from ocs_ci.framework.testlib import (
+    ManageTest,
+    tier1,
+    brown_squad,
+    skipif_ocs_version,
+)
+from ocs_ci.ocs import constants, ocp
+from ocs_ci.ocs.exceptions import CommandFailed
+from ocs_ci.framework import config
+
+logger = logging.getLogger(__name__)
+
+CONFIRM_DELETION_ANNOTATION = "uninstall.ocs.openshift.io/confirm-deletion"
+
+
+@brown_squad
+class TestStorageClusterDeletionGuard(ManageTest):
+    """
+    Verify that a ValidatingAdmissionPolicy prevents StorageCluster
+    deletion unless the confirm-deletion annotation is set.
+    """
+
+    @tier1
+    @skipif_ocs_version("<5.0")
+    # @pytest.mark.polarion_id("OCS-XXXX") - to be added once polarion test case is created
+    def test_storagecluster_delete_blocked_without_annotation(self, request):
+        """
+        Attempt to delete the StorageCluster without the
+        confirm-deletion annotation and verify the request
+        is rejected by the ValidatingAdmissionPolicy.
+        """
+        ns_name = config.ENV_DATA["cluster_namespace"]
+        sc_name = constants.DEFAULT_CLUSTERNAME
+
+        storage_cluster = ocp.OCP(
+            kind=constants.STORAGECLUSTER,
+            resource_name=sc_name,
+            namespace=ns_name,
+        )
+
+        annotations = storage_cluster.get().get("metadata", {}).get("annotations", {})
+        original_value = annotations.get(CONFIRM_DELETION_ANNOTATION)
+
+        def restore_annotation():
+            if original_value is not None:
+                logger.info("Restoring confirm-deletion annotation")
+                patch = (
+                    f'{{"metadata":{{"annotations":'
+                    f'{{"{CONFIRM_DELETION_ANNOTATION}":"{original_value}"}}}}}}'
+                )
+                storage_cluster.patch(
+                    resource_name=sc_name,
+                    params=patch,
+                    format_type="merge",
+                )
+            else:
+                logger.info("Removing confirm-deletion annotation")
+                storage_cluster.exec_oc_cmd(
+                    f"annotate storagecluster {sc_name} -n {ns_name} "
+                    f"{CONFIRM_DELETION_ANNOTATION}-"
+                )
+
+        request.addfinalizer(restore_annotation)
+
+        if original_value == "true":
+            logger.info("Removing confirm-deletion annotation before test")
+            storage_cluster.exec_oc_cmd(
+                f"annotate storagecluster {sc_name} -n {ns_name} "
+                f"{CONFIRM_DELETION_ANNOTATION}-"
+            )
+
+        logger.info(
+            "Attempting to delete StorageCluster without confirm-deletion annotation"
+        )
+        with pytest.raises(CommandFailed) as exc_info:
+            storage_cluster.delete(resource_name=sc_name)
+
+        error_msg = str(exc_info.value)
+        assert (
+            "StorageCluster deletion is IRREVERSIBLE" in error_msg
+        ), f"Expected deletion warning message, got: {error_msg}"
+        logger.info(
+            "StorageCluster deletion correctly blocked by ValidatingAdmissionPolicy"
+        )
+
+        # Verify StorageCluster still exists
+        assert storage_cluster.is_exist(
+            resource_name=sc_name
+        ), "StorageCluster should still exist after blocked deletion"


### PR DESCRIPTION
Adds happy path to check for annotation that blocks storagecluster deletion. Also adds the annotation before the storagecluster is deleted.

Ref: https://redhat.atlassian.net/browse/RHSTOR-9302

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a confirmation safeguard before StorageCluster removal on non-ROSA OCP 4.23 and later clusters.
  * Uninstallation now stops if the required confirmation cannot be applied, helping prevent accidental irreversible deletion.
  * StorageCluster deletion remains blocked unless explicit confirmation is provided.

* **Tests**
  * Added coverage verifying deletion is denied without confirmation and that the StorageCluster remains available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->