### PR TITLE
Fix Acm locators for Discovered app test and Waiting for alerts

### DIFF
--- a/ocs_ci/helpers/dr_helpers_ui.py
+++ b/ocs_ci/helpers/dr_helpers_ui.py
@@ -22,6 +22,7 @@ from selenium.common.exceptions import (
 from ocs_ci.framework import config
 from ocs_ci.helpers import dr_helpers
 from ocs_ci.ocs import constants
+from ocs_ci.ocs.acm.acm import get_acm_url
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.exceptions import (
     ResourceWrongStatusException,
@@ -901,7 +902,13 @@ def verify_pending_cleanup_alert_firing(
         + (f" for DRPC '{drpc_name}'" if drpc_name else "")
     )
 
-    acm_obj.refresh_page()
+    # If the browser is on a blank page (e.g. after session reset between
+    # iterations) refreshing stays blank. Navigate to ACM first.
+    if not acm_obj.driver.current_url.startswith("http"):
+        acm_obj.driver.get(get_acm_url())
+        acm_obj.page_has_loaded()
+    else:
+        acm_obj.refresh_page()
     acm_obj.navigate_data_services()
 
     # Navigate to Disaster Recovery Overview page where alerts are shown
@@ -1059,7 +1066,11 @@ def verify_pending_cleanup_alert_resolved(
     )
 
     # Navigate to DR Dashboard Overview page
-    acm_obj.refresh_page()
+    if not acm_obj.driver.current_url.startswith("http"):
+        acm_obj.driver.get(get_acm_url())
+        acm_obj.page_has_loaded()
+    else:
+        acm_obj.refresh_page()
     acm_obj.navigate_data_services()
     acm_obj.do_click(
         acm_loc["disaster-recovery-overview"],

--- a/ocs_ci/helpers/dr_helpers_ui.py
+++ b/ocs_ci/helpers/dr_helpers_ui.py
@@ -912,8 +912,8 @@ def verify_pending_cleanup_alert_firing(
         timeout=60,
     )
     acm_obj.page_has_loaded()
-    acm_obj.take_screenshot()
-    acm_obj.copy_dom()
+    acm_obj.take_screenshot(name_suffix="dr-overview-before-alert-check")
+    acm_obj.copy_dom(name_suffix="dr-overview-before-alert-check")
 
     if get_semantic_ocp_running_version() >= VERSION_4_22:
         # On OCP 4.22+ the MCO status-card is gone; alerts are in the OCP
@@ -945,15 +945,15 @@ def verify_pending_cleanup_alert_firing(
                 avoid_stale=True,
             )
             acm_obj.page_has_loaded()
-            acm_obj.take_screenshot()
-            acm_obj.copy_dom()
+            acm_obj.take_screenshot(name_suffix="notification-drawer-open")
+            acm_obj.copy_dom(name_suffix="notification-drawer-open")
             found = acm_obj.wait_until_expected_text_is_found(
                 locator=alert_locator,
                 expected_text=expected_text,
                 timeout=timeout,
                 use_fallback=False,
             )
-            acm_obj.take_screenshot()
+            acm_obj.take_screenshot(name_suffix="notification-drawer-alert-check")
             # Close the drawer regardless of outcome
             acm_obj.do_click(
                 acm_loc["notification-drawer-toggle"],
@@ -981,24 +981,18 @@ def verify_pending_cleanup_alert_firing(
         # Pre-4.22: alert is in the MCO status-card on the DR Overview page
         # Expand Critical alerts section (best-effort)
         try:
-            critical_alert = acm_obj.find_an_element_by_xpath(
-                acm_loc["critical-alert"][0]
-            ).get_attribute("aria-expanded")
-
+            critical_alert = acm_obj.get_element_attribute(
+                acm_loc["critical-alert"], "aria-expanded", safe=True
+            )
             if critical_alert == "false":
-                critical_alert_elem = wait_for_element_to_be_clickable(
-                    acm_loc["critical-alert"]
-                )
-                acm_obj.driver.execute_script(
-                    "arguments[0].click();", critical_alert_elem
-                )
-                acm_obj.take_screenshot()
+                acm_obj.do_click(acm_loc["critical-alert"], avoid_stale=True)
+                acm_obj.take_screenshot(name_suffix="critical-alert-expanded")
         except (NoSuchElementException, StaleElementReferenceException) as e:
             log.warning(
                 f"Could not expand Critical alerts section: {e}. "
                 "Proceeding to verify alert presence directly."
             )
-            acm_obj.take_screenshot()
+            acm_obj.take_screenshot(name_suffix="critical-alert-not-found")
 
         if drpc_name:
             alert_locator = (
@@ -1024,14 +1018,14 @@ def verify_pending_cleanup_alert_firing(
             f"found after {operation}"
             + (f" for DRPC '{drpc_name}'" if drpc_name else "")
         )
-        acm_obj.take_screenshot()
+        acm_obj.take_screenshot(name_suffix="alert-firing-found")
     else:
         log.error(
             f"Alert '{constants.ALERT_APPLICATION_CLEANUP_PENDING}' "
             f"NOT found after {operation}"
             + (f" for DRPC '{drpc_name}'" if drpc_name else "")
         )
-        acm_obj.take_screenshot()
+        acm_obj.take_screenshot(name_suffix="alert-firing-not-found")
         raise UnexpectedBehaviour(
             f"{constants.ALERT_APPLICATION_CLEANUP_PENDING} alert "
             f"did not appear after {operation}"
@@ -1073,32 +1067,26 @@ def verify_pending_cleanup_alert_resolved(
         enable_screenshot=True,
         timeout=60,
     )
-    acm_obj.take_screenshot()
+    acm_obj.take_screenshot(name_suffix="dr-overview-before-resolved-check")
 
     # Pre-4.22 only: expand the MCO status-card Critical alerts section.
     # On 4.22+ there is no such element; alerts are in the notification drawer.
     if get_semantic_ocp_running_version() < VERSION_4_22:
         try:
-            critical_alert = acm_obj.find_an_element_by_xpath(
-                acm_loc["critical-alert"][0]
-            ).get_attribute("aria-expanded")
-
+            critical_alert = acm_obj.get_element_attribute(
+                acm_loc["critical-alert"], "aria-expanded", safe=True
+            )
             if critical_alert == "false":
-                critical_alert_elem = wait_for_element_to_be_clickable(
-                    acm_loc["critical-alert"]
-                )
-                acm_obj.driver.execute_script(
-                    "arguments[0].click();", critical_alert_elem
-                )
-                acm_obj.take_screenshot()
+                acm_obj.do_click(acm_loc["critical-alert"], avoid_stale=True)
+                acm_obj.take_screenshot(name_suffix="critical-alert-expanded")
         except (NoSuchElementException, StaleElementReferenceException) as e:
             log.info(
                 f"Critical alerts section not found or not expandable: {e}. "
                 "This may indicate no critical alerts exist (expected)."
             )
-            acm_obj.take_screenshot()
+            acm_obj.take_screenshot(name_suffix="critical-alert-not-found")
         except Exception as e:
-            acm_obj.take_screenshot()
+            acm_obj.take_screenshot(name_suffix="critical-alert-error")
             raise UnexpectedBehaviour(
                 f"Unable to verify DR Dashboard critical-alert section after {operation} cleanup."
             ) from e
@@ -1131,15 +1119,15 @@ def verify_pending_cleanup_alert_resolved(
                 avoid_stale=True,
             )
             acm_obj.page_has_loaded()
-            acm_obj.take_screenshot()
-            acm_obj.copy_dom()
+            acm_obj.take_screenshot(name_suffix="notification-drawer-open-resolved")
+            acm_obj.copy_dom(name_suffix="notification-drawer-open-resolved")
             still_present = acm_obj.wait_until_expected_text_is_found(
                 locator=alert_locator,
                 expected_text=expected_text,
                 timeout=timeout,
                 use_fallback=False,
             )
-            acm_obj.take_screenshot()
+            acm_obj.take_screenshot(name_suffix="notification-drawer-resolved-check")
             acm_obj.do_click(
                 acm_loc["notification-drawer-toggle"],
                 avoid_stale=True,
@@ -1187,7 +1175,7 @@ def verify_pending_cleanup_alert_resolved(
             f"still present on DR Dashboard after {operation} cleanup"
             + (f" for DRPC '{drpc_name}'" if drpc_name else "")
         )
-        acm_obj.take_screenshot()
+        acm_obj.take_screenshot(name_suffix="alert-still-present")
         raise UnexpectedBehaviour(
             f"{constants.ALERT_APPLICATION_CLEANUP_PENDING} alert "
             f"did not clear after {operation} cleanup"
@@ -1199,7 +1187,7 @@ def verify_pending_cleanup_alert_resolved(
             f"successfully cleared from DR Dashboard after {operation}"
             + (f" for DRPC '{drpc_name}'" if drpc_name else "")
         )
-        acm_obj.take_screenshot()
+        acm_obj.take_screenshot(name_suffix="alert-cleared")
 
 
 def failover_relocate_ui(

--- a/ocs_ci/helpers/dr_helpers_ui.py
+++ b/ocs_ci/helpers/dr_helpers_ui.py
@@ -7,7 +7,11 @@ import time
 
 from typing import List
 
-from ocs_ci.utility.version import compare_versions
+from ocs_ci.utility.version import (
+    compare_versions,
+    get_semantic_ocp_running_version,
+    VERSION_4_22,
+)
 from selenium.common.exceptions import (
     ElementClickInterceptedException,
     NoSuchElementException,
@@ -874,6 +878,10 @@ def verify_pending_cleanup_alert_firing(
     """
     Verify that ApplicationCleanupPending alert is firing on DR Dashboard.
 
+    On OCP < 4.22 the alert is shown in the MCO status-card on the DR Overview
+    page.  On OCP >= 4.22 (PF v6) that panel was removed; alerts are now shown
+    in the OCP notification drawer (bell icon in the masthead).
+
     Args:
         acm_obj (AcmAddClusters): ACM Page Navigator Class
         operation (str): DR operation name for logging (Failover/Relocate)
@@ -881,7 +889,7 @@ def verify_pending_cleanup_alert_firing(
         namespace (str): Namespace of DRPC (optional, defaults to DR_OPS_NAMESPACE)
 
     Raises:
-        UnexpectedBehaviour: If alert is not found on DR Dashboard
+        UnexpectedBehaviour: If alert is not found
 
     """
     acm_loc = locators_for_current_ocp_version()["acm_page"]
@@ -892,6 +900,7 @@ def verify_pending_cleanup_alert_firing(
         f"alert is firing on DR Dashboard after {operation}"
         + (f" for DRPC '{drpc_name}'" if drpc_name else "")
     )
+
     acm_obj.refresh_page()
     acm_obj.navigate_data_services()
 
@@ -906,61 +915,106 @@ def verify_pending_cleanup_alert_firing(
     acm_obj.take_screenshot()
     acm_obj.copy_dom()
 
-    # Expand Critical alerts section (best-effort)
-    try:
-        critical_alert = acm_obj.find_an_element_by_xpath(
-            acm_loc["critical-alert"][0]
-        ).get_attribute("aria-expanded")
-
-        if critical_alert == "false":
-            critical_alert_elem = wait_for_element_to_be_clickable(
-                acm_loc["critical-alert"]
-            )
-            acm_obj.driver.execute_script("arguments[0].click();", critical_alert_elem)
-            acm_obj.take_screenshot()
-    except (NoSuchElementException, StaleElementReferenceException) as e:
-        log.warning(
-            f"Could not expand Critical alerts section: {e}. "
-            "Proceeding to verify alert presence directly."
+    if get_semantic_ocp_running_version() >= VERSION_4_22:
+        # On OCP 4.22+ the MCO status-card is gone; alerts are in the OCP
+        # notification drawer (bell icon).  Open it to make the alert elements
+        # visible in the DOM, then check with the drawer-anchored locator
+        # (overridden in acm_configuration_4_22).
+        log.info(
+            "OCP >= 4.22: opening notification drawer to check for "
+            f"'{constants.ALERT_APPLICATION_CLEANUP_PENDING}' alert"
+        )
+        acm_obj.do_click(
+            acm_loc["notification-drawer-toggle"],
+            avoid_stale=True,
+            enable_screenshot=True,
         )
         acm_obj.take_screenshot()
+        acm_obj.copy_dom()
 
-    # Verify alert is visible - use DRPC-specific locator if drpc_name provided
-    if drpc_name:
-        alert_locator = (
-            acm_loc["pending-cleanup-alert-drpc-message"][0].format(
-                drpc_name, namespace
-            ),
-            acm_loc["pending-cleanup-alert-drpc-message"][1],
+        if drpc_name:
+            alert_locator = (
+                acm_loc["pending-cleanup-alert-drpc-message"][0].format(
+                    drpc_name, namespace
+                ),
+                acm_loc["pending-cleanup-alert-drpc-message"][1],
+            )
+            expected_text = (
+                f"DRPC '{drpc_name}' in namespace '{namespace}' requires manual cleanup"
+            )
+        else:
+            alert_locator = acm_loc["notification-drawer-cleanup-alert-title"]
+            expected_text = constants.ALERT_APPLICATION_CLEANUP_PENDING
+
+        alert_found = acm_obj.wait_until_expected_text_is_found(
+            locator=alert_locator,
+            expected_text=expected_text,
+            timeout=120,
+            use_fallback=False,
         )
-        expected_text = f"DRPC '{drpc_name}'"
+        # Close the drawer regardless of outcome
+        acm_obj.do_click(
+            acm_loc["notification-drawer-toggle"],
+            avoid_stale=True,
+        )
     else:
-        alert_locator = acm_loc["pending-cleanup-alert"]
-        expected_text = constants.ALERT_APPLICATION_CLEANUP_PENDING
+        # Pre-4.22: alert is in the MCO status-card on the DR Overview page
+        # Expand Critical alerts section (best-effort)
+        try:
+            critical_alert = acm_obj.find_an_element_by_xpath(
+                acm_loc["critical-alert"][0]
+            ).get_attribute("aria-expanded")
 
-    alert_found = acm_obj.wait_until_expected_text_is_found(
-        locator=alert_locator,
-        expected_text=expected_text,
-        timeout=120,
-    )
+            if critical_alert == "false":
+                critical_alert_elem = wait_for_element_to_be_clickable(
+                    acm_loc["critical-alert"]
+                )
+                acm_obj.driver.execute_script(
+                    "arguments[0].click();", critical_alert_elem
+                )
+                acm_obj.take_screenshot()
+        except (NoSuchElementException, StaleElementReferenceException) as e:
+            log.warning(
+                f"Could not expand Critical alerts section: {e}. "
+                "Proceeding to verify alert presence directly."
+            )
+            acm_obj.take_screenshot()
+
+        if drpc_name:
+            alert_locator = (
+                acm_loc["pending-cleanup-alert-drpc-message"][0].format(
+                    drpc_name, namespace
+                ),
+                acm_loc["pending-cleanup-alert-drpc-message"][1],
+            )
+            expected_text = f"DRPC '{drpc_name}'"
+        else:
+            alert_locator = acm_loc["pending-cleanup-alert"]
+            expected_text = constants.ALERT_APPLICATION_CLEANUP_PENDING
+
+        alert_found = acm_obj.wait_until_expected_text_is_found(
+            locator=alert_locator,
+            expected_text=expected_text,
+            timeout=120,
+        )
 
     if alert_found:
         log.info(
             f"Alert '{constants.ALERT_APPLICATION_CLEANUP_PENDING}' "
-            f"found on DR Dashboard after {operation}"
+            f"found after {operation}"
             + (f" for DRPC '{drpc_name}'" if drpc_name else "")
         )
         acm_obj.take_screenshot()
     else:
         log.error(
             f"Alert '{constants.ALERT_APPLICATION_CLEANUP_PENDING}' "
-            f"NOT found on DR Dashboard after {operation}"
+            f"NOT found after {operation}"
             + (f" for DRPC '{drpc_name}'" if drpc_name else "")
         )
         acm_obj.take_screenshot()
         raise UnexpectedBehaviour(
             f"{constants.ALERT_APPLICATION_CLEANUP_PENDING} alert "
-            f"did not appear on DR Dashboard after {operation}"
+            f"did not appear after {operation}"
             + (f" for DRPC '{drpc_name}'" if drpc_name else "")
         )
 

--- a/ocs_ci/helpers/dr_helpers_ui.py
+++ b/ocs_ci/helpers/dr_helpers_ui.py
@@ -920,18 +920,6 @@ def verify_pending_cleanup_alert_firing(
         # notification drawer (bell icon).  Open it to make the alert elements
         # visible in the DOM, then check with the drawer-anchored locator
         # (overridden in acm_configuration_4_22).
-        log.info(
-            "OCP >= 4.22: opening notification drawer to check for "
-            f"'{constants.ALERT_APPLICATION_CLEANUP_PENDING}' alert"
-        )
-        acm_obj.do_click(
-            acm_loc["notification-drawer-toggle"],
-            avoid_stale=True,
-            enable_screenshot=True,
-        )
-        acm_obj.take_screenshot()
-        acm_obj.copy_dom()
-
         if drpc_name:
             alert_locator = (
                 acm_loc["pending-cleanup-alert-drpc-message"][0].format(
@@ -946,17 +934,49 @@ def verify_pending_cleanup_alert_firing(
             alert_locator = acm_loc["notification-drawer-cleanup-alert-title"]
             expected_text = constants.ALERT_APPLICATION_CLEANUP_PENDING
 
-        alert_found = acm_obj.wait_until_expected_text_is_found(
-            locator=alert_locator,
-            expected_text=expected_text,
-            timeout=120,
-            use_fallback=False,
-        )
-        # Close the drawer regardless of outcome
-        acm_obj.do_click(
-            acm_loc["notification-drawer-toggle"],
-            avoid_stale=True,
-        )
+        def _check_drawer(timeout=30):
+            """Open the notification drawer, screenshot, check the alert, close."""
+            log.info(
+                "OCP >= 4.22: opening notification drawer to check for "
+                f"'{constants.ALERT_APPLICATION_CLEANUP_PENDING}' alert"
+            )
+            acm_obj.do_click(
+                acm_loc["notification-drawer-toggle"],
+                avoid_stale=True,
+            )
+            acm_obj.page_has_loaded()
+            acm_obj.take_screenshot()
+            acm_obj.copy_dom()
+            found = acm_obj.wait_until_expected_text_is_found(
+                locator=alert_locator,
+                expected_text=expected_text,
+                timeout=timeout,
+                use_fallback=False,
+            )
+            acm_obj.take_screenshot()
+            # Close the drawer regardless of outcome
+            acm_obj.do_click(
+                acm_loc["notification-drawer-toggle"],
+                avoid_stale=True,
+            )
+            return found
+
+        # Quick first check — if the alert is already present this costs ~5 s.
+        alert_found = _check_drawer(timeout=30)
+        if not alert_found:
+            log.warning(
+                "Alert not found on first attempt — refreshing page and retrying"
+            )
+            acm_obj.refresh_page()
+            acm_obj.navigate_data_services()
+            acm_obj.do_click(
+                acm_loc["disaster-recovery-overview"],
+                avoid_stale=True,
+                timeout=60,
+            )
+            acm_obj.page_has_loaded()
+            # Full budget on the retry
+            alert_found = _check_drawer(timeout=120)
     else:
         # Pre-4.22: alert is in the MCO status-card on the DR Overview page
         # Expand Critical alerts section (best-effort)

--- a/ocs_ci/helpers/dr_helpers_ui.py
+++ b/ocs_ci/helpers/dr_helpers_ui.py
@@ -1075,50 +1075,111 @@ def verify_pending_cleanup_alert_resolved(
     )
     acm_obj.take_screenshot()
 
-    # Try to expand Critical alerts section if it exists
-    try:
-        critical_alert = acm_obj.find_an_element_by_xpath(
-            acm_loc["critical-alert"][0]
-        ).get_attribute("aria-expanded")
+    # Pre-4.22 only: expand the MCO status-card Critical alerts section.
+    # On 4.22+ there is no such element; alerts are in the notification drawer.
+    if get_semantic_ocp_running_version() < VERSION_4_22:
+        try:
+            critical_alert = acm_obj.find_an_element_by_xpath(
+                acm_loc["critical-alert"][0]
+            ).get_attribute("aria-expanded")
 
-        if critical_alert == "false":
-            critical_alert_elem = wait_for_element_to_be_clickable(
-                acm_loc["critical-alert"]
+            if critical_alert == "false":
+                critical_alert_elem = wait_for_element_to_be_clickable(
+                    acm_loc["critical-alert"]
+                )
+                acm_obj.driver.execute_script(
+                    "arguments[0].click();", critical_alert_elem
+                )
+                acm_obj.take_screenshot()
+        except (NoSuchElementException, StaleElementReferenceException) as e:
+            log.info(
+                f"Critical alerts section not found or not expandable: {e}. "
+                "This may indicate no critical alerts exist (expected)."
             )
-            acm_obj.driver.execute_script("arguments[0].click();", critical_alert_elem)
             acm_obj.take_screenshot()
-    except (NoSuchElementException, StaleElementReferenceException) as e:
-        log.info(
-            f"Critical alerts section not found or not expandable: {e}. "
-            "This may indicate no critical alerts exist (expected)."
-        )
-        acm_obj.take_screenshot()
-    except Exception as e:
-        acm_obj.take_screenshot()
-        raise UnexpectedBehaviour(
-            f"Unable to verify DR Dashboard critical-alert section after {operation} cleanup."
-        ) from e
+        except Exception as e:
+            acm_obj.take_screenshot()
+            raise UnexpectedBehaviour(
+                f"Unable to verify DR Dashboard critical-alert section after {operation} cleanup."
+            ) from e
 
-    # Verify alert is NOT visible - use DRPC-specific locator if drpc_name provided
-    if drpc_name:
-        alert_locator = (
-            acm_loc["pending-cleanup-alert-drpc-message"][0].format(
-                drpc_name, namespace
-            ),
-            acm_loc["pending-cleanup-alert-drpc-message"][1],
-        )
-        expected_text = f"DRPC '{drpc_name}'"
+    if get_semantic_ocp_running_version() >= VERSION_4_22:
+        # On 4.22+ alerts are in the notification drawer — must open it to
+        # check, then close it.  "Resolved" means the alert is NOT found.
+        if drpc_name:
+            alert_locator = (
+                acm_loc["pending-cleanup-alert-drpc-message"][0].format(
+                    drpc_name, namespace
+                ),
+                acm_loc["pending-cleanup-alert-drpc-message"][1],
+            )
+            expected_text = (
+                f"DRPC '{drpc_name}' in namespace '{namespace}' requires manual cleanup"
+            )
+        else:
+            alert_locator = acm_loc["notification-drawer-cleanup-alert-title"]
+            expected_text = constants.ALERT_APPLICATION_CLEANUP_PENDING
+
+        def _check_drawer_resolved(timeout=30):
+            """Open drawer, screenshot+DOM, check alert absent, close drawer."""
+            log.info(
+                "OCP >= 4.22: opening notification drawer to verify "
+                f"'{constants.ALERT_APPLICATION_CLEANUP_PENDING}' alert is cleared"
+            )
+            acm_obj.do_click(
+                acm_loc["notification-drawer-toggle"],
+                avoid_stale=True,
+            )
+            acm_obj.page_has_loaded()
+            acm_obj.take_screenshot()
+            acm_obj.copy_dom()
+            still_present = acm_obj.wait_until_expected_text_is_found(
+                locator=alert_locator,
+                expected_text=expected_text,
+                timeout=timeout,
+                use_fallback=False,
+            )
+            acm_obj.take_screenshot()
+            acm_obj.do_click(
+                acm_loc["notification-drawer-toggle"],
+                avoid_stale=True,
+            )
+            return still_present
+
+        alert_still_present = _check_drawer_resolved(timeout=30)
+        if alert_still_present:
+            log.warning(
+                "Alert still present on first check — refreshing page and retrying"
+            )
+            acm_obj.refresh_page()
+            acm_obj.navigate_data_services()
+            acm_obj.do_click(
+                acm_loc["disaster-recovery-overview"],
+                avoid_stale=True,
+                timeout=60,
+            )
+            acm_obj.page_has_loaded()
+            alert_still_present = _check_drawer_resolved(timeout=60)
     else:
-        alert_locator = acm_loc["pending-cleanup-alert"]
-        expected_text = constants.ALERT_APPLICATION_CLEANUP_PENDING
+        # Pre-4.22: alert is in the MCO status-card; drawer check not needed.
+        if drpc_name:
+            alert_locator = (
+                acm_loc["pending-cleanup-alert-drpc-message"][0].format(
+                    drpc_name, namespace
+                ),
+                acm_loc["pending-cleanup-alert-drpc-message"][1],
+            )
+            expected_text = f"DRPC '{drpc_name}'"
+        else:
+            alert_locator = acm_loc["pending-cleanup-alert"]
+            expected_text = constants.ALERT_APPLICATION_CLEANUP_PENDING
 
-    # use_fallback=False as this is intentional negative check (alert should NOT exist)
-    alert_still_present = acm_obj.wait_until_expected_text_is_found(
-        locator=alert_locator,
-        expected_text=expected_text,
-        timeout=60,
-        use_fallback=False,
-    )
+        alert_still_present = acm_obj.wait_until_expected_text_is_found(
+            locator=alert_locator,
+            expected_text=expected_text,
+            timeout=60,
+            use_fallback=False,
+        )
 
     if alert_still_present:
         log.error(

--- a/ocs_ci/helpers/dr_helpers_ui.py
+++ b/ocs_ci/helpers/dr_helpers_ui.py
@@ -903,9 +903,13 @@ def verify_pending_cleanup_alert_firing(
     )
 
     # If the browser is on a blank page (e.g. after session reset between
-    # iterations) refreshing stays blank. Navigate to ACM first.
+    # iterations) refreshing stays blank. Navigate to ACM console directly.
     if not acm_obj.driver.current_url.startswith("http"):
-        acm_obj.driver.get(get_acm_url())
+        restore_index = config.cur_index
+        config.switch_acm_ctx()
+        acm_url = get_acm_url()
+        config.switch_ctx(restore_index)
+        acm_obj.driver.get(acm_url)
         acm_obj.page_has_loaded()
     else:
         acm_obj.refresh_page()
@@ -1067,7 +1071,11 @@ def verify_pending_cleanup_alert_resolved(
 
     # Navigate to DR Dashboard Overview page
     if not acm_obj.driver.current_url.startswith("http"):
-        acm_obj.driver.get(get_acm_url())
+        restore_index = config.cur_index
+        config.switch_acm_ctx()
+        acm_url = get_acm_url()
+        config.switch_ctx(restore_index)
+        acm_obj.driver.get(acm_url)
         acm_obj.page_has_loaded()
     else:
         acm_obj.refresh_page()

--- a/ocs_ci/helpers/dr_helpers_ui.py
+++ b/ocs_ci/helpers/dr_helpers_ui.py
@@ -902,7 +902,9 @@ def verify_pending_cleanup_alert_firing(
         enable_screenshot=True,
         timeout=60,
     )
+    acm_obj.page_has_loaded()
     acm_obj.take_screenshot()
+    acm_obj.copy_dom()
 
     # Expand Critical alerts section (best-effort)
     try:

--- a/ocs_ci/ocs/acm/acm.py
+++ b/ocs_ci/ocs/acm/acm.py
@@ -849,8 +849,8 @@ def login_to_acm():
     driver = login_ui(url)
     page_nav = AcmPageNavigator()
     page_nav.page_has_loaded(retries=10, sleep_time=5)
-    locator = ["click-local-cluster", "click-admin-dropdown"]
-    expected_text = ["local-cluster", "Administrator"]
+    locator = ["click-local-cluster", "click-admin-dropdown", "click-fleet-management"]
+    expected_text = ["local-cluster", "Administrator", "Core platform"]
     for expected_text, locator in zip(expected_text, locator):
         # use_fallback=False: a timeout here is the expected "not found"
         # outcome for the alternative branch — suppress AI fallback noise.

--- a/ocs_ci/ocs/ui/acm_ui.py
+++ b/ocs_ci/ocs/ui/acm_ui.py
@@ -198,17 +198,17 @@ class AcmPageNavigator(BaseUI):
         )
         if find_element:
             log.info("Data Services page found")
+            # Use the version-aware locator so we don't hard-code the pre-4.22
+            # <button> XPath on platforms where it is a sidebar nav link.
+            ds_xpath, ds_by = self.acm_page_nav["data-services"]
             try:
-                element = self.driver.find_element(
-                    By.XPATH, "//button[normalize-space()='Data Services']"
-                )
+                element = self.driver.find_element(ds_by, ds_xpath)
                 expanded = element.get_attribute("aria-expanded")
             except StaleElementReferenceException:
                 # Page re-rendered between find and get_attribute; re-fetch.
-                element = self.driver.find_element(
-                    By.XPATH, "//button[normalize-space()='Data Services']"
-                )
+                element = self.driver.find_element(ds_by, ds_xpath)
                 expanded = element.get_attribute("aria-expanded")
+            # Nav links in PF v6 have no aria-expanded; treat None as already open.
             if expanded == "false":
                 self.do_click(
                     locator=self.acm_page_nav["data-services"],

--- a/ocs_ci/ocs/ui/acm_ui.py
+++ b/ocs_ci/ocs/ui/acm_ui.py
@@ -198,10 +198,18 @@ class AcmPageNavigator(BaseUI):
         )
         if find_element:
             log.info("Data Services page found")
-            element = self.driver.find_element(
-                By.XPATH, "//button[normalize-space()='Data Services']"
-            )
-            if element.get_attribute("aria-expanded") == "false":
+            try:
+                element = self.driver.find_element(
+                    By.XPATH, "//button[normalize-space()='Data Services']"
+                )
+                expanded = element.get_attribute("aria-expanded")
+            except StaleElementReferenceException:
+                # Page re-rendered between find and get_attribute; re-fetch.
+                element = self.driver.find_element(
+                    By.XPATH, "//button[normalize-space()='Data Services']"
+                )
+                expanded = element.get_attribute("aria-expanded")
+            if expanded == "false":
                 self.do_click(
                     locator=self.acm_page_nav["data-services"],
                     avoid_stale=True,
@@ -246,6 +254,9 @@ class AcmPageNavigator(BaseUI):
         if locator == "click-local-cluster":
             log.info("Select All Clusters view")
             self.do_click(self.acm_page_nav["all-clusters-view"])
+        elif locator == "click-fleet-management":
+            log.info("Select Fleet management (ACM) perspective")
+            self.do_click(self.acm_page_nav["fleet-management-item"])
         else:
             log.info("Select Fleet Management view")
             self.do_click(self.acm_page_nav["fleet-management-view"])

--- a/ocs_ci/ocs/ui/acm_ui.py
+++ b/ocs_ci/ocs/ui/acm_ui.py
@@ -230,6 +230,8 @@ class AcmPageNavigator(BaseUI):
                     "Successfully navigated to Disaster recovery Overview page under 'Data Services' on ACM console"
                 )
         else:
+            self.take_screenshot(name_suffix="data-services-not-found")
+            self.copy_dom(name_suffix="data-services-not-found")
             log.error(
                 "Couldn't navigate to Disaster recovery Overview page under 'Data Services' on ACM console"
             )

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -1880,12 +1880,12 @@ acm_configuration_4_22 = {
     ),
     "data-services": (
         "//*[@data-test-id='acm-perspective-nav']//*[normalize-space()='Data Services'] | "
-        "//nav[contains(@class,'pf-c-nav')]//a[normalize-space()='Data Services']",
+        "//nav[contains(@class,'c-nav')]//a[normalize-space()='Data Services']",
         By.XPATH,
     ),
     "disaster-recovery": (
         "//*[@data-test-id='acm-perspective-nav']//*[normalize-space()='Disaster recovery'] | "
-        "//nav[contains(@class,'pf-c-nav')]//a[normalize-space()='Disaster recovery']",
+        "//nav[contains(@class,'c-nav')]//a[normalize-space()='Disaster recovery']",
         By.XPATH,
     ),
     "perspective-switcher-toggle": (

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -1880,12 +1880,12 @@ acm_configuration_4_22 = {
     ),
     "data-services": (
         "//*[@data-test-id='acm-perspective-nav']//*[normalize-space()='Data Services'] | "
-        "//nav[contains(@class,'pf-v6-c-nav')]//a[normalize-space()='Data Services']",
+        "//nav[contains(@class,'pf-c-nav')]//a[normalize-space()='Data Services']",
         By.XPATH,
     ),
     "disaster-recovery": (
         "//*[@data-test-id='acm-perspective-nav']//*[normalize-space()='Disaster recovery'] | "
-        "//nav[contains(@class,'pf-v6-c-nav')]//a[normalize-space()='Disaster recovery']",
+        "//nav[contains(@class,'pf-c-nav')]//a[normalize-space()='Disaster recovery']",
         By.XPATH,
     ),
     "perspective-switcher-toggle": (

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -1877,6 +1877,16 @@ acm_configuration_4_22 = {
         "//*[@data-test-id='perspective-switcher-toggle']//h2[normalize-space()='Core platform']",
         By.XPATH,
     ),
+    "click-fleet-management": (
+        "//button[@data-test-id='perspective-switcher-toggle']"
+        "//*[normalize-space()='Core platform']",
+        By.XPATH,
+    ),
+    "fleet-management-item": (
+        "//li[@data-test-id='perspective-switcher-menu-option']"
+        "//button[@role='option' and .//h2[normalize-space()='Fleet management']]",
+        By.XPATH,
+    ),
     "click-local-cluster": (
         '//td[@data-label="Name"]//span[text()="local-cluster"]',
         By.XPATH,

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -1866,23 +1866,28 @@ acm_configuration_4_22 = {
         "//button[@data-quickstart-id='qs-masthead-notifications']",
         By.XPATH,
     ),
-    # Override pending-cleanup-alert-drpc-message to anchor the span search
-    # inside the notification drawer's Critical Alerts section.  Same text
-    # pattern as the pre-4.22 locator, just scoped to the drawer so it doesn't
-    # match stale DOM from a previously rendered page.
-    # Use //* (any element) — the drawer renders the message in a <p>, not <span>.
+    # Override pending-cleanup-alert-drpc-message to anchor the search inside
+    # the notification drawer's Critical Alerts group.
+    # DOM structure (PF v6): section > h1 > button >
+    #   div.pf-v6-c-notification-drawer__group-toggle-title "Critical Alerts"
+    # Alert description is in:
+    #   li > div.pf-v6-c-notification-drawer__list-item-description > span.Linkify
     "pending-cleanup-alert-drpc-message": (
-        "//section[.//h2[normalize-space()='Critical Alerts']]"
-        "//*[contains(text(), \"DRPC '{}' in namespace '{}' requires manual cleanup\")]",
+        "//section["
+        ".//div[contains(@class,'notification-drawer__group-toggle-title')"
+        " and normalize-space()='Critical Alerts']]"
+        "//div[contains(@class,'notification-drawer__list-item-description')]"
+        "//span[contains(text(), \"DRPC '{}' in namespace '{}' requires manual cleanup\")]",
         By.XPATH,
     ),
-    # Alert title span for any ApplicationCleanupPending entry in the drawer
+    # Alert title h2 for any ApplicationCleanupPending entry in the drawer
     # (used when no specific drpc_name is provided).
     "notification-drawer-cleanup-alert-title": (
-        "//section[.//h2[normalize-space()='Critical Alerts']]"
-        "//li//h2[normalize-space()='ApplicationCleanupPending'] | "
-        "//section[.//h2[normalize-space()='Critical Alerts']]"
-        "//li//span[normalize-space()='ApplicationCleanupPending']",
+        "//section["
+        ".//div[contains(@class,'notification-drawer__group-toggle-title')"
+        " and normalize-space()='Critical Alerts']]"
+        "//li//h2[contains(@class,'notification-drawer__list-item-header-title')"
+        " and normalize-space()='ApplicationCleanupPending']",
         By.XPATH,
     ),
     "data-services": (

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -1861,6 +1861,29 @@ acm_configuration_4_22 = {
     # OCP 4.22 Fleet Management perspective: nav entries are sidebar links, not
     # collapsible buttons.  Override both keys so navigate_data_services() uses
     # the correct element type instead of the pre-4.22 <button> XPath.
+    # Notification drawer (bell icon in masthead) — alerts moved here in PF v6.
+    "notification-drawer-toggle": (
+        "//button[@data-quickstart-id='qs-masthead-notifications']",
+        By.XPATH,
+    ),
+    # Override pending-cleanup-alert-drpc-message to anchor the span search
+    # inside the notification drawer's Critical Alerts section.  Same text
+    # pattern as the pre-4.22 locator, just scoped to the drawer so it doesn't
+    # match stale DOM from a previously rendered page.
+    "pending-cleanup-alert-drpc-message": (
+        "//section[.//h2[normalize-space()='Critical Alerts']]"
+        "//li//span[contains(text(), \"DRPC '{}' in namespace '{}' requires manual cleanup\")]",
+        By.XPATH,
+    ),
+    # Alert title span for any ApplicationCleanupPending entry in the drawer
+    # (used when no specific drpc_name is provided).
+    "notification-drawer-cleanup-alert-title": (
+        "//section[.//h2[normalize-space()='Critical Alerts']]"
+        "//li//h2[normalize-space()='ApplicationCleanupPending'] | "
+        "//section[.//h2[normalize-space()='Critical Alerts']]"
+        "//li//span[normalize-space()='ApplicationCleanupPending']",
+        By.XPATH,
+    ),
     "data-services": (
         "//*[@data-test-id='acm-perspective-nav']//*[normalize-space()='Data Services'] | "
         "//nav[contains(@class,'pf-v6-c-nav')]//a[normalize-space()='Data Services']",

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -1866,28 +1866,16 @@ acm_configuration_4_22 = {
         "//button[@data-quickstart-id='qs-masthead-notifications']",
         By.XPATH,
     ),
-    # Override pending-cleanup-alert-drpc-message to anchor the search inside
-    # the notification drawer's Critical Alerts group.
-    # DOM structure (PF v6): section > h1 > button >
-    #   div.pf-v6-c-notification-drawer__group-toggle-title "Critical Alerts"
-    # Alert description is in:
-    #   li > div.pf-v6-c-notification-drawer__list-item-description > span.Linkify
+    # Anchor both locators on the ul with aria-label="Notifications in the
+    # critical alerts group" — stable PF v6 accessibility attribute.
     "pending-cleanup-alert-drpc-message": (
-        "//section["
-        ".//div[contains(@class,'notification-drawer__group-toggle-title')"
-        " and normalize-space()='Critical Alerts']]"
-        "//div[contains(@class,'notification-drawer__list-item-description')]"
+        "//ul[@aria-label='Notifications in the critical alerts group']"
         "//span[contains(text(), \"DRPC '{}' in namespace '{}' requires manual cleanup\")]",
         By.XPATH,
     ),
-    # Alert title h2 for any ApplicationCleanupPending entry in the drawer
-    # (used when no specific drpc_name is provided).
     "notification-drawer-cleanup-alert-title": (
-        "//section["
-        ".//div[contains(@class,'notification-drawer__group-toggle-title')"
-        " and normalize-space()='Critical Alerts']]"
-        "//li//h2[contains(@class,'notification-drawer__list-item-header-title')"
-        " and normalize-space()='ApplicationCleanupPending']",
+        "//ul[@aria-label='Notifications in the critical alerts group']"
+        "//h2[normalize-space()='ApplicationCleanupPending']",
         By.XPATH,
     ),
     "data-services": (

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -1858,6 +1858,19 @@ acm_configuration_4_21 = {
 }
 
 acm_configuration_4_22 = {
+    # OCP 4.22 Fleet Management perspective: nav entries are sidebar links, not
+    # collapsible buttons.  Override both keys so navigate_data_services() uses
+    # the correct element type instead of the pre-4.22 <button> XPath.
+    "data-services": (
+        "//*[@data-test-id='acm-perspective-nav']//*[normalize-space()='Data Services'] | "
+        "//nav[contains(@class,'pf-v6-c-nav')]//a[normalize-space()='Data Services']",
+        By.XPATH,
+    ),
+    "disaster-recovery": (
+        "//*[@data-test-id='acm-perspective-nav']//*[normalize-space()='Disaster recovery'] | "
+        "//nav[contains(@class,'pf-v6-c-nav')]//a[normalize-space()='Disaster recovery']",
+        By.XPATH,
+    ),
     "perspective-switcher-toggle": (
         "//*[@data-test-id='perspective-switcher-toggle']",
         By.XPATH,

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -1870,9 +1870,10 @@ acm_configuration_4_22 = {
     # inside the notification drawer's Critical Alerts section.  Same text
     # pattern as the pre-4.22 locator, just scoped to the drawer so it doesn't
     # match stale DOM from a previously rendered page.
+    # Use //* (any element) — the drawer renders the message in a <p>, not <span>.
     "pending-cleanup-alert-drpc-message": (
         "//section[.//h2[normalize-space()='Critical Alerts']]"
-        "//li//span[contains(text(), \"DRPC '{}' in namespace '{}' requires manual cleanup\")]",
+        "//*[contains(text(), \"DRPC '{}' in namespace '{}' requires manual cleanup\")]",
         By.XPATH,
     ),
     # Alert title span for any ApplicationCleanupPending entry in the drawer

--- a/ocs_ci/utility/kubevirt_vm.py
+++ b/ocs_ci/utility/kubevirt_vm.py
@@ -232,8 +232,8 @@ class KubevirtVM(object):
         """
         for vm in vms:
             vm_name = get_vm_name(vm)
-            logger.info(f"Pausing the VM {vm_name}")
-            cmd = f"pause {vm_name}"
+            logger.info(f"UnPausing the VM {vm_name}")
+            cmd = f"unpause {vm_name}"
             self.run_kubevirt_vm_cmd(cmd)
 
         if wait:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ACM navigation across supported OpenShift versions, including Fleet Management and Core platform views.
  * Added recovery for temporary page-element issues when opening Data Services.
  * Corrected virtual machine unpause actions so VMs can return to a running state as expected.
  * Improved Disaster Recovery alert validation, including notification drawer support for newer OpenShift versions.
  * Added more reliable page-load handling and alert detection across supported interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->