### PR TITLE
Add GCP STS day-2 backingstore tests (OC + YAML and UI)

### DIFF
--- a/ocs_ci/ocs/bucket_utils.py
+++ b/ocs_ci/ocs/bucket_utils.py
@@ -845,6 +845,41 @@ def oc_create_azure_sts_backingstore(cld_mgr, backingstore_name, uls_name, regio
     create_resource(**bs_data)
 
 
+def oc_create_gcp_sts_backingstore(cld_mgr, backingstore_name, uls_name, region):
+    """
+    Create a new backingstore of type google-cloud-storage-sts via oc apply,
+    referencing the existing WIF secret from the default GCP STS backingstore
+
+    Args:
+        cld_mgr (CloudManager): holds GCP STS credentials for backingstore creation
+        backingstore_name (str): backingstore name
+        uls_name (str): underlying storage name
+        region (str): which region to create backingstore (should be the same as uls)
+
+    """
+    namespace = config.ENV_DATA["cluster_namespace"]
+    default_bs = OCP(
+        kind="backingstore",
+        namespace=namespace,
+        resource_name=constants.DEFAULT_NOOBAA_BACKINGSTORE,
+    ).get()
+    secret_name = default_bs["spec"]["googleCloudStorage"]["secret"]["name"]
+    bs_data = templating.load_yaml(constants.MCG_BACKINGSTORE_YAML)
+    bs_data["metadata"]["name"] = backingstore_name
+    bs_data["metadata"]["namespace"] = namespace
+    bs_data["spec"] = {
+        "type": constants.BACKINGSTORE_TYPE_GOOGLE,
+        "googleCloudStorage": {
+            "targetBucket": uls_name,
+            "secret": {
+                "name": secret_name,
+                "namespace": namespace,
+            },
+        },
+    }
+    create_resource(**bs_data)
+
+
 def oc_create_google_backingstore(cld_mgr, backingstore_name, uls_name, region):
     """
     Create a new backingstore with GCP underlying storage using oc create command

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -1855,6 +1855,7 @@ AWS_PLATFORM = "aws"
 AZURE_PLATFORM = "azure"
 AZURE_WITH_LOGS_PLATFORM = "azure-with-logs"
 AZURE_STS_PLATFORM = "azure-sts"
+GCP_STS_PLATFORM = "gcp-sts"
 GCP_PLATFORM = "gcp"
 VSPHERE_PLATFORM = "vsphere"
 BAREMETAL_PLATFORM = "baremetal"
@@ -3007,6 +3008,7 @@ CLOUD_MNGR_PLATFORMS = [
     "IBMCOS",
     "AWS_STS",
     "AZURE_STS",
+    "GCP_STS",
     "SELF_REF_MCG",
 ]
 

--- a/ocs_ci/ocs/resources/backingstore.py
+++ b/ocs_ci/ocs/resources/backingstore.py
@@ -18,6 +18,7 @@ from ocs_ci.ocs.bucket_utils import (
     cli_create_aws_sts_backingstore,
     cli_create_azure_sts_backingstore,
     oc_create_azure_sts_backingstore,
+    oc_create_gcp_sts_backingstore,
     oc_create_self_ref_mcg_backingstore,
     cli_create_self_ref_mcg_backingstore,
 )
@@ -291,6 +292,7 @@ def backingstore_factory(
                 "self-ref-mcg": oc_create_self_ref_mcg_backingstore,
                 "pv": oc_create_pv_backingstore,
                 "azure-sts": oc_create_azure_sts_backingstore,
+                "gcp-sts": oc_create_gcp_sts_backingstore,
             },
             "cli": {
                 "aws": cli_create_aws_backingstore,

--- a/ocs_ci/ocs/resources/cloud_manager.py
+++ b/ocs_ci/ocs/resources/cloud_manager.py
@@ -33,6 +33,7 @@ from ocs_ci.utility.utils import (
     load_auth_config,
     get_role_arn_from_sub,
     get_azure_sts_creds_from_sub,
+    get_gcp_sts_creds_from_sub,
 )
 
 logger = logging.getLogger(__name__)
@@ -61,6 +62,7 @@ class CloudManager(ABC):
             "AZURE": AzureClient,
             "AZURE_WITH_LOGS": AzureWithLogsClient,
             "AZURE_STS": AzureSTSClient,
+            "GCP_STS": GcpSTSClient,
             "IBMCOS": IbmCosClient,
             "RGW": RgwClient,
             "SELF_REF_MCG": SelfRefMcgClient,
@@ -132,6 +134,16 @@ class CloudManager(ABC):
             )
         except ClusterNotInSTSModeException:
             setattr(self, "azure_sts_client", None)
+
+        # set the client for GCP STS enabled cluster
+        try:
+            setattr(
+                self,
+                "gcp_sts_client",
+                cloud_map["GCP_STS"](full_auth_dict=cred_dict),
+            )
+        except ClusterNotInSTSModeException:
+            setattr(self, "gcp_sts_client", None)
 
         try:
             setattr(
@@ -875,3 +887,29 @@ class AzureSTSClient(AzureClient):
         ).decode("ascii")
 
         return create_resource(**bs_secret_data)
+
+
+class GcpSTSClient(GoogleClient):
+    """
+    Implementation of a GCP Client for STS (Workload Identity Federation) clusters.
+
+    Reuses GoogleClient's GCS storage client for ULS operations but provides
+    WIF parameters (project_number, pool_id, provider_id, service_account_email)
+    for creating google-cloud-storage-sts backingstores.
+
+    """
+
+    @config.run_with_provider_context_if_available
+    def __init__(self, full_auth_dict, *args, **kwargs):
+        sts_creds = get_gcp_sts_creds_from_sub()
+        gcp_auth_dict = full_auth_dict.get("GCP")
+        if not gcp_auth_dict:
+            logger.error("Cluster is in GCP STS mode, but no GCP credentials found")
+            raise ClusterNotInSTSModeException
+
+        self.project_number = sts_creds["project_number"]
+        self.pool_id = sts_creds["pool_id"]
+        self.provider_id = sts_creds["provider_id"]
+        self.service_account_email = sts_creds["service_account_email"]
+
+        super().__init__(auth_dict=gcp_auth_dict, *args, **kwargs)

--- a/ocs_ci/ocs/resources/cloud_uls.py
+++ b/ocs_ci/ocs/resources/cloud_uls.py
@@ -33,6 +33,7 @@ def cloud_uls_factory(
         "azure": set(),
         "azure-with-logs": set(),
         "azure-sts": set(),
+        "gcp-sts": set(),
         "ibmcos": set(),
         "rgw": set(),
         "self-ref-mcg": set(),
@@ -45,6 +46,7 @@ def cloud_uls_factory(
             "azure": cld_mgr.azure_client,
             "azure-with-logs": cld_mgr.azure_with_logs_client,
             "azure-sts": cld_mgr.azure_sts_client,
+            "gcp-sts": cld_mgr.gcp_sts_client,
             "ibmcos": cld_mgr.ibmcos_client,
         }
     except AttributeError as e:
@@ -67,6 +69,11 @@ def cloud_uls_factory(
         ulsMap["azure-sts"] = cld_mgr.azure_sts_client
     except AttributeError:
         log.warning("Cluster is not deployed in Azure STS mode")
+
+    try:
+        ulsMap["gcp-sts"] = cld_mgr.gcp_sts_client
+    except AttributeError:
+        log.warning("Cluster is not deployed in GCP STS mode")
 
     try:
         ulsMap["self-ref-mcg"] = cld_mgr.self_ref_mcg_client
@@ -96,6 +103,7 @@ def cloud_uls_factory(
             "azure": set(),
             "azure-with-logs": set(),
             "azure-sts": set(),
+            "gcp-sts": set(),
             "ibmcos": set(),
             "rgw": set(),
             "self-ref-mcg": set(),

--- a/ocs_ci/ocs/ui/page_objects/data_foundation_tabs_common.py
+++ b/ocs_ci/ocs/ui/page_objects/data_foundation_tabs_common.py
@@ -545,11 +545,18 @@ class CreateResourceForm(PageNavigator):
 
         logger.info("Select secret")
         switch_to_secret = self.mcg_stores.get("store_switch_to_secret")
-        if switch_to_secret and self.check_element_presence(
-            (switch_to_secret[1], switch_to_secret[0]), timeout=3, use_fallback=False
-        ):
-            logger.info("Clicking 'Switch to Secret' to reveal the secret dropdown")
-            self.do_click(switch_to_secret)
+        if switch_to_secret:
+            try:
+                WebDriverWait(self.driver, 3).until(
+                    expected_conditions.presence_of_element_located(
+                        (switch_to_secret[1], switch_to_secret[0])
+                    )
+                )
+            except TimeoutException:
+                pass
+            else:
+                logger.info("Clicking 'Switch to Secret' to reveal the secret dropdown")
+                self.do_click(switch_to_secret)
         self.do_click(self.mcg_stores["store_secret_dropdown"])
         self.do_click(format_locator(self.mcg_stores["store_secret_option"], secret))
 

--- a/ocs_ci/ocs/ui/page_objects/data_foundation_tabs_common.py
+++ b/ocs_ci/ocs/ui/page_objects/data_foundation_tabs_common.py
@@ -515,7 +515,8 @@ class CreateResourceForm(PageNavigator):
         Args:
             store_name (str): backing store or namespace store name
             provider (str): backing store or namespace store provider
-            region (str): backing store or namespace store region
+            region (str): backing store or namespace store region.
+                None to skip region selection (e.g. Google Cloud Storage).
             secret (str): backing store or namespace store secret
             uls_name (str): uls name
 
@@ -535,13 +536,20 @@ class CreateResourceForm(PageNavigator):
             format_locator(self.mcg_stores["store_dropdown_option"], value=provider)
         )
 
-        logger.info("Select region")
-        self.do_click(self.mcg_stores["store_region_dropdown"])
-        self.do_click(
-            format_locator(self.mcg_stores["store_dropdown_option"], value=region)
-        )
+        if region:
+            logger.info("Select region")
+            self.do_click(self.mcg_stores["store_region_dropdown"])
+            self.do_click(
+                format_locator(self.mcg_stores["store_dropdown_option"], value=region)
+            )
 
         logger.info("Select secret")
+        switch_to_secret = self.mcg_stores.get("store_switch_to_secret")
+        if switch_to_secret and self.check_element_presence(
+            (switch_to_secret[1], switch_to_secret[0]), timeout=3, use_fallback=False
+        ):
+            logger.info("Clicking 'Switch to Secret' to reveal the secret dropdown")
+            self.do_click(switch_to_secret)
         self.do_click(self.mcg_stores["store_secret_dropdown"])
         self.do_click(format_locator(self.mcg_stores["store_secret_option"], secret))
 

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -656,11 +656,16 @@ mcg_stores = {
         "//label[@for='region']/../following-sibling::*",
         By.XPATH,
     ),
-    "store_secret_dropdown": (
-        "//span[@class='text-muted' and text()='Select Secret']/../..",
+    "store_switch_to_secret": (
+        "//*[normalize-space()='Switch to Secret']",
         By.XPATH,
     ),
-    "store_target_bucket_input": ("//input[@id='target-bucket']", By.XPATH),
+    "store_secret_dropdown": (
+        "//label[normalize-space()='Secret Key']/../following-sibling::*//button[contains(@class, 'c-menu-toggle')] | "
+        "//span[normalize-space()='Select Secret']/ancestor::button[contains(@class, 'c-menu-toggle')]",
+        By.XPATH,
+    ),
+    "store_target_bucket_input": ("//input[@aria-label='Target Bucket']", By.XPATH),
     "create_store_btn": (
         "//button[@type='submit']",
         By.XPATH,

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -661,8 +661,8 @@ mcg_stores = {
         By.XPATH,
     ),
     "store_secret_dropdown": (
-        "//label[normalize-space()='Secret Key']/../following-sibling::*//button[contains(@class, 'menu-toggle')] | "
-        "//span[normalize-space()='Select Secret']/ancestor::button[contains(@class, 'menu-toggle')]",
+        "//label[normalize-space()='Secret Key']/../following-sibling::*//button[contains(@class, 'c-menu-toggle')] | "
+        "//span[normalize-space()='Select Secret']/ancestor::button[contains(@class, 'c-menu-toggle')]",
         By.XPATH,
     ),
     "store_target_bucket_input": ("//input[@aria-label='Target Bucket']", By.XPATH),

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -661,8 +661,8 @@ mcg_stores = {
         By.XPATH,
     ),
     "store_secret_dropdown": (
-        "//label[normalize-space()='Secret Key']/../following-sibling::*//button[contains(@class, 'c-menu-toggle')] | "
-        "//span[normalize-space()='Select Secret']/ancestor::button[contains(@class, 'c-menu-toggle')]",
+        "//label[normalize-space()='Secret Key']/../following-sibling::*//button[contains(@class, 'menu-toggle')] | "
+        "//span[normalize-space()='Select Secret']/ancestor::button[contains(@class, 'menu-toggle')]",
         By.XPATH,
     ),
     "store_target_bucket_input": ("//input[@aria-label='Target Bucket']", By.XPATH),

--- a/tests/functional/object/mcg/test_sts_bucket.py
+++ b/tests/functional/object/mcg/test_sts_bucket.py
@@ -58,7 +58,7 @@ class TestSTSBucket:
                         "backingstore_dict": {"gcp-sts": [(1, None)]},
                     },
                 ],
-                marks=[tier1, gcp_platform_required, polarion_id("OCS-8120")],
+                marks=[tier1, gcp_platform_required, polarion_id("OCS-8216")],
             ),
             pytest.param(
                 *[

--- a/tests/functional/object/mcg/test_sts_bucket.py
+++ b/tests/functional/object/mcg/test_sts_bucket.py
@@ -9,6 +9,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     sts_deployment_required,
     aws_platform_required,
     azure_platform_required,
+    gcp_platform_required,
     red_squad,
     mcg,
     polarion_id,
@@ -53,6 +54,15 @@ class TestSTSBucket:
             pytest.param(
                 *[
                     {
+                        "interface": "OC",
+                        "backingstore_dict": {"gcp-sts": [(1, None)]},
+                    },
+                ],
+                marks=[tier1, gcp_platform_required, polarion_id("OCS-8120")],
+            ),
+            pytest.param(
+                *[
+                    {
                         "interface": "CLI",
                         "namespace_policy_dict": {
                             "type": "Single",
@@ -70,6 +80,7 @@ class TestSTSBucket:
         ids=[
             "AWS-STS-BS-CLI",
             "AZURE-STS-BS-CLI",
+            "GCP-STS-BS-OC",
             "AZURE-STS-NSS-CLI",
             "STS-DEFAULT",
         ],
@@ -84,14 +95,20 @@ class TestSTSBucket:
     ):
         """
         Test full object round trip verification
-        on an STS-backed bucket (AWS STS or Azure STS)
+        on an STS-backed bucket (AWS STS, Azure STS, or GCP STS)
 
+        1. Create a backingstore, bucketclass, and OBC
+        2. Upload 5 randomly generated objects to the bucket
+        3. Download all objects from the bucket to a separate directory
+        4. Compare the downloaded objects against the originals
+        5. Delete all objects from the bucket
+        6. Verify the bucket is empty
         """
 
-        # create the bucket
+        # 1. Create a backingstore, bucketclass, and OBC
         bucketname = bucket_factory(bucketclass=bucketclass)[0].name
 
-        # upload randomly generated objects to the bucket
+        # 2. Upload 5 randomly generated objects to the bucket
         obj_list = write_random_test_objects_to_bucket(
             io_pod=awscli_pod_session,
             bucket_to_write=bucketname,
@@ -102,7 +119,7 @@ class TestSTSBucket:
         )
         logger.info(f"Uploaded {obj_list} to bucket {bucketname}")
 
-        # download the objects from bucket
+        # 3. Download all objects from the bucket
         sync_object_directory(
             podobj=awscli_pod_session,
             src=f"s3://{bucketname}",
@@ -113,6 +130,7 @@ class TestSTSBucket:
             f"Objects are downloaded to the dir {test_directory_setup.result_dir}"
         )
 
+        # 4. Compare downloaded objects against originals
         compare_directory(
             awscli_pod=awscli_pod_session,
             original_dir=test_directory_setup.origin_dir,
@@ -121,13 +139,14 @@ class TestSTSBucket:
             pattern="Random-Obj",
         )
 
-        # delete objects from the bucket
+        # 5. Delete all objects from the bucket
         s3_delete_objects(
             mcg_obj_session,
             bucketname=bucketname,
             object_keys=[{"Key": f"{obj}"} for obj in obj_list],
         )
 
+        # 6. Verify the bucket is empty
         assert check_if_objects_expired(
             mcg_obj=mcg_obj_session,
             bucket_name=bucketname,

--- a/tests/functional/object/mcg/ui/test_mcg_ui.py
+++ b/tests/functional/object/mcg/ui/test_mcg_ui.py
@@ -160,7 +160,7 @@ class TestStoreUserInterface(object):
     @tier2
     @sts_deployment_required
     @gcp_platform_required
-    @polarion_id("OCS-8121")
+    @polarion_id("OCS-8217")
     def test_gcp_sts_backingstore_ui_creation(
         self,
         setup_ui_class_factory,

--- a/tests/functional/object/mcg/ui/test_mcg_ui.py
+++ b/tests/functional/object/mcg/ui/test_mcg_ui.py
@@ -11,6 +11,9 @@ from ocs_ci.framework.pytest_customization.marks import (
     mcg,
     skipif_ibm_cloud_managed,
     provider_mode,
+    gcp_platform_required,
+    sts_deployment_required,
+    polarion_id,
 )
 from ocs_ci.ocs import constants
 from ocs_ci.helpers.helpers import create_unique_resource_name
@@ -152,6 +155,63 @@ class TestStoreUserInterface(object):
         assert test_store.check_resource_existence(
             should_exist=False
         ), f"resource kind='{kind}' name='{store_name}' preserved on cluster after deletion"
+
+    @ui
+    @tier2
+    @sts_deployment_required
+    @gcp_platform_required
+    @polarion_id("OCS-8121")
+    def test_gcp_sts_backingstore_ui_creation(
+        self,
+        setup_ui_class_factory,
+        cloud_uls_factory,
+    ):
+        """
+        Test GCP STS backingstore creation via the ODF UI
+
+        1. Get the WIF secret name from the default GCP STS backingstore
+        2. Create a GCS bucket for the backingstore target
+        3. Navigate to ODF UI and create a Google Cloud Storage backingstore
+        4. Verify the backingstore reaches Ready state
+
+        """
+        setup_ui_class_factory()
+        namespace = config.ENV_DATA["cluster_namespace"]
+
+        # 1. Get the WIF secret name from the default GCP STS backingstore
+        logger.test_step("Get the WIF secret from the default backingstore")
+        default_bs = OCP(
+            kind="backingstore",
+            namespace=namespace,
+            resource_name=constants.DEFAULT_NOOBAA_BACKINGSTORE,
+        ).get()
+        secret_name = default_bs["spec"]["googleCloudStorage"]["secret"]["name"]
+        logger.info(f"Using WIF secret: {secret_name}")
+
+        # 2. Create a GCS bucket for the backingstore target
+        logger.test_step("Create a GCS bucket as the underlying storage")
+        uls_name = list(cloud_uls_factory({"gcp": [(1, None)]})["gcp"])[0]
+        store_name = create_unique_resource_name(
+            resource_description="ui", resource_type="backingstore"
+        )
+
+        # 3. Navigate to ODF UI and create the backingstore
+        logger.test_step(
+            "Navigate to Backing Store tab and create GCP STS backingstore"
+        )
+        object_storage = PageNavigator().nav_object_storage_page()
+        store_tab = object_storage.nav_backing_store_tab()
+        _, store_ready = store_tab.create_store_verify_state(
+            kind="BackingStore",
+            store_name=store_name,
+            provider="Google Cloud Storage",
+            region=None,
+            secret=secret_name,
+            uls_name=uls_name,
+        )
+
+        # 4. Verify the backingstore is ready
+        assert store_ready, f"GCP STS backingstore '{store_name}' was not ready in time"
 
 
 @mcg


### PR DESCRIPTION
## Summary
- Add infrastructure for GCP STS (Workload Identity Federation) day-2 backingstore operations: `GcpSTSClient`, `oc_create_gcp_sts_backingstore`, cloud_uls and backingstore factory wiring
- Add `GCP-STS-BS-OC` parametrized variant to `test_sts_bucket_ops` for full IO round-trip via OC + YAML backingstore creation using an existing WIF secret
- Add `test_gcp_sts_backingstore_ui_creation` in `test_mcg_ui.py` for UI-based backingstore creation and verification
- Fix UI locators for PatternFly v6 (secret dropdown, target bucket input, Switch to Secret button) and support skipping region selection for GCS provider

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

- Added support for Google Cloud Workload Identity Federation (GCP STS) storage configurations.
- Added GCP STS backingstore creation through command-line and UI workflows.
- Added GCP STS cloud resource handling and platform recognition.

## UI Improvements

- Updated storage creation to support secret-based configuration and optional regions.
- Improved compatibility with the current secret-selection and target-bucket interface.

## Tests

- Added functional and UI coverage for creating and validating GCP STS backingstores.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->