### PR TITLE
rollback and improve proceed_to_login_console

### DIFF
--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -112,7 +112,6 @@ from ocs_ci.ocs.resources import packagemanifest
 from ocs_ci.ocs.resources.catalog_source import (
     CatalogSource,
     disable_specific_source,
-    is_catalog_source_ready,
 )
 from ocs_ci.ocs.resources.csv import CSV, get_csvs_start_with_prefix
 from ocs_ci.ocs.resources.install_plan import wait_for_install_plan_and_approve
@@ -1974,13 +1973,7 @@ class Deployment(object):
 
         live_deployment = config.DEPLOYMENT.get("live_deployment")
         if not live_deployment:
-            if is_catalog_source_ready():
-                logger.info(
-                    "CatalogSource %s already exists and is READY, skipping creation",
-                    constants.OPERATOR_CATALOG_SOURCE_NAME,
-                )
-            else:
-                create_catalog_source()
+            create_catalog_source()
 
         # Complete all CLI prep work (LSO catalog, disk attachment) before
         # opening the browser to avoid stale element errors caused by the

--- a/ocs_ci/ocs/ui/base_ui.py
+++ b/ocs_ci/ocs/ui/base_ui.py
@@ -1604,12 +1604,16 @@ def proceed_to_login_console():
     """
     driver = SeleniumDriver()
     login_loc = locators_for_current_ocp_version()["login"]
-    if login_loc["pre_login_page_title"].lower() in driver.title.lower():
-        proceed_btn = driver.find_element(
-            by=login_loc["proceed_to_login_btn"][1],
-            value=login_loc["proceed_to_login_btn"][0],
-        )
-        proceed_btn.click()
+    if driver.title == login_loc["pre_login_page_title"]:
+        try:
+            proceed_btn = wait_for_element_to_be_clickable(
+                login_loc["proceed_to_login_btn"], 60
+            )
+            proceed_btn.click()
+        except WebDriverException:
+            take_screenshot("proceed_to_login_console_click")
+            copy_dom("proceed_to_login_console_click")
+            raise
         try:
             WebDriverWait(driver, 60).until(ec.title_is(login_loc["login_page_title"]))
         except TimeoutException:


### PR DESCRIPTION
 Restore exact title match in proceed_to_login_console

```
  The function handles the oauth-proxy sign-in interstitial page
  (openshift/oauth-proxy templates.go, title exactly "Log In") that
  appears before the OAuth login page on ACM/oauth-proxy-protected
  routes. A regression in 93d215457 changed the exact title comparison
  to a case-insensitive substring check, causing the function to also
  match the actual OAuth login page ("Log in · Red Hat OpenShift
  Container Platform") and prematurely click its submit button before
  credentials are entered.
```

* imp
The oauth-proxy template  (openshift/oauth-proxy/templates.go) uses exactly <title>Log In</title>. The actual OAuth login page uses "Log in · Red Hat OpenShift Container Platform" (lowercase 'i').  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved login console navigation by accurately detecting the pre-login page.
  * Added more reliable waiting for the proceed button.
  * Captures diagnostic screenshots and page details when navigation encounters an error.
  * Improved non-live deployment reliability by consistently creating the required catalog source.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->