### PR TITLE
Fix must-gather OTHERS validation for external clusters on 4.20+

### DIFF
--- a/ocs_ci/ocs/must_gather/const_must_gather.py
+++ b/ocs_ci/ocs/must_gather/const_must_gather.py
@@ -1289,7 +1289,10 @@ GATHER_COMMANDS_VERSION = {
         ),
         "OTHERS_EXTERNAL": list(
             set(GATHER_COMMANDS_OTHERS_EXTERNAL + GATHER_COMMANDS_OTHERS_EXTERNAL_4_8)
-            - set(GATHER_COMMANDS_OTHERS_EXTERNAL_EXCLUDE)
+            - set(
+                GATHER_COMMANDS_OTHERS_EXTERNAL_EXCLUDE
+                + GATHER_COMMANDS_OTHERS_EXCLUDE_4_20
+            )
         ),
     },
 }

--- a/ocs_ci/ocs/must_gather/must_gather.py
+++ b/ocs_ci/ocs/must_gather/must_gather.py
@@ -117,6 +117,7 @@ class MustGather(object):
                 f"pool name as fallback for must-gather file matching"
             )
 
+        self.files_path.clear()
         self.get_all_paths()
         basenames = {}
         for p in self.full_paths:
@@ -422,8 +423,8 @@ class MustGather(object):
         """
         if config.ENV_DATA["platform"] not in MANAGED_SERVICE_PLATFORMS:
             self.verify_noobaa_diagnostics()
-        self.validate_file_size()
         self.validate_expected_files()
+        self.validate_file_size()
         self.print_invalid_files()
         self.compare_running_pods()
         self.print_must_gather_debug()

--- a/ocs_ci/ocs/must_gather/must_gather.py
+++ b/ocs_ci/ocs/must_gather/must_gather.py
@@ -142,20 +142,17 @@ class MustGather(object):
 
     def validate_file_size(self):
         """
-        Validate the file is not empty
+        Validate expected files are not empty
 
         """
         if self.type_log != "OTHERS":
             return
-        for path, subdirs, files in os.walk(self.root):
-            for file in files:
-                file_path = os.path.join(path, file)
-                if (
-                    Path(file_path).stat().st_size == 0
-                    and "noobaa-db-pg-0-init.log" not in file_path
-                ):
-                    logger.error(f"log file {file} empty!")
-                    self.empty_files.append(file)
+        for file, file_path in self.files_path.items():
+            if not os.path.isabs(file_path):
+                continue
+            if Path(file_path).stat().st_size == 0:
+                logger.error(f"log file {file} empty!")
+                self.empty_files.append(file)
 
     def validate_expected_files(self):
         """


### PR DESCRIPTION
## Summary
- Exclude CNPG-deprecated NooBaa DB files (`noobaa-db-pg-0.yaml`, `db-noobaa-db-pg-0.yaml`, `noobaa-db-pg-0.log`) from `OTHERS_EXTERNAL` expected file list in version 4.20
- Scope `validate_file_size` to only check files in the expected list instead of walking the entire must-gather directory tree

## Problem
On external clusters running ODF 4.20+, `test_must_gather[OTHERS]` fails because:
1. The `OTHERS_EXTERNAL` file list in `GATHER_COMMANDS_VERSION[4.20]` was missing `GATHER_COMMANDS_OTHERS_EXCLUDE_4_20` — the CNPG migration exclusion that was correctly applied to `OTHERS`
2. `validate_file_size` walked every file in the must-gather directory, flagging legitimately empty ceph outputs (e.g., `ceph_crash_ls` on healthy clusters, `rados_ls` with internal pool names on external clusters)

## Test plan
- [ ] Verify `test_must_gather[OTHERS]` passes on an external cluster with ODF 4.22+
- [ ] Verify `test_must_gather[OTHERS]` still passes on internal clusters
- [ ] Verify `test_must_gather[CEPH]` and `test_must_gather[JSON]` are unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved must-gather log validation by checking only mapped files and handling absolute paths consistently.
  * Ensured empty mapped log files are recorded for validation.
  * Excluded deprecated NooBaa PostgreSQL files from OCS 4.20 “Others” logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->