### PR TITLE
Add vSphere 5-MON deployment configs with unique rack labels

### DIFF
--- a/conf/deployment/vsphere/ipi_1az_rhcos_vsan_3m_6w_5mon.yaml
+++ b/conf/deployment/vsphere/ipi_1az_rhcos_vsan_3m_6w_5mon.yaml
@@ -1,0 +1,20 @@
+---
+# vSphere IPI vSAN: 3 masters, 6 workers, unique rack labels, 5 MONs
+DEPLOYMENT:
+  allow_lower_instance_requirements: false
+  ocs_operator_nodes_to_label: 6
+  unique_rack_node_labels: true
+  mon_count: 5
+ENV_DATA:
+  platform: 'vsphere'
+  deployment_type: 'ipi'
+  worker_replicas: 6
+  master_replicas: 3
+  worker_num_cpus: '16'
+  master_num_cpus: '4'
+  master_memory: '16384'
+  compute_memory: '65536'
+  fio_storageutilization_min_mbps: 10.0
+REPORTING:
+  polarion:
+    deployment_id: 'OCS-2363'

--- a/conf/deployment/vsphere/upi_1az_rhcos_vsan_3m_6w_5mon.yaml
+++ b/conf/deployment/vsphere/upi_1az_rhcos_vsan_3m_6w_5mon.yaml
@@ -1,0 +1,20 @@
+---
+# vSphere UPI vSAN: 3 masters, 6 workers, unique rack labels, 5 MONs
+DEPLOYMENT:
+  allow_lower_instance_requirements: false
+  ocs_operator_nodes_to_label: 6
+  unique_rack_node_labels: true
+  mon_count: 5
+ENV_DATA:
+  platform: 'vsphere'
+  deployment_type: 'upi'
+  worker_replicas: 6
+  master_replicas: 3
+  worker_num_cpus: '16'
+  master_num_cpus: '4'
+  master_memory: '16384'
+  compute_memory: '65536'
+  fio_storageutilization_min_mbps: 10.0
+REPORTING:
+  polarion:
+    deployment_id: 'OCS-2363'

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -90,6 +90,7 @@ from ocs_ci.ocs.exceptions import (
 )
 from ocs_ci.deployment.cert_manager import deploy_cert_manager
 from ocs_ci.deployment.zones import create_dummy_zone_labels
+from ocs_ci.deployment.racks import create_unique_rack_labels
 from ocs_ci.deployment.mce import MCEInstaller
 from ocs_ci.deployment.netsplit import get_netsplit_mc
 from ocs_ci.ocs.monitoring import (
@@ -219,6 +220,34 @@ from ocs_ci.deployment.kmm import deploy_kmm_operator
 from ocs_ci.deployment.image_registry import configure_image_registry_with_pvc
 
 logger = logging.getLogger(__name__)
+
+
+def get_expected_mon_count():
+    """
+    Return the expected number of ready MON pods for deployment consumers.
+
+    Validates DEPLOYMENT.mon_count when present. Defaults to 3 only when the
+    setting is absent. Used by StorageCluster monCount setup and the
+    deploy_ocs MON readiness wait_for_resource() call.
+
+    Returns:
+        int: Validated MON count (3 or 5)
+
+    Raises:
+        UnexpectedDeploymentConfiguration: If mon_count is set to any value
+            other than 3 or 5
+
+    """
+    if "mon_count" not in config.DEPLOYMENT:
+        return 3
+
+    mon_count = config.DEPLOYMENT["mon_count"]
+    # Require a real int (reject bool/float) and only the supported counts.
+    if type(mon_count) is not int or mon_count not in constants.SUPPORTED_MON_COUNTS:
+        raise UnexpectedDeploymentConfiguration(
+            f"DEPLOYMENT.mon_count must be 3 or 5, got {mon_count!r}"
+        )
+    return mon_count
 
 
 class Deployment(object):
@@ -1006,6 +1035,8 @@ class Deployment(object):
         self.do_deploy_submariner()
         self.do_gitops_deploy()
         self.do_deploy_oadp()
+        if config.DEPLOYMENT.get("unique_rack_node_labels"):
+            create_unique_rack_labels()
         self.do_deploy_ocs()
         self.do_deploy_rdr()
         self.do_deploy_mce()
@@ -2343,10 +2374,11 @@ class Deployment(object):
                 mon_pod_timeout = 1800
             else:
                 mon_pod_timeout = 900
+            expected_mon_count = get_expected_mon_count()
             assert pod.wait_for_resource(
                 condition="Running",
                 selector="app=rook-ceph-mon",
-                resource_count=3,
+                resource_count=expected_mon_count,
                 timeout=mon_pod_timeout,
             )
             assert pod.wait_for_resource(

--- a/ocs_ci/deployment/racks.py
+++ b/ocs_ci/deployment/racks.py
@@ -1,0 +1,51 @@
+# -*- coding: utf8 -*-
+
+import logging
+
+from ocs_ci.ocs import constants, exceptions
+from ocs_ci.ocs.node import get_worker_nodes
+from ocs_ci.ocs.ocp import OCP
+
+
+logger = logging.getLogger(__name__)
+
+MIN_WORKERS_FOR_UNIQUE_RACKS = 5
+
+
+def assign_unique_rack_labels(nodes, overwrite=True):
+    """
+    Assign a unique topology.rook.io/rack label to each given node.
+
+    Args:
+        nodes (list[str]): Node names to label
+        overwrite (bool): If True, overwrite existing rack labels
+
+    """
+    node_h = OCP(kind="node")
+    for index, node in enumerate(nodes):
+        rack = f"rack{index}"
+        logger.info("labeling node %s with %s=%s", node, constants.RACK_LABEL, rack)
+        oc_cmd = f"label node {node} {constants.RACK_LABEL}={rack}"
+        if overwrite:
+            oc_cmd += " --overwrite"
+        node_h.exec_oc_cmd(command=oc_cmd)
+
+
+def create_unique_rack_labels():
+    """
+    Label each worker node with a unique rack for 5-MON deployments.
+
+    Raises:
+        UnexpectedDeploymentConfiguration: If fewer than 5 worker nodes exist
+
+    """
+    logger.info("trying to setup unique_rack_node_labels")
+    workers = get_worker_nodes()
+    if len(workers) < MIN_WORKERS_FOR_UNIQUE_RACKS:
+        msg = (
+            f"unique_rack_node_labels requires at least "
+            f"{MIN_WORKERS_FOR_UNIQUE_RACKS} worker nodes, found {len(workers)}"
+        )
+        logger.error(msg)
+        raise exceptions.UnexpectedDeploymentConfiguration(msg)
+    assign_unique_rack_labels(workers)

--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -107,6 +107,9 @@ DEPLOYMENT:
   ignition_version: "3.2.0"
   # Label all nodes with "dummy" zone labels? Assumes zone lables are missing.
   dummy_zone_node_labels: False
+  # Label each worker with a unique topology.rook.io/rack value before ODF
+  # install (required for deploying with monCount: 5).
+  unique_rack_node_labels: False
   # Network split setup. When enabled, network split scripts will be deployed
   # on all master and worker nodes via MachineConfig during deployment.
   # See also: https://mbukatov.gitlab.io/ocp-network-split/

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -2214,6 +2214,9 @@ PDB_COUNT_ARBITER_VSPHERE = 5
 MGR_COUNT = 1
 MGR_COUNT_415 = 2
 
+# Supported Ceph MON counts for deployment
+SUPPORTED_MON_COUNTS = (3, 5)
+
 # Root Disk size
 CURRENT_VM_ROOT_DISK_SIZE = "60"
 VM_ROOT_DISK_SIZE = "120"

--- a/ocs_ci/utility/storage_cluster_setup.py
+++ b/ocs_ci/utility/storage_cluster_setup.py
@@ -21,6 +21,26 @@ from ocs_ci.utility.utils import get_az_count, run_cmd
 logger = logging.getLogger(__name__)
 
 
+def apply_ceph_cluster_mon_count(cluster_data, mon_count):
+    """
+    Set managedResources.cephCluster.monCount when mon_count is 5.
+
+    Args:
+        cluster_data (dict): StorageCluster CR data
+        mon_count (int | None): Desired mon count from DEPLOYMENT.mon_count
+
+    Returns:
+        dict: Updated cluster_data
+
+    """
+    if mon_count == 5:
+        cluster_data["spec"].setdefault("managedResources", {}).setdefault(
+            "cephCluster", {}
+        )["monCount"] = 5
+        logger.info("Setting StorageCluster managedResources.cephCluster.monCount=5")
+    return cluster_data
+
+
 class StorageClusterSetup(object):
     """
     Performs the setup of the StorageCluster for Data Foundation deployments
@@ -700,6 +720,12 @@ class StorageClusterSetup(object):
                 cp = managed_resources_ceph_cluster.setdefault("cleanupPolicy", {})
                 cp["wipeDevicesFromOtherClusters"] = True
 
+        # Lazy import avoids circular import with deployment.Deployment
+        from ocs_ci.deployment.deployment import get_expected_mon_count
+
+        cluster_data = apply_ceph_cluster_mon_count(
+            cluster_data, get_expected_mon_count()
+        )
         storage_cluster_override = config.DEPLOYMENT.get("storage_cluster_override", {})
         if storage_cluster_override:
             logger.info(


### PR DESCRIPTION
## Summary
- Add unique worker rack labeling before ODF install (`DEPLOYMENT.unique_rack_node_labels`) so 5-MON topology can be established at deploy time
- Set `managedResources.cephCluster.monCount: 5` when `DEPLOYMENT.mon_count` is 5 during StorageCluster creation
- Add vSphere IPI/UPI vSAN 6-worker deployment configs: `*_vsan_3m_6w_5mon.yaml`



## Test plan
- [x] Deploy with `conf/deployment/vsphere/upi_1az_rhcos_vsan_3m_6w_5mon.yaml` and confirm StorageCluster Ready + 5 MONs in quorum
- [x] Deploy with `conf/deployment/vsphere/ipi_1az_rhcos_vsan_3m_6w_5mon.yaml` and confirm the same



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added vSphere IPI and UPI deployment configurations for five-monitor clusters with defined resource, storage, and rack settings.
  * Added optional unique rack labeling for worker nodes.
  * Added configurable Ceph monitor counts, including support for five-monitor storage clusters.
* **Bug Fixes**
  * Added validation for invalid monitor counts.
  * Added validation to prevent unique rack assignments when fewer than five workers are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->