### PR TITLE
Identify hostedcluster namespace dynamically

### DIFF
--- a/ocs_ci/deployment/helpers/hypershift_base.py
+++ b/ocs_ci/deployment/helpers/hypershift_base.py
@@ -19,7 +19,6 @@ from ocs_ci.ocs.exceptions import (
     CommandFailed,
     TimeoutExpiredError,
     ClusterNotFoundException,
-    ResourceNotFoundError,
 )
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.resources.pod import wait_for_pods_to_be_in_statuses_concurrently
@@ -70,7 +69,7 @@ def get_hosted_cluster_names():
 
 def get_hosted_cluster_namespace(cluster_name=None):
     """
-    Resolve the namespace that contains the HostedCluster CR.
+    Resolve the namespace that contains the HostedCluster CR. Default value is constants.CLUSTERS_NAMESPACE
 
     Args:
         cluster_name (str): Name of the hosted cluster.
@@ -96,6 +95,8 @@ def get_hosted_cluster_namespace(cluster_name=None):
             return hc_namespace
 
         # Dynamic discovery — find from the list of HostedClusters across all namespaces
+        # If not available, return the default value constants.CLUSTERS_NAMESPACE because there are usages to identify
+        # if a cluster is hostedcluster or not.
         try:
             all_hc = OCP(kind=constants.HOSTED_CLUSTERS).get(all_namespaces=True)
             for item in all_hc.get("items", []):
@@ -107,14 +108,11 @@ def get_hosted_cluster_namespace(cluster_name=None):
                     break
         except CommandFailed as exc:
             logger.warning(
-                f"Could not list HostedClusters to resolve namespace for '{cluster_name}': {exc}"
+                f"Could not list HostedClusters to resolve namespace for '{cluster_name}': {exc}. "
+                f"Use the default value {constants.CLUSTERS_NAMESPACE}"
             )
-    if not hc_namespace:
-        raise ResourceNotFoundError(
-            f"No hostedcluster namespace found for '{cluster_name}'"
-        )
 
-    return hc_namespace
+    return hc_namespace or constants.CLUSTERS_NAMESPACE
 
 
 @catch_exceptions((CommandFailed, TimeoutExpiredError))

--- a/ocs_ci/deployment/helpers/hypershift_base.py
+++ b/ocs_ci/deployment/helpers/hypershift_base.py
@@ -19,6 +19,7 @@ from ocs_ci.ocs.exceptions import (
     CommandFailed,
     TimeoutExpiredError,
     ClusterNotFoundException,
+    ResourceNotFoundError,
 )
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.resources.pod import wait_for_pods_to_be_in_statuses_concurrently
@@ -61,12 +62,59 @@ def get_hosted_cluster_names():
     """
 
     logger.info("Getting HyperShift hosted cluster names")
-    hosted_clusters_obj = OCP(
-        kind=constants.HOSTED_CLUSTERS, namespace=constants.CLUSTERS_NAMESPACE
-    ).get()
+    hosted_clusters_obj = OCP(kind=constants.HOSTED_CLUSTERS).get(all_namespaces=True)
     return [
         cluster.get("metadata").get("name") for cluster in hosted_clusters_obj["items"]
     ]
+
+
+def get_hosted_cluster_namespace(cluster_name=None):
+    """
+    Resolve the namespace that contains the HostedCluster CR.
+
+    Args:
+        cluster_name (str): Name of the hosted cluster.
+
+    Returns:
+        str: Namespace on the management cluster that owns the HostedCluster CR.
+    """
+    cluster_name = cluster_name or config.ENV_DATA.get("cluster_name")
+
+    # Get the hostedcluster namespace if available in config
+    hc_namespace = config.ENV_DATA.get("hostedcluster_namespace")
+    with config.RunWithProviderConfigContextIfAvailable():
+        # Explicit per-cluster config override
+        hc_namespace = (
+            config.ENV_DATA.get("clusters", {})
+            .get(cluster_name, {})
+            .get("hostedcluster_namespace", hc_namespace)
+        )
+        if hc_namespace:
+            logger.debug(
+                f"Using configured hostedcluster_namespace '{hc_namespace}' for '{cluster_name}'"
+            )
+            return hc_namespace
+
+        # Dynamic discovery — find from the list of HostedClusters across all namespaces
+        try:
+            all_hc = OCP(kind=constants.HOSTED_CLUSTERS).get(all_namespaces=True)
+            for item in all_hc.get("items", []):
+                if item.get("metadata", {}).get("name") == cluster_name:
+                    hc_namespace = item["metadata"]["namespace"]
+                    logger.debug(
+                        f"Discovered hostedcluster_namespace '{hc_namespace}' for '{cluster_name}'"
+                    )
+                    break
+        except CommandFailed as exc:
+            logger.warning(
+                f"Could not list HostedClusters to resolve namespace for '{cluster_name}': {exc}"
+            )
+    if not hc_namespace:
+        raise ResourceNotFoundError(
+            f"No hostedcluster namespace found for '{cluster_name}'"
+        )
+
+    return hc_namespace
 
 
 @catch_exceptions((CommandFailed, TimeoutExpiredError))
@@ -249,7 +297,8 @@ def is_hosted_cluster(cluster_name=None):
     except ClusterNotFoundException:
         return False
     ocp_obj = OCP(
-        kind=constants.HOSTED_CLUSTERS, namespace=constants.CLUSTERS_NAMESPACE
+        kind=constants.HOSTED_CLUSTERS,
+        namespace=get_hosted_cluster_namespace(cluster_name),
     )
     return ocp_obj.is_exist(resource_name=cluster_name)
 
@@ -272,7 +321,7 @@ def get_hosted_cluster_type(cluster_name=None):
     config.switch_to_provider()
     ocp_hosted_cluster_obj = OCP(
         kind=constants.HOSTED_CLUSTERS,
-        namespace=constants.CLUSTERS_NAMESPACE,
+        namespace=get_hosted_cluster_namespace(cluster_name),
         resource_name=cluster_name,
     )
     return ocp_hosted_cluster_obj.get()["spec"]["platform"]["type"].lower()
@@ -293,7 +342,7 @@ def get_current_nodepool_size(name):
 
     logger.info(f"Getting existing nodepool of HyperShift hosted cluster {name}")
     with config.RunWithProviderConfigContextIfAvailable():
-        nodepools = OCP(kind="nodepools", namespace=constants.CLUSTERS_NAMESPACE).get()
+        nodepools = OCP(kind="nodepools").get(all_namespaces=True)
     total = sum(
         item.get("status", {}).get("replicas", 0)
         for item in nodepools.get("items", [])
@@ -316,7 +365,7 @@ def get_desired_nodepool_size(name: str):
 
     logger.info(f"Getting desired nodepool of HyperShift hosted cluster {name}")
     with config.RunWithProviderConfigContextIfAvailable():
-        nodepools = OCP(kind="nodepools", namespace=constants.CLUSTERS_NAMESPACE).get()
+        nodepools = OCP(kind="nodepools").get(all_namespaces=True)
     total = sum(
         item.get("spec", {}).get("replicas", 0)
         for item in nodepools.get("items", [])
@@ -384,7 +433,7 @@ def get_hosted_cluster_kubeconfig_name(name: str):
     with config.RunWithProviderConfigContextIfAvailable():
         data = OCP(
             kind=constants.HOSTED_CLUSTERS,
-            namespace=constants.CLUSTERS_NAMESPACE,
+            namespace=get_hosted_cluster_namespace(name),
             resource_name=name,
         ).get()
     return data.get("status", {}).get("kubeconfig", {}).get("name", "")
@@ -1195,7 +1244,7 @@ class HyperShiftBase:
             with config.RunWithProviderConfigContextIfAvailable():
                 data = OCP(
                     kind=constants.HOSTED_CLUSTERS,
-                    namespace=constants.CLUSTERS_NAMESPACE,
+                    namespace=get_hosted_cluster_namespace(name),
                     resource_name=name,
                 ).get()
             history = data.get("status", {}).get("version", {}).get("history", [])
@@ -1270,7 +1319,7 @@ class HyperShiftBase:
                     return True
                 ocp_hc = OCP(
                     kind=constants.HOSTED_CLUSTERS,
-                    namespace=constants.CLUSTERS_NAMESPACE,
+                    namespace=get_hosted_cluster_namespace(name),
                 )
                 hosted = ocp_hc.get(name)
                 existing = hosted.get("spec", {}).get("imageContentSources") or []
@@ -1673,7 +1722,8 @@ def get_hosted_cluster_condition_status(cluster_name, condition_type="Available"
 
     try:
         ocp_hc = OCP(
-            kind=constants.HOSTED_CLUSTERS, namespace=constants.CLUSTERS_NAMESPACE
+            kind=constants.HOSTED_CLUSTERS,
+            namespace=get_hosted_cluster_namespace(cluster_name),
         )
         jsonpath = f'{{.status.conditions[?(@.type=="{condition_type}")].status}}'
 

--- a/ocs_ci/deployment/hub_spoke.py
+++ b/ocs_ci/deployment/hub_spoke.py
@@ -21,6 +21,7 @@ from ocs_ci.deployment.deployment import Deployment
 from ocs_ci.deployment.helpers.hypershift_base import (
     HyperShiftBase,
     get_hosted_cluster_names,
+    get_hosted_cluster_namespace,
     kubeconfig_exists_decorator,
     get_current_nodepool_size,
     get_available_hosted_clusters_to_ocp_ver_dict,
@@ -2079,7 +2080,7 @@ def get_hosted_cluster_version_history(cluster_name: str):
     with config.RunWithProviderConfigContextIfAvailable():
         ocp_hc = OCP(
             kind=constants.HOSTED_CLUSTERS,
-            namespace=constants.CLUSTERS_NAMESPACE,
+            namespace=get_hosted_cluster_namespace(cluster_name),
         )
         hosted = ocp_hc.get(cluster_name)
         history = hosted.get("status", {}).get("version", {}).get("history") or []
@@ -2388,7 +2389,7 @@ class HypershiftHostedOCP(
             with config.RunWithProviderConfigContextIfAvailable():
                 ocp_hc = OCP(
                     kind=constants.HOSTED_CLUSTERS,
-                    namespace=constants.CLUSTERS_NAMESPACE,
+                    namespace=get_hosted_cluster_namespace(self.name),
                 )
                 patch_body = json.dumps({"spec": {"release": {"image": image}}})
                 logger.info(
@@ -2423,7 +2424,7 @@ class HypershiftHostedOCP(
             with config.RunWithProviderConfigContextIfAvailable():
                 ocp_np = OCP(
                     kind="nodepools",
-                    namespace=constants.CLUSTERS_NAMESPACE,
+                    namespace=get_hosted_cluster_namespace(self.name),
                 )
                 patch_body = json.dumps({"spec": {"release": {"image": image}}})
                 logger.info(
@@ -2460,7 +2461,10 @@ class HypershiftHostedOCP(
 
         try:
             with config.RunWithProviderConfigContextIfAvailable():
-                ocp_np = OCP(kind="nodepools", namespace=constants.CLUSTERS_NAMESPACE)
+                ocp_np = OCP(
+                    kind="nodepools",
+                    namespace=get_hosted_cluster_namespace(self.name),
+                )
                 jsonpath = '{.status.conditions[?(@.type=="UpdatingVersion")].status}'
 
                 def _sample():
@@ -5534,7 +5538,7 @@ class HypershiftAWSHostedOCP(SpokeOCP, HyperShiftBase, Deployment, MCEInstaller,
 
         hc_ocp = OCP(
             kind=constants.HOSTED_CLUSTERS,
-            namespace=constants.CLUSTERS_NAMESPACE,
+            namespace=get_hosted_cluster_namespace(self.name),
         )
         if hc_ocp.is_exist(resource_name=self.name):
             logger.warning(
@@ -5566,7 +5570,7 @@ class HypershiftAWSHostedOCP(SpokeOCP, HyperShiftBase, Deployment, MCEInstaller,
 
         np_ocp = OCP(
             kind="nodepools",
-            namespace=constants.CLUSTERS_NAMESPACE,
+            namespace=get_hosted_cluster_namespace(self.name),
         )
         try:
             nodepools = np_ocp.get()

--- a/ocs_ci/ocs/platform_nodes.py
+++ b/ocs_ci/ocs/platform_nodes.py
@@ -55,6 +55,7 @@ from ocs_ci.utility.csr import (
     get_nodes_csr,
     wait_for_all_nodes_csr_and_approve,
 )
+from ocs_ci.deployment.helpers.hypershift_base import get_hosted_cluster_namespace
 from ocs_ci.utility.utils import (
     get_cluster_name,
     get_infra_id,
@@ -3766,11 +3767,8 @@ class HypershiftAWSNode(AWSNodes):
             list: List of NodePool dicts from the API response.
         """
         with config.RunWithProviderConfigContextIfAvailable():
-            nodepool_ocp = ocp.OCP(
-                kind="NodePool",
-                namespace=constants.CLUSTERS_NAMESPACE,
-            )
-            nodepools = nodepool_ocp.get().get("items", [])
+            nodepool_ocp = ocp.OCP(kind="NodePool")
+            nodepools = nodepool_ocp.get(all_namespaces=True).get("items", [])
 
         cluster_nodepools = [
             np
@@ -3835,7 +3833,9 @@ class HypershiftAWSNode(AWSNodes):
         with config.RunWithProviderConfigContextIfAvailable():
             nodepool_ocp = ocp.OCP(
                 kind="NodePool",
-                namespace=constants.CLUSTERS_NAMESPACE,
+                namespace=get_hosted_cluster_namespace(
+                    config.ENV_DATA.get("cluster_name")
+                ),
                 resource_name=np_name,
             )
             np_data = nodepool_ocp.get()
@@ -3878,7 +3878,7 @@ class HypershiftAWSNode(AWSNodes):
         with config.RunWithProviderConfigContextIfAvailable():
             nodepool_ocp = ocp.OCP(
                 kind="NodePool",
-                namespace=constants.CLUSTERS_NAMESPACE,
+                namespace=get_hosted_cluster_namespace(cluster_name),
                 resource_name=np_name,
             )
             patch = {"spec": {"replicas": new_replicas}}

--- a/tests/functional/z_cluster/cluster_expansion/test_nodes_with_hcp.py
+++ b/tests/functional/z_cluster/cluster_expansion/test_nodes_with_hcp.py
@@ -15,6 +15,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     ignore_leftovers,
     runs_on_provider,
 )
+from ocs_ci.deployment.helpers.hypershift_base import get_hosted_cluster_namespace
 from ocs_ci.framework.testlib import ManageTest
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.cluster import CephCluster
@@ -381,7 +382,9 @@ class TestAddNodeToClientCluster(ManageTest):
                     with config.RunWithProviderConfigContextIfAvailable():
                         nodepool_ocp = ocp.OCP(
                             kind="NodePool",
-                            namespace=constants.CLUSTERS_NAMESPACE,
+                            namespace=get_hosted_cluster_namespace(
+                                config.ENV_DATA.get("cluster_name")
+                            ),
                             resource_name=self._np_name,
                         )
                         patch = {"spec": {"replicas": self._initial_replicas}}
@@ -409,7 +412,9 @@ class TestAddNodeToClientCluster(ManageTest):
         with config.RunWithProviderConfigContextIfAvailable():
             nodepool_ocp = ocp.OCP(
                 kind="NodePool",
-                namespace=constants.CLUSTERS_NAMESPACE,
+                namespace=get_hosted_cluster_namespace(
+                    config.ENV_DATA.get("cluster_name")
+                ),
                 resource_name=np_name,
             )
             patch = {"spec": {"replicas": target_replicas}}

--- a/tests/libtest/test_provider_create_hosted_cluster.py
+++ b/tests/libtest/test_provider_create_hosted_cluster.py
@@ -7,6 +7,7 @@ import random
 from ocs_ci.deployment.deployment import validate_acm_hub_install, Deployment
 from ocs_ci.deployment.helpers.hypershift_base import (
     get_hosted_cluster_names,
+    get_hosted_cluster_namespace,
     get_random_hosted_cluster_name,
 )
 from ocs_ci.deployment.hub_spoke import (
@@ -917,7 +918,7 @@ class TestAWSHCPDestroy:
 
         hc_ocp = OCP(
             kind=constants.HOSTED_CLUSTERS,
-            namespace=constants.CLUSTERS_NAMESPACE,
+            namespace=get_hosted_cluster_namespace(cluster_name),
         )
         assert not hc_ocp.is_exist(
             resource_name=cluster_name


### PR DESCRIPTION
The namespace of all the hostedclusters is now expected to be "clusters". This is not always true. The namespace should be identified correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved HostedCluster and NodePool operations for environments where resources are deployed in cluster-specific namespaces.
  - Added automatic namespace discovery when the namespace is not explicitly configured.
  - Updated cluster expansion, upgrades, progress tracking, kubeconfig retrieval, condition checks, and cleanup workflows to target the correct resources.
  - Improved AWS hosted control plane resource discovery across namespaces, reducing failures caused by fixed-namespace assumptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->