### PR TITLE
Handle kubelet log rotation in test_pod_log_after_upgrade

### DIFF
--- a/tests/functional/upgrade/test_resources.py
+++ b/tests/functional/upgrade/test_resources.py
@@ -126,13 +126,22 @@ def test_pod_log_after_upgrade():
     pod_objs = get_osd_pods() + get_mon_pods() + get_mgr_pods()
     pod_names = [osd_pod_obj.name for osd_pod_obj in pod_objs]
     expected_log_after_upgrade = "set uid:gid to 167:167 (ceph:ceph)"
+    early_startup_marker = "ceph version"
     log.info(
         f"Check that the log '{expected_log_after_upgrade}' "
         f"appears after the osd/mon/mg pod is initialized"
     )
     for pod_name in pod_names:
         pod_logs = get_pod_logs(pod_name=pod_name, all_containers=True)
-        assert expected_log_after_upgrade in pod_logs, (
+        if expected_log_after_upgrade in pod_logs:
+            continue
+        if early_startup_marker not in pod_logs:
+            log.warning(
+                f"Pod {pod_name}: early startup logs were rotated out by kubelet, "
+                f"cannot verify '{expected_log_after_upgrade}'"
+            )
+            continue
+        assert False, (
             f"The expected log after upgrade '{expected_log_after_upgrade}' does not exist"
             f" on pod {pod_name}"
         )


### PR DESCRIPTION
- Detect kubelet log rotation in `test_pod_log_after_upgrade` by checking for a co-located early startup marker (`"ceph version"`)
- When both the expected init message and the startup marker are absent, warn and skip (log rotation confirmed)
- When the startup marker IS present but the init message is missing, still assert (genuine failure)
- Fixes flaky failure on active MGR pods whose high debug output (~72K lines/hr) causes kubelet to rotate out init entries

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved upgrade verification when early startup logs have been rotated.
  * Prevented false failures when expected log entries are unavailable due to log rotation.
  * Continued to flag cases where logs are present but the expected entry is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->