### PR TITLE
RHSTOR-8840/8290: add standalone FDF deployment support

### DIFF
--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -1296,7 +1296,17 @@ class Deployment(object):
         rosa_hcp_non_ga = platform == constants.ROSA_HCP_PLATFORM and bool(
             config.DEPLOYMENT.get("ocs_registry_image")
         )
-        if config.DEPLOYMENT.get("live_deployment") and not rosa_hcp_non_ga:
+        if config.DEPLOYMENT.get("fdf_standalone_deployment", False):
+            # Standalone FDF (RHSTOR-8840): resolve odf-operator from the IBM
+            # catalog source created by StandaloneFDFCatalogSource, not redhat-operators.
+            subscription_yaml_data["spec"][
+                "source"
+            ] = constants.FDF_STANDALONE_CATALOG_SOURCE_NAME
+            logger.info(
+                "FDF standalone: subscription source set to '%s'",
+                constants.FDF_STANDALONE_CATALOG_SOURCE_NAME,
+            )
+        elif config.DEPLOYMENT.get("live_deployment") and not rosa_hcp_non_ga:
             subscription_yaml_data["spec"]["source"] = config.DEPLOYMENT.get(
                 "live_content_source", defaults.LIVE_CONTENT_SOURCE
             )
@@ -1472,7 +1482,20 @@ class Deployment(object):
         upgrade = config.UPGRADE.get("upgrade", False)
         rosa_hcp = config.ENV_DATA.get("platform") == constants.ROSA_HCP_PLATFORM
         rosa_hcp_non_ga = rosa_hcp and bool(config.DEPLOYMENT.get("ocs_registry_image"))
-        if (not live_deployment or rosa_hcp_non_ga) and not (
+        # Standalone FDF (RHSTOR-8840): create the IBM catalog source so that
+        # the odf-operator package becomes visible in OperatorHub. After this
+        # the rest of the ODF deployment path runs unchanged.
+        fdf_standalone = config.DEPLOYMENT.get("fdf_standalone_deployment", False)
+        if fdf_standalone:
+            from ocs_ci.deployment.fdf_standalone import (
+                create_fdf_standalone_catalog_source,
+            )
+
+            logger.test_step(
+                "Create FDF standalone CatalogSource (ibm-operators) and wait READY"
+            )
+            create_fdf_standalone_catalog_source()
+        elif (not live_deployment or rosa_hcp_non_ga) and not (
             stage_testing and konflux_build and not rosa_hcp
         ):
             log_step("Create catalog source and wait it to be READY")

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -166,6 +166,7 @@ from ocs_ci.utility.deployment import (
     workaround_mark_disks_as_ssd,
 )
 from ocs_ci.utility.flexy import load_cluster_info
+from ocs_ci.deployment.fdf_standalone import create_fdf_standalone_catalog_source
 from ocs_ci.utility.networking import (
     annotate_worker_nodes_with_mon_ip,
 )
@@ -1353,7 +1354,17 @@ class Deployment(object):
         rosa_hcp_non_ga = platform == constants.ROSA_HCP_PLATFORM and bool(
             config.DEPLOYMENT.get("ocs_registry_image")
         )
-        if config.DEPLOYMENT.get("live_deployment") and not rosa_hcp_non_ga:
+        if config.DEPLOYMENT.get("fdf_standalone_deployment", False):
+            # Standalone FDF (RHSTOR-8840): resolve odf-operator from the IBM
+            # catalog source created by StandaloneFDFCatalogSource, not redhat-operators.
+            subscription_yaml_data["spec"][
+                "source"
+            ] = constants.FDF_STANDALONE_CATALOG_SOURCE_NAME
+            logger.info(
+                "FDF standalone: subscription source set to '%s'",
+                constants.FDF_STANDALONE_CATALOG_SOURCE_NAME,
+            )
+        elif config.DEPLOYMENT.get("live_deployment") and not rosa_hcp_non_ga:
             subscription_yaml_data["spec"]["source"] = config.DEPLOYMENT.get(
                 "live_content_source", defaults.LIVE_CONTENT_SOURCE
             )
@@ -1525,6 +1536,19 @@ class Deployment(object):
             simulate_full_ceph_bluestore_process_on_wnodes()
             add_new_disks_for_lso = False
 
+        # Standalone FDF (RHSTOR-8840): create the IBM catalog source BEFORE
+        # the ui_deployment early-return so the ibm-operators CatalogSource is
+        # present and READY regardless of whether the rest of the install is
+        # driven by the UI or the CLI path.  deployment_with_ui() will then
+        # find the CatalogSource already READY and skip its own
+        # create_catalog_source() call (see that method below).
+        fdf_standalone = config.DEPLOYMENT.get("fdf_standalone_deployment", False)
+        if fdf_standalone:
+            logger.test_step(
+                "Create FDF standalone CatalogSource (ibm-operators) and wait READY"
+            )
+            create_fdf_standalone_catalog_source()
+
         if ui_deployment and ui_deployment_conditions():
             log_step("Start ODF deployment with UI")
             self.deployment_with_ui()
@@ -1577,8 +1601,14 @@ class Deployment(object):
         upgrade = config.UPGRADE.get("upgrade", False)
         rosa_hcp = config.ENV_DATA.get("platform") == constants.ROSA_HCP_PLATFORM
         rosa_hcp_non_ga = rosa_hcp and bool(config.DEPLOYMENT.get("ocs_registry_image"))
-        if (not live_deployment or rosa_hcp_non_ga) and not (
-            stage_testing and konflux_build and not rosa_hcp
+        # fdf_standalone CatalogSource is created above (before ui_deployment
+        # early-return) so it is available for both UI and CLI paths.
+        # Here we only need to fall through to the normal OCS catalog source
+        # when fdf_standalone is NOT set.
+        if (
+            not fdf_standalone
+            and (not live_deployment or rosa_hcp_non_ga)
+            and not (stage_testing and konflux_build and not rosa_hcp)
         ):
             log_step("Create catalog source and wait it to be READY")
             create_catalog_source(image)
@@ -2064,7 +2094,16 @@ class Deployment(object):
         from ocs_ci.ocs.ui.deployment_ui import DeploymentUI
 
         live_deployment = config.DEPLOYMENT.get("live_deployment")
-        if not live_deployment:
+        fdf_standalone = config.DEPLOYMENT.get("fdf_standalone_deployment", False)
+        if fdf_standalone:
+            # ibm-operators CatalogSource was already created and verified READY
+            # by create_fdf_standalone_catalog_source() before this method was
+            # called — nothing to do here.
+            logger.info(
+                "FDF standalone: ibm-operators CatalogSource already created, "
+                "skipping create_catalog_source()"
+            )
+        elif not live_deployment:
             create_catalog_source()
 
         # Complete all CLI prep work (LSO catalog, disk attachment) before
@@ -2144,12 +2183,18 @@ class Deployment(object):
 
         if not config.DEPLOYMENT.get("multi_storagecluster"):
             live_deployment = config.DEPLOYMENT.get("live_deployment")
+            fdf_standalone = config.DEPLOYMENT.get("fdf_standalone_deployment", False)
             logger.info("Deploying OCS with external mode RHCS")
             ui_deployment = config.DEPLOYMENT.get("ui_deployment")
             if not ui_deployment:
                 logger.info("Creating namespace and operator group.")
                 run_cmd(f"oc apply -f {constants.OLM_YAML}")
-            if not live_deployment:
+            if fdf_standalone:
+                logger.test_step(
+                    "Create FDF standalone CatalogSource (ibm-operators) and wait READY"
+                )
+                create_fdf_standalone_catalog_source()
+            elif not live_deployment:
                 create_catalog_source(image)
             self.subscribe_ocs()
             operator_selector = get_selector_for_ocs_operator()

--- a/ocs_ci/deployment/fdf_standalone.py
+++ b/ocs_ci/deployment/fdf_standalone.py
@@ -1,0 +1,256 @@
+"""
+Standalone Fusion Data Foundation (FDF) deployment — RHSTOR-8840.
+
+FDF standalone installs *identically* to ODF.  The only difference from the
+standard ODF deployment path is that the operator is distributed through an
+IBM-owned CatalogSource (``ibm-operators`` in ``openshift-marketplace``)
+rather than the default Red Hat operators catalog.
+
+Deployment flow
+---------------
+1. ``StandaloneFDFCatalogSource.create_catalog_source()`` creates the
+   ``ibm-operators`` CatalogSource and waits for it to become READY.
+2. The existing ODF ``deploy_ocs_via_operator`` path then proceeds as normal:
+   namespace, OperatorGroup, Subscription (pointing at the new catalog),
+   StorageSystem, StorageCluster — all unchanged.
+
+Usage (conf yaml)::
+
+    DEPLOYMENT:
+      fdf_standalone_deployment: true
+      fdf_standalone_catalog_image: "cp.stg.icr.io/cp/df/isf-data-foundation-catalog:4.23.0-40"
+
+The ``fdf_standalone_catalog_image`` must be the full image reference
+(registry + path + tag) as shown in the RHSTOR-8840 example::
+
+    apiVersion: operators.coreos.com/v1alpha1
+    kind: CatalogSource
+    metadata:
+      name: ibm-operators
+      namespace: openshift-marketplace
+    spec:
+      image: cp.stg.icr.io/cp/df/isf-data-foundation-catalog:4.23.0-40
+      ...
+"""
+
+import logging
+import tempfile
+
+from ocs_ci.framework import config
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.resources.catalog_source import CatalogSource
+from ocs_ci.utility import templating
+from ocs_ci.utility.deployment import get_and_apply_idms_from_catalog
+from ocs_ci.utility.utils import exec_cmd
+
+logger = logging.getLogger(__name__)
+
+
+def _apply_fdf_mirror_sets(catalog_image):
+    """
+    Extract and apply the IDMS rules embedded in the FDF catalog image.
+
+    The standard ODF deployment path calls
+    ``get_and_apply_idms_from_catalog(image)`` inside
+    ``create_catalog_source()``.  This step extracts an ``idms.yaml``
+    baked into the catalog image via ``oc image extract``, then applies
+    it to the cluster and waits for all MachineConfigPools to finish
+    rolling out — so that CRI-O on every node knows to redirect
+    ``registry.redhat.io`` digest pulls to the IBM staging registry.
+
+    Without this step, the operator pods created from the CSV will fail
+    with ``ImagePullBackOff`` because the digest referenced by the CSV
+    does not yet exist on ``registry.redhat.io`` (it is a pre-release
+    build served from ``cp.stg.icr.io``).
+
+    The FDF-within-Fusion path uses a separate static IDMS file
+    (``image-digest-mirror-set.yaml``).  For the standalone path we
+    prefer to extract the IDMS directly from the catalog image — the
+    same authoritative source used by the ODF path — so that the mirrors
+    always match the exact build being installed.
+
+    Args:
+        catalog_image (str): Full catalog image reference, e.g.
+            ``cp.stg.icr.io/cp/df/isf-data-foundation-catalog:4.23.0-40``
+    """
+    logger.info(
+        "Extracting and applying IDMS rules from FDF catalog image '%s'",
+        catalog_image,
+    )
+    idms_path = get_and_apply_idms_from_catalog(image=catalog_image)
+    if idms_path:
+        logger.info("IDMS applied from catalog image, path: %s", idms_path)
+    else:
+        logger.warning(
+            "No idms.yaml found inside catalog image '%s' — "
+            "falling back to static FDF image mirror sets",
+            catalog_image,
+        )
+        # Fallback: apply the static FDF mirror sets shipped with ocs-ci.
+        # These cover the same registry redirects but are not build-specific.
+        from ocs_ci.deployment.fusion_data_foundation import (
+            FusionDataFoundationDeployment,
+        )
+
+        fdf = FusionDataFoundationDeployment()
+        fdf.create_image_tag_mirror_set()
+        fdf.create_image_digest_mirror_set()
+        logger.info("Static FDF image mirror sets applied as fallback")
+
+
+class StandaloneFDFCatalogSource:
+    """
+    Manages the CatalogSource required for a standalone FDF deployment.
+
+    All other deployment steps (namespace, OperatorGroup, Subscription,
+    StorageCluster) are handled by the existing ODF code path in
+    :func:`ocs_ci.deployment.deployment.Deployment.deploy_ocs_via_operator`.
+
+    The CatalogSource created here has name
+    :data:`~ocs_ci.ocs.constants.FDF_STANDALONE_CATALOG_SOURCE_NAME`
+    (``ibm-operators``) in ``openshift-marketplace``, matching the
+    example YAML provided in the RHSTOR-8840 analysis document.
+    """
+
+    def __init__(self):
+        self.kubeconfig = config.RUN["kubeconfig"]
+        self.catalog_image = config.DEPLOYMENT.get("fdf_standalone_catalog_image", "")
+        self.catalog_source_name = constants.FDF_STANDALONE_CATALOG_SOURCE_NAME
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def create_catalog_source(self):
+        """
+        Create (or verify) the FDF standalone CatalogSource and wait for READY.
+
+        * If the CatalogSource already exists with the same image → wait READY.
+        * If it exists with a different image → re-apply with the new image.
+        * If it does not exist → create from template and wait READY.
+
+        The ``catalog_image`` is validated upstream by
+        :func:`_validate_catalog_image` before this method is called.
+        """
+        catsrc = CatalogSource(
+            resource_name=self.catalog_source_name,
+            namespace=constants.MARKETPLACE_NAMESPACE,
+        )
+
+        if catsrc.is_exist():
+            current_image = self._get_current_image(catsrc)
+            if current_image == self.catalog_image:
+                logger.info(
+                    "FDF standalone CatalogSource '%s' already exists with "
+                    "matching image — waiting for READY",
+                    self.catalog_source_name,
+                )
+                catsrc.wait_for_state("READY", timeout=600)
+                return
+            logger.warning(
+                "FDF standalone CatalogSource '%s' exists but image differs "
+                "(current=%s, expected=%s) — re-applying",
+                self.catalog_source_name,
+                current_image,
+                self.catalog_image,
+            )
+
+        logger.info(
+            "Creating FDF standalone CatalogSource '%s' with image '%s'",
+            self.catalog_source_name,
+            self.catalog_image,
+        )
+        self._apply_catalog_source_yaml()
+        catsrc.wait_for_state("READY", timeout=600)
+        logger.info(
+            "FDF standalone CatalogSource '%s' is READY", self.catalog_source_name
+        )
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _apply_catalog_source_yaml(self):
+        """Render the template, inject the catalog image, and apply via oc."""
+        catsrc_data = templating.load_yaml(constants.FDF_STANDALONE_CATSRC_YAML)
+        catsrc_data["spec"]["image"] = self.catalog_image
+
+        with tempfile.NamedTemporaryFile(
+            mode="w+", prefix="fdf_standalone_catsrc_", suffix=".yaml", delete=False
+        ) as tmp:
+            templating.dump_data_to_temp_yaml(catsrc_data, tmp.name)
+            exec_cmd(
+                f"oc --kubeconfig {self.kubeconfig} apply -f {tmp.name}",
+                timeout=120,
+            )
+
+    @staticmethod
+    def _get_current_image(catsrc: CatalogSource) -> str:
+        """Return the full image URL (url:tag) set on an existing CatalogSource, or ''."""
+        try:
+            # get_image_url() returns the registry/path portion (no tag).
+            # get_image_name() returns only the tag.
+            # Reconstruct the full reference to compare against fdf_standalone_catalog_image.
+            url = catsrc.get_image_url() or ""
+            tag = catsrc.get_image_name() or ""
+            if url and tag:
+                return f"{url}:{tag}"
+            return url or tag
+        except Exception:
+            return ""
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers used by deployment.py
+# ---------------------------------------------------------------------------
+
+
+def _validate_catalog_image():
+    """
+    Return the configured catalog image, raising ``ValueError`` early if unset.
+
+    Centralises the check so neither ``_apply_fdf_mirror_sets`` nor
+    ``StandaloneFDFCatalogSource.create_catalog_source`` can be reached
+    with an empty image string.
+
+    Returns:
+        str: The non-empty ``fdf_standalone_catalog_image`` config value.
+
+    Raises:
+        ValueError: when ``fdf_standalone_catalog_image`` is not set in config.
+    """
+    catalog_image = config.DEPLOYMENT.get("fdf_standalone_catalog_image", "")
+    if not catalog_image:
+        raise ValueError(
+            "config.DEPLOYMENT['fdf_standalone_catalog_image'] must be set "
+            "for standalone FDF deployment.\n"
+            "Example: 'cp.stg.icr.io/cp/df/isf-data-foundation-catalog:4.23.0-40'"
+        )
+    return catalog_image
+
+
+def create_fdf_standalone_catalog_source():
+    """
+    Entry-point called from :func:`deploy_ocs_via_operator` when
+    ``config.DEPLOYMENT['fdf_standalone_deployment']`` is *True*.
+
+    Mirrors the standard ODF ``create_catalog_source()`` flow:
+
+    1. Validate ``fdf_standalone_catalog_image`` is set — raises
+       ``ValueError`` immediately if missing, before any cluster calls.
+    2. Extract and apply the IDMS rules embedded in the FDF catalog image
+       so that CRI-O on every node redirects ``registry.redhat.io``
+       digest pulls to the IBM staging registry before the operator pods
+       start.  Waits for all MachineConfigPools to finish rolling out.
+    3. Create (or verify) the ``ibm-operators`` CatalogSource and wait
+       for READY so that the standard ODF Subscription can resolve
+       ``odf-operator`` from it.
+    """
+    catalog_image = _validate_catalog_image()
+    _apply_fdf_mirror_sets(catalog_image)
+    StandaloneFDFCatalogSource().create_catalog_source()
+
+
+def is_fdf_standalone_deployment() -> bool:
+    """Return *True* when the run is configured for standalone FDF."""
+    return bool(config.DEPLOYMENT.get("fdf_standalone_deployment", False))

--- a/ocs_ci/deployment/fdf_standalone.py
+++ b/ocs_ci/deployment/fdf_standalone.py
@@ -20,7 +20,15 @@ Usage (conf yaml)::
       fdf_standalone_deployment: true
       fdf_standalone_catalog_image: "cp.stg.icr.io/cp/df/isf-data-foundation-catalog:4.23.0-40"
 
-The ``fdf_standalone_catalog_image`` must be the full image reference
+``fdf_standalone_catalog_image`` falls back to ``ocs_registry_image`` when not
+set, so the existing ``--ocs-registry-image`` CLI argument and
+``OCS_REGISTRY_IMAGE`` Jenkins parameter work without any new parameter::
+
+    DEPLOYMENT:
+      fdf_standalone_deployment: true
+      ocs_registry_image: "cp.stg.icr.io/cp/df/isf-data-foundation-catalog:4.23.0-40"
+
+The catalog image must be the full image reference
 (registry + path + tag) as shown in the RHSTOR-8840 example::
 
     apiVersion: operators.coreos.com/v1alpha1
@@ -34,6 +42,7 @@ The ``fdf_standalone_catalog_image`` must be the full image reference
 """
 
 import logging
+import re
 import tempfile
 
 from ocs_ci.framework import config
@@ -44,6 +53,27 @@ from ocs_ci.utility.deployment import get_and_apply_idms_from_catalog
 from ocs_ci.utility.utils import exec_cmd
 
 logger = logging.getLogger(__name__)
+
+# Matches a tagged reference (registry/path/name:tag) or a digested reference
+# (registry/path/name@sha256:<hex>).  Both formats are accepted by oc image extract.
+_IMAGE_REF_RE = re.compile(
+    r"^[a-zA-Z0-9][a-zA-Z0-9.\-:/]+"  # registry + path
+    r"(?::[a-zA-Z0-9_.\-]+|@sha256:[a-fA-F0-9]{64})$"  # :tag or @sha256:<hex>
+)
+
+_CATALOG_IMAGE_MISSING_MSG = (
+    "A catalog image must be set for standalone FDF deployment. "
+    "Set 'fdf_standalone_catalog_image' or use the existing "
+    "'ocs_registry_image' config key (--ocs-registry-image CLI / "
+    "OCS_REGISTRY_IMAGE Jenkins parameter).\n"
+    "Example: 'cp.stg.icr.io/cp/df/isf-data-foundation-catalog:4.23.0-40'"
+)
+_CATALOG_IMAGE_INVALID_MSG = (
+    "Invalid catalog image reference '{image}'. "
+    "Expected a tagged (registry/path:tag) or digested (registry/path@sha256:<hex>) "
+    "image reference.\n"
+    "Example: 'cp.stg.icr.io/cp/df/isf-data-foundation-catalog:4.23.0-40'"
+)
 
 
 def _apply_fdf_mirror_sets(catalog_image):
@@ -77,7 +107,10 @@ def _apply_fdf_mirror_sets(catalog_image):
         "Extracting and applying IDMS rules from FDF catalog image '%s'",
         catalog_image,
     )
-    idms_path = get_and_apply_idms_from_catalog(image=catalog_image)
+    idms_path = get_and_apply_idms_from_catalog(
+        image=catalog_image,
+        insecure=config.DEPLOYMENT.get("disconnected", False),
+    )
     if idms_path:
         logger.info("IDMS applied from catalog image, path: %s", idms_path)
     else:
@@ -114,7 +147,9 @@ class StandaloneFDFCatalogSource:
 
     def __init__(self):
         self.kubeconfig = config.RUN["kubeconfig"]
-        self.catalog_image = config.DEPLOYMENT.get("fdf_standalone_catalog_image", "")
+        self.catalog_image = config.DEPLOYMENT.get(
+            "fdf_standalone_catalog_image"
+        ) or config.DEPLOYMENT.get("ocs_registry_image", "")
         self.catalog_source_name = constants.FDF_STANDALONE_CATALOG_SOURCE_NAME
 
     # ------------------------------------------------------------------
@@ -207,25 +242,36 @@ class StandaloneFDFCatalogSource:
 
 def _validate_catalog_image():
     """
-    Return the configured catalog image, raising ``ValueError`` early if unset.
+    Return the validated catalog image, raising ``ValueError`` early if unset
+    or malformed.
+
+    Checks ``fdf_standalone_catalog_image`` first, then falls back to
+    ``ocs_registry_image`` so the existing ``--ocs-registry-image`` CLI
+    argument and ``OCS_REGISTRY_IMAGE`` Jenkins parameter work without
+    introducing a new parameter.
 
     Centralises the check so neither ``_apply_fdf_mirror_sets`` nor
     ``StandaloneFDFCatalogSource.create_catalog_source`` can be reached
-    with an empty image string.
+    with a missing, whitespace-only, or malformed image reference.
 
     Returns:
-        str: The non-empty ``fdf_standalone_catalog_image`` config value.
+        str: The resolved, stripped, non-empty catalog image reference.
 
     Raises:
-        ValueError: when ``fdf_standalone_catalog_image`` is not set in config.
+        ValueError: when neither ``fdf_standalone_catalog_image`` nor
+            ``ocs_registry_image`` is set, or when the resolved value is not a
+            valid tagged (``registry/path:tag``) or digested
+            (``registry/path@sha256:<hex>``) image reference.
     """
-    catalog_image = config.DEPLOYMENT.get("fdf_standalone_catalog_image", "")
+    raw = config.DEPLOYMENT.get(
+        "fdf_standalone_catalog_image"
+    ) or config.DEPLOYMENT.get("ocs_registry_image", "")
+    # Reject non-string types (e.g. accidental integer in YAML) and whitespace-only values.
+    catalog_image = raw.strip() if isinstance(raw, str) else ""
     if not catalog_image:
-        raise ValueError(
-            "config.DEPLOYMENT['fdf_standalone_catalog_image'] must be set "
-            "for standalone FDF deployment.\n"
-            "Example: 'cp.stg.icr.io/cp/df/isf-data-foundation-catalog:4.23.0-40'"
-        )
+        raise ValueError(_CATALOG_IMAGE_MISSING_MSG)
+    if not _IMAGE_REF_RE.match(catalog_image):
+        raise ValueError(_CATALOG_IMAGE_INVALID_MSG.format(image=catalog_image))
     return catalog_image
 
 

--- a/ocs_ci/deployment/fdf_standalone.py
+++ b/ocs_ci/deployment/fdf_standalone.py
@@ -1,0 +1,175 @@
+"""
+Standalone Fusion Data Foundation (FDF) deployment — RHSTOR-8840.
+
+FDF standalone installs *identically* to ODF.  The only difference from the
+standard ODF deployment path is that the operator is distributed through an
+IBM-owned CatalogSource (``ibm-operators`` in ``openshift-marketplace``)
+rather than the default Red Hat operators catalog.
+
+Deployment flow
+---------------
+1. ``StandaloneFDFCatalogSource.create_catalog_source()`` creates the
+   ``ibm-operators`` CatalogSource and waits for it to become READY.
+2. The existing ODF ``deploy_ocs_via_operator`` path then proceeds as normal:
+   namespace, OperatorGroup, Subscription (pointing at the new catalog),
+   StorageSystem, StorageCluster — all unchanged.
+
+Usage (conf yaml)::
+
+    DEPLOYMENT:
+      fdf_standalone_deployment: true
+      fdf_standalone_catalog_image: "cp.stg.icr.io/cp/df/isf-data-foundation-catalog:4.23.0-40"
+
+The ``fdf_standalone_catalog_image`` must be the full image reference
+(registry + path + tag) as shown in the RHSTOR-8840 example::
+
+    apiVersion: operators.coreos.com/v1alpha1
+    kind: CatalogSource
+    metadata:
+      name: ibm-operators
+      namespace: openshift-marketplace
+    spec:
+      image: cp.stg.icr.io/cp/df/isf-data-foundation-catalog:4.23.0-40
+      ...
+"""
+
+import logging
+import tempfile
+
+from ocs_ci.framework import config
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.resources.catalog_source import CatalogSource
+from ocs_ci.utility import templating
+from ocs_ci.utility.utils import exec_cmd
+
+logger = logging.getLogger(__name__)
+
+
+class StandaloneFDFCatalogSource:
+    """
+    Manages the CatalogSource required for a standalone FDF deployment.
+
+    All other deployment steps (namespace, OperatorGroup, Subscription,
+    StorageCluster) are handled by the existing ODF code path in
+    :func:`ocs_ci.deployment.deployment.Deployment.deploy_ocs_via_operator`.
+
+    The CatalogSource created here has name
+    :data:`~ocs_ci.ocs.constants.FDF_STANDALONE_CATALOG_SOURCE_NAME`
+    (``ibm-operators``) in ``openshift-marketplace``, matching the
+    example YAML provided in the RHSTOR-8840 analysis document.
+    """
+
+    def __init__(self):
+        self.kubeconfig = config.RUN["kubeconfig"]
+        self.catalog_image = config.DEPLOYMENT.get("fdf_standalone_catalog_image", "")
+        self.catalog_source_name = constants.FDF_STANDALONE_CATALOG_SOURCE_NAME
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def create_catalog_source(self):
+        """
+        Create (or verify) the FDF standalone CatalogSource and wait for READY.
+
+        * If the CatalogSource already exists with the same image → wait READY.
+        * If it exists with a different image → re-apply with the new image.
+        * If it does not exist → create from template and wait READY.
+
+        Raises:
+            ValueError: when ``fdf_standalone_catalog_image`` is not set in config.
+        """
+        if not self.catalog_image:
+            raise ValueError(
+                "config.DEPLOYMENT['fdf_standalone_catalog_image'] must be set "
+                "for standalone FDF deployment.\n"
+                "Example: 'cp.stg.icr.io/cp/df/isf-data-foundation-catalog:4.23.0-40'"
+            )
+
+        catsrc = CatalogSource(
+            resource_name=self.catalog_source_name,
+            namespace=constants.MARKETPLACE_NAMESPACE,
+        )
+
+        if catsrc.is_exist():
+            current_image = self._get_current_image(catsrc)
+            if current_image == self.catalog_image:
+                logger.info(
+                    "FDF standalone CatalogSource '%s' already exists with "
+                    "matching image — waiting for READY",
+                    self.catalog_source_name,
+                )
+                catsrc.wait_for_state("READY", timeout=600)
+                return
+            logger.warning(
+                "FDF standalone CatalogSource '%s' exists but image differs "
+                "(current=%s, expected=%s) — re-applying",
+                self.catalog_source_name,
+                current_image,
+                self.catalog_image,
+            )
+
+        logger.info(
+            "Creating FDF standalone CatalogSource '%s' with image '%s'",
+            self.catalog_source_name,
+            self.catalog_image,
+        )
+        self._apply_catalog_source_yaml()
+        catsrc.wait_for_state("READY", timeout=600)
+        logger.info(
+            "FDF standalone CatalogSource '%s' is READY", self.catalog_source_name
+        )
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _apply_catalog_source_yaml(self):
+        """Render the template, inject the catalog image, and apply via oc."""
+        catsrc_data = templating.load_yaml(constants.FDF_STANDALONE_CATSRC_YAML)
+        catsrc_data["spec"]["image"] = self.catalog_image
+
+        with tempfile.NamedTemporaryFile(
+            mode="w+", prefix="fdf_standalone_catsrc_", suffix=".yaml", delete=False
+        ) as tmp:
+            templating.dump_data_to_temp_yaml(catsrc_data, tmp.name)
+            exec_cmd(
+                f"oc --kubeconfig {self.kubeconfig} apply -f {tmp.name}",
+                timeout=120,
+            )
+
+    @staticmethod
+    def _get_current_image(catsrc: CatalogSource) -> str:
+        """Return the full image URL (url:tag) set on an existing CatalogSource, or ''."""
+        try:
+            # get_image_url() returns the registry/path portion (no tag).
+            # get_image_name() returns only the tag.
+            # Reconstruct the full reference to compare against fdf_standalone_catalog_image.
+            url = catsrc.get_image_url() or ""
+            tag = catsrc.get_image_name() or ""
+            if url and tag:
+                return f"{url}:{tag}"
+            return url or tag
+        except Exception:
+            return ""
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers used by deployment.py
+# ---------------------------------------------------------------------------
+
+
+def create_fdf_standalone_catalog_source():
+    """
+    Entry-point called from :func:`deploy_ocs_via_operator` when
+    ``config.DEPLOYMENT['fdf_standalone_deployment']`` is *True*.
+
+    Creates the ``ibm-operators`` CatalogSource and waits for READY so that
+    the standard ODF Subscription can resolve ``odf-operator`` from it.
+    """
+    StandaloneFDFCatalogSource().create_catalog_source()
+
+
+def is_fdf_standalone_deployment() -> bool:
+    """Return *True* when the run is configured for standalone FDF."""
+    return bool(config.DEPLOYMENT.get("fdf_standalone_deployment", False))

--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -143,6 +143,13 @@ DEPLOYMENT:
   ec_default_pools: False
   # FDF
   fdf_upgrade_registry: "cp.stg.icr.io/cp/df"
+  # Standalone FDF (RHSTOR-8840): set true to deploy FDF via its own IBM catalog
+  # source instead of the full Fusion Operator stack. All other deployment steps
+  # (namespace, OperatorGroup, Subscription, StorageCluster) reuse the ODF path.
+  fdf_standalone_deployment: false
+  # Full image reference (registry + path + tag) for the standalone FDF catalog.
+  # Example: cp.stg.icr.io/cp/df/isf-data-foundation-catalog:4.23.0-40
+  fdf_standalone_catalog_image: ""
 
 # Section for reporting configuration
 REPORTING:

--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -146,6 +146,13 @@ DEPLOYMENT:
   ec_default_pools: False
   # FDF
   fdf_upgrade_registry: "cp.stg.icr.io/cp/df"
+  # Standalone FDF (RHSTOR-8840): set true to deploy FDF via its own IBM catalog
+  # source instead of the full Fusion Operator stack. All other deployment steps
+  # (namespace, OperatorGroup, Subscription, StorageCluster) reuse the ODF path.
+  fdf_standalone_deployment: false
+  # Full image reference (registry + path + tag) for the standalone FDF catalog.
+  # Example: cp.stg.icr.io/cp/df/isf-data-foundation-catalog:4.23.0-40
+  fdf_standalone_catalog_image: ""
 
 # Section for reporting configuration
 REPORTING:

--- a/ocs_ci/framework/conf/fdf_version/fdf-4.23.yaml
+++ b/ocs_ci/framework/conf/fdf_version/fdf-4.23.yaml
@@ -1,0 +1,9 @@
+---
+DEPLOYMENT:
+  fdf_pre_release: true
+  fdf_image_tag: v4.23
+  fdf_pre_release_registry: cp.stg.icr.io/cp/df
+  fdf_pre_release_image_digest: null
+REPORTING:
+  default_ocs_must_gather_latest_tag: 'v4.23'
+  default_ocs_must_gather_image: "quay.io/rhceph-dev/odf4-odf-must-gather-rhel9"

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -3855,6 +3855,13 @@ ISF_OPERATOR_IDMS_YAML = "image-digest-mirror-set.yaml.j2"
 FDF_IMAGE_DIGEST_MIRROR_SET_FILENAME = "idms.yaml"
 FDF_SERVICE_NAME = "odfmanager"
 
+# Standalone FDF deployment (RHSTOR-8840)
+# CatalogSource name matches the example YAML from the RHSTOR-8840 analysis doc.
+FDF_STANDALONE_CATALOG_SOURCE_NAME = "ibm-operators"
+FDF_STANDALONE_CATSRC_YAML = os.path.join(
+    FDF_TEMPLATE_DIR, "fdf_standalone_catsrc.yaml"
+)
+
 CREATE = "create"
 EDIT = "edit"
 DELETE = "delete"

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -3861,6 +3861,14 @@ ISF_OPERATOR_IDMS_YAML = "image-digest-mirror-set.yaml.j2"
 FDF_IMAGE_DIGEST_MIRROR_SET_FILENAME = "idms.yaml"
 FDF_SERVICE_NAME = "odfmanager"
 
+# Standalone FDF deployment (RHSTOR-8840)
+# CatalogSource name matches the example YAML from the RHSTOR-8840 analysis doc.
+FDF_STANDALONE_CATALOG_SOURCE_NAME = "ibm-operators"
+FDF_STANDALONE_OPERATOR_SELECTOR = f"catalog={FDF_STANDALONE_CATALOG_SOURCE_NAME}"
+FDF_STANDALONE_CATSRC_YAML = os.path.join(
+    FDF_TEMPLATE_DIR, "fdf_standalone_catsrc.yaml"
+)
+
 CREATE = "create"
 EDIT = "edit"
 DELETE = "delete"

--- a/ocs_ci/ocs/resources/packagemanifest.py
+++ b/ocs_ci/ocs/resources/packagemanifest.py
@@ -306,7 +306,8 @@ def get_selector_for_ocs_operator():
             return constants.OPERATOR_INTERNAL_SELECTOR
     except CommandFailed:
         log.info("Internal catalog source not found!")
-    # TODO: we might need to limit this to ODF only as FDF might come from different source
+    if config.DEPLOYMENT.get("fdf_standalone_deployment", False):
+        return constants.FDF_STANDALONE_OPERATOR_SELECTOR
     return constants.REDHAT_OPERATOR_SELECTOR
 
 

--- a/ocs_ci/templates/fusion-data-foundation/fdf_standalone_catsrc.yaml
+++ b/ocs_ci/templates/fusion-data-foundation/fdf_standalone_catsrc.yaml
@@ -1,0 +1,27 @@
+---
+# CatalogSource for standalone Fusion Data Foundation (RHSTOR-8840).
+#
+# FDF standalone installs identically to ODF. The only difference is that
+# the odf-operator package is served from this IBM catalog source instead of
+# the default Red Hat operators catalog.  Once this CatalogSource is READY,
+# the standard ODF Subscription (pointing spec.source here) installs FDF.
+#
+# spec.image is overwritten at deploy-time from:
+#   config.DEPLOYMENT["fdf_standalone_catalog_image"]
+# Example value: cp.stg.icr.io/cp/df/isf-data-foundation-catalog:4.23.0-40
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: ibm-operators
+  namespace: openshift-marketplace
+spec:
+  displayName: IBM
+  image: PLACEHOLDER
+  publisher: IBM
+  sourceType: grpc
+  grpcPodConfig:
+    securityContextConfig: legacy
+  priority: 100
+  updateStrategy:
+    registryPoll:
+      interval: 60m

--- a/ocs_ci/templates/fusion-data-foundation/fdf_standalone_catsrc.yaml
+++ b/ocs_ci/templates/fusion-data-foundation/fdf_standalone_catsrc.yaml
@@ -1,0 +1,26 @@
+# CatalogSource for standalone Fusion Data Foundation (RHSTOR-8840).
+#
+# FDF standalone installs identically to ODF. The only difference is that
+# the odf-operator package is served from this IBM catalog source instead of
+# the default Red Hat operators catalog.  Once this CatalogSource is READY,
+# the standard ODF Subscription (pointing spec.source here) installs FDF.
+#
+# spec.image is overwritten at deploy-time from:
+#   config.DEPLOYMENT["fdf_standalone_catalog_image"]
+# Example value: cp.stg.icr.io/cp/df/isf-data-foundation-catalog:4.23.0-40
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: ibm-operators
+  namespace: openshift-marketplace
+spec:
+  displayName: IBM
+  image: PLACEHOLDER
+  publisher: IBM
+  sourceType: grpc
+  grpcPodConfig:
+    securityContextConfig: legacy
+  priority: 100
+  updateStrategy:
+    registryPoll:
+      interval: 60m


### PR DESCRIPTION
- New StandaloneFDFCatalogSource in fdf_standalone.py creates the ibm-operators CatalogSource and waits for READY
- deploy_ocs_via_operator branches into standalone FDF path when fdf_standalone_deployment=true, skipping the OCS catalog source
- subscribe_ocs sets spec.source=ibm-operators for standalone FDF
- _get_current_image reconstructs full url:tag for correct image comparison
- New template fdf_standalone_catsrc.yaml; fdf-4.23.yaml version config
- Default config keys: fdf_standalone_deployment, fdf_standalone_catalog_image

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for standalone Fusion Data Foundation deployments through a dedicated IBM operator catalog.
  * Added configuration options to enable standalone deployment and provide the catalog image.
  * Catalog setup validates the image, applies mirror settings, and waits until ready.
  * UI, CLI, and external-mode installations now use the standalone catalog when enabled.
  * Prevented duplicate catalog creation and automatically selects the appropriate FDF operator catalog.
  * Existing catalog resources are reconciled when necessary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->