### PR TITLE
Remove test skip after bug fix

### DIFF
--- a/tests/cross_functional/system_test/test_mcg_bucket_notification.py
+++ b/tests/cross_functional/system_test/test_mcg_bucket_notification.py
@@ -13,7 +13,6 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_proxy_cluster,
     skipif_noobaa_external_pgsql,
     skipif_external_mode,
-    jira,
 )
 from ocs_ci.ocs.bucket_utils import (
     write_random_test_objects_to_bucket,
@@ -49,7 +48,6 @@ from ocs_ci.utility.utils import TimeoutSampler
 @skipif_external_mode
 @magenta_squad
 @ignore_leftover_label(constants.CUSTOM_MCG_LABEL)
-@jira("DFBUGS-4469")
 class TestBucketNotificationSystemTest:
 
     @pytest.fixture(autouse=True, scope="class")


### PR DESCRIPTION
Removing skip label since bug is fixed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed an obsolete test tracking annotation from the bucket notification system test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->