### PR TITLE
Fix unpause cmd for kubevirt vm's

### DIFF
--- a/ocs_ci/utility/kubevirt_vm.py
+++ b/ocs_ci/utility/kubevirt_vm.py
@@ -232,8 +232,8 @@ class KubevirtVM(object):
         """
         for vm in vms:
             vm_name = get_vm_name(vm)
-            logger.info(f"Pausing the VM {vm_name}")
-            cmd = f"pause {vm_name}"
+            logger.info(f"UnPausing the VM {vm_name}")
+            cmd = f"unpause {vm_name}"
             self.run_kubevirt_vm_cmd(cmd)
 
         if wait:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected virtual machine recovery behavior to unpause paused virtual machines instead of pausing them again.
  * Added clearer action logging for VM unpause operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->