### PR TITLE
Fix test_add_capacity_ui for OCP 4.23 UI changes

### DIFF
--- a/ocs_ci/ocs/ui/add_replace_device_ui.py
+++ b/ocs_ci/ocs/ui/add_replace_device_ui.py
@@ -3,6 +3,7 @@ import time
 
 from ocs_ci.ocs.ui.page_objects.page_navigator import PageNavigator
 from ocs_ci.ocs.ui.views import ODF_OPERATOR
+from ocs_ci.utility import version
 
 
 logger = logging.getLogger(__name__)
@@ -22,13 +23,16 @@ class AddReplaceDeviceUI(PageNavigator):
         Add Capacity via UI
 
         """
-        self.navigate_installed_operators_page()
-        if self.operator_name is ODF_OPERATOR:
-            self.do_click(self.add_capacity_ui_loc["odf_operator"])
-            self.do_click(self.add_capacity_ui_loc["storage_system_tab"])
+        if self.ocp_version_full >= version.VERSION_4_23:
+            self.nav_storage_cluster_default_page()
         else:
-            self.do_click(self.add_capacity_ui_loc["ocs_operator"])
-            self.do_click(self.add_capacity_ui_loc["storage_cluster_tab"])
+            self.navigate_installed_operators_page()
+            if self.operator_name is ODF_OPERATOR:
+                self.do_click(self.add_capacity_ui_loc["odf_operator"])
+                self.do_click(self.add_capacity_ui_loc["storage_system_tab"])
+            else:
+                self.do_click(self.add_capacity_ui_loc["ocs_operator"])
+                self.do_click(self.add_capacity_ui_loc["storage_cluster_tab"])
         time.sleep(1)
         logger.info("Click on kebab menu of Storage Systems")
         self.do_click(self.add_capacity_ui_loc["kebab_storage_cluster"])

--- a/ocs_ci/ocs/ui/add_replace_device_ui.py
+++ b/ocs_ci/ocs/ui/add_replace_device_ui.py
@@ -25,6 +25,7 @@ class AddReplaceDeviceUI(PageNavigator):
         """
         if self.ocp_version_full >= version.VERSION_4_23:
             self.nav_storage_cluster_default_page()
+            kebab_locator = self.attach_storage_loc["storage_cluster_actions"]
         else:
             self.navigate_installed_operators_page()
             if self.operator_name is ODF_OPERATOR:
@@ -33,9 +34,10 @@ class AddReplaceDeviceUI(PageNavigator):
             else:
                 self.do_click(self.add_capacity_ui_loc["ocs_operator"])
                 self.do_click(self.add_capacity_ui_loc["storage_cluster_tab"])
+            kebab_locator = self.add_capacity_ui_loc["kebab_storage_cluster"]
         time.sleep(1)
-        logger.info("Click on kebab menu of Storage Systems")
-        self.do_click(self.add_capacity_ui_loc["kebab_storage_cluster"])
+        logger.info("Click on kebab menu")
+        self.do_click(kebab_locator)
         self.take_screenshot()
         logger.info("Click on Add Capacity button under the kebab menu")
         self.wait_until_expected_text_is_found(

--- a/ocs_ci/ocs/ui/page_objects/page_navigator.py
+++ b/ocs_ci/ocs/ui/page_objects/page_navigator.py
@@ -219,6 +219,13 @@ class PageNavigator(BaseUI):
             avoid_stale=True,
         )
         self.page_has_loaded(retries=25, sleep_time=1)
+        if self.ocp_version_full >= version.VERSION_4_23:
+            logger.info("OCP >=4.23: clicking Operators (OLMv0) tab")
+            self.do_click(
+                self.page_nav["operators_olmv0_tab"],
+                enable_screenshot=True,
+            )
+            self.page_has_loaded(retries=25, sleep_time=1)
         if self.ocp_version_full >= version.VERSION_4_9:
             self.do_click(self.page_nav["drop_down_projects"])
             self.do_click(self.page_nav["choose_all_projects"])

--- a/ocs_ci/ocs/ui/page_objects/page_navigator.py
+++ b/ocs_ci/ocs/ui/page_objects/page_navigator.py
@@ -219,13 +219,6 @@ class PageNavigator(BaseUI):
             avoid_stale=True,
         )
         self.page_has_loaded(retries=25, sleep_time=1)
-        if self.ocp_version_full >= version.VERSION_4_23:
-            logger.info("OCP >=4.23: clicking Operators (OLMv0) tab")
-            self.do_click(
-                self.page_nav["operators_olmv0_tab"],
-                enable_screenshot=True,
-            )
-            self.page_has_loaded(retries=25, sleep_time=1)
         if self.ocp_version_full >= version.VERSION_4_9:
             self.do_click(self.page_nav["drop_down_projects"])
             self.do_click(self.page_nav["choose_all_projects"])

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -972,10 +972,6 @@ page_nav = {
         "//a[text()='Installed Operators'] | //a[text()='Installed Software']",
         By.XPATH,
     ),
-    "operators_olmv0_tab": (
-        'a[data-test="horizontal-link-Operators (OLMv0)"]',
-        By.CSS_SELECTOR,
-    ),
     "Storage": ("//button[text()='Storage']", By.XPATH),
     "persistentvolumes_page": ("PersistentVolumes", By.LINK_TEXT),
     "persistentvolumeclaims_page": ("PersistentVolumeClaims", By.LINK_TEXT),

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -972,9 +972,8 @@ page_nav = {
         By.XPATH,
     ),
     "operators_olmv0_tab": (
-        "//a[contains(text(),'Operators') and contains(text(),'OLMv0')]"
-        " | //button[contains(text(),'Operators') and contains(text(),'OLMv0')]",
-        By.XPATH,
+        'a[data-test="horizontal-link-Operators (OLMv0)"]',
+        By.CSS_SELECTOR,
     ),
     "Storage": ("//button[text()='Storage']", By.XPATH),
     "persistentvolumes_page": ("PersistentVolumes", By.LINK_TEXT),

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -226,7 +226,8 @@ deployment_4_9 = {
         By.CSS_SELECTOR,
     ),
     "storage_system_tab": (
-        'a[data-test-id="horizontal-link-Storage System"]',
+        'a[data-test-id="horizontal-link-Storage System"],'
+        'a[data-test-id="horizontal-link-Storage cluster"]',
         By.CSS_SELECTOR,
     ),
     "internal_mode_odf": ('input[id="bs-existing"]', By.CSS_SELECTOR),
@@ -1977,7 +1978,8 @@ add_capacity = {
         By.CSS_SELECTOR,
     ),
     "storage_system_tab": (
-        'a[data-test-id="horizontal-link-Storage System"]',
+        'a[data-test-id="horizontal-link-Storage System"],'
+        'a[data-test-id="horizontal-link-Storage cluster"]',
         By.CSS_SELECTOR,
     ),
     "kebab_storage_cluster": ("//button[@data-test-id='kebab-button']", By.XPATH),

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -227,7 +227,7 @@ deployment_4_9 = {
     ),
     "storage_system_tab": (
         'a[data-test-id="horizontal-link-Storage System"],'
-        'a[data-test-id="horizontal-link-Storage cluster"]',
+        'a[data-test="nav"][href*="storage-cluster"]',
         By.CSS_SELECTOR,
     ),
     "internal_mode_odf": ('input[id="bs-existing"]', By.CSS_SELECTOR),
@@ -1979,7 +1979,7 @@ add_capacity = {
     ),
     "storage_system_tab": (
         'a[data-test-id="horizontal-link-Storage System"],'
-        'a[data-test-id="horizontal-link-Storage cluster"]',
+        'a[data-test="nav"][href*="storage-cluster"]',
         By.CSS_SELECTOR,
     ),
     "kebab_storage_cluster": ("//button[@data-test-id='kebab-button']", By.XPATH),

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -967,7 +967,15 @@ page_nav = {
     ),
     "operatorhub_page": ("OperatorHub", By.LINK_TEXT),
     "software_catalog": ("Software Catalog", By.LINK_TEXT),
-    "installed_operators_page": ("Installed Operators", By.LINK_TEXT),
+    "installed_operators_page": (
+        "//a[text()='Installed Operators'] | //a[text()='Installed Software']",
+        By.XPATH,
+    ),
+    "operators_olmv0_tab": (
+        "//a[contains(text(),'Operators') and contains(text(),'OLMv0')]"
+        " | //button[contains(text(),'Operators') and contains(text(),'OLMv0')]",
+        By.XPATH,
+    ),
     "Storage": ("//button[text()='Storage']", By.XPATH),
     "persistentvolumes_page": ("PersistentVolumes", By.LINK_TEXT),
     "persistentvolumeclaims_page": ("PersistentVolumeClaims", By.LINK_TEXT),


### PR DESCRIPTION
## Summary
- OCP 4.23 removed the "Storage System" tab from the operator page. For OCP >= 4.23, navigate directly via sidebar (Storage → Storage cluster) using `nav_storage_cluster_default_page()` and the scoped `storage_cluster_actions` kebab locator.
- OCP 4.23 renamed "Installed Operators" to "Installed Software". Updated `installed_operators_page` locator to match both labels via XPath union.
- ~~OCP 4.23 added an "Operators (OLMv0)" sub-tab~~ — **Removed**: verified on OCP 5.0 (ODF 5.0.0-32.stable) that this sub-tab is no longer present. The OLMv0 tab click and `operators_olmv0_tab` locator have been dropped.
- Added `VERSION_4_23` constant in `version.py`.

Fixes: https://github.com/red-hat-storage/ocs-ci/issues/15936

## Files Changed
- `ocs_ci/utility/version.py` — Added `VERSION_4_23` constant
- `ocs_ci/ocs/ui/views.py` — Updated `installed_operators_page` locator to match both "Installed Operators" and "Installed Software", updated `storage_system_tab` CSS selector; removed `operators_olmv0_tab` locator
- `ocs_ci/ocs/ui/page_objects/page_navigator.py` — Removed OLMv0 tab click (tab no longer present in OCP 5.0)
- `ocs_ci/ocs/ui/add_replace_device_ui.py` — Sidebar navigation + scoped kebab locator for OCP >= 4.23

## Test Plan
- [x] Ran `test_add_capacity_internal` on OCP 4.23.0-nightly with ODF 4.23.0-41.stable on IBM Cloud VPC IPI
- [x] Jenkins Build #71549 — 1 Pass, 0 Fail
- [x] All 6 OSDs verified Running, Ceph rebalance completed (HEALTH_OK)
- [x] Verified on OCP 5.0 (ODF 5.0.0-32.stable): "Installed Operators" label is back (no "Installed Software"), "Operators (OLMv0)" sub-tab is absent — XPath union locator and removal of OLMv0 click confirmed correct

Jenkins: https://jenkins-csb-odf-qe-ocs4.dno.corp.redhat.com/job/qe-deploy-ocs-cluster/71549/console

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved storage configuration navigation across supported platform versions.
  - Updated navigation to recognize both “Installed Operators” and “Installed Software” labels.
  - Enhanced storage cluster detection for more reliable access to storage settings.
  - Generalized menu messaging for clearer guidance during device replacement or capacity expansion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->