### PR TITLE
FDF Config Version Updates

### DIFF
--- a/ocs_ci/framework/conf/fdf_version/fdf-4.18.yaml
+++ b/ocs_ci/framework/conf/fdf_version/fdf-4.18.yaml
@@ -5,5 +5,5 @@ DEPLOYMENT:
   fdf_pre_release_registry: cp.stg.icr.io/cp/df
   fdf_pre_release_image_digest: null
 REPORTING:
-  default_ocs_must_gather_latest_tag: 'latest-4.18'
+  default_ocs_must_gather_latest_tag: 'v4.18'
   default_ocs_must_gather_image: "quay.io/rhceph-dev/odf4-odf-must-gather-rhel9"

--- a/ocs_ci/framework/conf/fdf_version/fdf-4.23.yaml
+++ b/ocs_ci/framework/conf/fdf_version/fdf-4.23.yaml
@@ -1,0 +1,9 @@
+---
+DEPLOYMENT:
+  fdf_pre_release: true
+  fdf_image_tag: v4.23
+  fdf_pre_release_registry: cp.stg.icr.io/cp/df
+  fdf_pre_release_image_digest: null
+REPORTING:
+  default_ocs_must_gather_latest_tag: 'v4.23'
+  default_ocs_must_gather_image: "quay.io/rhceph-dev/odf4-odf-must-gather-rhel9"

--- a/ocs_ci/framework/conf/fdf_version/fdf-5.0.yaml
+++ b/ocs_ci/framework/conf/fdf_version/fdf-5.0.yaml
@@ -1,0 +1,9 @@
+---
+DEPLOYMENT:
+  fdf_pre_release: true
+  fdf_image_tag: v5.0
+  fdf_pre_release_registry: cp.stg.icr.io/cp/df
+  fdf_pre_release_image_digest: null
+REPORTING:
+  default_ocs_must_gather_latest_tag: 'v5.0'
+  default_ocs_must_gather_image: "quay.io/rhceph-dev/odf4-odf-must-gather-rhel9"


### PR DESCRIPTION
* Add FDF 5.0 config
* Add FDF 4.23 config
* Fix FDF 4.18 must gather tag

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deployment configuration support for FDF 4.23 and 5.0 releases.
  * Added reporting defaults for must-gather images and tags in new FDF configurations.

* **Bug Fixes**
  * Updated the FDF 4.18 must-gather default tag to use the correct version format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->