### PR TITLE
fix ACM cluster switcher

### DIFF
--- a/ocs_ci/deployment/hub_spoke.py
+++ b/ocs_ci/deployment/hub_spoke.py
@@ -3785,6 +3785,8 @@ class HypershiftAWSHostedOCP(SpokeOCP, HyperShiftBase, Deployment, MCEInstaller,
         Returns:
             str: Cluster name if successful, empty string if failed
         """
+        # timeout is stretched due to AWS EC2 capacity/provisioning delays
+        nodes_creation_timeout = 100 * 60
 
         logger.info(
             f"Creating AWS HCP cluster '{self.name}' with release image: {release_image}"
@@ -3915,7 +3917,7 @@ class HypershiftAWSHostedOCP(SpokeOCP, HyperShiftBase, Deployment, MCEInstaller,
 
             logger.info(f"Verifying HostedCluster '{self.name}' was created...")
             for sample in TimeoutSampler(
-                timeout=300, sleep=10, func=get_hosted_cluster_names
+                timeout=nodes_creation_timeout, sleep=30, func=get_hosted_cluster_names
             ):
                 if self.name in sample:
                     logger.info(f"HostedCluster '{self.name}' created successfully")

--- a/ocs_ci/ocs/ui/base_ui.py
+++ b/ocs_ci/ocs/ui/base_ui.py
@@ -1634,6 +1634,16 @@ def navigate_to_local_cluster(**kwargs):
     else:
         timeout = 30
 
+    try:
+        wait_for_element_to_be_visible(acm_page_loc["single-perspective"], 3)
+        logger.info(
+            "Single perspective detected (no multicluster hub). "
+            "Already on local cluster — skipping cluster navigation."
+        )
+        return
+    except TimeoutException:
+        pass
+
     all_clusters_dropdown = acm_page_loc["all-clusters_dropdown"]
     try:
         logger.info("Navigate to Local Cluster page. Click all clusters dropdown")

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -1867,16 +1867,22 @@ acm_configuration_4_21 = {
 }
 
 acm_configuration_4_22 = {
+    "single-perspective": (
+        "//*[@id='only-one-perspective']",
+        By.XPATH,
+    ),
     "all-clusters_dropdown": (
         "//button[@data-test-id='perspective-switcher-toggle']",
         By.XPATH,
     ),
     "local-cluster_dropdown_item": (
-        "//button[@data-test-id='perspective-switcher-toggle']//*[normalize-space()='local-cluster']",
+        "//*[@data-test-id='perspective-switcher-toggle']//*[normalize-space()='local-cluster'] | "
+        "//*[@data-test-id='perspective-switcher-toggle']//*[normalize-space()='Core platform']",
         By.XPATH,
     ),
     "local-cluster_dropdown": (
-        "//h2[normalize-space()='Administrator']",
+        "//h2[normalize-space()='Administrator'] | "
+        "//*[@data-test-id='perspective-switcher-toggle']//h2[normalize-space()='Core platform']",
         By.XPATH,
     ),
     "click-local-cluster": (


### PR DESCRIPTION
Fix the problem caused by PR https://github.com/red-hat-storage/ocs-ci/pull/15828 

https://reportportal-ocs4.apps.dno.ocp-hub.prod.psi.redhat.com/ui/#ocs/launches/all/53583/2286788/2286806/log
```
ocs_ci/ocs/ui/validation_ui.py:335: in odf_overview_ui
    self.odf_console_plugin_check()
ocs_ci/ocs/ui/validation_ui.py:210: in odf_console_plugin_check
    navigate_to_local_cluster()
ocs_ci/ocs/ui/base_ui.py:1606: in navigate_to_local_cluster
    wait_for_element_to_be_visible(acm_page_loc["local-cluster_dropdown"], timeout)
ocs_ci/ocs/ui/base_ui.py:90: in wait_for_element_to_be_visible
    web_element = wait.until(
 ```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation in single-perspective environments by skipping unavailable multicluster controls.
  * Updated perspective switching to recognize current single-perspective and local-cluster labels.
  * Preserved compatibility with administrator-based perspective matching.

* **Improvements**
  * Increased the wait time for hosted cluster creation, accommodating longer provisioning and capacity delays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->