### PR TITLE
fix: scale MCP wait timeout dynamically for huge pages on large clusters

### DIFF
--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -6076,17 +6076,41 @@ def enable_huge_pages():
         + config.ENV_DATA["master_replicas"]
         + config.ENV_DATA.get("infra_replicas", 0)
     )
-    timeout = 1200
     if not len(get_nodes(node_type=constants.WORKER_MACHINE)):
+        timeout = _mcp_timeout_for_node_count(num_nodes)
         wait_for_machineconfigpool_status(
             node_type=constants.MASTER_MACHINE, timeout=timeout
         )
     else:
-        if num_nodes >= 6:
-            timeout = 2400
+        timeout = _mcp_timeout_for_node_count(num_nodes)
         wait_for_machineconfigpool_status(
             node_type=constants.WORKER_MACHINE, timeout=timeout
         )
+
+
+def _mcp_timeout_for_node_count(num_nodes):
+    """
+    Return an appropriate MachineConfigPool wait timeout based on cluster size.
+
+    Thresholds:
+        < 6  nodes  ->  1200 s (20 min)
+        6-11 nodes  ->  2400 s (40 min)
+        12-17 nodes ->  3600 s (60 min)
+        >= 18 nodes ->  4440 s (74 min)
+
+    Args:
+        num_nodes (int): Total number of nodes in the cluster.
+
+    Returns:
+        int: Timeout in seconds.
+    """
+    if num_nodes >= 18:
+        return 4440
+    if num_nodes >= 12:
+        return 3600
+    if num_nodes >= 6:
+        return 2400
+    return 1200
 
 
 def disable_huge_pages():
@@ -6098,7 +6122,24 @@ def disable_huge_pages():
     exec_cmd(f"oc delete -f {constants.HUGE_PAGES_TEMPLATE}")
     time.sleep(10)
     log.info("Waiting for machine config to be ready")
-    wait_for_machineconfigpool_status(node_type=constants.WORKER_MACHINE, timeout=1200)
+    # Wait for Master nodes ready state when Compact mode 3M 0W config
+    from ocs_ci.ocs.node import get_nodes
+
+    num_nodes = (
+        config.ENV_DATA["worker_replicas"]
+        + config.ENV_DATA["master_replicas"]
+        + config.ENV_DATA.get("infra_replicas", 0)
+    )
+    if not len(get_nodes(node_type=constants.WORKER_MACHINE)):
+        timeout = _mcp_timeout_for_node_count(num_nodes)
+        wait_for_machineconfigpool_status(
+            node_type=constants.MASTER_MACHINE, timeout=timeout
+        )
+    else:
+        timeout = _mcp_timeout_for_node_count(num_nodes)
+        wait_for_machineconfigpool_status(
+            node_type=constants.WORKER_MACHINE, timeout=timeout
+        )
 
 
 def encode(message):


### PR DESCRIPTION
The disable_huge_pages() function used a hardcoded timeout of 1200s for wait_for_machineconfigpool_status(), causing teardown failures on clusters with >= 6 nodes where MCO rolling updates take significantly longer.

Introduce _mcp_timeout_for_node_count() as a shared helper that maps cluster size to an appropriate timeout, and use it in both enable_huge_pages() and disable_huge_pages():

  < 6  nodes  ->  1200s (20 min)
  6-11 nodes  ->  2400s (40 min)
  12-17 nodes ->  3600s (60 min)
  >= 18 nodes ->  4400s (~73 min)

Fixes: test_hugepages_post_odf_deployment ERROR at teardown where READYMACHINECOUNT was stuck at 5/18 and timed out after 1200s on an 18-node cluster.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of large-page configuration changes across clusters with different node counts.
  * Adjusted wait times based on the total number of configured worker, master, and infrastructure nodes.
  * Updated node-pool selection to better support clusters with and without worker nodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->