### PR TITLE
use download_with_retries for downloading terraform and ignition provider

### DIFF
--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -5560,7 +5560,7 @@ def get_terraform(version=None, bin_dir=None):
     previous_dir = os.getcwd()
     os.chdir(bin_dir)
     url = f"https://releases.hashicorp.com/terraform/{version}/" f"{terraform_zip_file}"
-    download_file(url, terraform_zip_file)
+    download_with_retries(url, terraform_zip_file)
     run_cmd(f"unzip -o {terraform_zip_file}")
     delete_file(terraform_zip_file)
     # return to the previous working directory
@@ -5596,7 +5596,7 @@ def get_terraform_ignition_provider(terraform_dir, version=None):
     )
 
     # Download and untar
-    download_file(url, terraform_ignition_provider_zip_file)
+    download_with_retries(url, terraform_ignition_provider_zip_file)
     run_cmd(f"unzip -o {terraform_ignition_provider_zip_file}")
 
     # move the ignition provider binary to plugins path


### PR DESCRIPTION
This might avoid some temporary issues with terraform download service.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of Terraform and Ignition provider downloads by adding automatic retry handling for transient download failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->