### PR TITLE
fix: use split instead of fixed slice for CNV image tag extraction

### DIFF
--- a/ocs_ci/deployment/cnv.py
+++ b/ocs_ci/deployment/cnv.py
@@ -64,7 +64,7 @@ class CNVInstaller(object):
         logger.info("Adding CatalogSource for CNV")
         cnv_catalog_source_data = templating.load_yaml(CNV_CATALOG_SOURCE_YAML)
         cnv_catalog_source_name = cnv_catalog_source_data.get("metadata").get("name")
-        cnv_image_tag = config.DEPLOYMENT.get("ocs_csv_channel")[-4:]
+        cnv_image_tag = config.DEPLOYMENT.get("ocs_csv_channel").split("-")[-1]
         cnv_catalog_source_data["spec"][
             "image"
         ] = f"{constants.CNV_QUAY_NIGHTLY_IMAGE}:{cnv_image_tag}"
@@ -134,7 +134,9 @@ class CNVInstaller(object):
             ] = constants.OPERATOR_CATALOG_SOURCE_NAME
             cnv_sub_channel = "stable"
         else:
-            cnv_channel_version = config.DEPLOYMENT.get("ocs_csv_channel")[-4:]
+            cnv_channel_version = config.DEPLOYMENT.get("ocs_csv_channel").split("-")[
+                -1
+            ]
             cnv_sub_channel = f"nightly-{cnv_channel_version}"
 
         cnv_subscription_yaml_data["spec"]["channel"] = f"{cnv_sub_channel}"


### PR DESCRIPTION
config.DEPLOYMENT.get("ocs_csv_channel") returns values like "stable-4.20" or "stable-5.0". The previous [-4:] slice assumed a 4-character version suffix, which incorrectly included the leading dash for 3-character versions like "5.0".

Replace [-4:] with .split("-")[-1] at both callsites in create_cnv_catalog_source() and create_cnv_subscription() so the version is extracted correctly regardless of its length.


Fixes: #15879 



--------Before fix --------

`quay.io/openshift-cnv/nightly-catalog:-5.0
`

--------After fix --------

`quay.io/openshift-cnv/nightly-catalog:5.0`