### PR TITLE
Increase mon healthcheck log polling timeout from 300s to 720s

### DIFF
--- a/tests/functional/z_cluster/test_ceph_mon_healthcheck.py
+++ b/tests/functional/z_cluster/test_ceph_mon_healthcheck.py
@@ -128,7 +128,9 @@ class TestCephMonHealthCheck(ManageTest):
         wait_for_mon_status(
             mon_id=mon_id, status=constants.MON_STATUS_DOWN, timeout=180
         )
-        res = verify_mon_healthcheck_timeout_value_in_logs(mon_id, mon_timeout_seconds)
+        res = verify_mon_healthcheck_timeout_value_in_logs(
+            mon_id, mon_timeout_seconds, timeout=720
+        )
         assert res, "Mon healthcheck timeout value not found in logs"
         # Add a small gap to the timeout to account for any delays
         timeout_gap = 180


### PR DESCRIPTION
## Summary
  - Increase the `timeout` parameter in `verify_mon_healthcheck_timeout_value_in_logs()` from 300s (5 min) to 720s (12 min)
  - Rook has a ~10-minute failed reconcile timeout before emitting the `"waiting for timeout"` log message — the test was giving up before it appeared
  - Confirmed platform-independent failure on both HCI baremetal (launch 46224) and vSphere UPI IPv6 (launch 44728)
  
  Ref: [DFBUGS-5895](https://redhat.atlassian.net/browse/DFBUGS-5895) — Travis Nielsen confirmed the Rook behavior is expected and no product fix is needed.

  ## Test plan
  - [ ] Run `test_patch_and_verify_mon_healthcheck[3m-20s]` (OCS-7428) — verify it now waits long enough for the log
  message
  - [ ] Run `test_patch_and_verify_mon_healthcheck[12m-30s]` (OCS-7429) — verify no regression


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased the allowed verification window for monitoring healthcheck timeout messages in logs.
  * Improves test reliability for environments where expected log entries take longer to appear.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->