### PR TITLE
Use ACM 5.0 Build for OCP 5.0 and OCP 4.23

### DIFF
--- a/ocs_ci/framework/conf/ocp_version/ocp-4.23-config.yaml
+++ b/ocs_ci/framework/conf/ocp_version/ocp-4.23-config.yaml
@@ -17,9 +17,9 @@ ENV_DATA:
     "10": "rhcos-10.2.20260423-0-vmware.x86_64"
   # Legacy single template (fallback if vm_templates not defined)
   vm_template: "rhcos-9.8.20260428-0-vmware.x86_64"
-  acm_hub_channel: "release-2.17"
-  acm_version: "2.17"
-  mce_version: "2.17"
+  acm_hub_channel: "release-5.0"
+  acm_version: "5.0"
+  mce_version: "5.0"
   submariner_version: "0.24.0"
   submariner_image: "quay.io/redhat-user-workloads/submariner-tenant/submariner-fbc-4-22@sha256:1a666c3c2c99b1148f184f54efcee293f45cfff32cf9ca7a239097fe574ff700"
   oadp_version: "1.6"

--- a/ocs_ci/framework/conf/ocp_version/ocp-5.0-config.yaml
+++ b/ocs_ci/framework/conf/ocp_version/ocp-5.0-config.yaml
@@ -18,9 +18,9 @@ ENV_DATA:
   # Legacy single template (fallback if vm_templates not defined)
   vm_template: "rhcos-10.2.20260423-0-vmware.x86_64"
   rhcos_version: "10"
-  acm_hub_channel: "release-2.17"
-  acm_version: "2.17"
-  mce_version: "2.17"
+  acm_hub_channel: "release-5.0"
+  acm_version: "5.0"
+  mce_version: "5.0"
   submariner_version: "0.24.0"
   submariner_image: "quay.io/redhat-user-workloads/submariner-tenant/submariner-fbc-4-22@sha256:1a666c3c2c99b1148f184f54efcee293f45cfff32cf9ca7a239097fe574ff700"
   oadp_version: "1.6"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Configuration Updates**
  - Updated ACM Hub, ACM, and MCE component versions to 5.0 for OCP 4.23 and OCP 5.0 environments.
  - Updated the associated release channels to use the corresponding 5.0 releases.
  - Keeps environment configurations aligned across supported OpenShift versions.
  - Provides consistent component versions and release selections for deployments across both environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->