### PR TITLE
`test_multiregion_mirror` - use Jira mark instead of unconditionally skipping the test

### DIFF
--- a/tests/functional/object/mcg/test_multi_region.py
+++ b/tests/functional/object/mcg/test_multi_region.py
@@ -14,6 +14,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     runs_on_provider,
     mcg,
     tier2,
+    jira,
 )
 from ocs_ci.framework.testlib import MCGTest
 from ocs_ci.ocs import ocp, constants
@@ -87,9 +88,7 @@ class TestMultiRegion(MCGTest):
     @tier4a
     @skipif_ocs_version("==4.4")
     @pytest.mark.polarion_id("OCS-1784")
-    @pytest.mark.skip(
-        reason="DFBUGS-6945: noobaa-core-0 OOMKilled breaks RPC operations"
-    )
+    @jira("DFBUGS-9429")
     def test_multiregion_mirror(
         self,
         cld_mgr,


### PR DESCRIPTION
## Summary
Replace the unconditional `@pytest.mark.skip` on `test_multiregion_mirror` with a `@jira("[DFBUGS-9429](https://redhat.atlassian.net/browse/DFBUGS-9429)")` marker so the test automatically resumes running once the bug is resolved, instead of requiring a separate PR to remove the skip.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated multi-region mirror test tracking and removed its unconditional skip, allowing the test to run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->