### PR TITLE
Add test for support user-namespace feature (RHSTOR-8028)

### DIFF
--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -7796,10 +7796,10 @@ def verify_file_ownership(pod_obj, file_path, expected_uid, expected_gid):
     assert len(parts) >= 4, f"Unexpected ls -ln output for {file_path}: {out}"
     file_uid = int(parts[2])
     file_gid = int(parts[3])
-    assert file_uid == expected_uid, (
-        f"File UID {file_uid} != expected " f"{expected_uid} for {file_path}"
-    )
-    assert file_gid == expected_gid, (
-        f"File GID {file_gid} != expected " f"{expected_gid} for {file_path}"
-    )
+    assert (
+        file_uid == expected_uid
+    ), f"File UID {file_uid} != expected {expected_uid} for {file_path}"
+    assert (
+        file_gid == expected_gid
+    ), f"File GID {file_gid} != expected {expected_gid} for {file_path}"
     return file_uid, file_gid

--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -7732,7 +7732,7 @@ def create_userns_pod(
     Create a pod with user namespace isolation (hostUsers=false)
     and a restricted-v2 compatible security context.
 
-    The pod runs ``sleep 3600`` so it stays alive for exec
+    The pod runs ``sleep infinity`` so it stays alive for exec
     commands.
 
     Args:
@@ -7757,7 +7757,7 @@ def create_userns_pod(
         namespace=namespace,
         node_name=node_name,
         pod_name=pod_name,
-        command=["sh", "-c", "sleep 3600"],
+        command=["sh", "-c", "sleep infinity"],
         security_context={
             "allowPrivilegeEscalation": False,
             "capabilities": {"drop": ["ALL"]},

--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -7793,6 +7793,7 @@ def verify_file_ownership(pod_obj, file_path, expected_uid, expected_gid):
     out = pod_obj.exec_sh_cmd_on_pod(f"ls -ln {file_path}")
     logger.info(f"ls -ln {file_path}: {out}")
     parts = out.split()
+    assert len(parts) >= 4, f"Unexpected ls -ln output for {file_path}: {out}"
     file_uid = int(parts[2])
     file_gid = int(parts[3])
     assert file_uid == expected_uid, (

--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -7704,11 +7704,11 @@ def create_userns_project(project_name=None, uid_range="10000/1000"):
 
     ns_ocp = ocp.OCP(kind="namespace")
     ns_ocp.annotate(
-        f"openshift.io/sa.scc.supplemental-groups={uid_range}",
+        f"{constants.SA_SCC_SUPPLEMENTAL_GROUPS}={uid_range}",
         resource_name=namespace,
     )
     ns_ocp.annotate(
-        f"openshift.io/sa.scc.uid-range={uid_range}",
+        f"{constants.SA_SCC_UID_RANGE}={uid_range}",
         resource_name=namespace,
     )
     logger.info(

--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -285,6 +285,7 @@ def create_pod(
     volumemounts=None,
     pvc_read_only_mode=None,
     priorityClassName=None,
+    host_users=None,
 ):
     """
     Create a pod
@@ -312,6 +313,8 @@ def create_pod(
         deployment (bool): True for Deployment creation, False otherwise
         scc (dict): Set security context on pod like fsGroup, runAsUer, runAsGroup
         volumemounts (list): Value of mountPath parameter in pod yaml
+        host_users (bool): Set spec.hostUsers on the pod
+            (False enables user namespaces)
 
     Returns:
         Pod: A Pod instance
@@ -443,6 +446,11 @@ def create_pod(
             pod_data["spec"]["template"]["securityContext"] = scc
         else:
             pod_data["spec"]["securityContext"] = scc
+    if host_users is not None:
+        if deployment:
+            pod_data["spec"]["template"]["spec"]["hostUsers"] = host_users
+        else:
+            pod_data["spec"]["hostUsers"] = host_users
     if node_name:
         if deployment:
             pod_data["spec"]["template"]["spec"]["nodeName"] = node_name
@@ -7669,3 +7677,128 @@ def delete_cephfs_ec_pool(pool_name):
             f"Ceph pool '{full_pool_name}' was not removed within timeout. "
             "The pool entry was already removed from StorageCluster CR."
         )
+
+
+def create_userns_project(project_name=None, uid_range="10000/1000"):
+    """
+    Create a project with restricted PSA policy and user namespace
+    UID/GID annotations.
+
+    Sets both ``openshift.io/sa.scc.uid-range`` and
+    ``openshift.io/sa.scc.supplemental-groups`` to *uid_range*.
+
+    Args:
+        project_name (str): Name for the new project.
+            Auto-generated if not provided.
+        uid_range (str): UID/GID range in ``start/count`` format
+            (default ``10000/1000``).
+
+    Returns:
+        ocp.OCP: Project object (kind ``Project``)
+    """
+    namespace = project_name or create_unique_resource_name("test-userns", "namespace")
+    project_obj = ocp.OCP(kind="Project", namespace=namespace)
+    assert project_obj.new_project(
+        namespace, policy=constants.PSA_RESTRICTED
+    ), f"Failed to create project {namespace}"
+
+    ns_ocp = ocp.OCP(kind="namespace")
+    ns_ocp.annotate(
+        f"openshift.io/sa.scc.supplemental-groups={uid_range}",
+        resource_name=namespace,
+    )
+    ns_ocp.annotate(
+        f"openshift.io/sa.scc.uid-range={uid_range}",
+        resource_name=namespace,
+    )
+    logger.info(
+        f"Created user namespace project {namespace} "
+        f"with restricted PSA and uid-range={uid_range}"
+    )
+    return project_obj
+
+
+def create_userns_pod(
+    pvc_name,
+    namespace,
+    run_as_user=10900,
+    run_as_group=10900,
+    interface_type=None,
+    node_name=None,
+    mount_path="/mnt/test",
+    pod_name=None,
+):
+    """
+    Create a pod with user namespace isolation (hostUsers=false)
+    and a restricted-v2 compatible security context.
+
+    The pod runs ``sleep 3600`` so it stays alive for exec
+    commands.
+
+    Args:
+        pvc_name (str): PVC to attach
+        namespace (str): Target namespace
+        run_as_user (int): Container UID (default 10900)
+        run_as_group (int): Container GID (default 10900)
+        interface_type (str): CephFileSystem or CephBlockPool
+            (default CephFileSystem)
+        node_name (str): Schedule on this node (optional)
+        mount_path (str): Container mount path for the PVC
+            (default ``/mnt/test``)
+        pod_name (str): Explicit pod name (optional)
+
+    Returns:
+        Pod: Created Pod object
+    """
+    interface_type = interface_type or constants.CEPHFILESYSTEM
+    return create_pod(
+        interface_type=interface_type,
+        pvc_name=pvc_name,
+        namespace=namespace,
+        node_name=node_name,
+        pod_name=pod_name,
+        command=["sh", "-c", "sleep 3600"],
+        security_context={
+            "allowPrivilegeEscalation": False,
+            "capabilities": {"drop": ["ALL"]},
+            "seccompProfile": {
+                "type": "RuntimeDefault",
+            },
+        },
+        scc={
+            "runAsUser": run_as_user,
+            "runAsGroup": run_as_group,
+            "runAsNonRoot": True,
+        },
+        volumemounts=[
+            {"mountPath": mount_path, "name": "mypvc"},
+        ],
+        host_users=False,
+    )
+
+
+def verify_file_ownership(pod_obj, file_path, expected_uid, expected_gid):
+    """
+    Verify file ownership inside a pod using ``ls -ln``.
+
+    Args:
+        pod_obj (Pod): Pod to exec into
+        file_path (str): Absolute path to the file
+        expected_uid (int): Expected numeric UID
+        expected_gid (int): Expected numeric GID
+
+    Returns:
+        tuple: ``(uid, gid)`` parsed from ``ls -ln`` output
+    """
+    out = pod_obj.exec_sh_cmd_on_pod(f"ls -ln {file_path}")
+    logger.info(f"ls -ln {file_path}: {out}")
+    parts = out.split()
+    file_uid = int(parts[2])
+    file_gid = int(parts[3])
+    assert file_uid == expected_uid, (
+        f"File UID {file_uid} != expected " f"{expected_uid} for {file_path}"
+    )
+    assert file_gid == expected_gid, (
+        f"File GID {file_gid} != expected " f"{expected_gid} for {file_path}"
+    )
+    return file_uid, file_gid

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -1850,6 +1850,10 @@ PSA_PRIVILEGED = "privileged"
 PSA_BASELINE = "baseline"
 PSA_RESTRICTED = "restricted"
 
+# SCC annotations for user namespaces
+SA_SCC_UID_RANGE = "openshift.io/sa.scc.uid-range"
+SA_SCC_SUPPLEMENTAL_GROUPS = "openshift.io/sa.scc.supplemental-groups"
+
 # Platforms
 AWS_PLATFORM = "aws"
 AZURE_PLATFORM = "azure"

--- a/ocs_ci/ocs/node.py
+++ b/ocs_ci/ocs/node.py
@@ -3917,18 +3917,16 @@ def get_host_uid_for_pod(node_name, pod_name):
         int: Host-level real UID of the container process
     """
     oc_cmd = OCP()
-    pod_id_cmd = f"crictl pods --name ^{pod_name}$" f" --state ready -q | head -1"
+    pod_id_cmd = f"crictl pods --name ^{pod_name}$ --state ready -q | head -1"
     pod_id = oc_cmd.exec_oc_debug_cmd(node=node_name, cmd_list=[pod_id_cmd]).strip()
-    assert pod_id, f"crictl found no ready pod matching " f"{pod_name} on {node_name}"
+    assert pod_id, f"crictl found no ready pod matching {pod_name} on {node_name}"
     log.info(f"crictl pod ID for {pod_name}: {pod_id}")
 
-    container_id_cmd = f"crictl ps --pod {pod_id}" f" --state running -q | head -1"
+    container_id_cmd = f"crictl ps --pod {pod_id} --state running -q | head -1"
     container_id = oc_cmd.exec_oc_debug_cmd(
         node=node_name, cmd_list=[container_id_cmd]
     ).strip()
-    assert container_id, (
-        f"No running container found in pod {pod_id} " f"on {node_name}"
-    )
+    assert container_id, f"No running container found in pod {pod_id} on {node_name}"
     log.info(f"Container ID: {container_id}")
 
     inspect_cmd = f"crictl inspect {container_id}"
@@ -3939,14 +3937,12 @@ def get_host_uid_for_pod(node_name, pod_name):
         f"output for pod {pod_name} on node {node_name}"
     )
     pid = pid_match.group(1)
-    log.info(f"Container PID for {pod_name} " f"on {node_name}: {pid}")
+    log.info(f"Container PID for {pod_name} on {node_name}: {pid}")
 
     status_cmd = f"cat /proc/{pid}/status"
     status_output = oc_cmd.exec_oc_debug_cmd(node=node_name, cmd_list=[status_cmd])
     uid_match = re.search(r"Uid:\s+(\d+)", status_output)
-    assert uid_match, (
-        f"Could not parse Uid from /proc/{pid}/status " f"on node {node_name}"
-    )
+    assert uid_match, f"Could not parse Uid from /proc/{pid}/status on node {node_name}"
     host_uid = int(uid_match.group(1))
-    log.info(f"Host UID for {pod_name} " f"on {node_name}: {host_uid}")
+    log.info(f"Host UID for {pod_name} on {node_name}: {host_uid}")
     return host_uid

--- a/ocs_ci/ocs/node.py
+++ b/ocs_ci/ocs/node.py
@@ -3917,13 +3917,21 @@ def get_host_uid_for_pod(node_name, pod_name):
         int: Host-level real UID of the container process
     """
     oc_cmd = OCP()
-    inspect_cmd = (
-        f"crictl inspect "
-        f"$(crictl ps "
-        f"--pod $(crictl pods --name {pod_name}"
-        f" --state ready -q | head -1) "
-        f"--state running -q | head -1)"
+    pod_id_cmd = f"crictl pods --name ^{pod_name}$" f" --state ready -q | head -1"
+    pod_id = oc_cmd.exec_oc_debug_cmd(node=node_name, cmd_list=[pod_id_cmd]).strip()
+    assert pod_id, f"crictl found no ready pod matching " f"{pod_name} on {node_name}"
+    log.info(f"crictl pod ID for {pod_name}: {pod_id}")
+
+    container_id_cmd = f"crictl ps --pod {pod_id}" f" --state running -q | head -1"
+    container_id = oc_cmd.exec_oc_debug_cmd(
+        node=node_name, cmd_list=[container_id_cmd]
+    ).strip()
+    assert container_id, (
+        f"No running container found in pod {pod_id} " f"on {node_name}"
     )
+    log.info(f"Container ID: {container_id}")
+
+    inspect_cmd = f"crictl inspect {container_id}"
     inspect_output = oc_cmd.exec_oc_debug_cmd(node=node_name, cmd_list=[inspect_cmd])
     pid_match = re.search(r'"pid"\s*:\s*(\d+)', inspect_output)
     assert pid_match, (

--- a/ocs_ci/ocs/node.py
+++ b/ocs_ci/ocs/node.py
@@ -3898,3 +3898,47 @@ def check_cluster_resources(ram_gb=65, cpu_cores=6):
             f"Resource capacity check failed due to environment or parsing error: {e}"
         )
         return True
+
+
+def get_host_uid_for_pod(node_name, pod_name):
+    """
+    Get the host-level UID for the container process of a pod.
+
+    Uses ``crictl`` on the node (via ``oc debug``) to find the
+    container PID, then reads ``/proc/<pid>/status`` to extract the
+    real UID as seen by the host kernel.  Useful for verifying user
+    namespace UID remapping (``hostUsers: false``).
+
+    Args:
+        node_name (str): Node where the pod runs
+        pod_name (str): Kubernetes pod name
+
+    Returns:
+        int: Host-level real UID of the container process
+    """
+    oc_cmd = OCP()
+    inspect_cmd = (
+        f"crictl inspect "
+        f"$(crictl ps "
+        f"--pod $(crictl pods --name {pod_name}"
+        f" --state ready -q | head -1) "
+        f"--state running -q | head -1)"
+    )
+    inspect_output = oc_cmd.exec_oc_debug_cmd(node=node_name, cmd_list=[inspect_cmd])
+    pid_match = re.search(r'"pid"\s*:\s*(\d+)', inspect_output)
+    assert pid_match, (
+        f"Could not find container PID in crictl inspect "
+        f"output for pod {pod_name} on node {node_name}"
+    )
+    pid = pid_match.group(1)
+    log.info(f"Container PID for {pod_name} " f"on {node_name}: {pid}")
+
+    status_cmd = f"cat /proc/{pid}/status"
+    status_output = oc_cmd.exec_oc_debug_cmd(node=node_name, cmd_list=[status_cmd])
+    uid_match = re.search(r"Uid:\s+(\d+)", status_output)
+    assert uid_match, (
+        f"Could not parse Uid from /proc/{pid}/status " f"on node {node_name}"
+    )
+    host_uid = int(uid_match.group(1))
+    log.info(f"Host UID for {pod_name} " f"on {node_name}: {host_uid}")
+    return host_uid

--- a/tests/functional/pv/pv_services/test_user_namespace_cephfs.py
+++ b/tests/functional/pv/pv_services/test_user_namespace_cephfs.py
@@ -57,11 +57,11 @@ class TestUserNamespaceCephFS(ManageTest):
             10-13. Assert host UID is remapped on worker-1.
             14. Assert different remapped UID on worker-2.
         """
-        logger.info("Step 1: Create project with restricted PSA")
+        logger.test_step("Step 1: Create project with restricted PSA")
         project_obj = create_userns_project(uid_range=USERNS_UID_RANGE)
         teardown_project_factory(project_obj)
         ns_name = project_obj.namespace
-        logger.info("Step 2: Create CephFS RWX PVC (1Gi)")
+        logger.test_step("Step 2: Create CephFS RWX PVC (1Gi)")
         pvc_obj = pvc_factory(
             interface=constants.CEPHFILESYSTEM,
             project=project_obj,
@@ -69,7 +69,7 @@ class TestUserNamespaceCephFS(ManageTest):
             access_mode=constants.ACCESS_MODE_RWX,
         )
         logger.info(f"PVC {pvc_obj.name} created and Bound")
-        logger.info("Steps 3-6: Deploy pods with hostUsers=false")
+        logger.test_step("Steps 3-6: Deploy pods with hostUsers=false")
         worker_nodes = node.get_worker_nodes()
         assert len(worker_nodes) >= 2, (
             f"Need >= 2 worker nodes, " f"found {len(worker_nodes)}"
@@ -96,7 +96,7 @@ class TestUserNamespaceCephFS(ManageTest):
         node2 = pod2.get()["spec"]["nodeName"]
         logger.info(f"Pod {pod1.name} on {node1}, " f"Pod {pod2.name} on {node2}")
         assert node1 != node2, f"Both pods on same node: {node1}"
-        logger.info("Step 7: Write from pod-1 and read back")
+        logger.test_step("Step 7: Write from pod-1 and read back")
         out = pod1.exec_sh_cmd_on_pod(
             "id && echo testing > /mnt/test/a " "&& cat /mnt/test/a && sync"
         )
@@ -105,18 +105,18 @@ class TestUserNamespaceCephFS(ManageTest):
             f"Expected uid={CONTAINER_UID} in id output, " f"got: {out}"
         )
         assert "testing" in out, f"Expected 'testing' in output: {out}"
-        logger.info("Step 8: Read from pod-2 and write new file")
+        logger.test_step("Step 8: Read from pod-2 and write new file")
         out = pod2.exec_sh_cmd_on_pod(
             "cat /mnt/test/a " "&& echo testing_again > /mnt/test/b && sync"
         )
         logger.info(f"Pod-2 output: {out}")
         assert "testing" in out, f"Pod-2 could not read file from pod-1: {out}"
-        logger.info("Step 9: Cross-read from pod-1")
+        logger.test_step("Step 9: Cross-read from pod-1")
         out = pod1.exec_sh_cmd_on_pod("cat /mnt/test/b")
         logger.info(f"Pod-1 cross-read: {out}")
         assert "testing_again" in out, f"Pod-1 could not read file from pod-2: {out}"
         logger.info("Shared I/O validation passed")
-        logger.info(f"Steps 10-13: Verify UID remapping on {node1}")
+        logger.test_step(f"Steps 10-13: Verify UID remapping on {node1}")
         host_uid_1 = node.get_host_uid_for_pod(node1, pod1.name)
         assert host_uid_1 != CONTAINER_UID, (
             f"Host UID {host_uid_1} equals container UID "
@@ -127,7 +127,7 @@ class TestUserNamespaceCephFS(ManageTest):
             f"Remapping confirmed on {node1}: "
             f"host UID {host_uid_1} != {CONTAINER_UID}"
         )
-        logger.info(f"Step 14: Verify UID remapping on {node2}")
+        logger.test_step(f"Step 14: Verify UID remapping on {node2}")
         host_uid_2 = node.get_host_uid_for_pod(node2, pod2.name)
         assert host_uid_2 != CONTAINER_UID, (
             f"Host UID {host_uid_2} equals container UID "
@@ -174,11 +174,11 @@ class TestUserNamespaceCephFS(ManageTest):
             11. Verify data persists.
             12. Verify ownership persists.
         """
-        logger.info("Step 1: Create project with restricted PSA")
+        logger.test_step("Step 1: Create project with restricted PSA")
         project_obj = create_userns_project(uid_range=USERNS_UID_RANGE)
         teardown_project_factory(project_obj)
         ns_name = project_obj.namespace
-        logger.info("Step 2: Create CephFS RWO PVC (1Gi)")
+        logger.test_step("Step 2: Create CephFS RWO PVC (1Gi)")
         pvc_obj = pvc_factory(
             interface=constants.CEPHFILESYSTEM,
             project=project_obj,
@@ -186,7 +186,7 @@ class TestUserNamespaceCephFS(ManageTest):
             access_mode=constants.ACCESS_MODE_RWO,
         )
         logger.info(f"PVC {pvc_obj.name} created and Bound")
-        logger.info("Step 3: Deploy pod with hostUsers=false")
+        logger.test_step("Step 3: Deploy pod with hostUsers=false")
         worker_nodes = node.get_worker_nodes()
         assert len(worker_nodes) >= 1, "No worker nodes"
         target_node = worker_nodes[0]
@@ -204,18 +204,18 @@ class TestUserNamespaceCephFS(ManageTest):
         )
         pod_node = pod_obj.get()["spec"]["nodeName"]
         logger.info(f"Pod {pod_obj.name} running on {pod_node}")
-        logger.info("Step 4: Verify container UID")
+        logger.test_step("Step 4: Verify container UID")
         out = pod_obj.exec_sh_cmd_on_pod("id")
         logger.info(f"Container id: {out}")
         assert (
             f"uid={CONTAINER_UID}" in out
         ), f"Expected uid={CONTAINER_UID}, got: {out}"
-        logger.info("Steps 5-6: Write and read file")
+        logger.test_step("Steps 5-6: Write and read file")
         pod_obj.exec_sh_cmd_on_pod("echo rwo-test > /mnt/test/file1 && sync")
         out = pod_obj.exec_sh_cmd_on_pod("cat /mnt/test/file1")
         logger.info(f"File content: {out}")
         assert "rwo-test" in out, f"File content mismatch: {out}"
-        logger.info("Step 7: Verify file ownership")
+        logger.test_step("Step 7: Verify file ownership")
         verify_file_ownership(
             pod_obj,
             "/mnt/test/file1",
@@ -225,7 +225,7 @@ class TestUserNamespaceCephFS(ManageTest):
         logger.info(
             f"Ownership correct: " f"{CONTAINER_UID}:{SUPPLEMENTAL_GROUPS_BASE}"
         )
-        logger.info("Step 8: Verify host UID remapping")
+        logger.test_step("Step 8: Verify host UID remapping")
         host_uid = node.get_host_uid_for_pod(pod_node, pod_obj.name)
         assert host_uid != CONTAINER_UID, (
             f"Host UID {host_uid} equals container UID "
@@ -235,11 +235,11 @@ class TestUserNamespaceCephFS(ManageTest):
             f"Remapping confirmed: host UID {host_uid} "
             f"!= container UID {CONTAINER_UID}"
         )
-        logger.info(f"Step 9: Delete pod {pod_obj.name}")
+        logger.test_step(f"Step 9: Delete pod {pod_obj.name}")
         pod_obj.delete()
         pod_obj.ocp.wait_for_delete(resource_name=pod_obj.name)
         logger.info(f"Pod {pod_obj.name} deleted")
-        logger.info("Step 10: Recreate pod with same PVC")
+        logger.test_step("Step 10: Recreate pod with same PVC")
         pod_obj.create()
         wait_for_resource_state(
             resource=pod_obj,
@@ -247,11 +247,11 @@ class TestUserNamespaceCephFS(ManageTest):
             timeout=300,
         )
         logger.info(f"Pod {pod_obj.name} recreated and Running")
-        logger.info("Step 11: Verify data persists")
+        logger.test_step("Step 11: Verify data persists")
         out = pod_obj.exec_sh_cmd_on_pod("cat /mnt/test/file1")
         logger.info(f"Persisted content: {out}")
         assert "rwo-test" in out, f"Data did not persist after pod restart: " f"{out}"
-        logger.info("Step 12: Verify ownership persists")
+        logger.test_step("Step 12: Verify ownership persists")
         verify_file_ownership(
             pod_obj,
             "/mnt/test/file1",

--- a/tests/functional/pv/pv_services/test_user_namespace_cephfs.py
+++ b/tests/functional/pv/pv_services/test_user_namespace_cephfs.py
@@ -104,7 +104,7 @@ class TestUserNamespaceCephFS(ManageTest):
         assert f"uid={CONTAINER_UID}" in out, (
             f"Expected uid={CONTAINER_UID} in id output, " f"got: {out}"
         )
-        assert "testing" in out
+        assert "testing" in out, f"Expected 'testing' in output: {out}"
         logger.info("Step 8: Read from pod-2 and write new file")
         out = pod2.exec_sh_cmd_on_pod(
             "cat /mnt/test/a " "&& echo testing_again > /mnt/test/b && sync"

--- a/tests/functional/pv/pv_services/test_user_namespace_cephfs.py
+++ b/tests/functional/pv/pv_services/test_user_namespace_cephfs.py
@@ -33,7 +33,7 @@ class TestUserNamespaceCephFS(ManageTest):
     with UID remapping and data persistence.
     """
 
-    @polarion_id("OCS-XXXX")
+    @polarion_id("OCS-8224")
     def test_user_namespace_shared_io_and_uid_remapping(
         self,
         teardown_project_factory,
@@ -146,7 +146,7 @@ class TestUserNamespaceCephFS(ManageTest):
         )
         logger.info("User namespace shared I/O and UID remapping " "test passed")
 
-    @polarion_id("OCS-XXXX")
+    @polarion_id("OCS-8225")
     def test_user_namespace_rwo_ownership_and_persistence(
         self,
         teardown_project_factory,

--- a/tests/functional/pv/pv_services/test_user_namespace_cephfs.py
+++ b/tests/functional/pv/pv_services/test_user_namespace_cephfs.py
@@ -26,7 +26,7 @@ USERNS_UID_RANGE = "10000/1000"
 
 @tier1
 @green_squad
-@skipif_ocs_version("<4.22")
+@skipif_ocs_version("<4.23")
 class TestUserNamespaceCephFS(ManageTest):
     """
     Verify CephFS I/O under user namespaces (hostUsers=false)

--- a/tests/functional/pv/pv_services/test_user_namespace_cephfs.py
+++ b/tests/functional/pv/pv_services/test_user_namespace_cephfs.py
@@ -1,0 +1,263 @@
+"""
+Tests for user namespace support with CephFS shared storage.
+"""
+
+import logging
+from ocs_ci.framework.pytest_customization.marks import (
+    green_squad,
+    skipif_ocs_version,
+)
+from ocs_ci.framework.testlib import ManageTest, tier1, polarion_id
+from ocs_ci.ocs import constants, node
+from ocs_ci.helpers.helpers import (
+    create_userns_project,
+    create_userns_pod,
+    verify_file_ownership,
+    wait_for_resource_state,
+)
+
+logger = logging.getLogger(__name__)
+
+CONTAINER_UID = 10900
+CONTAINER_GID = 10900
+SUPPLEMENTAL_GROUPS_BASE = 10000
+USERNS_UID_RANGE = "10000/1000"
+
+
+@tier1
+@green_squad
+@skipif_ocs_version("<4.22")
+class TestUserNamespaceCephFS(ManageTest):
+    """
+    Verify CephFS I/O under user namespaces (hostUsers=false)
+    with UID remapping and data persistence.
+    """
+
+    @polarion_id("OCS-XXXX")
+    def test_user_namespace_shared_io_and_uid_remapping(
+        self,
+        teardown_project_factory,
+        pvc_factory,
+        teardown_factory,
+    ):
+        """
+        Two pods on different workers share a CephFS RWX volume
+        under user namespace isolation.
+
+        Steps:
+            1. Create project with restricted PSA and UID
+               annotations.
+            2. Create CephFS RWX PVC (1Gi).
+            3-5. Deploy two pods on different workers with
+                 hostUsers=false.
+            6. Verify both pods are Running.
+            7. Write file from pod-1, verify container uid.
+            8. Read file from pod-2, write another file.
+            9. Read second file from pod-1 (cross-pod I/O).
+            10-13. Assert host UID is remapped on worker-1.
+            14. Assert different remapped UID on worker-2.
+        """
+        logger.info("Step 1: Create project with restricted PSA")
+        project_obj = create_userns_project(uid_range=USERNS_UID_RANGE)
+        teardown_project_factory(project_obj)
+        ns_name = project_obj.namespace
+        logger.info("Step 2: Create CephFS RWX PVC (1Gi)")
+        pvc_obj = pvc_factory(
+            interface=constants.CEPHFILESYSTEM,
+            project=project_obj,
+            size=1,
+            access_mode=constants.ACCESS_MODE_RWX,
+        )
+        logger.info(f"PVC {pvc_obj.name} created and Bound")
+        logger.info("Steps 3-6: Deploy pods with hostUsers=false")
+        worker_nodes = node.get_worker_nodes()
+        assert len(worker_nodes) >= 2, (
+            f"Need >= 2 worker nodes, " f"found {len(worker_nodes)}"
+        )
+        pods = []
+        for i in range(2):
+            p = create_userns_pod(
+                pvc_name=pvc_obj.name,
+                namespace=ns_name,
+                node_name=worker_nodes[i],
+            )
+            teardown_factory(p)
+            pods.append(p)
+
+        for p in pods:
+            wait_for_resource_state(
+                resource=p,
+                state=constants.STATUS_RUNNING,
+                timeout=300,
+            )
+
+        pod1, pod2 = pods
+        node1 = pod1.get()["spec"]["nodeName"]
+        node2 = pod2.get()["spec"]["nodeName"]
+        logger.info(f"Pod {pod1.name} on {node1}, " f"Pod {pod2.name} on {node2}")
+        assert node1 != node2, f"Both pods on same node: {node1}"
+        logger.info("Step 7: Write from pod-1 and read back")
+        out = pod1.exec_sh_cmd_on_pod(
+            "id && echo testing > /mnt/test/a " "&& cat /mnt/test/a && sync"
+        )
+        logger.info(f"Pod-1 output: {out}")
+        assert f"uid={CONTAINER_UID}" in out, (
+            f"Expected uid={CONTAINER_UID} in id output, " f"got: {out}"
+        )
+        assert "testing" in out
+        logger.info("Step 8: Read from pod-2 and write new file")
+        out = pod2.exec_sh_cmd_on_pod(
+            "cat /mnt/test/a " "&& echo testing_again > /mnt/test/b && sync"
+        )
+        logger.info(f"Pod-2 output: {out}")
+        assert "testing" in out, f"Pod-2 could not read file from pod-1: {out}"
+        logger.info("Step 9: Cross-read from pod-1")
+        out = pod1.exec_sh_cmd_on_pod("cat /mnt/test/b")
+        logger.info(f"Pod-1 cross-read: {out}")
+        assert "testing_again" in out, f"Pod-1 could not read file from pod-2: {out}"
+        logger.info("Shared I/O validation passed")
+        logger.info(f"Steps 10-13: Verify UID remapping on {node1}")
+        host_uid_1 = node.get_host_uid_for_pod(node1, pod1.name)
+        assert host_uid_1 != CONTAINER_UID, (
+            f"Host UID {host_uid_1} equals container UID "
+            f"{CONTAINER_UID} — remapping not active "
+            f"on {node1}"
+        )
+        logger.info(
+            f"Remapping confirmed on {node1}: "
+            f"host UID {host_uid_1} != {CONTAINER_UID}"
+        )
+        logger.info(f"Step 14: Verify UID remapping on {node2}")
+        host_uid_2 = node.get_host_uid_for_pod(node2, pod2.name)
+        assert host_uid_2 != CONTAINER_UID, (
+            f"Host UID {host_uid_2} equals container UID "
+            f"{CONTAINER_UID} — remapping not active "
+            f"on {node2}"
+        )
+        assert host_uid_1 != host_uid_2, (
+            f"Host UIDs should differ across nodes: "
+            f"worker-1={host_uid_1}, "
+            f"worker-2={host_uid_2}"
+        )
+        logger.info(
+            f"Remapping confirmed on {node2}: "
+            f"host UID {host_uid_2} != {CONTAINER_UID} "
+            f"and != worker-1 UID {host_uid_1}"
+        )
+        logger.info("User namespace shared I/O and UID remapping " "test passed")
+
+    @polarion_id("OCS-XXXX")
+    def test_user_namespace_rwo_ownership_and_persistence(
+        self,
+        teardown_project_factory,
+        pvc_factory,
+        teardown_factory,
+    ):
+        """
+        Single pod with CephFS RWO volume under user namespace.
+        Verifies file ownership, UID remapping, and data
+        persistence across pod restart.
+
+        Steps:
+            1. Create project with restricted PSA and UID
+               annotations.
+            2. Create CephFS RWO PVC (1Gi).
+            3. Deploy pod with hostUsers=false.
+            4. Verify container uid=10900.
+            5. Write file and read back.
+            6. Verify file content.
+            7. Verify file ownership (uid=10900,
+               gid=10000 supplemental-groups base).
+            8. Verify host UID is remapped.
+            9. Delete pod.
+            10. Recreate pod with same PVC.
+            11. Verify data persists.
+            12. Verify ownership persists.
+        """
+        logger.info("Step 1: Create project with restricted PSA")
+        project_obj = create_userns_project(uid_range=USERNS_UID_RANGE)
+        teardown_project_factory(project_obj)
+        ns_name = project_obj.namespace
+        logger.info("Step 2: Create CephFS RWO PVC (1Gi)")
+        pvc_obj = pvc_factory(
+            interface=constants.CEPHFILESYSTEM,
+            project=project_obj,
+            size=1,
+            access_mode=constants.ACCESS_MODE_RWO,
+        )
+        logger.info(f"PVC {pvc_obj.name} created and Bound")
+        logger.info("Step 3: Deploy pod with hostUsers=false")
+        worker_nodes = node.get_worker_nodes()
+        assert len(worker_nodes) >= 1, "No worker nodes"
+        target_node = worker_nodes[0]
+
+        pod_obj = create_userns_pod(
+            pvc_name=pvc_obj.name,
+            namespace=ns_name,
+            node_name=target_node,
+        )
+        teardown_factory(pod_obj)
+        wait_for_resource_state(
+            resource=pod_obj,
+            state=constants.STATUS_RUNNING,
+            timeout=300,
+        )
+        pod_node = pod_obj.get()["spec"]["nodeName"]
+        logger.info(f"Pod {pod_obj.name} running on {pod_node}")
+        logger.info("Step 4: Verify container UID")
+        out = pod_obj.exec_sh_cmd_on_pod("id")
+        logger.info(f"Container id: {out}")
+        assert (
+            f"uid={CONTAINER_UID}" in out
+        ), f"Expected uid={CONTAINER_UID}, got: {out}"
+        logger.info("Steps 5-6: Write and read file")
+        pod_obj.exec_sh_cmd_on_pod("echo rwo-test > /mnt/test/file1 && sync")
+        out = pod_obj.exec_sh_cmd_on_pod("cat /mnt/test/file1")
+        logger.info(f"File content: {out}")
+        assert "rwo-test" in out, f"File content mismatch: {out}"
+        logger.info("Step 7: Verify file ownership")
+        verify_file_ownership(
+            pod_obj,
+            "/mnt/test/file1",
+            CONTAINER_UID,
+            SUPPLEMENTAL_GROUPS_BASE,
+        )
+        logger.info(
+            f"Ownership correct: " f"{CONTAINER_UID}:{SUPPLEMENTAL_GROUPS_BASE}"
+        )
+        logger.info("Step 8: Verify host UID remapping")
+        host_uid = node.get_host_uid_for_pod(pod_node, pod_obj.name)
+        assert host_uid != CONTAINER_UID, (
+            f"Host UID {host_uid} equals container UID "
+            f"{CONTAINER_UID} — remapping not active"
+        )
+        logger.info(
+            f"Remapping confirmed: host UID {host_uid} "
+            f"!= container UID {CONTAINER_UID}"
+        )
+        logger.info(f"Step 9: Delete pod {pod_obj.name}")
+        pod_obj.delete()
+        pod_obj.ocp.wait_for_delete(resource_name=pod_obj.name)
+        logger.info(f"Pod {pod_obj.name} deleted")
+        logger.info("Step 10: Recreate pod with same PVC")
+        pod_obj.create()
+        wait_for_resource_state(
+            resource=pod_obj,
+            state=constants.STATUS_RUNNING,
+            timeout=300,
+        )
+        logger.info(f"Pod {pod_obj.name} recreated and Running")
+        logger.info("Step 11: Verify data persists")
+        out = pod_obj.exec_sh_cmd_on_pod("cat /mnt/test/file1")
+        logger.info(f"Persisted content: {out}")
+        assert "rwo-test" in out, f"Data did not persist after pod restart: " f"{out}"
+        logger.info("Step 12: Verify ownership persists")
+        verify_file_ownership(
+            pod_obj,
+            "/mnt/test/file1",
+            CONTAINER_UID,
+            SUPPLEMENTAL_GROUPS_BASE,
+        )
+        logger.info(
+            f"Ownership persisted: " f"{CONTAINER_UID}:{SUPPLEMENTAL_GROUPS_BASE}"
+        )

--- a/tests/functional/pv/pv_services/test_user_namespace_cephfs.py
+++ b/tests/functional/pv/pv_services/test_user_namespace_cephfs.py
@@ -19,7 +19,6 @@ from ocs_ci.helpers.helpers import (
 logger = logging.getLogger(__name__)
 
 CONTAINER_UID = 10900
-CONTAINER_GID = 10900
 SUPPLEMENTAL_GROUPS_BASE = 10000
 USERNS_UID_RANGE = "10000/1000"
 
@@ -71,9 +70,9 @@ class TestUserNamespaceCephFS(ManageTest):
         logger.info(f"PVC {pvc_obj.name} created and Bound")
         logger.test_step("Steps 3-6: Deploy pods with hostUsers=false")
         worker_nodes = node.get_worker_nodes()
-        assert len(worker_nodes) >= 2, (
-            f"Need >= 2 worker nodes, " f"found {len(worker_nodes)}"
-        )
+        assert (
+            len(worker_nodes) >= 2
+        ), f"Need >= 2 worker nodes, found {len(worker_nodes)}"
         pods = []
         for i in range(2):
             p = create_userns_pod(
@@ -94,16 +93,16 @@ class TestUserNamespaceCephFS(ManageTest):
         pod1, pod2 = pods
         node1 = pod1.get()["spec"]["nodeName"]
         node2 = pod2.get()["spec"]["nodeName"]
-        logger.info(f"Pod {pod1.name} on {node1}, " f"Pod {pod2.name} on {node2}")
+        logger.info(f"Pod {pod1.name} on {node1}, Pod {pod2.name} on {node2}")
         assert node1 != node2, f"Both pods on same node: {node1}"
         logger.test_step("Step 7: Write from pod-1 and read back")
         out = pod1.exec_sh_cmd_on_pod(
             "id && echo testing > /mnt/test/a " "&& cat /mnt/test/a && sync"
         )
         logger.info(f"Pod-1 output: {out}")
-        assert f"uid={CONTAINER_UID}" in out, (
-            f"Expected uid={CONTAINER_UID} in id output, " f"got: {out}"
-        )
+        assert (
+            f"uid={CONTAINER_UID}" in out
+        ), f"Expected uid={CONTAINER_UID} in id output, got: {out}"
         assert "testing" in out, f"Expected 'testing' in output: {out}"
         logger.test_step("Step 8: Read from pod-2 and write new file")
         out = pod2.exec_sh_cmd_on_pod(
@@ -222,9 +221,7 @@ class TestUserNamespaceCephFS(ManageTest):
             CONTAINER_UID,
             SUPPLEMENTAL_GROUPS_BASE,
         )
-        logger.info(
-            f"Ownership correct: " f"{CONTAINER_UID}:{SUPPLEMENTAL_GROUPS_BASE}"
-        )
+        logger.info(f"Ownership correct: {CONTAINER_UID}:{SUPPLEMENTAL_GROUPS_BASE}")
         logger.test_step("Step 8: Verify host UID remapping")
         host_uid = node.get_host_uid_for_pod(pod_node, pod_obj.name)
         assert host_uid != CONTAINER_UID, (
@@ -250,7 +247,7 @@ class TestUserNamespaceCephFS(ManageTest):
         logger.test_step("Step 11: Verify data persists")
         out = pod_obj.exec_sh_cmd_on_pod("cat /mnt/test/file1")
         logger.info(f"Persisted content: {out}")
-        assert "rwo-test" in out, f"Data did not persist after pod restart: " f"{out}"
+        assert "rwo-test" in out, f"Data did not persist after pod restart: {out}"
         logger.test_step("Step 12: Verify ownership persists")
         verify_file_ownership(
             pod_obj,
@@ -258,6 +255,4 @@ class TestUserNamespaceCephFS(ManageTest):
             CONTAINER_UID,
             SUPPLEMENTAL_GROUPS_BASE,
         )
-        logger.info(
-            f"Ownership persisted: " f"{CONTAINER_UID}:{SUPPLEMENTAL_GROUPS_BASE}"
-        )
+        logger.info(f"Ownership persisted: {CONTAINER_UID}:{SUPPLEMENTAL_GROUPS_BASE}")


### PR DESCRIPTION
Add tier1 tests validating CephFS I/O under user namespace isolation with UID remapping verification via crictl.
 Includes reusable helpers for project setup, pod creation, file ownership checks, and host UID inspection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for running pods with isolated user namespaces and configurable host-user mapping.
  * Added restricted project and pod workflows with configurable UID/GID ranges and security settings.
  * Added support for isolated, PVC-backed pods with configurable ownership and security settings.
  * Added host-level UID inspection for user-namespace pods.
* **Tests**
  * Added CephFS functional coverage for shared access, read/write behavior, ownership persistence, pod restarts, and UID remapping across workers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->