### PR TITLE
Fix TLS scan RGW endpoint discovery and skip on disconnected clusters

### DIFF
--- a/ocs_ci/helpers/tlsprofile_helper.py
+++ b/ocs_ci/helpers/tlsprofile_helper.py
@@ -303,6 +303,55 @@ def _tls_scan_run_oc(args, kubeconfig=None, timeout=60):
     return completed.stdout.decode()
 
 
+def _find_fallback_ports(selector, component, pod):
+    fallback_ports = selector.get("fallback_ports", [])
+    if fallback_ports or component != "all":
+        return fallback_ports
+    pod_labels = pod.get("metadata", {}).get("labels", {})
+    for comp_sel in TLS_SCAN_COMPONENT_SELECTORS.values():
+        comp_label = comp_sel.get("label", "")
+        comp_fb = comp_sel.get("fallback_ports", [])
+        if comp_fb and "=" in comp_label:
+            key, val = comp_label.split("=", 1)
+            if pod_labels.get(key) == val:
+                return comp_fb
+    return []
+
+
+def _build_container_endpoints(container, pod_name, pod_ns, pod_ip, fallback_ports):
+    c_name = container["name"]
+    cmd_parts = container.get("command", []) + container.get("args", [])
+    process = ""
+    if cmd_parts:
+        process = cmd_parts[0].rsplit("/", 1)[-1][:15]
+    if not process:
+        process = container.get("image", "").split("/")[-1].split(":")[0][:15]
+    declared_ports = container.get("ports", [])
+    port_numbers = [
+        p.get("containerPort") for p in declared_ports if p.get("containerPort")
+    ]
+    if not port_numbers and fallback_ports:
+        log.info(
+            "TLS scan: pod %s container %s has no declared ports, "
+            "using fallback ports %s",
+            pod_name,
+            c_name,
+            fallback_ports,
+        )
+        port_numbers = fallback_ports
+    return [
+        {
+            "pod_namespace": pod_ns,
+            "pod_name": pod_name,
+            "pod_ip": pod_ip,
+            "container_name": c_name,
+            "port": str(port),
+            "process": process,
+        }
+        for port in port_numbers
+    ]
+
+
 def _tls_scan_discover_endpoints(kubeconfig, namespaces, component="all"):
     selector = TLS_SCAN_COMPONENT_SELECTORS.get(component, {})
     label = selector.get("label")
@@ -334,53 +383,13 @@ def _tls_scan_discover_endpoints(kubeconfig, namespaces, component="all"):
                 continue
             if name_filter and name_filter not in pod_name:
                 continue
-            fallback_ports = selector.get("fallback_ports", [])
-            if not fallback_ports and component == "all":
-                pod_labels = pod.get("metadata", {}).get("labels", {})
-                for comp_sel in TLS_SCAN_COMPONENT_SELECTORS.values():
-                    comp_label = comp_sel.get("label", "")
-                    comp_fb = comp_sel.get("fallback_ports", [])
-                    if comp_fb and "=" in comp_label:
-                        key, val = comp_label.split("=", 1)
-                        if pod_labels.get(key) == val:
-                            fallback_ports = comp_fb
-                            break
+            fallback_ports = _find_fallback_ports(selector, component, pod)
             for container in pod["spec"]["containers"]:
-                c_name = container["name"]
-                cmd_parts = container.get("command", []) + container.get("args", [])
-                process = ""
-                if cmd_parts:
-                    process = cmd_parts[0].rsplit("/", 1)[-1][:15]
-                if not process:
-                    process = (
-                        container.get("image", "").split("/")[-1].split(":")[0][:15]
+                endpoints.extend(
+                    _build_container_endpoints(
+                        container, pod_name, pod_ns, pod_ip, fallback_ports
                     )
-                declared_ports = container.get("ports", [])
-                port_numbers = [
-                    p.get("containerPort")
-                    for p in declared_ports
-                    if p.get("containerPort")
-                ]
-                if not port_numbers and fallback_ports:
-                    log.info(
-                        "TLS scan: pod %s container %s has no declared ports, "
-                        "using fallback ports %s",
-                        pod_name,
-                        c_name,
-                        fallback_ports,
-                    )
-                    port_numbers = fallback_ports
-                for port in port_numbers:
-                    endpoints.append(
-                        {
-                            "pod_namespace": pod_ns,
-                            "pod_name": pod_name,
-                            "pod_ip": pod_ip,
-                            "container_name": c_name,
-                            "port": str(port),
-                            "process": process,
-                        }
-                    )
+                )
 
     log.info(
         "TLS scan: discovered %d endpoints for component %r in %d namespace(s)",

--- a/ocs_ci/helpers/tlsprofile_helper.py
+++ b/ocs_ci/helpers/tlsprofile_helper.py
@@ -240,9 +240,15 @@ TLS_SCANNER_NAMESPACE = "scantls-system"
 # Seconds between ``oc get pod … jsonpath={.status.phase}`` samples (scanner pod startup).
 TLS_SCAN_POD_PHASE_POLL_SLEEP = 2
 
+RGW_HTTP_PORT = 8080
+RGW_SSL_PORT = 443
+
 TLS_SCAN_COMPONENT_SELECTORS = {
     "noobaa": {"label": "app=noobaa"},
-    "rgw": {"label": "app=rook-ceph-rgw"},
+    "rgw": {
+        "label": "app=rook-ceph-rgw",
+        "fallback_ports": [RGW_HTTP_PORT, RGW_SSL_PORT],
+    },
     "ceph": {"label": "rook_cluster=openshift-storage"},
     "csi": {"name_filter": "csi"},
     "all": {},
@@ -328,6 +334,7 @@ def _tls_scan_discover_endpoints(kubeconfig, namespaces, component="all"):
                 continue
             if name_filter and name_filter not in pod_name:
                 continue
+            fallback_ports = selector.get("fallback_ports", [])
             for container in pod["spec"]["containers"]:
                 c_name = container["name"]
                 cmd_parts = container.get("command", []) + container.get("args", [])
@@ -338,19 +345,32 @@ def _tls_scan_discover_endpoints(kubeconfig, namespaces, component="all"):
                     process = (
                         container.get("image", "").split("/")[-1].split(":")[0][:15]
                     )
-                for port_info in container.get("ports", []):
-                    port = port_info.get("containerPort")
-                    if port:
-                        endpoints.append(
-                            {
-                                "pod_namespace": pod_ns,
-                                "pod_name": pod_name,
-                                "pod_ip": pod_ip,
-                                "container_name": c_name,
-                                "port": str(port),
-                                "process": process,
-                            }
-                        )
+                declared_ports = container.get("ports", [])
+                port_numbers = [
+                    p.get("containerPort")
+                    for p in declared_ports
+                    if p.get("containerPort")
+                ]
+                if not port_numbers and fallback_ports:
+                    log.info(
+                        "TLS scan: pod %s container %s has no declared ports, "
+                        "using fallback ports %s",
+                        pod_name,
+                        c_name,
+                        fallback_ports,
+                    )
+                    port_numbers = fallback_ports
+                for port in port_numbers:
+                    endpoints.append(
+                        {
+                            "pod_namespace": pod_ns,
+                            "pod_name": pod_name,
+                            "pod_ip": pod_ip,
+                            "container_name": c_name,
+                            "port": str(port),
+                            "process": process,
+                        }
+                    )
 
     log.info(
         "TLS scan: discovered %d endpoints for component %r in %d namespace(s)",

--- a/ocs_ci/helpers/tlsprofile_helper.py
+++ b/ocs_ci/helpers/tlsprofile_helper.py
@@ -335,6 +335,16 @@ def _tls_scan_discover_endpoints(kubeconfig, namespaces, component="all"):
             if name_filter and name_filter not in pod_name:
                 continue
             fallback_ports = selector.get("fallback_ports", [])
+            if not fallback_ports and component == "all":
+                pod_labels = pod.get("metadata", {}).get("labels", {})
+                for comp_sel in TLS_SCAN_COMPONENT_SELECTORS.values():
+                    comp_label = comp_sel.get("label", "")
+                    comp_fb = comp_sel.get("fallback_ports", [])
+                    if comp_fb and "=" in comp_label:
+                        key, val = comp_label.split("=", 1)
+                        if pod_labels.get(key) == val:
+                            fallback_ports = comp_fb
+                            break
             for container in pod["spec"]["containers"]:
                 c_name = container["name"]
                 cmd_parts = container.get("command", []) + container.get("args", [])

--- a/tests/functional/tlsprofile/test_centralized_tlsprofile_configuration.py
+++ b/tests/functional/tlsprofile/test_centralized_tlsprofile_configuration.py
@@ -7,6 +7,7 @@ from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import (
     brown_squad,
     ignore_leftover_label,
+    skipif_disconnected_cluster,
     skipif_external_mode,
     skipif_fips_enabled,
     skipif_managed_service,
@@ -49,6 +50,7 @@ def require_tlsprofile_crd():
 @brown_squad
 @tier3
 @skipif_ocs_version("<4.22")
+@skipif_disconnected_cluster
 @skipif_fips_enabled
 @skipif_external_mode
 @skipif_managed_service


### PR DESCRIPTION
## Summary
- Fix RGW endpoint discovery when pod spec has no `ports` — fall back to well-known ports (8080, 443)
- Skip TLS profile tests on disconnected clusters (scanner needs internet access)

## Test plan
- [x] Validated locally: wildcard selector (MCG + RGW)
- [x] Validated locally: noobaa.io selector
- [x] Validated locally: ceph.rook.io (RGW) selector

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RGW TLS endpoint discovery with HTTP and HTTPS fallback ports when container ports are not declared.
  * Preserved explicitly declared container ports when available.
  * Improved endpoint selection across RGW components.

* **Test Improvements**
  * Centralized TLS profile tests are now skipped on disconnected clusters where they cannot run successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->