### PR TITLE
Skip sgdisk disk wipe when binary is missing on RHCOS nodes

### DIFF
--- a/ocs_ci/deployment/baremetal.py
+++ b/ocs_ci/deployment/baremetal.py
@@ -1508,7 +1508,9 @@ def clean_disk(
         device (str): path to the device to be cleaned up
         size (int): size of the device, if not provided, it will be obtained via `lsblk -n --output SIZE -b {device}`
             command
-        run_sgdisk (bool): run `sgdisk --zap-all {device}` command (default: True)
+        run_sgdisk (bool): run `sgdisk --zap-all {device}` command (default:
+            True). Skipped automatically when `sgdisk` is not present on the
+            node (e.g. OCP 5.0+ RHCOS images).
         ocp_obj (obj): OCP object, if not provided, new one is initialized
         namespace (str): namespace where the oc_debug command will be executed
 
@@ -1523,12 +1525,28 @@ def clean_disk(
     )
 
     logger.info(out)
-    out = ocp_obj.exec_oc_debug_cmd(
-        node=node_name,
-        cmd_list=[f"sgdisk --zap-all {device}"],
-        namespace=namespace,
-    )
-    logger.info(out)
+    if run_sgdisk:
+        sgdisk_check = ocp_obj.exec_oc_debug_cmd(
+            node=node_name,
+            cmd_list=["command -v sgdisk || echo SGDISK_MISSING"],
+            namespace=namespace,
+        )
+        if "SGDISK_MISSING" in str(sgdisk_check):
+            logger.warning(
+                "sgdisk not found on node %s; skipping sgdisk --zap-all "
+                "for %s (wipefs and bluestore dd cleanup still run)",
+                node_name,
+                device,
+            )
+        else:
+            out = ocp_obj.exec_oc_debug_cmd(
+                node=node_name,
+                cmd_list=[f"sgdisk --zap-all {device}"],
+                namespace=namespace,
+            )
+            logger.info(out)
+    else:
+        logger.info("Skipping sgdisk --zap-all for %s (run_sgdisk=False)", device)
 
     # Write different portion because bluestore replicates its metadata at multiple places on the device
     # (at 0 / 1Gb / 10Gb / 100Gb / 1000Gb etc.)


### PR DESCRIPTION
## Summary
  - `clean_disk()` was failing on OCP 5.0+ RHCOS when `sgdisk` is not installed (`sgdisk: command not found` after
  a successful `wipefs`).
  - Probe for `sgdisk` with `command -v sgdisk` and skip `--zap-all` when missing; continue with `wipefs` and
  Bluestore `dd` cleanup.
  - Honor the existing `run_sgdisk=False` path (previously ignored).
  ## Motivation
  Baremetal/AI OCP deploy post-steps call `clean_disks()` → `clean_disk()`. On nodes without `gdisk`/`sgdisk`,
  retries end in `CommandFailed` and block OCS deployment even though partition/FS wipe via `wipefs` already
  succeeded.
  ## Test plan
  - [x] Temp probe on ikave-ibm5 worker: `command -v sgdisk || echo SGDISK_MISSING` returns `SGDISK_MISSING`
  without `CMD FAILED`
  - [ ] Re-run baremetal/AI OCP deploy (or `clean_disks` path) on OCP 5.0 RHCOS without `sgdisk`
  - [ ] Confirm older OCP/RHCOS with `sgdisk` still runs `sgdisk --zap-all`


Link to Jenkins job failure: https://jenkins-csb-odf-qe-ocs4.dno.corp.redhat.com/job/qe-deploy-ocs-cluster-multi/1382/consoleFull

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved disk cleanup during bare-metal deployment by handling optional disk sanitization more safely.
  - Skips the sanitization step when the required utility is unavailable instead of failing unexpectedly.
  - Added clearer logging when sanitization is enabled, unavailable, or intentionally skipped.
  - Existing filesystem and BlueStore cleanup operations continue to run as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->