### PR TITLE
Add mclock IOPS override test automation (RHSTOR-8677)

### DIFF
--- a/ocs_ci/helpers/odf_cli.py
+++ b/ocs_ci/helpers/odf_cli.py
@@ -407,6 +407,123 @@ class ODFCliRunner:
         """
         return self.run_command(" object disable remote-obc")
 
+    def run_ceph_config_get(self, entity, config_name):
+        """
+        Get a Ceph config value via ODF CLI.
+
+        Args:
+            entity (str): Ceph entity
+                (e.g., "osd", "osd.0", "global").
+            config_name (str): Config option name.
+
+        Returns:
+            str: The config value string (stripped).
+
+        """
+        output = self.run_command(f"ceph config get {entity} {config_name}")
+        return output.stdout.decode().strip()
+
+    def run_ceph_config_set(self, entity, config_name, value):
+        """
+        Set a Ceph config value via ODF CLI.
+
+        Args:
+            entity (str): Ceph entity
+                (e.g., "osd.0", "global").
+            config_name (str): Config option name.
+            value (str): Value to set.
+
+        Returns:
+            CompletedProcess: Command result.
+
+        """
+        return self.run_command(f"ceph config set {entity} {config_name} {value}")
+
+    def run_ceph_config_rm(self, entity, config_name):
+        """
+        Remove a Ceph config override via ODF CLI.
+
+        Args:
+            entity (str): Ceph entity
+                (e.g., "osd.0", "global").
+            config_name (str): Config option name.
+
+        Returns:
+            CompletedProcess: Command result.
+
+        """
+        return self.run_command(f"ceph config rm {entity} {config_name}")
+
+    def run_ceph_config_show(self, entity):
+        """
+        Show effective Ceph config for an entity via ODF CLI.
+
+        Args:
+            entity (str): Ceph entity (e.g., "osd.0").
+
+        Returns:
+            str: Full config show output.
+
+        """
+        output = self.run_command(f"ceph config show {entity}")
+        return output.stdout.decode()
+
+    def run_ceph_config_dump(self):
+        """
+        Dump all Ceph config overrides via ODF CLI.
+
+        Returns:
+            str: Full config dump output.
+
+        """
+        output = self.run_command("ceph config dump")
+        return output.stdout.decode()
+
+    def wait_for_ceph_config_value(
+        self, entity, config_name, expected_value, timeout=60
+    ):
+        """
+        Poll until a Ceph config value matches the expected value.
+
+        Args:
+            entity (str): Ceph entity (e.g., "osd.0", "global").
+            config_name (str): Config option name.
+            expected_value (str): Expected value to wait for.
+            timeout (int): Max seconds to wait (default: 60).
+
+        Returns:
+            str: The matching config value.
+
+        Raises:
+            TimeoutExpiredError: If the value does not match
+                within the timeout.
+
+        """
+        from ocs_ci.utility.utils import TimeoutSampler
+
+        log.info(
+            "Waiting for %s %s to reach %s",
+            entity,
+            config_name,
+            expected_value,
+        )
+        for value in TimeoutSampler(
+            timeout=timeout,
+            sleep=5,
+            func=self.run_ceph_config_get,
+            entity=entity,
+            config_name=config_name,
+        ):
+            if value and float(value) == float(expected_value):
+                log.info(
+                    "%s %s reached expected value %s",
+                    entity,
+                    config_name,
+                    expected_value,
+                )
+                return value
+        return None
+
 
 class ODFCLICephfsSnapRunner(ODFCliRunner):
     """

--- a/ocs_ci/ocs/cluster.py
+++ b/ocs_ci/ocs/cluster.py
@@ -1479,6 +1479,51 @@ def get_osd_utilization():
     return osd_filled
 
 
+def get_osd_bdev_type(osd_id=0):
+    """
+    Get the bluestore device type for an OSD.
+
+    Args:
+        osd_id (int): OSD ID to query (default: 0).
+
+    Returns:
+        str: Device type reported by the OSD ("ssd" or "hdd").
+
+    """
+    ct_pod = pod.get_ceph_tools_pod()
+    metadata = ct_pod.exec_ceph_cmd(ceph_cmd=f"ceph osd metadata osd.{osd_id}")
+    bdev_type = metadata.get("bluestore_bdev_type", "hdd")
+    logger.info("OSD %s bluestore_bdev_type: %s", osd_id, bdev_type)
+    return bdev_type
+
+
+def get_mclock_max_capacity_iops_config_key(osd_id=0):
+    """
+    Return the mclock max capacity IOPS config key and its
+    default value based on the OSD disk type.
+
+    Args:
+        osd_id (int): OSD ID to query for disk type
+            (default: 0).
+
+    Returns:
+        tuple: (config_key, default_value) e.g.
+            ("osd_mclock_max_capacity_iops_hdd", 315.0) or
+            ("osd_mclock_max_capacity_iops_ssd", 21500.0).
+
+    """
+    bdev_type = get_osd_bdev_type(osd_id)
+    if bdev_type == "ssd":
+        return (
+            constants.MCLOCK_MAX_CAPACITY_IOPS_SSD,
+            constants.MCLOCK_MAX_CAPACITY_IOPS_SSD_DEFAULT,
+        )
+    return (
+        constants.MCLOCK_MAX_CAPACITY_IOPS_HDD,
+        constants.MCLOCK_MAX_CAPACITY_IOPS_HDD_DEFAULT,
+    )
+
+
 def get_ceph_df_detail(format="json-pretty", out_yaml_format=True):
     """
     Get ceph osd df detail

--- a/ocs_ci/ocs/cluster.py
+++ b/ocs_ci/ocs/cluster.py
@@ -1518,9 +1518,13 @@ def get_mclock_max_capacity_iops_config_key(osd_id=0):
             constants.MCLOCK_MAX_CAPACITY_IOPS_SSD,
             constants.MCLOCK_MAX_CAPACITY_IOPS_SSD_DEFAULT,
         )
-    return (
-        constants.MCLOCK_MAX_CAPACITY_IOPS_HDD,
-        constants.MCLOCK_MAX_CAPACITY_IOPS_HDD_DEFAULT,
+    if bdev_type == "hdd":
+        return (
+            constants.MCLOCK_MAX_CAPACITY_IOPS_HDD,
+            constants.MCLOCK_MAX_CAPACITY_IOPS_HDD_DEFAULT,
+        )
+    raise ValueError(
+        f"Unsupported bluestore_bdev_type '{bdev_type}' " f"for osd.{osd_id}"
     )
 
 

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -3970,6 +3970,12 @@ MCLOCK_HIGH_CLIENT_OPS = "high_client_ops"
 MCLOCK_BALANCED = "balanced"
 MCLOCK_HIGH_RECOVERY_OPS = "high_recovery_ops"
 
+# mclock IOPS config keys
+MCLOCK_MAX_CAPACITY_IOPS_SSD = "osd_mclock_max_capacity_iops_ssd"
+MCLOCK_MAX_CAPACITY_IOPS_HDD = "osd_mclock_max_capacity_iops_hdd"
+MCLOCK_MAX_CAPACITY_IOPS_SSD_DEFAULT = 21500.0
+MCLOCK_MAX_CAPACITY_IOPS_HDD_DEFAULT = 315.0
+
 # chaos Tests constants
 KRKN_DIR = os.path.join(DATA_DIR, "krkn")
 KRKN_CHAOS_DIR = os.path.join(TOP_DIR, "ocs_ci", "krkn_chaos")

--- a/tests/functional/odf-cli/test_mclock_iops_override.py
+++ b/tests/functional/odf-cli/test_mclock_iops_override.py
@@ -1,0 +1,269 @@
+import logging
+
+import pytest
+
+from ocs_ci.ocs.cluster import (
+    ceph_health_check,
+    get_mclock_max_capacity_iops_config_key,
+)
+from ocs_ci.ocs.exceptions import CommandFailed
+from ocs_ci.ocs.resources import pod
+from ocs_ci.utility.retry import catch_exceptions
+from ocs_ci.framework.testlib import (
+    tier1,
+    brown_squad,
+    skipif_ocs_version,
+    skipif_external_mode,
+    runs_on_provider,
+    ManageTest,
+)
+
+log = logging.getLogger(__name__)
+
+
+@tier1
+@brown_squad
+@skipif_ocs_version("<4.15")
+@skipif_external_mode
+@runs_on_provider
+class TestMclockIopsOverride(ManageTest):
+    """
+    Test OSD mClock max capacity IOPS override via ODF CLI.
+
+    Covers reading, setting (per-OSD and global), persisting
+    across OSD pod restart, and removing the override.
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup(self, request, odf_cli_setup):
+        """
+        Determine the mclock IOPS config key and default value
+        based on the cluster disk type.
+        """
+        self.odf_cli = odf_cli_setup
+        self.custom_iops_value = "80000"
+        self.config_key, self.default_value = get_mclock_max_capacity_iops_config_key()
+        log.info(
+            "Using config key %s with default %s",
+            self.config_key,
+            self.default_value,
+        )
+
+        osd_pods = pod.get_osd_pods()
+        self.osd_ids = sorted([pod.get_osd_pod_id(p) for p in osd_pods])
+        log.info("Discovered OSD IDs: %s", self.osd_ids)
+
+        def finalizer():
+            log.info("Cleaning up mclock IOPS overrides")
+            safe_rm = catch_exceptions(CommandFailed)(self.odf_cli.run_ceph_config_rm)
+            for osd_id in self.osd_ids:
+                safe_rm(f"osd.{osd_id}", self.config_key)
+            safe_rm("global", self.config_key)
+
+        request.addfinalizer(finalizer)
+
+    def test_get_mclock_iops_value(self):
+        """
+        Test Case 1: Get osd_mclock_max_capacity_iops value via
+        ODF CLI.
+
+        Steps:
+            1. Get the cluster-wide IOPS value via
+               ``odf ceph config get``.
+            2. Get the per-OSD value via ``odf ceph config get``
+               for each OSD.
+            3. Verify the returned values match the expected
+               default and are consistent across OSDs.
+
+        """
+        value = self.odf_cli.run_ceph_config_get("osd", self.config_key)
+        log.info(
+            "Cluster-wide %s value: %s",
+            self.config_key,
+            value,
+        )
+        assert value, f"odf ceph config get returned empty " f"for {self.config_key}"
+        assert float(value) == self.default_value, (
+            f"Expected default {self.default_value}, " f"got {value}"
+        )
+
+        for osd_id in self.osd_ids:
+            osd_value = self.odf_cli.run_ceph_config_get(
+                f"osd.{osd_id}", self.config_key
+            )
+            assert float(osd_value) == self.default_value, (
+                f"osd.{osd_id} expected {self.default_value}, " f"got {osd_value}"
+            )
+            log.info(
+                "osd.%s %s = %s (matches default)",
+                osd_id,
+                self.config_key,
+                osd_value,
+            )
+
+    def test_override_mclock_iops_per_osd(self):
+        """
+        Test Case 2: Override osd_mclock_max_capacity_iops per OSD
+        via ODF CLI.
+
+        Steps:
+            1. Set a custom IOPS value for osd.0.
+            2. Verify osd.0 reports the new value.
+            3. Verify other OSDs still have the original value.
+            4. Verify the override appears in ceph config dump.
+
+        """
+        target_osd = self.osd_ids[0]
+        other_osd = self.osd_ids[1]
+
+        self.odf_cli.run_ceph_config_set(
+            f"osd.{target_osd}",
+            self.config_key,
+            self.custom_iops_value,
+        )
+        self.odf_cli.wait_for_ceph_config_value(
+            f"osd.{target_osd}",
+            self.config_key,
+            self.custom_iops_value,
+        )
+
+        other_value = self.odf_cli.run_ceph_config_get(
+            f"osd.{other_osd}", self.config_key
+        )
+        assert float(other_value) == self.default_value, (
+            f"osd.{other_osd} should still be "
+            f"{self.default_value}, got {other_value}"
+        )
+
+        dump_output = self.odf_cli.run_ceph_config_dump()
+        assert (
+            self.config_key in dump_output
+        ), f"{self.config_key} not found in ceph config dump"
+        log.info("Per-OSD override visible in config dump")
+
+    def test_override_mclock_iops_cluster_wide(self):
+        """
+        Test Case 3: Override osd_mclock_max_capacity_iops
+        cluster-wide.
+
+        Steps:
+            1. Remove any per-OSD overrides.
+            2. Set a global IOPS value.
+            3. Verify all OSDs report the new value.
+
+        """
+        for osd_id in self.osd_ids:
+            self.odf_cli.run_ceph_config_rm(f"osd.{osd_id}", self.config_key)
+
+        self.odf_cli.run_ceph_config_set(
+            "global", self.config_key, self.custom_iops_value
+        )
+        log.info(
+            "Set global %s=%s",
+            self.config_key,
+            self.custom_iops_value,
+        )
+
+        for osd_id in self.osd_ids:
+            self.odf_cli.wait_for_ceph_config_value(
+                f"osd.{osd_id}",
+                self.config_key,
+                self.custom_iops_value,
+            )
+
+    def test_mclock_iops_persists_after_osd_restart(self):
+        """
+        Test Case 4: IOPS override persists after OSD pod restart.
+
+        Steps:
+            1. Set a custom per-OSD IOPS value for osd.0.
+            2. Verify the override is in place.
+            3. Delete the OSD pod for osd.0 to trigger a restart.
+            4. Wait for the OSD pod to come back up.
+            5. Verify the IOPS value is still the custom value.
+            6. Verify cluster health returns to HEALTH_OK.
+
+        """
+        target_osd = self.osd_ids[0]
+
+        self.odf_cli.run_ceph_config_set(
+            f"osd.{target_osd}",
+            self.config_key,
+            self.custom_iops_value,
+        )
+        self.odf_cli.wait_for_ceph_config_value(
+            f"osd.{target_osd}",
+            self.config_key,
+            self.custom_iops_value,
+        )
+
+        osd_pod_list = pod.get_osd_pods_having_ids([target_osd])
+        assert osd_pod_list, f"No OSD pod found for osd.{target_osd}"
+        osd_pod_obj = osd_pod_list[0]
+        log.info("Deleting OSD pod %s", osd_pod_obj.name)
+        osd_pod_obj.delete(wait=True)
+
+        log.info("Waiting for OSD pod to restart")
+        pod.wait_for_pods_to_be_running(timeout=300)
+
+        self.odf_cli.wait_for_ceph_config_value(
+            f"osd.{target_osd}",
+            self.config_key,
+            self.custom_iops_value,
+        )
+
+        dump_output = self.odf_cli.run_ceph_config_dump()
+        assert (
+            self.config_key in dump_output
+        ), f"{self.config_key} not in config dump after restart"
+
+        ceph_health_check(tries=20, delay=30)
+        log.info("Cluster health is OK after OSD restart")
+
+    def test_remove_mclock_iops_override_reverts_to_default(self):
+        """
+        Test Case 5: Remove IOPS override reverts to default.
+
+        Steps:
+            1. Set a custom per-OSD IOPS value for osd.0.
+            2. Verify the override is in place.
+            3. Remove the override.
+            4. Verify the value reverts to the default.
+            5. Verify ceph config dump no longer shows a per-OSD
+               entry.
+
+        """
+        target_osd = self.osd_ids[0]
+
+        self.odf_cli.run_ceph_config_set(
+            f"osd.{target_osd}",
+            self.config_key,
+            self.custom_iops_value,
+        )
+        self.odf_cli.wait_for_ceph_config_value(
+            f"osd.{target_osd}",
+            self.config_key,
+            self.custom_iops_value,
+        )
+
+        self.odf_cli.run_ceph_config_rm(f"osd.{target_osd}", self.config_key)
+        log.info("Removed override for osd.%s", target_osd)
+
+        value_after = self.odf_cli.run_ceph_config_get("osd", self.config_key)
+        assert float(value_after) == self.default_value, (
+            f"After removal expected {self.default_value}, " f"got {value_after}"
+        )
+        log.info("Value reverted to default: %s", value_after)
+
+        dump_output = self.odf_cli.run_ceph_config_dump()
+        osd_entry = f"osd.{target_osd}"
+        for line in dump_output.splitlines():
+            if osd_entry in line and self.config_key in line:
+                pytest.fail(
+                    f"Per-OSD entry for {osd_entry} still in "
+                    f"config dump after removal"
+                )
+        log.info(
+            "No per-OSD %s entry in config dump",
+            self.config_key,
+        )

--- a/tests/functional/odf-cli/test_mclock_iops_override.py
+++ b/tests/functional/odf-cli/test_mclock_iops_override.py
@@ -53,12 +53,38 @@ class TestMclockIopsOverride(ManageTest):
         self.osd_ids = sorted([pod.get_osd_pod_id(p) for p in osd_pods])
         log.info("Discovered OSD IDs: %s", self.osd_ids)
 
+        self.original_values = {}
+        for osd_id in self.osd_ids:
+            entity = f"osd.{osd_id}"
+            self.original_values[entity] = self.odf_cli.run_ceph_config_get(
+                entity, self.config_key
+            )
+        self.original_values["global"] = self.odf_cli.run_ceph_config_get(
+            "global", self.config_key
+        )
+        log.info(
+            "Saved original IOPS values: %s",
+            self.original_values,
+        )
+
         def finalizer():
             log.info("Cleaning up mclock IOPS overrides")
             safe_rm = catch_exceptions(CommandFailed)(self.odf_cli.run_ceph_config_rm)
+            safe_set = catch_exceptions(CommandFailed)(self.odf_cli.run_ceph_config_set)
             for osd_id in self.osd_ids:
                 safe_rm(f"osd.{osd_id}", self.config_key)
             safe_rm("global", self.config_key)
+            for entity, orig in self.original_values.items():
+                value = self.odf_cli.run_ceph_config_get(entity, self.config_key)
+                if float(value) != float(orig):
+                    log.warning(
+                        "%s value %s differs from original %s," " restoring",
+                        entity,
+                        value,
+                        orig,
+                    )
+                    safe_set(entity, self.config_key, orig)
+            log.info("All OSDs reverted to original values")
 
         request.addfinalizer(finalizer)
 
@@ -249,7 +275,11 @@ class TestMclockIopsOverride(ManageTest):
         self.odf_cli.run_ceph_config_rm(f"osd.{target_osd}", self.config_key)
         log.info("Removed override for osd.%s", target_osd)
 
-        value_after = self.odf_cli.run_ceph_config_get("osd", self.config_key)
+        value_after = self.odf_cli.wait_for_ceph_config_value(
+            f"osd.{target_osd}",
+            self.config_key,
+            str(self.default_value),
+        )
         assert float(value_after) == self.default_value, (
             f"After removal expected {self.default_value}, " f"got {value_after}"
         )


### PR DESCRIPTION
## Summary
  - Add `ceph config get/set/rm/show/dump` helpers to `ODFCliRunner` with a `wait_for_ceph_config_value` polling method
  - Add `get_osd_bdev_type` and `get_mclock_max_capacity_iops_config_key` helpers to `cluster.py` for disk-type-aware
  config key resolution
  - Add mclock IOPS constants (`MCLOCK_MAX_CAPACITY_IOPS_SSD`, `MCLOCK_MAX_CAPACITY_IOPS_HDD` and their defaults) to
  `constants.py`
  - Add `TestMclockIopsOverride` test class covering: reading defaults, per-OSD override, cluster-wide override,
  persistence across OSD pod restart, and removal reverting to default

  ## Test plan
  - [ ] Run `test_mclock_iops_override.py` on a cluster with ODF >= 4.15
  - [ ] Verify all five test cases pass on both SSD and HDD-backed clusters
  - [ ] Confirm finalizer cleans up overrides after each test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for viewing, setting, removing, and exporting Ceph configuration through the ODF CLI.
  - Added automatic selection of mClock IOPS settings based on OSD storage type, with HDD and SSD defaults.
  - Added polling support to wait for configuration values to reach an expected state.

- **Tests**
  - Added functional coverage for per-OSD and cluster-wide IOPS overrides, persistence after OSD restarts, and restoration of defaults after removal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->