### PR TITLE
helpers/dr_helpers: skip ODF CLI DR validation on hosted clusters

### DIFF
--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -88,7 +88,6 @@ from ocs_ci.helpers.helpers import (
 )
 from ocs_ci.helpers import helpers
 from ocs_ci.helpers.odf_cli import ODFCliRunner
-from ocs_ci.deployment.helpers.hypershift_base import is_hosted_cluster
 
 logger = logging.getLogger(__name__)
 
@@ -4533,13 +4532,16 @@ def validate_application_odf_cli(
         Skips the test on validation failure.
 
     """
-    cluster_name = config.ENV_DATA.get("cluster_name")
-    if is_hosted_cluster(cluster_name):
-        logger.info(
-            f"Skipping ODF CLI DR {action} for DRPC '{drpc_name}': "
-            f"cluster '{cluster_name}' is a hosted cluster"
-        )
-        return None
+    for cluster in config.clusters:
+        if cluster.MULTICLUSTER.get("is_hosted", False):
+            cluster_name = cluster.MULTICLUSTER.get(
+                "name", cluster.ENV_DATA.get("cluster_name", "unknown")
+            )
+            logger.info(
+                f"Skipping ODF CLI DR {action} for DRPC '{drpc_name}': "
+                f"cluster '{cluster_name}' is a hosted cluster"
+            )
+            return None
 
     dir_label = dr_action or f"{action}-app"
     output_dir = os.path.join(

--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -4526,10 +4526,13 @@ def validate_application_odf_cli(
 
     Returns:
         str or None: The stdout output from the command,
-            or None if gather failed
+            or None if any cluster in the multicluster config is a hosted
+            cluster, or if gather failed.
 
     Note:
-        Skips the test on validation failure.
+        Returns None immediately (without running any command) when any
+        cluster in ``config.clusters`` has ``is_hosted=True``.  Skips
+        the test on validation failure.
 
     """
     for cluster in config.clusters:

--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -88,6 +88,7 @@ from ocs_ci.helpers.helpers import (
 )
 from ocs_ci.helpers import helpers
 from ocs_ci.helpers.odf_cli import ODFCliRunner
+from ocs_ci.deployment.helpers.hypershift_base import is_hosted_cluster
 
 logger = logging.getLogger(__name__)
 
@@ -4532,6 +4533,14 @@ def validate_application_odf_cli(
         Skips the test on validation failure.
 
     """
+    cluster_name = config.ENV_DATA.get("cluster_name")
+    if is_hosted_cluster(cluster_name):
+        logger.info(
+            f"Skipping ODF CLI DR {action} for DRPC '{drpc_name}': "
+            f"cluster '{cluster_name}' is a hosted cluster"
+        )
+        return None
+
     dir_label = dr_action or f"{action}-app"
     output_dir = os.path.join(
         os.path.expanduser(config.RUN["log_dir"]),


### PR DESCRIPTION
validate_application_odf_cli now checks if the current cluster is a hosted cluster via is_hosted_cluster() and returns early with a log message instead of running the ODF CLI command. This avoids failures on environments where the ODF CLI DR tooling is not applicable to hosted clusters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * ODF CLI validation is now skipped for hosted clusters, preventing unsupported command execution.
  * Added logging to clarify when validation is skipped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->