### PR TITLE
Fix race condition in pvpool priority class reconciliation wait

### DIFF
--- a/tests/functional/object/mcg/test_noobaa_priority_class.py
+++ b/tests/functional/object/mcg/test_noobaa_priority_class.py
@@ -1,6 +1,7 @@
 import json
 import logging
 
+from ocs_ci.ocs.exceptions import CommandFailed
 from ocs_ci.framework.pytest_customization.marks import (
     mcg,
     red_squad,
@@ -371,7 +372,14 @@ class TestNoobaaPriorityClass(MCGTest):
                 continue
             all_match = True
             for pod in pods:
-                pod_dict = pod.get()
+                try:
+                    pod_dict = pod.get()
+                except CommandFailed:
+                    logger.info(
+                        f"Pod {pod.name} disappeared during reconciliation, retrying"
+                    )
+                    all_match = False
+                    break
                 actual_pc = pod_dict["spec"].get("priorityClassName")
                 phase = pod_dict.get("status", {}).get("phase")
                 if actual_pc != expected_pc or phase != "Running":


### PR DESCRIPTION
## Summary

- Catch `CommandFailed` (NotFound) in `_wait_for_pvpool_pods_priority_class` when a pod disappears between the label-based list and name-based fetch during operator reconciliation
- The polling loop now retries with a fresh pod list instead of crashing the test

## Changes

- Added `CommandFailed` import from `ocs_ci.ocs.exceptions`
- Wrapped `pod.get()` in a try/except inside the polling loop body - when the operator deletes a pod mid-iteration, the exception is caught, logged, and the loop retries on the next `TimeoutSampler` cycle

Fixes: https://github.com/red-hat-storage/ocs-ci/issues/15901

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reconciliation reliability when PVPool pods are removed during processing.
  * Temporary pod disappearance is now handled with retries instead of causing the operation to fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->