### PR TITLE
Add PVC Volume Health Annotation Test (RHSTOR-7596)

### DIFF
--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -7803,3 +7803,125 @@ def verify_file_ownership(pod_obj, file_path, expected_uid, expected_gid):
         file_gid == expected_gid
     ), f"File GID {file_gid} != expected {expected_gid} for {file_path}"
     return file_uid, file_gid
+
+
+def assert_pvc_volume_health_event(pvc_obj, reason, event_type, message_substr):
+    """
+    Assert that at least one K8s event matching the given criteria exists
+    for the PVC, with ``source.component == 'CSI-Addons'``.
+
+    Args:
+        pvc_obj: PVC object
+        reason (str): Expected event reason
+            (e.g. 'VolumeConditionHealthy', 'VolumeConditionAbnormal')
+        event_type (str): Expected event type ('Normal' or 'Warning')
+        message_substr (str): Substring expected in the event message
+
+    Returns:
+        list: Matching event dicts (for caller to do additional checks)
+    """
+    from ocs_ci.ocs.ocp import OCP
+
+    event_ocp = OCP(kind="Event", namespace=pvc_obj.namespace)
+    events = event_ocp.get(
+        field_selector=f"involvedObject.name={pvc_obj.name}",
+    )["items"]
+    matching = [
+        e
+        for e in events
+        if e.get("reason") == reason and message_substr in e.get("message", "")
+    ]
+    assert len(matching) >= 1, (
+        f"No {reason} events with '{message_substr}' "
+        f"for PVC {pvc_obj.name}. "
+        f"Events: {[(e.get('reason'), e.get('message')) for e in events]}"
+    )
+    for evt in matching:
+        assert (
+            evt["type"] == event_type
+        ), f"Expected event type '{event_type}', got '{evt['type']}'"
+        source = evt.get("source", {})
+        assert source.get("component") == "CSI-Addons", (
+            f"Expected source.component 'CSI-Addons', "
+            f"got '{source.get('component')}'"
+        )
+    return matching
+
+
+def blocklist_cephfs_client(pvc_obj):
+    """
+    Find the CephFS client for a PVC's subvolume, add it to the
+    Ceph OSD blocklist, and evict it from the active MDS.
+
+    Args:
+        pvc_obj: PVC object (must be CephFS-backed and have a bound PV)
+
+    Returns:
+        tuple: (client_id, client_addr) for use in cleanup
+    """
+    import json as _json
+
+    from ocs_ci.ocs.ocp import OCP
+    from ocs_ci.ocs.resources.pod import get_ceph_tools_pod
+
+    pvc_obj.reload()
+    pv_name = pvc_obj.backed_pv
+    assert pv_name, f"PVC {pvc_obj.name} has no bound PV"
+
+    pv_ocp = OCP(kind="pv", resource_name=pv_name)
+    pv_data = pv_ocp.get()
+    subvolume_path = pv_data["spec"]["csi"]["volumeAttributes"]["subvolumePath"]
+    logger.info(f"Subvolume path: {subvolume_path}")
+
+    toolbox = get_ceph_tools_pod()
+    client_ls_out = toolbox.exec_sh_cmd_on_pod(command="ceph tell mds.0 client ls")
+    clients = _json.loads(client_ls_out)
+
+    client_id = None
+    client_addr = None
+    for c in clients:
+        root = c.get("client_metadata", {}).get("root", "")
+        if subvolume_path in root:
+            client_id = c["id"]
+            client_addr = c["inst"].split(" ")[-1]
+            break
+
+    assert (
+        client_id is not None
+    ), f"No CephFS client found for subvolume {subvolume_path}"
+    logger.info(f"Found client id={client_id}, addr={client_addr}")
+
+    toolbox.exec_sh_cmd_on_pod(command=f"ceph osd blocklist add {client_addr}")
+    logger.info(f"Blocklisted client {client_addr}")
+
+    fs_status_out = toolbox.exec_sh_cmd_on_pod(command="ceph fs status -f json")
+    fs_status = _json.loads(fs_status_out)
+    active_mds = [m["name"] for m in fs_status["mdsmap"] if m["state"] == "active"][0]
+    logger.info(f"Active MDS: {active_mds}")
+
+    try:
+        toolbox.exec_sh_cmd_on_pod(
+            command=f"ceph tell mds.{active_mds} client evict id={client_id}"
+        )
+        logger.info(f"Evicted client id={client_id}")
+    except Exception:
+        logger.warning("Client eviction returned error (may already be disconnected)")
+
+    return client_id, client_addr
+
+
+def remove_cephfs_client_blocklist(client_addr):
+    """
+    Remove a CephFS client address from the Ceph OSD blocklist.
+
+    Args:
+        client_addr (str): Client address previously blocklisted
+    """
+    from ocs_ci.ocs.resources.pod import get_ceph_tools_pod
+
+    try:
+        toolbox = get_ceph_tools_pod()
+        toolbox.exec_sh_cmd_on_pod(command=f"ceph osd blocklist rm {client_addr}")
+        logger.info(f"Removed blocklist for {client_addr}")
+    except Exception:
+        logger.warning(f"Failed to remove blocklist for {client_addr}")

--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -7859,8 +7859,6 @@ def blocklist_cephfs_client(pvc_obj):
     Returns:
         tuple: (client_id, client_addr) for use in cleanup
     """
-    import json as _json
-
     from ocs_ci.ocs.ocp import OCP
     from ocs_ci.ocs.resources.pod import get_ceph_tools_pod
 
@@ -7875,7 +7873,7 @@ def blocklist_cephfs_client(pvc_obj):
 
     toolbox = get_ceph_tools_pod()
     client_ls_out = toolbox.exec_sh_cmd_on_pod(command="ceph tell mds.0 client ls")
-    clients = _json.loads(client_ls_out)
+    clients = json.loads(client_ls_out)
 
     client_id = None
     client_addr = None
@@ -7894,18 +7892,25 @@ def blocklist_cephfs_client(pvc_obj):
     toolbox.exec_sh_cmd_on_pod(command=f"ceph osd blocklist add {client_addr}")
     logger.info(f"Blocklisted client {client_addr}")
 
-    fs_status_out = toolbox.exec_sh_cmd_on_pod(command="ceph fs status -f json")
-    fs_status = _json.loads(fs_status_out)
-    active_mds = [m["name"] for m in fs_status["mdsmap"] if m["state"] == "active"][0]
-    logger.info(f"Active MDS: {active_mds}")
-
     try:
+        fs_status_out = toolbox.exec_sh_cmd_on_pod(command="ceph fs status -f json")
+        fs_status = json.loads(fs_status_out)
+        active_mds = [m["name"] for m in fs_status["mdsmap"] if m["state"] == "active"][
+            0
+        ]
+        logger.info(f"Active MDS: {active_mds}")
+
         toolbox.exec_sh_cmd_on_pod(
             command=f"ceph tell mds.{active_mds} client evict id={client_id}"
         )
         logger.info(f"Evicted client id={client_id}")
     except Exception:
-        logger.warning("Client eviction returned error (may already be disconnected)")
+        logger.warning(
+            f"MDS lookup or client eviction failed after blocklisting "
+            f"{client_addr}. Removing blocklist before re-raising."
+        )
+        remove_cephfs_client_blocklist(client_addr)
+        raise
 
     return client_id, client_addr
 
@@ -7914,14 +7919,23 @@ def remove_cephfs_client_blocklist(client_addr):
     """
     Remove a CephFS client address from the Ceph OSD blocklist.
 
+    Idempotent: logs a warning if the address is not currently
+    blocklisted. Re-raises unexpected errors.
+
     Args:
         client_addr (str): Client address previously blocklisted
     """
+    from ocs_ci.ocs.exceptions import CommandFailed
     from ocs_ci.ocs.resources.pod import get_ceph_tools_pod
 
+    toolbox = get_ceph_tools_pod()
     try:
-        toolbox = get_ceph_tools_pod()
         toolbox.exec_sh_cmd_on_pod(command=f"ceph osd blocklist rm {client_addr}")
         logger.info(f"Removed blocklist for {client_addr}")
-    except Exception:
-        logger.warning(f"Failed to remove blocklist for {client_addr}")
+    except CommandFailed as ex:
+        if "isn't blocklisted" in str(ex) or "not blocklisted" in str(ex):
+            logger.warning(
+                f"{client_addr} is not currently blocklisted, " f"nothing to remove"
+            )
+        else:
+            raise

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -330,6 +330,7 @@ ENCRYPTIONKEYROTATIONCRONJOB = "encryptionkeyrotationcronjobs.csiaddons.openshif
 ENCRYPTIONKEYROTATIONJOB = "encryptionkeyrotationjobs.csiaddons.openshift.io"
 RECLAIMSPACE_SCHEDULE_ANNOTATION = "reclaimspace.csiaddons.openshift.io/schedule"
 KEYROTATION_SCHEDULE_ANNOTATION = "keyrotation.csiaddons.openshift.io/schedule"
+VOLUME_HEALTH_ANNOTATION_PREFIX = "csiaddons.openshift.io/volumehealth."
 DEFAULT_CEPH_DEVICECLASS = "defaultCephDeviceClass"
 CRD_KIND = "CustomResourceDefinition"
 # ClientProfileSpec defines the desired state of Ceph CSI

--- a/ocs_ci/ocs/resources/csi_addons.py
+++ b/ocs_ci/ocs/resources/csi_addons.py
@@ -247,24 +247,27 @@ def get_csi_addon_pod_on_node(node_name, driver):
     Raises:
         AssertionError: If no matching pod is found.
     """
-    label = (
-        constants.CSI_CEPHFS_ADDON_NODEPLUGIN_LABEL_420
-        if driver == "cephfs"
-        else constants.CSI_RBD_ADDON_NODEPLUGIN_LABEL_420
-    )
+    _DRIVER_LABELS = {
+        "cephfs": constants.CSI_CEPHFS_ADDON_NODEPLUGIN_LABEL_420,
+        "rbd": constants.CSI_RBD_ADDON_NODEPLUGIN_LABEL_420,
+    }
+    try:
+        label = _DRIVER_LABELS[driver]
+    except KeyError as exc:
+        raise ValueError(f"Unsupported CSI driver: {driver!r}") from exc
+
     namespace = config.ENV_DATA.get("cluster_namespace", "openshift-storage")
     pod_ocp = OCP(kind="pod", namespace=namespace)
     pods = pod_ocp.get(
         selector=label,
-        field_selector=f"spec.nodeName={node_name}",
+        field_selector=f"spec.nodeName={node_name},status.phase=Running",
     )["items"]
-    logger.assertion(
-        f"csi-addons pod with label {label} " f"exists on node {node_name}"
-    )
-    assert pods, f"No csi-addons pod with label {label} " f"found on node {node_name}"
+    pods = [p for p in pods if not p.get("metadata", {}).get("deletionTimestamp")]
+    logger.assertion(f"csi-addons pod with label {label} exists on node {node_name}")
+    assert pods, f"No csi-addons pod with label {label} found on node {node_name}"
     pod_name = pods[0]["metadata"]["name"]
     logger.info(
-        "Found csi-addons pod '%s' on node '%s' " "(driver=%s)",
+        "Found csi-addons pod '%s' on node '%s' (driver=%s)",
         pod_name,
         node_name,
         driver,

--- a/ocs_ci/ocs/resources/csi_addons.py
+++ b/ocs_ci/ocs/resources/csi_addons.py
@@ -246,6 +246,7 @@ def get_csi_addon_pod_on_node(node_name, driver):
 
     Raises:
         AssertionError: If no matching pod is found.
+        ValueError: If `driver` is not "cephfs" or "rbd".
     """
     _DRIVER_LABELS = {
         "cephfs": constants.CSI_CEPHFS_ADDON_NODEPLUGIN_LABEL_420,

--- a/ocs_ci/ocs/resources/csi_addons.py
+++ b/ocs_ci/ocs/resources/csi_addons.py
@@ -231,3 +231,42 @@ def get_csi_addons_config_value(key: str, default: str = "") -> str:
             default,
         )
         return default
+
+
+def get_csi_addon_pod_on_node(node_name, driver):
+    """
+    Find the csi-addons sidecar pod running on a specific node.
+
+    Args:
+        node_name (str): Name of the worker node.
+        driver (str): CSI driver type — 'cephfs' or 'rbd'.
+
+    Returns:
+        str: Pod name of the csi-addons sidecar on that node.
+
+    Raises:
+        AssertionError: If no matching pod is found.
+    """
+    label = (
+        constants.CSI_CEPHFS_ADDON_NODEPLUGIN_LABEL_420
+        if driver == "cephfs"
+        else constants.CSI_RBD_ADDON_NODEPLUGIN_LABEL_420
+    )
+    namespace = config.ENV_DATA.get("cluster_namespace", "openshift-storage")
+    pod_ocp = OCP(kind="pod", namespace=namespace)
+    pods = pod_ocp.get(
+        selector=label,
+        field_selector=f"spec.nodeName={node_name}",
+    )["items"]
+    logger.assertion(
+        f"csi-addons pod with label {label} " f"exists on node {node_name}"
+    )
+    assert pods, f"No csi-addons pod with label {label} " f"found on node {node_name}"
+    pod_name = pods[0]["metadata"]["name"]
+    logger.info(
+        "Found csi-addons pod '%s' on node '%s' " "(driver=%s)",
+        pod_name,
+        node_name,
+        driver,
+    )
+    return pod_name

--- a/ocs_ci/ocs/resources/pvc.py
+++ b/ocs_ci/ocs/resources/pvc.py
@@ -182,6 +182,21 @@ class PVC(OCS):
         """
         return self.backed_pv_obj.get()["spec"]["csi"]["volumeHandle"]
 
+    def get_volume_health_annotations(self):
+        """
+        Get all volumehealth annotations from this PVC.
+
+        Returns:
+            dict: Annotation key-value pairs whose keys start
+                with VOLUME_HEALTH_ANNOTATION_PREFIX.
+        """
+        annotations = self.get().get("metadata", {}).get("annotations", {})
+        return {
+            k: v
+            for k, v in annotations.items()
+            if k.startswith(constants.VOLUME_HEALTH_ANNOTATION_PREFIX)
+        }
+
     def resize_pvc(self, new_size, verify=False, timeout=240):
         """
         Modify the capacity of PVC

--- a/ocs_ci/ocs/resources/pvc.py
+++ b/ocs_ci/ocs/resources/pvc.py
@@ -4,6 +4,8 @@ General PVC object
 
 import logging
 import time
+import json
+import pytest
 from concurrent.futures import ThreadPoolExecutor
 from uuid import uuid4
 
@@ -196,6 +198,60 @@ class PVC(OCS):
             for k, v in annotations.items()
             if k.startswith(constants.VOLUME_HEALTH_ANNOTATION_PREFIX)
         }
+
+    def wait_for_volume_health_state(
+        self, expected_state, timeout=180, interval=15, expected_count=1
+    ):
+        """
+        Poll until at least ``expected_count`` volumehealth annotations
+        report ``expected_state``.
+
+        Args:
+            expected_state (str): Target state ('healthy' or 'unhealthy')
+            timeout (int): Seconds to wait before failing
+            interval (int): Seconds between polls
+            expected_count (int): Minimum annotations that must match
+
+        Returns:
+            dict: The volumehealth annotations at the time the condition
+                was met
+
+        Raises:
+            pytest.fail: If the condition is not met within the timeout
+        """
+
+        health_annotations = {}
+        try:
+            for sample in TimeoutSampler(
+                timeout=timeout,
+                sleep=interval,
+                func=self.get_volume_health_annotations,
+            ):
+                health_annotations = sample
+                if health_annotations:
+                    matching = sum(
+                        1
+                        for v in health_annotations.values()
+                        if json.loads(v).get("state") == expected_state
+                    )
+                    if matching >= expected_count:
+                        log.info(
+                            f"Found {matching} annotation(s) with "
+                            f"state='{expected_state}' on PVC {self.name}"
+                        )
+                        return health_annotations
+                log.debug(
+                    f"Waiting for {expected_count} annotation(s) with "
+                    f"state='{expected_state}' on PVC {self.name}"
+                )
+        except TimeoutExpiredError:
+            all_annots = self.get().get("metadata", {}).get("annotations", {})
+            pytest.fail(
+                f"Expected {expected_count} annotation(s) with "
+                f"state='{expected_state}' on PVC {self.name} "
+                f"within {timeout}s. Annotations: {all_annots}"
+            )
+        return health_annotations
 
     def resize_pvc(self, new_size, verify=False, timeout=240):
         """

--- a/ocs_ci/ocs/resources/pvc.py
+++ b/ocs_ci/ocs/resources/pvc.py
@@ -5,7 +5,6 @@ General PVC object
 import logging
 import time
 import json
-import pytest
 from concurrent.futures import ThreadPoolExecutor
 from uuid import uuid4
 
@@ -217,7 +216,7 @@ class PVC(OCS):
                 was met
 
         Raises:
-            pytest.fail: If the condition is not met within the timeout
+            TimeoutExpiredError: If the condition is not met within the timeout
         """
 
         health_annotations = {}
@@ -246,7 +245,7 @@ class PVC(OCS):
                 )
         except TimeoutExpiredError:
             all_annots = self.get().get("metadata", {}).get("annotations", {})
-            pytest.fail(
+            raise TimeoutExpiredError(
                 f"Expected {expected_count} annotation(s) with "
                 f"state='{expected_state}' on PVC {self.name} "
                 f"within {timeout}s. Annotations: {all_annots}"

--- a/test_pvc_volume_health_annotation.py
+++ b/test_pvc_volume_health_annotation.py
@@ -1,0 +1,281 @@
+"""
+Tests for PVC volume health annotation feature (RHSTOR-7596).
+"""
+
+import json
+import logging
+import time
+from datetime import datetime
+
+import pytest
+
+from ocs_ci.framework.pytest_customization.marks import (
+    green_squad,
+    skipif_ocs_version,
+)
+from ocs_ci.framework.testlib import ManageTest, tier1
+from ocs_ci.framework import config
+from ocs_ci.ocs import constants, ocp, node
+from ocs_ci.ocs.exceptions import TimeoutExpiredError
+from ocs_ci.ocs.resources import pod
+from ocs_ci.ocs.resources.csi_addons import (
+    get_csi_addon_pod_on_node,
+)
+from ocs_ci.utility.utils import ceph_health_check, TimeoutSampler
+
+logger = logging.getLogger(__name__)
+
+ANNOTATION_POLL_TIMEOUT = 180
+ANNOTATION_POLL_INTERVAL = 15
+REPORTER_TICK_WAIT = 60
+
+
+@tier1
+@green_squad
+@skipif_ocs_version("<4.22")
+@pytest.mark.parametrize(
+    argnames=["interface"],
+    argvalues=[
+        pytest.param(
+            constants.CEPHFILESYSTEM,
+            marks=pytest.mark.polarion_id("OCS-XXXX"),
+        ),
+        pytest.param(
+            constants.CEPHBLOCKPOOL,
+            marks=pytest.mark.polarion_id("OCS-XXXX"),
+        ),
+    ],
+)
+class TestPVCVolumeHealthAnnotation(ManageTest):
+    """
+    Test PVC volume health annotations written by CSI-Addons
+    sidecars for both CephFS and RBD storage interfaces.
+    """
+
+    def test_pvc_healthy_annotation(self, interface, pvc_factory, pod_factory):
+        """
+        Verify healthy volumehealth annotations on a PVC.
+
+        CephFS: RWX PVC with 2 pods on different nodes.
+        RBD: RWO PVC (Filesystem volumeMode) with 1 pod.
+
+        Steps:
+            1. Verify Ceph health is HEALTH_OK.
+            2. Create PVC (5Gi), wait for Bound.
+            3. Create pod(s) mounting the PVC.
+            4. Run FIO I/O (fs, 512M) on all pods.
+            5. Wait for reporter tick (~60s).
+            6. Poll and assert volumehealth annotation count.
+            7. Validate JSON and node UID match.
+            8. Assert VolumeConditionHealthy K8s event.
+            9. Verify PV name in csi-addons sidecar logs.
+        """
+        ns = config.ENV_DATA["cluster_namespace"]
+
+        if interface == constants.CEPHFILESYSTEM:
+            access_mode = constants.ACCESS_MODE_RWX
+            expected_count = 2
+            driver = "cephfs"
+        else:
+            access_mode = constants.ACCESS_MODE_RWO
+            expected_count = 1
+            driver = "rbd"
+        logger.info("Step 1: Verify Ceph health is HEALTH_OK")
+        ceph_health_check(tries=3, delay=10)
+        logger.info(f"Step 2: Create {driver.upper()} PVC " f"({access_mode}, 5Gi)")
+        pvc_obj = pvc_factory(
+            interface=interface,
+            size=5,
+            access_mode=access_mode,
+        )
+        logger.info(f"PVC {pvc_obj.name} created and Bound")
+        pod_objs = []
+        if interface == constants.CEPHFILESYSTEM:
+            logger.info("Step 3: Create 2 pods on different nodes")
+            worker_nodes = node.get_worker_nodes()
+            assert len(worker_nodes) >= 2, (
+                f"Need >= 2 worker nodes, " f"found {len(worker_nodes)}"
+            )
+            for i in range(2):
+                p = pod_factory(
+                    pvc=pvc_obj,
+                    interface=interface,
+                    node_name=worker_nodes[i],
+                )
+                pod_objs.append(p)
+            node1 = pod_objs[0].get()["spec"]["nodeName"]
+            node2 = pod_objs[1].get()["spec"]["nodeName"]
+            logger.info(
+                f"Pod {pod_objs[0].name} on {node1}, "
+                f"Pod {pod_objs[1].name} on {node2}"
+            )
+            assert node1 != node2, f"Both pods on same node: {node1}"
+        else:
+            logger.info("Step 3: Create 1 pod mounting the PVC")
+            p = pod_factory(
+                pvc=pvc_obj,
+                interface=interface,
+            )
+            pod_objs.append(p)
+            pod_node = p.get()["spec"]["nodeName"]
+            logger.info(f"Pod {p.name} on {pod_node}")
+        logger.info("Step 4: Run FIO I/O on all pods")
+        for p in pod_objs:
+            p.run_io(
+                storage_type="fs",
+                size="512M",
+                fio_filename=p.name,
+            )
+        for p in pod_objs:
+            pod.get_fio_rw_iops(p)
+        logger.info("FIO I/O completed")
+        logger.info(f"Step 5: Wait {REPORTER_TICK_WAIT}s " f"for reporter tick")
+        time.sleep(REPORTER_TICK_WAIT)
+        logger.info(
+            f"Step 6: Poll for {expected_count} "
+            f"volumehealth annotation(s) "
+            f"(timeout={ANNOTATION_POLL_TIMEOUT}s)"
+        )
+        health_annotations = {}
+        try:
+            for sample in TimeoutSampler(
+                timeout=ANNOTATION_POLL_TIMEOUT,
+                sleep=ANNOTATION_POLL_INTERVAL,
+                func=pvc_obj.get_volume_health_annotations,
+            ):
+                health_annotations = sample
+                if len(health_annotations) >= expected_count:
+                    logger.info(
+                        f"Found {len(health_annotations)} "
+                        f"volumehealth annotation(s)"
+                    )
+                    break
+                logger.debug(
+                    f"Found {len(health_annotations)}/" f"{expected_count}, waiting"
+                )
+        except TimeoutExpiredError:
+            all_annots = pvc_obj.get().get("metadata", {}).get("annotations", {})
+            logger.error(f"PVC annotations at timeout: " f"{all_annots}")
+            pytest.fail(
+                f"Expected {expected_count} volumehealth "
+                f"annotation(s) on PVC {pvc_obj.name}, "
+                f"found {len(health_annotations)} "
+                f"within {ANNOTATION_POLL_TIMEOUT}s"
+            )
+        logger.assertion(
+            f"Exactly {expected_count} volumehealth " f"annotation(s) present"
+        )
+        assert len(health_annotations) == expected_count, (
+            f"Expected {expected_count}, " f"found {len(health_annotations)}"
+        )
+        pod_node_names = [p.get()["spec"]["nodeName"] for p in pod_objs]
+        expected_node_uids = set()
+        for node_name in pod_node_names:
+            node_ocp = ocp.OCP(kind="node", resource_name=node_name)
+            uid = node_ocp.get()["metadata"]["uid"]
+            expected_node_uids.add(uid)
+            expected_key = f"{constants.VOLUME_HEALTH_ANNOTATION_PREFIX}" f"{uid}"
+            logger.assertion(
+                f"Annotation key for node {node_name} " f"(uid={uid}) exists"
+            )
+            assert expected_key in health_annotations, (
+                f"Missing key {expected_key}. "
+                f"Found: "
+                f"{list(health_annotations.keys())}"
+            )
+        logger.info("Step 7: Validate annotation JSON content")
+        for key, value in health_annotations.items():
+            parsed = json.loads(value)
+            logger.info(f"Annotation {key}: {parsed}")
+            logger.assertion(f"state is 'healthy', " f"got '{parsed.get('state')}'")
+            assert parsed.get("state") == "healthy", (
+                f"Expected 'healthy', " f"got '{parsed.get('state')}'"
+            )
+            last_checked = parsed.get("lastChecked", "")
+            logger.assertion(f"lastChecked is valid RFC3339: " f"{last_checked}")
+            dt_last = datetime.fromisoformat(last_checked.replace("Z", "+00:00"))
+            assert dt_last.tzinfo is not None, (
+                f"lastChecked missing timezone: " f"{last_checked}"
+            )
+            since = parsed.get("since", "")
+            logger.assertion(f"since is valid RFC3339: {since}")
+            dt_since = datetime.fromisoformat(since.replace("Z", "+00:00"))
+            assert dt_since.tzinfo is not None, f"since missing timezone: {since}"
+            ann_node = parsed.get("node", "")
+            logger.assertion(f"node field present: {ann_node}")
+            assert ann_node, "node field is missing or empty"
+            key_suffix = key.replace(
+                constants.VOLUME_HEALTH_ANNOTATION_PREFIX,
+                "",
+            )
+            logger.assertion(f"Key suffix {key_suffix} matches " f"a pod's node UID")
+            assert key_suffix in expected_node_uids, (
+                f"Key suffix {key_suffix} not in "
+                f"expected UIDs: {expected_node_uids}"
+            )
+        logger.info(
+            f"Step 8: Check VolumeConditionHealthy " f"events for PVC {pvc_obj.name}"
+        )
+        pvc_ns = pvc_obj.namespace
+        event_ocp = ocp.OCP(kind="Event", namespace=pvc_ns)
+        events = event_ocp.get(
+            field_selector=(f"involvedObject.name={pvc_obj.name}"),
+        )["items"]
+        health_events = [
+            e
+            for e in events
+            if e.get("reason") == "VolumeConditionHealthy"
+            and "volume is in a healthy condition" in e.get("message", "")
+        ]
+        logger.assertion(
+            "At least 1 VolumeConditionHealthy event " "with healthy message"
+        )
+        assert len(health_events) >= 1, (
+            f"No VolumeConditionHealthy events with "
+            f"healthy message for PVC {pvc_obj.name}. "
+            f"Event messages: "
+            f"{[(e.get('reason'), e.get('message')) for e in events]}"
+        )
+        for evt in health_events:
+            logger.info(
+                f"Event: reason={evt.get('reason')}, "
+                f"type={evt.get('type')}, "
+                f"message={evt.get('message')}"
+            )
+            logger.assertion("Event type is 'Normal'")
+            assert evt["type"] == "Normal", (
+                f"Expected 'Normal', " f"got '{evt['type']}'"
+            )
+            source = evt.get("source", {})
+            logger.assertion("source.component is 'CSI-Addons'")
+            assert source.get("component") == "CSI-Addons", (
+                f"Expected 'CSI-Addons', " f"got '{source.get('component')}'"
+            )
+            event_host = source.get("host", "")
+            logger.assertion(f"source.host '{event_host}' " f"matches a pod node")
+            assert event_host in pod_node_names, (
+                f"source.host '{event_host}' not in " f"pod nodes: {pod_node_names}"
+            )
+        logger.info("Step 8b: Verify event in 'oc describe pvc'")
+        describe_output = pvc_obj.describe()
+        logger.assertion("VolumeConditionHealthy in describe output")
+        assert "VolumeConditionHealthy" in describe_output, (
+            "VolumeConditionHealthy not in " "'oc describe pvc' output"
+        )
+        logger.info("Step 9: Check csi-addons sidecar logs")
+        pvc_obj.reload()
+        pv_name = pvc_obj.backed_pv
+        assert pv_name, f"PVC {pvc_obj.name} has no backed PV"
+        for node_name in pod_node_names:
+            addon_pod = get_csi_addon_pod_on_node(node_name, driver)
+            log_output = pod.get_pod_logs(
+                pod_name=addon_pod,
+                container="csi-addons",
+                namespace=ns,
+                tail=200,
+            )
+            logger.assertion(f"PV {pv_name} in csi-addons logs " f"on node {node_name}")
+            assert pv_name in log_output, (
+                f"PV '{pv_name}' not in logs of " f"{addon_pod} on {node_name}"
+            )
+        logger.info(f"{driver.upper()} PVC volume health " f"annotation test passed")

--- a/tests/functional/pv/pv_services/test_pvc_volume_health_annotation.py
+++ b/tests/functional/pv/pv_services/test_pvc_volume_health_annotation.py
@@ -12,6 +12,7 @@ import pytest
 from ocs_ci.framework.pytest_customization.marks import (
     green_squad,
     skipif_ocs_version,
+    jira,
 )
 from ocs_ci.framework.testlib import ManageTest, tier1
 from ocs_ci.framework import config
@@ -33,6 +34,7 @@ REPORTER_TICK_WAIT = 60
 @tier1
 @green_squad
 @skipif_ocs_version("<4.22")
+@jira("DFBUGS-9421", run=False)
 @pytest.mark.parametrize(
     argnames=["interface"],
     argvalues=[

--- a/tests/functional/pv/pv_services/test_pvc_volume_health_annotation.py
+++ b/tests/functional/pv/pv_services/test_pvc_volume_health_annotation.py
@@ -341,7 +341,6 @@ class TestPVCVolumeHealthUnhealthy(ManageTest):
         pod_obj.delete()
         pod_obj.ocp.wait_for_delete(pod_obj.name)
         logger.info(f"Deleted pod {pod_obj.name}")
-        pod_obj.delete = lambda **kwargs: None
 
         logger.info("Recreating pod for fresh CephFS mount")
         new_pod = pod_factory(

--- a/tests/functional/pv/pv_services/test_pvc_volume_health_annotation.py
+++ b/tests/functional/pv/pv_services/test_pvc_volume_health_annotation.py
@@ -38,11 +38,11 @@ REPORTER_TICK_WAIT = 60
     argvalues=[
         pytest.param(
             constants.CEPHFILESYSTEM,
-            marks=pytest.mark.polarion_id("OCS-XXXX"),
+            marks=pytest.mark.polarion_id("OCS-8219"),
         ),
         pytest.param(
             constants.CEPHBLOCKPOOL,
-            marks=pytest.mark.polarion_id("OCS-XXXX"),
+            marks=pytest.mark.polarion_id("OCS-8220"),
         ),
     ],
 )

--- a/tests/functional/pv/pv_services/test_pvc_volume_health_annotation.py
+++ b/tests/functional/pv/pv_services/test_pvc_volume_health_annotation.py
@@ -240,6 +240,7 @@ class TestPVCVolumeHealthAnnotation(ManageTest):
 @tier1
 @green_squad
 @skipif_ocs_version("<4.23")
+@jira("DFBUGS-9421", run=False)
 class TestPVCVolumeHealthUnhealthy(ManageTest):
     """
     Test PVC volume health annotation transitions to unhealthy state

--- a/tests/functional/pv/pv_services/test_pvc_volume_health_annotation.py
+++ b/tests/functional/pv/pv_services/test_pvc_volume_health_annotation.py
@@ -16,19 +16,25 @@ from ocs_ci.framework.pytest_customization.marks import (
 )
 from ocs_ci.framework.testlib import ManageTest, tier1
 from ocs_ci.framework import config
+from ocs_ci.helpers.helpers import (
+    assert_pvc_volume_health_event,
+    blocklist_cephfs_client,
+    remove_cephfs_client_blocklist,
+)
 from ocs_ci.ocs import constants, ocp, node
-from ocs_ci.ocs.exceptions import TimeoutExpiredError
 from ocs_ci.ocs.resources import pod
 from ocs_ci.ocs.resources.csi_addons import (
     get_csi_addon_pod_on_node,
 )
-from ocs_ci.utility.utils import ceph_health_check, TimeoutSampler
+from ocs_ci.utility.utils import ceph_health_check
 
 logger = logging.getLogger(__name__)
 
 ANNOTATION_POLL_TIMEOUT = 180
 ANNOTATION_POLL_INTERVAL = 15
 REPORTER_TICK_WAIT = 60
+UNHEALTHY_POLL_TIMEOUT = 300
+RECOVERY_POLL_TIMEOUT = 300
 
 
 @tier1
@@ -82,9 +88,9 @@ class TestPVCVolumeHealthAnnotation(ManageTest):
             access_mode = constants.ACCESS_MODE_RWO
             expected_count = 1
             driver = "rbd"
-        logger.info("Step 1: Verify Ceph health is HEALTH_OK")
+        logger.test_step("Verify Ceph health is HEALTH_OK")
         ceph_health_check(tries=3, delay=10)
-        logger.info(f"Step 2: Create {driver.upper()} PVC " f"({access_mode}, 5Gi)")
+        logger.test_step(f"Create {driver.upper()} PVC ({access_mode}, 5Gi)")
         pvc_obj = pvc_factory(
             interface=interface,
             size=5,
@@ -93,11 +99,14 @@ class TestPVCVolumeHealthAnnotation(ManageTest):
         logger.info(f"PVC {pvc_obj.name} created and Bound")
         pod_objs = []
         if interface == constants.CEPHFILESYSTEM:
-            logger.info("Step 3: Create 2 pods on different nodes")
+            logger.test_step("Create 2 pods on different nodes")
             worker_nodes = node.get_worker_nodes()
-            assert len(worker_nodes) >= 2, (
-                f"Need >= 2 worker nodes, " f"found {len(worker_nodes)}"
+            logger.assertion(
+                f"Worker node count: expected >= 2, actual={len(worker_nodes)}"
             )
+            assert (
+                len(worker_nodes) >= 2
+            ), f"Need >= 2 worker nodes, found {len(worker_nodes)}"
             for i in range(2):
                 p = pod_factory(
                     pvc=pvc_obj,
@@ -111,9 +120,10 @@ class TestPVCVolumeHealthAnnotation(ManageTest):
                 f"Pod {pod_objs[0].name} on {node1}, "
                 f"Pod {pod_objs[1].name} on {node2}"
             )
+            logger.assertion(f"Pods on different nodes: {node1} != {node2}")
             assert node1 != node2, f"Both pods on same node: {node1}"
         else:
-            logger.info("Step 3: Create 1 pod mounting the PVC")
+            logger.test_step("Create 1 pod mounting the PVC")
             p = pod_factory(
                 pvc=pvc_obj,
                 interface=interface,
@@ -121,7 +131,7 @@ class TestPVCVolumeHealthAnnotation(ManageTest):
             pod_objs.append(p)
             pod_node = p.get()["spec"]["nodeName"]
             logger.info(f"Pod {p.name} on {pod_node}")
-        logger.info("Step 4: Run FIO I/O on all pods")
+        logger.test_step("Run FIO I/O on all pods")
         for p in pod_objs:
             p.run_io(
                 storage_type="fs",
@@ -131,74 +141,47 @@ class TestPVCVolumeHealthAnnotation(ManageTest):
         for p in pod_objs:
             pod.get_fio_rw_iops(p)
         logger.info("FIO I/O completed")
-        logger.info(f"Step 5: Wait {REPORTER_TICK_WAIT}s " f"for reporter tick")
+        logger.test_step(f"Wait {REPORTER_TICK_WAIT}s for reporter tick")
         time.sleep(REPORTER_TICK_WAIT)
-        logger.info(
-            f"Step 6: Poll for {expected_count} "
-            f"volumehealth annotation(s) "
-            f"(timeout={ANNOTATION_POLL_TIMEOUT}s)"
+
+        logger.test_step(f"Poll for {expected_count} volumehealth annotation(s)")
+        health_annotations = pvc_obj.wait_for_volume_health_state(
+            expected_state="healthy",
+            timeout=ANNOTATION_POLL_TIMEOUT,
+            interval=ANNOTATION_POLL_INTERVAL,
+            expected_count=expected_count,
         )
-        health_annotations = {}
-        try:
-            for sample in TimeoutSampler(
-                timeout=ANNOTATION_POLL_TIMEOUT,
-                sleep=ANNOTATION_POLL_INTERVAL,
-                func=pvc_obj.get_volume_health_annotations,
-            ):
-                health_annotations = sample
-                if len(health_annotations) >= expected_count:
-                    logger.info(
-                        f"Found {len(health_annotations)} "
-                        f"volumehealth annotation(s)"
-                    )
-                    break
-                logger.debug(
-                    f"Found {len(health_annotations)}/" f"{expected_count}, waiting"
-                )
-        except TimeoutExpiredError:
-            all_annots = pvc_obj.get().get("metadata", {}).get("annotations", {})
-            logger.error(f"PVC annotations at timeout: " f"{all_annots}")
-            pytest.fail(
-                f"Expected {expected_count} volumehealth "
-                f"annotation(s) on PVC {pvc_obj.name}, "
-                f"found {len(health_annotations)} "
-                f"within {ANNOTATION_POLL_TIMEOUT}s"
-            )
-        logger.assertion(
-            f"Exactly {expected_count} volumehealth " f"annotation(s) present"
-        )
-        assert len(health_annotations) == expected_count, (
-            f"Expected {expected_count}, " f"found {len(health_annotations)}"
-        )
+        logger.assertion(f"Exactly {expected_count} volumehealth annotation(s) present")
+        assert (
+            len(health_annotations) == expected_count
+        ), f"Expected {expected_count}, found {len(health_annotations)}"
         pod_node_names = [p.get()["spec"]["nodeName"] for p in pod_objs]
         expected_node_uids = set()
         for node_name in pod_node_names:
             node_ocp = ocp.OCP(kind="node", resource_name=node_name)
             uid = node_ocp.get()["metadata"]["uid"]
             expected_node_uids.add(uid)
-            expected_key = f"{constants.VOLUME_HEALTH_ANNOTATION_PREFIX}" f"{uid}"
-            logger.assertion(
-                f"Annotation key for node {node_name} " f"(uid={uid}) exists"
-            )
+            expected_key = f"{constants.VOLUME_HEALTH_ANNOTATION_PREFIX}{uid}"
+            logger.assertion(f"Annotation key for node {node_name} (uid={uid}) exists")
             assert expected_key in health_annotations, (
                 f"Missing key {expected_key}. "
-                f"Found: "
-                f"{list(health_annotations.keys())}"
+                f"Found: {list(health_annotations.keys())}"
             )
-        logger.info("Step 7: Validate annotation JSON content")
+        logger.test_step("Validate annotation JSON content")
+
         for key, value in health_annotations.items():
             parsed = json.loads(value)
             logger.info(f"Annotation {key}: {parsed}")
-            logger.assertion(f"state is 'healthy', " f"got '{parsed.get('state')}'")
-            assert parsed.get("state") == "healthy", (
-                f"Expected 'healthy', " f"got '{parsed.get('state')}'"
-            )
+            logger.assertion(f"state is 'healthy', got '{parsed.get('state')}'")
+            assert (
+                parsed.get("state") == "healthy"
+            ), f"Expected 'healthy', got '{parsed.get('state')}'"
             last_checked = parsed.get("lastChecked", "")
-            logger.assertion(f"lastChecked is valid RFC3339: " f"{last_checked}")
+            logger.assertion(f"lastChecked is valid RFC3339: {last_checked}")
             dt_last = datetime.fromisoformat(last_checked.replace("Z", "+00:00"))
-            assert dt_last.tzinfo is not None, (
-                f"lastChecked missing timezone: " f"{last_checked}"
-            )
+            assert (
+                dt_last.tzinfo is not None
+            ), f"lastChecked missing timezone: {last_checked}"
             since = parsed.get("since", "")
             logger.assertion(f"since is valid RFC3339: {since}")
             dt_since = datetime.fromisoformat(since.replace("Z", "+00:00"))
@@ -210,63 +193,34 @@ class TestPVCVolumeHealthAnnotation(ManageTest):
                 constants.VOLUME_HEALTH_ANNOTATION_PREFIX,
                 "",
             )
-            logger.assertion(f"Key suffix {key_suffix} matches " f"a pod's node UID")
+            logger.assertion(f"Key suffix {key_suffix} matches a pod's node UID")
             assert key_suffix in expected_node_uids, (
                 f"Key suffix {key_suffix} not in "
                 f"expected UIDs: {expected_node_uids}"
             )
-        logger.info(
-            f"Step 8: Check VolumeConditionHealthy " f"events for PVC {pvc_obj.name}"
-        )
-        pvc_ns = pvc_obj.namespace
-        event_ocp = ocp.OCP(kind="Event", namespace=pvc_ns)
-        events = event_ocp.get(
-            field_selector=(f"involvedObject.name={pvc_obj.name}"),
-        )["items"]
-        health_events = [
-            e
-            for e in events
-            if e.get("reason") == "VolumeConditionHealthy"
-            and "volume is in a healthy condition" in e.get("message", "")
-        ]
-        logger.assertion(
-            "At least 1 VolumeConditionHealthy event " "with healthy message"
-        )
-        assert len(health_events) >= 1, (
-            f"No VolumeConditionHealthy events with "
-            f"healthy message for PVC {pvc_obj.name}. "
-            f"Event messages: "
-            f"{[(e.get('reason'), e.get('message')) for e in events]}"
+        logger.test_step(f"Check VolumeConditionHealthy events for PVC {pvc_obj.name}")
+        health_events = assert_pvc_volume_health_event(
+            pvc_obj,
+            reason="VolumeConditionHealthy",
+            event_type="Normal",
+            message_substr="volume is in a healthy condition",
         )
         for evt in health_events:
-            logger.info(
-                f"Event: reason={evt.get('reason')}, "
-                f"type={evt.get('type')}, "
-                f"message={evt.get('message')}"
-            )
-            logger.assertion("Event type is 'Normal'")
-            assert evt["type"] == "Normal", (
-                f"Expected 'Normal', " f"got '{evt['type']}'"
-            )
-            source = evt.get("source", {})
-            logger.assertion("source.component is 'CSI-Addons'")
-            assert source.get("component") == "CSI-Addons", (
-                f"Expected 'CSI-Addons', " f"got '{source.get('component')}'"
-            )
-            event_host = source.get("host", "")
-            logger.assertion(f"source.host '{event_host}' " f"matches a pod node")
-            assert event_host in pod_node_names, (
-                f"source.host '{event_host}' not in " f"pod nodes: {pod_node_names}"
-            )
-        logger.info("Step 8b: Verify event in 'oc describe pvc'")
+            event_host = evt.get("source", {}).get("host", "")
+            logger.assertion(f"source.host '{event_host}' matches a pod node")
+            assert (
+                event_host in pod_node_names
+            ), f"source.host '{event_host}' not in pod nodes: {pod_node_names}"
+        logger.test_step("Verify event in 'oc describe pvc'")
         describe_output = pvc_obj.describe()
         logger.assertion("VolumeConditionHealthy in describe output")
-        assert "VolumeConditionHealthy" in describe_output, (
-            "VolumeConditionHealthy not in " "'oc describe pvc' output"
-        )
-        logger.info("Step 9: Check csi-addons sidecar logs")
+        assert (
+            "VolumeConditionHealthy" in describe_output
+        ), "VolumeConditionHealthy not in 'oc describe pvc' output"
+        logger.test_step("Check csi-addons sidecar logs")
         pvc_obj.reload()
         pv_name = pvc_obj.backed_pv
+        logger.assertion(f"PVC {pvc_obj.name} has backed PV: {pv_name}")
         assert pv_name, f"PVC {pvc_obj.name} has no backed PV"
         for node_name in pod_node_names:
             addon_pod = get_csi_addon_pod_on_node(node_name, driver)
@@ -276,8 +230,134 @@ class TestPVCVolumeHealthAnnotation(ManageTest):
                 namespace=ns,
                 tail=200,
             )
-            logger.assertion(f"PV {pv_name} in csi-addons logs " f"on node {node_name}")
-            assert pv_name in log_output, (
-                f"PV '{pv_name}' not in logs of " f"{addon_pod} on {node_name}"
-            )
-        logger.info(f"{driver.upper()} PVC volume health " f"annotation test passed")
+            logger.assertion(f"PV {pv_name} in csi-addons logs on node {node_name}")
+            assert (
+                pv_name in log_output
+            ), f"PV '{pv_name}' not in logs of {addon_pod} on {node_name}"
+        logger.info(f"{driver.upper()} PVC volume health annotation test passed")
+
+
+@tier1
+@green_squad
+@skipif_ocs_version("<4.23")
+class TestPVCVolumeHealthUnhealthy(ManageTest):
+    """
+    Test PVC volume health annotation transitions to unhealthy state
+    when Ceph connectivity is disrupted, and recovers when restored.
+    """
+
+    def _create_pvc_and_pod_with_io(self, pvc_factory, pod_factory):
+        """
+        Create a CephFS RWO PVC, mount it in a pod, and run FIO I/O.
+
+        Returns:
+            tuple: (pvc_obj, pod_obj)
+        """
+        logger.info("Create CephFS RWO PVC (5Gi)")
+        pvc_obj = pvc_factory(
+            interface=constants.CEPHFILESYSTEM,
+            size=5,
+            access_mode=constants.ACCESS_MODE_RWO,
+        )
+        logger.info(f"PVC {pvc_obj.name} created and Bound")
+
+        logger.info("Create pod mounting the PVC")
+        pod_obj = pod_factory(
+            pvc=pvc_obj,
+            interface=constants.CEPHFILESYSTEM,
+        )
+        pod_node = pod_obj.get()["spec"]["nodeName"]
+        logger.info(f"Pod {pod_obj.name} on {pod_node}")
+
+        logger.info("Run FIO I/O")
+        pod_obj.run_io(
+            storage_type="fs",
+            size="512M",
+            fio_filename=pod_obj.name,
+        )
+        pod.get_fio_rw_iops(pod_obj)
+        logger.info("FIO I/O completed")
+        return pvc_obj, pod_obj
+
+    @pytest.mark.polarion_id("OCS-8228")
+    def test_pvc_health_unhealthy_via_ceph_blocklist(
+        self, pvc_factory, pod_factory, request
+    ):
+        """
+        Verify PVC health transitions to unhealthy when the CephFS
+        client is blocklisted, and recovers after removal + pod restart.
+
+        Steps:
+            1. Create CephFS RWO PVC + pod, run I/O, wait for healthy.
+            2. Identify the worker node running the pod.
+            3. Find CephFS client, blocklist + evict via toolbox.
+            4. Wait ~1-2 min for reporter tick.
+            5. Assert annotation state == 'unhealthy'.
+            6. Assert VolumeConditionAbnormal Warning event.
+            7. (Manual) Check ODF dashboard PVC health widget.
+            8. Remove blocklist, restart pod.
+            9. Wait ~1-2 min, assert state == 'healthy'.
+        """
+        logger.test_step("Verify Ceph health")
+        ceph_health_check(tries=3, delay=10)
+
+        pvc_obj, pod_obj = self._create_pvc_and_pod_with_io(pvc_factory, pod_factory)
+
+        logger.info("Wait for healthy annotation")
+        time.sleep(REPORTER_TICK_WAIT)
+        pvc_obj.wait_for_volume_health_state("healthy")
+
+        logger.test_step("Identify the worker node running the pod")
+        pod_node = pod_obj.get()["spec"]["nodeName"]
+        logger.info(f"Pod {pod_obj.name} running on {pod_node}")
+
+        logger.test_step("Find CephFS client and blocklist via toolbox")
+        client_id, client_addr = blocklist_cephfs_client(pvc_obj)
+
+        def finalizer():
+            remove_cephfs_client_blocklist(client_addr)
+
+        request.addfinalizer(finalizer)
+
+        logger.test_step("Wait ~2 min for reporter tick")
+        time.sleep(REPORTER_TICK_WAIT * 2)
+
+        logger.test_step("Assert annotation state == 'unhealthy'")
+        pvc_obj.wait_for_volume_health_state(
+            "unhealthy", timeout=UNHEALTHY_POLL_TIMEOUT
+        )
+
+        logger.test_step("Assert VolumeConditionAbnormal Warning event")
+        assert_pvc_volume_health_event(
+            pvc_obj,
+            reason="VolumeConditionAbnormal",
+            event_type="Warning",
+            message_substr="health-check has not responded",
+        )
+        logger.test_step("Remove blocklist and restart pod")
+        remove_cephfs_client_blocklist(client_addr)
+
+        pod_data = pod_obj.get()
+        pod_ns = pod_data["metadata"]["namespace"]
+        pod_name = pod_data["metadata"]["name"]
+        pod_ocp = ocp.OCP(kind="Pod", namespace=pod_ns)
+        pod_ocp.delete(resource_name=pod_name)
+        logger.info(f"Deleted pod {pod_name}")
+
+        logger.info("Recreating pod for fresh CephFS mount")
+        new_pod = pod_factory(
+            pvc=pvc_obj,
+            interface=constants.CEPHFILESYSTEM,
+        )
+        new_pod_node = new_pod.get()["spec"]["nodeName"]
+        logger.info(f"New pod {new_pod.name} on {new_pod_node}")
+        logger.test_step("Wait ~2 min, assert state == 'healthy'")
+        time.sleep(REPORTER_TICK_WAIT * 2)
+        pvc_obj.wait_for_volume_health_state("healthy", timeout=RECOVERY_POLL_TIMEOUT)
+        assert_pvc_volume_health_event(
+            pvc_obj,
+            reason="VolumeConditionHealthy",
+            event_type="Normal",
+            message_substr="volume is in a healthy condition",
+        )
+        logger.info("PVC health unhealthy via ceph blocklist test passed")

--- a/tests/functional/pv/pv_services/test_pvc_volume_health_annotation.py
+++ b/tests/functional/pv/pv_services/test_pvc_volume_health_annotation.py
@@ -33,7 +33,7 @@ REPORTER_TICK_WAIT = 60
 
 @tier1
 @green_squad
-@skipif_ocs_version("<4.22")
+@skipif_ocs_version("<4.23")
 @jira("DFBUGS-9421", run=False)
 @pytest.mark.parametrize(
     argnames=["interface"],

--- a/tests/functional/pv/pv_services/test_pvc_volume_health_annotation.py
+++ b/tests/functional/pv/pv_services/test_pvc_volume_health_annotation.py
@@ -338,12 +338,10 @@ class TestPVCVolumeHealthUnhealthy(ManageTest):
         logger.test_step("Remove blocklist and restart pod")
         remove_cephfs_client_blocklist(client_addr)
 
-        pod_data = pod_obj.get()
-        pod_ns = pod_data["metadata"]["namespace"]
-        pod_name = pod_data["metadata"]["name"]
-        pod_ocp = ocp.OCP(kind="Pod", namespace=pod_ns)
-        pod_ocp.delete(resource_name=pod_name)
-        logger.info(f"Deleted pod {pod_name}")
+        pod_obj.delete()
+        pod_obj.ocp.wait_for_delete(pod_obj.name)
+        logger.info(f"Deleted pod {pod_obj.name}")
+        pod_obj.delete = lambda **kwargs: None
 
         logger.info("Recreating pod for fresh CephFS mount")
         new_pod = pod_factory(


### PR DESCRIPTION
Adds a tier1 test verifying that CSI-Addons sidecars correctly annotate PVCs with volume health status for both CephFS (RWX, 2 pods on different nodes) and RBD (RWO, 1 pod). The test validates annotation count, JSON payload (state,
  timestamps, node), Kubernetes events, and sidecar logs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for identifying CSI Addons node-plugin pods on specific cluster nodes.
  - Added access to PVC volume-health annotations for improved storage health visibility.
  - Added standardized handling for CSI Addons volume-health annotation keys.

- **Improvements**
  - Improved reliability when retrieving volume-health metadata.
  - Added validation for healthy and unhealthy CephFS and RBD PVC health reporting, including recovery verification, events, timestamps, node details, and diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->