### PR TITLE
[release-4.21] cephx keyrotation automation

### DIFF
--- a/conf/ocsci/krkn_chaos_config.yaml
+++ b/conf/ocsci/krkn_chaos_config.yaml
@@ -116,6 +116,18 @@ ENV_DATA:
       # Maximum concurrent background operations
       max_concurrent_operations: 3
 
+      # CephX key rotation during chaos (requires ODF 4.19+, non-external mode)
+      enable_cephx_keyrotation: true
+      # Minimum delay between rotation iterations; a single rotation may take longer.
+      cephx_keyrotation_interval: 180
+      cephx_keys:
+        components:
+          - rook_daemon  # mon, mgr, osd, mds
+          - csi
+          - rbdMirrorPeer
+        rotation_timeout: 1200
+        keep_prior_key_count_max: 1
+
       # Enabled operation types (comment out to disable specific operations)
       enabled_operations:
         - snapshot_lifecycle      # PVC snapshot create/restore/delete/verify
@@ -126,4 +138,5 @@ ENV_DATA:
         - rgw_restart            # RGW pod restart (ObjectStore)
         - reclaim_space          # CSI-Addons ReclaimSpace on RBD volumes
         - longevity_operations   # Comprehensive snapshot/restore/expand testing
+        - cephx_keyrotation      # CephX rotation (rook_daemon, csi, rbdMirrorPeer)
         # - volume_replication   # CSI-Addons VolumeReplication (requires DR)

--- a/conf/ocsci/resiliency_tests_config.yaml
+++ b/conf/ocsci/resiliency_tests_config.yaml
@@ -118,6 +118,18 @@ ENV_DATA:
       # Maximum concurrent background operations
       max_concurrent_operations: 3
 
+      # CephX key rotation during resiliency testing (requires ODF 4.19+, non-external mode)
+      enable_cephx_keyrotation: true
+      # Minimum delay between rotation iterations; a single rotation may take longer.
+      cephx_keyrotation_interval: 180
+      cephx_keys:
+        components:
+          - rook_daemon  # mon, mgr, osd, mds
+          - csi
+          - rbdMirrorPeer
+        rotation_timeout: 1200
+        keep_prior_key_count_max: 1
+
       # Enabled operation types (comment out to disable specific operations)
       enabled_operations:
         - snapshot_lifecycle      # PVC snapshot create/restore/delete/verify
@@ -128,6 +140,7 @@ ENV_DATA:
         - rgw_restart            # RGW pod restart (ObjectStore)
         - reclaim_space          # CSI-Addons ReclaimSpace on RBD volumes
         - longevity_operations   # Comprehensive snapshot/restore/expand testing
+        - cephx_keyrotation      # CephX rotation (rook_daemon, csi, rbdMirrorPeer)
         # - volume_replication   # CSI-Addons VolumeReplication (requires DR)
 
     # Workload scaling configuration for resiliency tests

--- a/ocs_ci/helpers/cephx_bg_ops_config.py
+++ b/ocs_ci/helpers/cephx_bg_ops_config.py
@@ -1,0 +1,36 @@
+"""
+Shared accessors for CephX key rotation settings in background_cluster_operations.
+
+Used by krkn and resiliency workload config loaders and BackgroundClusterOperations.
+"""
+
+from typing import Any, Dict, List
+
+DEFAULT_CEPHX_KEYS = ["rook_daemon"]
+DEFAULT_CEPHX_KEYROTATION_INTERVAL = 180
+
+
+def is_cephx_keyrotation_enabled(bg_ops_config: Dict[str, Any]) -> bool:
+    """Return whether CephX key rotation background ops are enabled."""
+    return bg_ops_config.get("enable_cephx_keyrotation", False)
+
+
+def get_cephx_keys(bg_ops_config: Dict[str, Any]) -> List[str]:
+    """
+    Normalize cephx_keys from background_cluster_operations config.
+
+    Accepts a list or a dict with a ``components`` key; defaults to rook_daemon.
+    """
+    cephx_keys = bg_ops_config.get("cephx_keys", DEFAULT_CEPHX_KEYS)
+    if isinstance(cephx_keys, dict):
+        cephx_keys = cephx_keys.get("components", DEFAULT_CEPHX_KEYS)
+    return list(cephx_keys or DEFAULT_CEPHX_KEYS)
+
+
+def get_cephx_keyrotation_interval(bg_ops_config: Dict[str, Any]) -> int:
+    """Return minimum seconds between CephX key rotation iterations."""
+    return int(
+        bg_ops_config.get(
+            "cephx_keyrotation_interval", DEFAULT_CEPHX_KEYROTATION_INTERVAL
+        )
+    )

--- a/ocs_ci/helpers/cephx_keyrotation/__init__.py
+++ b/ocs_ci/helpers/cephx_keyrotation/__init__.py
@@ -1,0 +1,34 @@
+"""
+CephX key rotation helpers.
+
+Prefer importing from this package::
+
+    from ocs_ci.helpers.cephx_keyrotation import CephXKeyRotation
+
+Focused mixins are exported for direct reuse/extension. Production call sites
+should normally use the ``CephXKeyRotation`` facade, which composes all mixins.
+"""
+
+from ocs_ci.helpers.cephx_keyrotation.auth import CephXAuthHelper
+from ocs_ci.helpers.cephx_keyrotation.cluster import CephXClusterHelper
+from ocs_ci.helpers.cephx_keyrotation.core import CephXKeyRotationCore
+from ocs_ci.helpers.cephx_keyrotation.daemon import CephXDaemonRotation
+from ocs_ci.helpers.cephx_keyrotation.facade import CephXKeyRotation
+from ocs_ci.helpers.cephx_keyrotation.io import CephXIOHelper
+from ocs_ci.helpers.cephx_keyrotation.metrics import CephXMetricsHelper
+from ocs_ci.helpers.cephx_keyrotation.mon import CephXMONHelper
+from ocs_ci.helpers.cephx_keyrotation.osd import CephXOSDHelper
+from ocs_ci.helpers.cephx_keyrotation.security import CephXSecurityHelper
+
+__all__ = [
+    "CephXKeyRotation",
+    "CephXKeyRotationCore",
+    "CephXAuthHelper",
+    "CephXSecurityHelper",
+    "CephXClusterHelper",
+    "CephXDaemonRotation",
+    "CephXOSDHelper",
+    "CephXMONHelper",
+    "CephXMetricsHelper",
+    "CephXIOHelper",
+]

--- a/ocs_ci/helpers/cephx_keyrotation/auth.py
+++ b/ocs_ci/helpers/cephx_keyrotation/auth.py
@@ -1,0 +1,421 @@
+"""Ceph auth entity/key/caps helpers for CephX rotation."""
+
+import logging
+import re
+
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.exceptions import CommandFailed, UnexpectedBehaviour
+from ocs_ci.ocs.ocp import OCP
+from ocs_ci.ocs.resources.pod import (
+    get_pod_logs,
+)
+from ocs_ci.utility.retry import retry
+
+log = logging.getLogger(__name__)
+
+
+class CephXAuthHelper:
+    """Auth store discovery, key snapshots, and capability checks."""
+
+    @staticmethod
+    def _extract_key_type_from_auth_entry(auth_entry):
+        if not isinstance(auth_entry, dict):
+            return None
+        for field in ("key_type", "keyType", "type"):
+            value = auth_entry.get(field)
+            if value:
+                return str(value).lower()
+        return None
+
+    def get_auth_entity_key_type(self, entity, toolbox_pod=None):
+        """Return the CephX key type for *entity* when exposed by Ceph."""
+        toolbox = toolbox_pod or self.get_ceph_cli_pod()
+        try:
+            result = toolbox.exec_cmd_on_pod(
+                f"ceph auth get {entity} --format json",
+                out_yaml_format=True,
+            )
+        except CommandFailed as exc:
+            if "ENOENT" in str(exc):
+                log.warning(f"Ceph auth entity {entity} not found")
+                return None
+            raise
+
+        if isinstance(result, list) and result:
+            result = result[0]
+        key_type = self._extract_key_type_from_auth_entry(result)
+        if key_type:
+            return key_type
+
+        text = toolbox.exec_cmd_on_pod(
+            f"ceph auth get {entity}",
+            out_yaml_format=False,
+        )
+        match = re.search(r"key[_\s-]*type\s*[=:]\s*(\S+)", text, re.IGNORECASE)
+        if match:
+            return match.group(1).lower()
+
+        auth_listing = toolbox.exec_cmd_on_pod(
+            "ceph auth ls",
+            out_yaml_format=False,
+        )
+        entity_pattern = re.compile(
+            rf"^{re.escape(entity)}\b.*?(?:key[_\s-]*type\s*[=:]\s*(\S+))",
+            re.IGNORECASE | re.MULTILINE | re.DOTALL,
+        )
+        listing_match = entity_pattern.search(auth_listing)
+        if listing_match:
+            return listing_match.group(1).lower()
+        return None
+
+    def assert_auth_entities_key_type(
+        self, entities, expected_key_type, toolbox_pod=None
+    ):
+        """Assert Ceph auth entities use the requested key type."""
+        expected = expected_key_type.lower()
+        mismatched = []
+        unknown = []
+        for entity in entities:
+            actual = self.get_auth_entity_key_type(entity, toolbox_pod)
+            if not actual:
+                unknown.append(entity)
+                continue
+            if actual != expected:
+                mismatched.append(f"{entity}={actual}")
+            else:
+                log.info(f"{entity} uses key type {actual}")
+
+        if mismatched:
+            raise UnexpectedBehaviour(
+                f"Entities not using key type {expected}: {', '.join(mismatched)}"
+            )
+
+        insecure = self.get_insecure_service_key_type_entities(toolbox_pod)
+        insecure_for_entities = [
+            f"{entity}={key_type}"
+            for entity, key_type in insecure
+            if entity in entities
+        ]
+        if insecure_for_entities:
+            raise UnexpectedBehaviour(
+                "Entities still reported with insecure key types in health detail: "
+                f"{', '.join(insecure_for_entities)}"
+            )
+
+        if unknown:
+            log.warning(
+                "Could not read key type from ceph auth for: "
+                f"{', '.join(unknown)}; relying on health detail checks"
+            )
+        log.info(f"Verified key type {expected} for entities: {', '.join(entities)}")
+
+    def verify_pods_no_auth_bad_key(self, pods, tail=500):
+        """
+        Assert pod logs do not contain AUTH_BAD_KEY authentication failures.
+
+        Args:
+            pods: Iterable of Pod objects, pod name strings, or pod dicts.
+            tail (int): Number of log lines to scan.
+        """
+        for pod in pods:
+            if isinstance(pod, str):
+                pod_name = pod
+                namespace = self.namespace
+                container = None
+            elif hasattr(pod, "name"):
+                pod_name = pod.name
+                namespace = pod.namespace
+                containers = pod.data.get("spec", {}).get("containers", [])
+                container = containers[0]["name"] if containers else None
+            else:
+                pod_name = pod["metadata"]["name"]
+                namespace = pod["metadata"]["namespace"]
+                containers = pod["spec"].get("containers", [])
+                container = containers[0]["name"] if containers else None
+
+            auth_errors = get_pod_logs(
+                pod_name=pod_name,
+                container=container,
+                namespace=namespace,
+                tail=str(tail),
+                grep=constants.AUTH_BAD_KEY_LOG,
+                return_empty_string=True,
+            )
+            if auth_errors and constants.AUTH_BAD_KEY_LOG in auth_errors:
+                raise UnexpectedBehaviour(
+                    f"AUTH_BAD_KEY errors found in {namespace}/{pod_name} logs: "
+                    f"{auth_errors.strip()}"
+                )
+            log.info(f"No AUTH_BAD_KEY errors in {namespace}/{pod_name} logs")
+
+    @retry(CommandFailed, tries=5, delay=10, backoff=1)
+    def get_auth_key(self, entity, toolbox_pod=None):
+        """
+        Return the current CephX key for *entity* from the toolbox.
+
+        Uses ``ceph auth get-key <entity>`` (not ``ceph auth <entity>``, which is
+        invalid). Works for daemon entities (``osd.0``, ``mgr.a``, ``mds.*``,
+        shared ``mon.`` / ``mon.a``) and client entities (``client.admin``, CSI
+        users, etc.).
+
+        Args:
+            entity (str): Ceph auth entity name.
+            toolbox_pod: Optional rook-ceph-tools pod object.
+
+        Returns:
+            str: Key string, or empty string if the entity does not exist.
+        """
+        toolbox = toolbox_pod or self.get_ceph_cli_pod()
+        try:
+            result = toolbox.exec_cmd_on_pod(
+                f"ceph auth get-key {entity} --format json",
+                out_yaml_format=True,
+            )
+        except CommandFailed as exc:
+            if "ENOENT" in str(exc):
+                log.warning(f"Ceph auth entity {entity} not found")
+                return ""
+            raise
+        if isinstance(result, dict):
+            return result.get("key", "")
+        return str(result).strip()
+
+    @staticmethod
+    def log_auth_key_snapshot(label, keys):
+        """Log CephX auth keys for a snapshot (before/after rotation)."""
+        log.info(f"CephX auth keys {label}:")
+        for entity in sorted(keys):
+            key = keys[entity]
+            log.info(f"  {entity}: {key if key else '<empty>'}")
+
+    @staticmethod
+    def log_auth_key_comparison(old_keys, new_keys):
+        """Log per-entity CephX key comparison without exposing key values."""
+        log.info("CephX auth key comparison (before vs after rotation):")
+        for entity in sorted(set(old_keys) | set(new_keys)):
+            old_key = old_keys.get(entity, "")
+            new_key = new_keys.get(entity, "")
+            if not old_key and not new_key:
+                status = "MISSING"
+            elif old_key == new_key:
+                status = "UNCHANGED"
+            else:
+                status = "CHANGED"
+            log.info(f"  {entity}: {status}")
+
+    def capture_auth_keys(self, entities, toolbox_pod=None, label=None):
+        """
+        Snapshot CephX keys for a list of entities (for before/after comparison).
+
+        Args:
+            label (str): When set, log the captured keys under this label.
+
+        Returns:
+            dict: entity name to key string.
+        """
+        keys = {}
+        for entity in entities:
+            keys[entity] = self.get_auth_key(entity, toolbox_pod=toolbox_pod)
+        if label:
+            self.log_auth_key_snapshot(label, keys)
+        return keys
+
+    def discover_csi_auth_entities(self, toolbox_pod=None):
+        """Return CSI-related ``client.csi*`` auth entities."""
+        return [
+            entity
+            for entity in self.list_auth_entities(toolbox_pod=toolbox_pod)
+            if entity.startswith("client.csi")
+        ]
+
+    def discover_rbd_mirror_auth_entities(self, toolbox_pod=None):
+        """Return RBD mirror related client auth entities."""
+        prefixes = (
+            "client.rbd-mirror",
+            "client.rbd_mirror",
+            "client.rbd-mirror-peer",
+        )
+        entities = []
+        for prefix in prefixes:
+            entities.extend(self.list_auth_entities(prefix, toolbox_pod))
+        return sorted(set(entities))
+
+    def discover_cephclient_auth_entities(self, toolbox_pod=None):
+        """Return auth entities associated with CephClient CRs when present."""
+        cc_obj = OCP(kind=constants.CEPHCLIENT, namespace=self.namespace)
+        try:
+            resources = cc_obj.get()
+        except CommandFailed as exc:
+            log.info(
+                "CephClient kind unavailable; skipping CephClient auth discovery "
+                f"({exc})"
+            )
+            return []
+        items = resources.get("items", [])
+        if not items and resources.get("metadata"):
+            items = [resources]
+
+        entities = []
+        for item in items:
+            name = item.get("metadata", {}).get("name")
+            if not name:
+                continue
+            for candidate in (f"client.{name}", f"client.ceph-{name}"):
+                if self._auth_entity_exists(candidate, toolbox_pod):
+                    entities.append(candidate)
+        return sorted(set(entities))
+
+    def discover_all_rotation_auth_entities(self, toolbox_pod=None):
+        """
+        Discover auth entities for daemons, CSI, RBD mirror, and CephClients.
+        """
+        entities = self.flatten_daemon_auth_entities(
+            self.discover_rook_daemon_auth_entities(toolbox_pod)
+        )
+        entities.extend(self.discover_csi_auth_entities(toolbox_pod))
+        entities.extend(self.discover_rbd_mirror_auth_entities(toolbox_pod))
+        entities.extend(self.discover_cephclient_auth_entities(toolbox_pod))
+        return sorted(set(entities))
+
+    def assert_auth_keys_unchanged(
+        self,
+        old_keys,
+        entities=None,
+        toolbox_pod=None,
+        context="while rotation is Disabled",
+    ):
+        """Assert CephX auth keys did not change."""
+        entities = entities or list(old_keys.keys())
+        new_keys = self.capture_auth_keys(entities, toolbox_pod=toolbox_pod)
+        self.log_auth_key_comparison(old_keys, new_keys)
+        changed = [
+            entity
+            for entity in entities
+            if old_keys.get(entity) != new_keys.get(entity)
+        ]
+        if changed:
+            raise UnexpectedBehaviour(
+                f"CephX auth keys changed {context}: {', '.join(changed)}"
+            )
+        log.info(f"CephX auth keys unchanged for entities: {', '.join(entities)}")
+
+    def list_auth_entities(self, prefix=None, toolbox_pod=None):
+        """
+        List Ceph auth entities, optionally filtered by prefix.
+
+        Returns:
+            list[str]: Sorted entity names.
+        """
+        auth_dump = self._get_auth_entities_dict(toolbox_pod)
+        entities = sorted(auth_dump.keys())
+        if prefix:
+            entities = [entity for entity in entities if entity.startswith(prefix)]
+        return entities
+
+    def _auth_entity_exists(self, entity, toolbox_pod=None):
+        """Return True when *entity* is present in the Ceph auth store."""
+        toolbox = toolbox_pod or self.get_ceph_cli_pod()
+        try:
+            toolbox.exec_cmd_on_pod(
+                f"ceph auth get-key {entity} --format json",
+                out_yaml_format=True,
+            )
+            return True
+        except CommandFailed:
+            return False
+
+    def auth_entity_exists(self, entity, toolbox_pod=None):
+        """Return True if *entity* exists in the Ceph auth store."""
+        return self._auth_entity_exists(entity, toolbox_pod=toolbox_pod)
+
+    def get_auth_caps(self, entity, toolbox_pod=None):
+        """
+        Return capability map for a Ceph auth entity.
+
+        Returns:
+            dict: capability name to value (e.g. mon, mgr, osd).
+        """
+        toolbox = toolbox_pod or self.get_ceph_cli_pod()
+        try:
+            result = toolbox.exec_ceph_cmd(f"ceph auth get {entity}")
+        except CommandFailed as exc:
+            if "ENOENT" in str(exc):
+                log.warning(f"Ceph auth entity {entity} not found")
+                return {}
+            raise
+        if isinstance(result, dict):
+            return result.get("caps", {}) or {}
+        return {}
+
+    def capture_auth_caps(self, entities, toolbox_pod=None):
+        """Snapshot auth capabilities for *entities*."""
+        return {
+            entity: self.get_auth_caps(entity, toolbox_pod=toolbox_pod)
+            for entity in entities
+        }
+
+    @retry(UnexpectedBehaviour, tries=5, delay=20)
+    def verify_auth_caps_unchanged(self, old_caps, entities=None, toolbox_pod=None):
+        """Assert capabilities are unchanged after rotation."""
+        entities = entities or list(old_caps.keys())
+        new_caps = self.capture_auth_caps(entities, toolbox_pod=toolbox_pod)
+        changed = [
+            entity
+            for entity in entities
+            if old_caps.get(entity) != new_caps.get(entity)
+        ]
+        if changed:
+            raise UnexpectedBehaviour(
+                f"CephX capabilities changed after rotation for: {', '.join(changed)}"
+            )
+        log.info(f"CephX capabilities unchanged for entities: {', '.join(entities)}")
+        return new_caps
+
+    def verify_auth_keys_changed(self, old_keys, entities=None, toolbox_pod=None):
+        """
+        Assert that keys for *entities* differ from *old_keys* after rotation.
+
+        Args:
+            old_keys (dict): Output of :meth:`capture_auth_keys`.
+            entities (list): Subset to check (default: all keys in *old_keys*).
+
+        Returns:
+            dict: entity to new key mapping.
+        """
+        entities = entities or list(old_keys.keys())
+        new_keys = self.capture_auth_keys(entities, toolbox_pod=toolbox_pod)
+        self.log_auth_key_comparison(old_keys, new_keys)
+        unchanged = [
+            entity
+            for entity in entities
+            if old_keys.get(entity) and old_keys[entity] == new_keys.get(entity)
+        ]
+        if unchanged:
+            raise UnexpectedBehaviour(
+                f"CephX keys unchanged after rotation for: {', '.join(unchanged)}"
+            )
+        changed = [
+            entity
+            for entity in entities
+            if old_keys.get(entity) != new_keys.get(entity)
+        ]
+        log.info(
+            f"CephX keys rotated for entities: "
+            f"{', '.join(changed) if changed else ', '.join(entities)}"
+        )
+        return new_keys
+
+    @retry(CommandFailed, tries=5, delay=15, backoff=1)
+    def _get_auth_entities_dict(self, toolbox_pod=None):
+        """
+        Return the parsed ``ceph auth ls`` dict from the toolbox.
+
+        Retries on transient toolbox auth failures such as
+        ``handle_auth_bad_method`` / RADOS permission denied while mons are
+        hunting after key rotation or cluster settle.
+        """
+        toolbox = toolbox_pod or self.get_ceph_cli_pod()
+        result = toolbox.exec_ceph_cmd("ceph auth ls")
+        if isinstance(result, dict):
+            return result
+        raise UnexpectedBehaviour("Unexpected output from 'ceph auth ls'")

--- a/ocs_ci/helpers/cephx_keyrotation/cluster.py
+++ b/ocs_ci/helpers/cephx_keyrotation/cluster.py
@@ -1,0 +1,895 @@
+"""Cluster readiness, reconcile, operator, and PG helpers for CephX tests."""
+
+import json
+import logging
+import time
+
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.exceptions import CommandFailed, UnexpectedBehaviour
+from ocs_ci.ocs.ocp import OCP
+from ocs_ci.ocs.resources.pod import (
+    Pod,
+    get_operator_pods,
+    get_pod_logs,
+    get_pods_having_label,
+    wait_for_matching_pattern_in_pod_logs,
+)
+from ocs_ci.ocs.resources.storage_cluster import StorageCluster
+from ocs_ci.utility.utils import TimeoutSampler
+
+log = logging.getLogger(__name__)
+
+
+class CephXClusterHelper:
+    """Cluster Ready/reconcile, operator lifecycle, and PG wait helpers."""
+
+    def get_cephcluster_phase(self):
+        """Return CephCluster ``status.phase``."""
+        status = self._get_cluster_dict().get("status") or {}
+        return status.get("phase")
+
+    def get_storagecluster_phase(self):
+        """Return StorageCluster ``status.phase``."""
+        status = self._get_storage_cluster_dict().get("status") or {}
+        return status.get("phase")
+
+    def assert_decreasing_daemon_key_generation_rejected(self, lower_generation=None):
+        """
+        Assert StorageCluster rejects decreasing daemon ``keyGeneration``.
+
+        Patches ``managedResources.cephCluster.security.cephx.daemon.keyGeneration``
+        to a value lower than the current StorageCluster generation and expects
+        admission validation failure containing
+        ``constants.CEPHX_KEY_GENERATION_DECREASE_ERROR``.
+
+        Args:
+            lower_generation (int): Explicit lower generation. Defaults to
+                current StorageCluster generation - 1.
+
+        Returns:
+            int: The rejected lower generation that was attempted.
+
+        Raises:
+            UnexpectedBehaviour: If the patch succeeds or fails with an
+                unexpected error.
+        """
+        current_generation = self.get_spec_key_generation(self.COMPONENT_DAEMON)
+        if current_generation < 1:
+            raise UnexpectedBehaviour(
+                "StorageCluster daemon keyGeneration is unset; cannot verify "
+                "decrease rejection"
+            )
+
+        if lower_generation is None:
+            lower_generation = current_generation - 1
+        lower_generation = int(lower_generation)
+        if lower_generation >= current_generation:
+            raise UnexpectedBehaviour(
+                f"lower_generation={lower_generation} must be < current "
+                f"StorageCluster keyGeneration={current_generation}"
+            )
+
+        component_config = dict(
+            self.get_storagecluster_component_spec(self.COMPONENT_DAEMON)
+        )
+        component_config["keyRotationPolicy"] = self.KEY_ROTATION_POLICY_KEY_GENERATION
+        component_config["keyGeneration"] = lower_generation
+
+        log.info(
+            "Attempting to decrease StorageCluster daemon keyGeneration "
+            f"{current_generation} -> {lower_generation} (expect rejection)"
+        )
+        try:
+            self.patch_storagecluster_cephx_component(
+                self.COMPONENT_DAEMON, component_config
+            )
+        except CommandFailed as exc:
+            err = str(exc)
+            if constants.CEPHX_KEY_GENERATION_DECREASE_ERROR not in err:
+                raise UnexpectedBehaviour(
+                    "Expected StorageCluster admission error containing "
+                    f"'{constants.CEPHX_KEY_GENERATION_DECREASE_ERROR}', got: {err}"
+                ) from exc
+            log.info(
+                "StorageCluster correctly rejected daemon keyGeneration decrease "
+                f"to {lower_generation}"
+            )
+            return lower_generation
+
+        raise UnexpectedBehaviour(
+            "StorageCluster accepted a decreased daemon keyGeneration "
+            f"({current_generation} -> {lower_generation}); expected rejection"
+        )
+
+    def assert_invalid_daemon_key_generation_type_rejected(
+        self, invalid_value, expected_json_type
+    ):
+        """
+        Assert StorageCluster rejects non-integer daemon ``keyGeneration``.
+
+        Patches only
+        ``/spec/managedResources/cephCluster/security/cephx/daemon/keyGeneration``
+        with a non-integer JSON value.
+
+        Expected rejection: non-null values fail with an OpenAPI type error
+        (``must be of type integer: "<expected_json_type>"``); ``null`` fails
+        with ``keyGeneration cannot be removed once set`` (null is treated as
+        removing the field once it has been set).
+
+        Args:
+            invalid_value: Value to patch (e.g. ``"abc"``, ``True``, ``None``).
+            expected_json_type (str): Reported JSON type in the OpenAPI error
+                (``string`` or ``boolean``). Ignored when ``invalid_value`` is
+                ``None`` (null uses the remove-once-set validation path).
+
+        Returns:
+            str: Admission error text.
+
+        Raises:
+            UnexpectedBehaviour: If the patch succeeds or fails unexpectedly.
+        """
+        daemon_spec = self.get_storagecluster_component_spec(self.COMPONENT_DAEMON)
+        path = "/spec/managedResources/cephCluster/security/cephx/daemon/keyGeneration"
+        op = "replace" if "keyGeneration" in daemon_spec else "add"
+        # Ensure parent daemon object exists before adding keyGeneration.
+        if op == "add" and not daemon_spec:
+            restore_generation = max(
+                self.DEFAULT_DAEMON_KEY_GENERATION,
+                self.get_desired_cephx_key_gen(),
+            )
+            self.patch_storagecluster_cephx_component(
+                self.COMPONENT_DAEMON,
+                {
+                    "keyRotationPolicy": self.KEY_ROTATION_POLICY_KEY_GENERATION,
+                    "keyGeneration": restore_generation,
+                },
+            )
+            op = "replace"
+
+        patch_ops = [{"op": op, "path": path, "value": invalid_value}]
+        value_repr = (
+            "null"
+            if invalid_value is None
+            else (
+                str(invalid_value).lower()
+                if isinstance(invalid_value, bool)
+                else repr(invalid_value)
+            )
+        )
+        expect_remove_error = invalid_value is None
+        expected_error = (
+            constants.CEPHX_KEY_GENERATION_REMOVE_ERROR
+            if expect_remove_error
+            else constants.CEPHX_KEY_GENERATION_TYPE_ERROR
+        )
+        log.info(
+            "Attempting invalid StorageCluster daemon keyGeneration=%s "
+            "(expect rejection containing %r%s)",
+            value_repr,
+            expected_error,
+            ("" if expect_remove_error else f", json type={expected_json_type}"),
+        )
+        try:
+            self._get_storagecluster_ocp().patch(
+                params=json.dumps(patch_ops), format_type="json"
+            )
+        except CommandFailed as exc:
+            err = str(exc)
+            if expected_error not in err:
+                raise UnexpectedBehaviour(
+                    "Expected StorageCluster validation error containing "
+                    f"'{expected_error}', got: {err}"
+                ) from exc
+            if not expect_remove_error:
+                type_token = f'"{expected_json_type}"'
+                if type_token not in err and expected_json_type not in err:
+                    raise UnexpectedBehaviour(
+                        "Expected type validation error to mention JSON type "
+                        f"{type_token}, got: {err}"
+                    ) from exc
+            log.info(
+                "StorageCluster correctly rejected invalid daemon "
+                f"keyGeneration={value_repr}"
+            )
+            return err
+
+        raise UnexpectedBehaviour(
+            "StorageCluster accepted non-integer daemon keyGeneration="
+            f"{value_repr}; expected validation rejection containing "
+            f"'{expected_error}'"
+        )
+
+    def get_cephcluster_daemon_key_generation(self):
+        """
+        Return CephCluster daemon ``keyGeneration`` for SC recovery.
+
+        Prefers ``spec.security.cephx.daemon.keyGeneration`` when set; otherwise
+        uses the highest reported ``status.cephx`` daemon generation.
+        """
+        cc_daemon = self.get_spec_cephx().get("daemon") or {}
+        if cc_daemon.get("keyGeneration") is not None:
+            return int(cc_daemon["keyGeneration"])
+        return int(self.get_component_status_key_generation(self.COMPONENT_DAEMON) or 0)
+
+    def recover_storagecluster_daemon_key_generation_from_cephcluster(self):
+        """
+        Restore StorageCluster daemon ``keyGeneration`` from CephCluster.
+
+        Used when a bad patch (e.g. ``null``) deleted the field from
+        StorageCluster and left the cluster in Error. Copies the CephCluster
+        daemon generation onto StorageCluster and waits for Ready.
+        """
+        self.ensure_daemon_key_generations_aligned()
+
+    def ensure_daemon_key_generations_aligned(self):
+        """
+        Ensure StorageCluster daemon ``keyGeneration`` matches CephCluster.
+
+        CephCluster is the source of truth (spec.daemon.keyGeneration when set,
+        otherwise highest status.cephx daemon generation). StorageCluster is
+        patched to that value. If a direct replace is rejected because
+        keyGeneration cannot be decreased, the field is removed and re-added.
+
+        Returns:
+            int: Aligned daemon keyGeneration.
+
+        Raises:
+            UnexpectedBehaviour: If CephCluster has no generation or StorageCluster
+                still mismatches after alignment.
+        """
+        path = "/spec/managedResources/cephCluster/security/cephx/daemon/keyGeneration"
+        cc_generation = self.get_cephcluster_daemon_key_generation()
+        if cc_generation < 1:
+            raise UnexpectedBehaviour(
+                "Cannot align StorageCluster daemon keyGeneration: "
+                "CephCluster has no daemon keyGeneration in spec or status"
+            )
+
+        daemon_spec = self.get_storagecluster_component_spec(self.COMPONENT_DAEMON)
+        sc_generation = int(daemon_spec.get("keyGeneration", 0) or 0)
+        if "keyGeneration" in daemon_spec and sc_generation == cc_generation:
+            log.info(
+                "StorageCluster and CephCluster daemon keyGeneration already "
+                f"aligned at {cc_generation}"
+            )
+            return cc_generation
+
+        # Parent daemon object must exist before add/replace of keyGeneration.
+        if not daemon_spec:
+            self.patch_storagecluster_cephx_component(
+                self.COMPONENT_DAEMON,
+                {
+                    "keyRotationPolicy": self.KEY_ROTATION_POLICY_KEY_GENERATION,
+                    "keyGeneration": cc_generation,
+                },
+            )
+            self.wait_for_cluster_ready()
+            aligned = self.get_spec_key_generation(self.COMPONENT_DAEMON)
+            if aligned != cc_generation:
+                raise UnexpectedBehaviour(
+                    "Failed to align StorageCluster daemon keyGeneration: "
+                    f"StorageCluster={aligned}, CephCluster={cc_generation}"
+                )
+            log.info(
+                "Aligned StorageCluster daemon keyGeneration to CephCluster "
+                f"value {cc_generation}"
+            )
+            return cc_generation
+
+        sc_obj = self._get_storagecluster_ocp()
+        log.info(
+            "Aligning StorageCluster daemon keyGeneration "
+            f"({sc_generation if 'keyGeneration' in daemon_spec else None}) "
+            f"to CephCluster value {cc_generation}"
+        )
+        try:
+            op = "replace" if "keyGeneration" in daemon_spec else "add"
+            sc_obj.patch(
+                params=json.dumps([{"op": op, "path": path, "value": cc_generation}]),
+                format_type="json",
+            )
+        except CommandFailed as exc:
+            err = str(exc)
+            if (
+                "keyGeneration" in daemon_spec
+                and sc_generation > cc_generation
+                and constants.CEPHX_KEY_GENERATION_DECREASE_ERROR in err
+            ):
+                log.warning(
+                    "Direct keyGeneration decrease rejected; removing and "
+                    f"re-adding keyGeneration={cc_generation}"
+                )
+                sc_obj.patch(
+                    params=json.dumps([{"op": "remove", "path": path}]),
+                    format_type="json",
+                )
+                sc_obj.patch(
+                    params=json.dumps(
+                        [{"op": "add", "path": path, "value": cc_generation}]
+                    ),
+                    format_type="json",
+                )
+            else:
+                raise
+
+        self._storagecluster_obj = None
+        self.wait_for_cluster_ready()
+        aligned = self.get_spec_key_generation(self.COMPONENT_DAEMON)
+        if aligned != cc_generation:
+            raise UnexpectedBehaviour(
+                "Failed to align StorageCluster daemon keyGeneration: "
+                f"StorageCluster={aligned}, CephCluster={cc_generation}"
+            )
+        log.info(
+            "Aligned StorageCluster daemon keyGeneration to CephCluster "
+            f"value {cc_generation}"
+        )
+        return cc_generation
+
+    def record_all_cephx_status_generations(self):
+        """Snapshot status/spec keyGeneration values for rotation components."""
+        generations = {}
+        status = self.get_status_cephx()
+        for entity in self.CEPHX_STATUS_GENERATION_ENTITIES:
+            entry = status.get(entity) or {}
+            generations[entity] = int(entry.get("keyGeneration", 0) or 0)
+        generations["filesystem_daemon"] = self.get_filesystem_daemon_key_generation()
+        for component in self.ROTATION_COMPONENTS:
+            generations[f"spec_{component}"] = self.get_spec_key_generation(component)
+        return generations
+
+    def assert_cephx_status_generations_unchanged(
+        self, baseline, context="while rotation is Disabled"
+    ):
+        """Assert CephX keyGeneration values did not change."""
+        current = self.record_all_cephx_status_generations()
+        changed = {
+            name: {"before": baseline[name], "after": current[name]}
+            for name in baseline
+            if baseline[name] != current[name]
+        }
+        if changed:
+            raise UnexpectedBehaviour(
+                f"CephX keyGeneration values changed {context}: {changed}"
+            )
+        log.info("CephX keyGeneration values unchanged")
+
+    def assert_reported_cephx_generations_unchanged(
+        self, baseline, context="while rotation is blocked"
+    ):
+        """Assert reported ``status.cephx`` generations did not change (ignore spec)."""
+        current = self.record_all_cephx_status_generations()
+        changed = {
+            name: {"before": baseline[name], "after": current[name]}
+            for name in baseline
+            if not name.startswith("spec_") and baseline[name] != current[name]
+        }
+        if changed:
+            raise UnexpectedBehaviour(
+                f"Reported CephX keyGeneration values changed {context}: {changed}"
+            )
+        log.info("Reported CephX keyGeneration values unchanged")
+
+    def trigger_reconciliation_cycles(self, cycles=3, sleep_between=60):
+        """Trigger multiple CephCluster reconciles."""
+        for cycle in range(1, cycles + 1):
+            log.info(f"Triggering CephCluster reconcile cycle {cycle}/{cycles}")
+            self.trigger_cephcluster_reconcile()
+            if cycle < cycles:
+                time.sleep(sleep_between)
+
+    def wait_for_cluster_ready(self, timeout=900):
+        """Wait until CephCluster and StorageCluster reach Ready phase."""
+        cephcluster = OCP(
+            kind=constants.CEPH_CLUSTER,
+            namespace=self.namespace,
+            resource_name=self.ceph_cluster_name,
+        )
+        # CephCluster has status.phase but generic OCP defaults _has_phase to False.
+        cephcluster._has_phase = True
+        log.info(f"Waiting for CephCluster {self.ceph_cluster_name} to be Ready")
+        cephcluster.wait_for_phase(phase=constants.STATUS_READY, timeout=timeout)
+
+        storage_cluster = StorageCluster(
+            resource_name=constants.DEFAULT_CLUSTERNAME,
+            namespace=self.namespace,
+        )
+        log.info("Waiting for StorageCluster to be Ready")
+        storage_cluster.wait_for_phase(phase=constants.STATUS_READY, timeout=timeout)
+
+    def wait_for_cluster_fully_recovered(self, timeout=1500, sleep=15):
+        """
+        Wait until PGs are active+clean and CephCluster/StorageCluster are Ready.
+
+        Use after daemon CephX rotation or after restoring intentionally
+        disrupted OSDs/MONs so subsequent health checks do not race recovery.
+        """
+        log.info(
+            "Waiting for full cluster recovery "
+            f"(PGs active+clean, cluster Ready; timeout={timeout}s)"
+        )
+        self.wait_for_pgs_active_clean(timeout=timeout, sleep=sleep)
+        self.wait_for_cluster_ready(timeout=timeout)
+
+    def wait_for_cephcluster_rotation(self, timeout=1500, sleep=15):
+        """
+        Wait until CephCluster finishes CephX rotation reconcile.
+
+        Expected flow after a StorageCluster-initiated rotation:
+        ``Progressing`` (per-component messages such as Processing OSD…) →
+        ``Ready``. ``Error`` fails immediately.
+
+        ``Ready`` is accepted only after ``Progressing`` was observed so a
+        pre-reconcile Ready phase is not mistaken for completion.
+
+        Args:
+            timeout (int): Max seconds to wait (default 25 minutes).
+            sleep (int): Seconds between polls (default 15).
+
+        Returns:
+            bool: True when CephCluster is Ready after Progressing.
+
+        Raises:
+            UnexpectedBehaviour: If phase is Error, or Ready is not reached
+                within *timeout* after Progressing was seen.
+        """
+        cephcluster = OCP(
+            kind=constants.CEPH_CLUSTER,
+            namespace=self.namespace,
+            resource_name=self.ceph_cluster_name,
+        )
+        log.info(
+            f"Waiting for CephCluster {self.ceph_cluster_name} rotation "
+            f"(Progressing→Ready; Error fails; timeout={timeout}s, "
+            f"poll every {sleep}s)"
+        )
+        seen_progressing = False
+        last_phase = None
+        last_message = ""
+
+        def _poll_rotation_state():
+            """
+            Returns:
+                str: ``ready``, ``error``, or ``waiting``.
+            """
+            nonlocal seen_progressing, last_phase, last_message
+            cephcluster.reload_data()
+            status = cephcluster.data.get("status") or {}
+            phase = status.get("phase")
+            message = status.get("message", "") or ""
+            last_phase = phase
+            last_message = message
+            msg_suffix = f" message={message}" if message else ""
+
+            if phase == constants.STATUS_ERROR:
+                log.error(
+                    f"CephCluster {self.ceph_cluster_name} entered Error during "
+                    f"CephX key rotation{msg_suffix}"
+                )
+                return "error"
+
+            if phase == constants.STATUS_PROGRESSING:
+                if not seen_progressing:
+                    log.info(
+                        f"CephCluster {self.ceph_cluster_name} entered "
+                        f"Progressing{msg_suffix}"
+                    )
+                else:
+                    log.info(
+                        f"CephCluster {self.ceph_cluster_name} still "
+                        f"Progressing{msg_suffix}"
+                    )
+                seen_progressing = True
+                return "waiting"
+
+            if phase == constants.STATUS_READY:
+                if seen_progressing:
+                    log.info(
+                        f"CephCluster {self.ceph_cluster_name} rotation "
+                        f"completed; phase=Ready{msg_suffix}"
+                    )
+                    return "ready"
+                log.info(
+                    f"CephCluster {self.ceph_cluster_name} phase=Ready "
+                    "(pre-reconcile); waiting for Progressing"
+                )
+                return "waiting"
+
+            log.info(
+                f"CephCluster {self.ceph_cluster_name} phase={phase}"
+                f"{msg_suffix}; waiting for Progressing→Ready"
+            )
+            return "waiting"
+
+        for state in TimeoutSampler(timeout, sleep, _poll_rotation_state):
+            if state == "error":
+                raise UnexpectedBehaviour(
+                    f"CephCluster {self.ceph_cluster_name} entered Error during "
+                    f"CephX key rotation (phase={last_phase}"
+                    f"{f' message={last_message}' if last_message else ''})"
+                )
+            if state == "ready":
+                return True
+
+        raise UnexpectedBehaviour(
+            f"CephCluster {self.ceph_cluster_name} did not complete CephX "
+            f"rotation within {timeout}s "
+            f"(seen_progressing={seen_progressing}, last phase={last_phase}, "
+            f"message={last_message})"
+        )
+
+    def wait_for_storagecluster_reconciliation(self, timeout=600, sleep=10):
+        """
+        Wait until StorageCluster reconciliation completes after a CephX patch.
+
+        During key rotation reconcile the StorageCluster may temporarily enter
+        ``Error`` (or ``Progressing``). Keep polling until phase is ``Ready``.
+
+        Args:
+            timeout (int): Max seconds to wait (default 10 minutes).
+            sleep (int): Seconds between polls (default 10).
+
+        Returns:
+            bool: True when StorageCluster is Ready.
+
+        Raises:
+            UnexpectedBehaviour: If Ready is not reached within *timeout*.
+        """
+        storage_cluster = StorageCluster(
+            resource_name=constants.DEFAULT_CLUSTERNAME,
+            namespace=self.namespace,
+        )
+        log.info(
+            "Waiting for StorageCluster reconciliation after CephX key rotation "
+            f"(timeout={timeout}s, poll every {sleep}s; Error phase is tolerated)"
+        )
+
+        def _is_ready():
+            storage_cluster.reload_data()
+            phase = (storage_cluster.data.get("status") or {}).get("phase")
+            message = (storage_cluster.data.get("status") or {}).get("message", "")
+            if phase == constants.STATUS_READY:
+                log.info("StorageCluster reconciliation completed; phase=Ready")
+                return True
+            log.info(
+                f"StorageCluster phase={phase}"
+                f"{f' message={message}' if message else ''}; "
+                "waiting for Ready (temporary Error during reconcile is expected)"
+            )
+            return False
+
+        for ready in TimeoutSampler(timeout, sleep, _is_ready):
+            if ready:
+                return True
+
+        storage_cluster.reload_data()
+        phase = (storage_cluster.data.get("status") or {}).get("phase")
+        message = (storage_cluster.data.get("status") or {}).get("message", "")
+        raise UnexpectedBehaviour(
+            "StorageCluster did not reach Ready within "
+            f"{timeout}s after CephX key rotation "
+            f"(last phase={phase}, message={message})"
+        )
+
+    def verify_csi_node_plugin_logs_for_auth_errors(self, since_time=None):
+        """
+        Collect AUTH_BAD_KEY lines from CSI RBD node plugin logs.
+
+        Returns:
+            list: Matching log lines (may be non-empty when old CSI keys are deleted).
+        """
+        from ocs_ci.helpers.helpers import get_event_line_datetime
+
+        matches = []
+        for csi_pod in self.get_csi_node_plugin_pods():
+            logs = get_pod_logs(
+                pod_name=csi_pod.name,
+                namespace=self.namespace,
+            )
+            if since_time:
+                filtered = []
+                for line in logs.splitlines():
+                    log_time = get_event_line_datetime(line)
+                    if log_time and log_time > since_time:
+                        filtered.append(line)
+                logs = "\n".join(filtered)
+            for line in logs.splitlines():
+                if constants.AUTH_BAD_KEY_LOG in line:
+                    matches.append(f"{csi_pod.name}: {line.strip()}")
+        if matches:
+            log.warning(
+                "CSI node plugin AUTH_BAD_KEY log lines:\n" + "\n".join(matches[:10])
+            )
+        else:
+            log.info("No AUTH_BAD_KEY lines found in CSI node plugin logs")
+        return matches
+
+    def verify_operator_logs_do_not_contain_warnings(
+        self, patterns, since_time=None, require_match=False
+    ):
+        """Fail if operator logs since *since_time* contain warning-level patterns."""
+        from ocs_ci.helpers.helpers import get_logs_rook_ceph_operator
+
+        logs = (
+            self.get_operator_logs_since(since_time)
+            if since_time
+            else get_logs_rook_ceph_operator().splitlines()
+        )
+        matches = []
+        for line in logs:
+            lower_line = line.lower()
+            if "warning" not in lower_line and " error" not in lower_line:
+                continue
+            if any(pattern.lower() in lower_line for pattern in patterns):
+                matches.append(line)
+        if matches and require_match:
+            raise UnexpectedBehaviour(
+                f"Expected warning patterns in operator logs: {patterns}"
+            )
+        if matches and not require_match:
+            sample = "\n".join(matches[:5])
+            raise UnexpectedBehaviour(
+                "Unexpected bootstrap deletion warnings in operator logs:\n" f"{sample}"
+            )
+
+    def get_csi_node_plugin_pods(self):
+        """Return CSI RBD node plugin pods for the cluster namespace."""
+        pods = get_pods_having_label(
+            constants.CSI_RBDPLUGIN_LABEL, namespace=self.namespace
+        )
+        if not pods:
+            pods = get_pods_having_label(
+                constants.CSI_RBDPLUGIN_LABEL_419, namespace=self.namespace
+            )
+        return [Pod(**pod) for pod in pods]
+
+    def wait_for_pgs_active_clean(self, timeout=600, sleep=15):
+        """Wait until all PGs are in active+clean state."""
+        from ocs_ci.ocs.cluster import CephCluster
+
+        ceph_cluster = CephCluster()
+        log.info("Waiting for all PGs to reach active+clean state")
+
+        for ready in TimeoutSampler(timeout, sleep, ceph_cluster.get_rebalance_status):
+            if ready:
+                log.info("All PGs are active+clean")
+                return True
+
+        raise UnexpectedBehaviour(
+            f"PGs did not reach active+clean state within {timeout}s"
+        )
+
+    def trigger_cephcluster_reconcile(self):
+        """Annotate the CephCluster to trigger a Rook operator reconcile."""
+        annotation = f"ocs-ci/reconcile-trigger={int(time.time())}"
+        log.info(f"Triggering CephCluster reconcile via annotation {annotation}")
+        self.cephcluster_obj.annotate(annotation=annotation)
+
+    def restart_rook_ceph_operator(self):
+        """
+        Restart the rook-ceph-operator by deleting its pod.
+
+        Returns:
+            str: Name of the deleted operator pod.
+        """
+        operator_pods = get_operator_pods(namespace=self.namespace)
+        if not operator_pods:
+            raise UnexpectedBehaviour(
+                f"rook-ceph-operator pod not found in {self.namespace}"
+            )
+        operator_pod = operator_pods[0]
+        operator_name = operator_pod.name
+        log.info(f"Restarting rook-ceph-operator pod {operator_name}")
+        operator_pod.delete()
+        return operator_name
+
+    def wait_for_rook_ceph_operator_ready(
+        self, previous_pod_name=None, timeout=300, sleep=15
+    ):
+        """
+        Wait until rook-ceph-operator is Running after a restart.
+
+        Args:
+            previous_pod_name (str): Prior pod name; wait until a new pod is Running.
+        """
+        log.info(
+            "Waiting for rook-ceph-operator to be Running "
+            f"(previous pod={previous_pod_name or 'unknown'})"
+        )
+
+        def _operator_ready():
+            pods = get_operator_pods(namespace=self.namespace)
+            if not pods:
+                return False
+            pod = pods[0]
+            phase = pod.data.get("status", {}).get("phase")
+            if phase != constants.STATUS_RUNNING:
+                return False
+            if previous_pod_name and pod.name == previous_pod_name:
+                return False
+            return True
+
+        for ready in TimeoutSampler(timeout, sleep, _operator_ready):
+            if ready:
+                operator_pod = get_operator_pods(namespace=self.namespace)[0]
+                log.info(f"rook-ceph-operator pod {operator_pod.name} is Running")
+                return operator_pod
+
+        raise UnexpectedBehaviour(
+            f"rook-ceph-operator did not become Running within {timeout}s"
+        )
+
+    def get_operator_logs_since(self, since_time):
+        """Return rook-ceph-operator log lines newer than *since_time*."""
+        from ocs_ci.helpers.helpers import (
+            get_event_line_datetime,
+            get_logs_rook_ceph_operator,
+        )
+
+        new_logs = []
+        for line in get_logs_rook_ceph_operator().splitlines():
+            log_time = get_event_line_datetime(line)
+            if since_time and log_time and log_time > since_time:
+                new_logs.append(line)
+        return new_logs
+
+    def verify_operator_no_key_rotation_logs(
+        self,
+        since_time,
+        rotation_patterns=None,
+    ):
+        """
+        Assert rook-ceph-operator did not log CephX key rotation after *since_time*.
+
+        Args:
+            since_time (datetime): Only scan operator logs newer than this timestamp.
+            rotation_patterns (tuple): Substrings that indicate rotation activity.
+        """
+        rotation_patterns = (
+            rotation_patterns or constants.CEPHX_KEY_ROTATION_OPERATOR_LOG_PATTERNS
+        )
+        matches = []
+        for line in self.get_operator_logs_since(since_time):
+            lower_line = line.lower()
+            if any(pattern.lower() in lower_line for pattern in rotation_patterns):
+                matches.append(line)
+
+        if matches:
+            sample = "\n".join(matches[:5])
+            raise UnexpectedBehaviour(
+                "rook-ceph-operator logged CephX key rotation after re-reconcile:\n"
+                f"{sample}"
+            )
+        log.info(
+            "No CephX key rotation messages in rook-ceph-operator logs "
+            "after re-reconcile"
+        )
+
+    def wait_for_operator_log_pattern(self, pattern, timeout=300, sleep=5, since=None):
+        """Wait until *pattern* appears in rook-ceph-operator logs."""
+        operator_pods = get_operator_pods(namespace=self.namespace)
+        if not operator_pods:
+            raise UnexpectedBehaviour("rook-ceph-operator pod not found")
+        return wait_for_matching_pattern_in_pod_logs(
+            pod_name=operator_pods[0].name,
+            pattern=pattern,
+            namespace=self.namespace,
+            since=since,
+            timeout=timeout,
+            sleep=sleep,
+        )
+
+    def verify_operator_logs_contain_any_pattern(
+        self, patterns, since_time=None, require_match=True
+    ):
+        """Assert operator logs since *since_time* contain at least one *patterns*."""
+        from ocs_ci.helpers.helpers import get_logs_rook_ceph_operator
+
+        if since_time:
+            logs = self.get_operator_logs_since(since_time)
+        else:
+            logs = get_logs_rook_ceph_operator().splitlines()
+
+        matches = []
+        for line in logs:
+            lower_line = line.lower()
+            if any(pattern.lower() in lower_line for pattern in patterns):
+                matches.append(line)
+        if require_match and not matches:
+            raise UnexpectedBehaviour(
+                f"rook-ceph-operator logs missing expected patterns: {patterns}"
+            )
+        if matches:
+            log.info(f"Found {len(matches)} operator log lines matching {patterns}")
+            for line in matches[:5]:
+                log.info(f"  operator: {line}")
+        return matches
+
+    def wait_for_cephcluster_reconcile_failure(
+        self,
+        timeout=600,
+        sleep=15,
+        message_patterns=None,
+        operator_log_since=None,
+    ):
+        """
+        Wait until CephCluster reports a reconcile failure.
+
+        Args:
+            timeout (int): Max seconds to wait.
+            sleep (int): Poll interval in seconds.
+            message_patterns (iterable|None): If set, status.message (or a
+                failing Ready-condition message) must contain at least one
+                pattern (case-insensitive). Without patterns, any non-Ready
+                phase matches — which can false-positive on normal
+                Progressing reconcile — so callers that inject a specific
+                fault should pass patterns for that fault.
+            operator_log_since: Optional log marker from
+                ``get_last_log_time_date()``. When set with
+                *message_patterns*, rook-ceph-operator logs since the marker
+                are also accepted as failure evidence while the CephCluster
+                is not Ready (status.message can lag behind operator errors).
+        """
+        patterns = tuple(message_patterns or ())
+        log.info(
+            "Waiting for CephCluster reconcile failure"
+            + (f" matching {patterns}" if patterns else "")
+            + (" (also checking rook-ceph-operator logs)" if operator_log_since else "")
+        )
+
+        def _message_matches(text):
+            if not patterns:
+                return True
+            lower = (text or "").lower()
+            return any(pattern.lower() in lower for pattern in patterns)
+
+        def _reconcile_failed():
+            self._reload()
+            status = self.cephcluster_obj.data.get("status", {}) or {}
+            phase = status.get("phase")
+            message = status.get("message", "") or ""
+            if phase and phase != constants.STATUS_READY and _message_matches(message):
+                log.info(f"CephCluster phase={phase} message={message}")
+                return True
+            for condition in status.get("conditions", []) or []:
+                if (
+                    condition.get("type") == "Ready"
+                    and condition.get("status") != "True"
+                    and _message_matches(condition.get("message", "") or "")
+                ):
+                    log.info(f"CephCluster Ready condition false: {condition}")
+                    return True
+            if (
+                patterns
+                and operator_log_since
+                and phase
+                and phase != constants.STATUS_READY
+            ):
+                matches = self.verify_operator_logs_contain_any_pattern(
+                    patterns,
+                    since_time=operator_log_since,
+                    require_match=False,
+                )
+                if matches:
+                    log.info(
+                        "CephCluster phase=%s message=%s; OSD rotate failure "
+                        "confirmed via rook-ceph-operator logs",
+                        phase,
+                        message,
+                    )
+                    return True
+            log.debug(
+                "CephCluster reconcile failure not matched yet "
+                f"(phase={phase}, message={message})"
+            )
+            return False
+
+        for failed in TimeoutSampler(timeout, sleep, _reconcile_failed):
+            if failed:
+                return True
+
+        raise UnexpectedBehaviour(
+            "CephCluster did not report reconcile failure"
+            + (f" matching {patterns}" if patterns else "")
+            + f" within {timeout}s"
+        )

--- a/ocs_ci/helpers/cephx_keyrotation/core.py
+++ b/ocs_ci/helpers/cephx_keyrotation/core.py
@@ -1,0 +1,741 @@
+"""CephX key rotation core: StorageCluster/CephCluster spec, status, and patch ops."""
+
+import json
+import logging
+
+from ocs_ci.framework import config
+from ocs_ci.ocs import constants, defaults
+from ocs_ci.ocs.exceptions import UnexpectedBehaviour
+from ocs_ci.ocs.ocp import OCP
+from ocs_ci.ocs.resources.pod import (
+    get_ceph_tools_pod,
+)
+from ocs_ci.utility.utils import TimeoutSampler
+
+log = logging.getLogger(__name__)
+
+
+class CephXKeyRotationCore:
+    """Spec/status/patch and component rotation primitives for CephX."""
+
+    KEY_ROTATION_POLICY_KEY_GENERATION = "KeyGeneration"
+
+    KEY_ROTATION_POLICY_DISABLED = "Disabled"
+
+    DEFAULT_DAEMON_KEY_GENERATION = 2
+
+    COMPONENT_DAEMON = "daemon"
+
+    COMPONENT_CSI = "csi"
+
+    COMPONENT_RBD_MIRROR_PEER = "rbdMirrorPeer"
+
+    CONFIG_KEY_ROOK_DAEMON = "rook_daemon"
+
+    ROTATION_COMPONENTS = (
+        COMPONENT_DAEMON,
+        COMPONENT_CSI,
+        COMPONENT_RBD_MIRROR_PEER,
+    )
+
+    STORAGECLUSTER_CEPHX_MANAGED_RESOURCES = {
+        COMPONENT_DAEMON: "cephCluster",
+        COMPONENT_CSI: "cephCluster",
+        COMPONENT_RBD_MIRROR_PEER: "cephCluster",
+    }
+
+    CEPHX_KEY_CONFIG_ALIASES = {
+        CONFIG_KEY_ROOK_DAEMON: COMPONENT_DAEMON,
+        "daemon": COMPONENT_DAEMON,
+    }
+
+    CEPHX_KEY_CONFIG_NAMES = frozenset(
+        (*ROTATION_COMPONENTS, *CEPHX_KEY_CONFIG_ALIASES)
+    )
+
+    ROOK_DAEMON_STATUS_ENTITIES = (
+        constants.CEPHCLUSTER_CEPHX_KEYROTATION_STATUS_ENTITIES
+    )
+
+    DAEMON_STATUS_ENTITIES = (
+        "admin",
+        "mgr",
+        "osd",
+        "crashCollector",
+        "cephExporter",
+    )
+
+    CEPHX_STATUS_GENERATION_ENTITIES = (
+        "admin",
+        "mgr",
+        "osd",
+        "mon",
+        "csi",
+        "rbdMirrorPeer",
+        "crashCollector",
+        "cephExporter",
+    )
+
+    def __init__(
+        self,
+        ceph_cluster_name=None,
+        namespace=None,
+        cephfilesystem_name=None,
+    ):
+        """
+        Args:
+            ceph_cluster_name (str): CephCluster resource name.
+            namespace (str): Cluster namespace (default: openshift-storage).
+            cephfilesystem_name (str): CephFilesystem resource name.
+        """
+        self.ceph_cluster_name = ceph_cluster_name or constants.CEPH_CLUSTER_NAME
+        self.namespace = namespace or config.ENV_DATA["cluster_namespace"]
+        self.cephfilesystem_name = cephfilesystem_name or defaults.CEPHFILESYSTEM_NAME
+        self.cephcluster_obj = OCP(
+            kind=constants.CEPH_CLUSTER,
+            resource_name=self.ceph_cluster_name,
+            namespace=self.namespace,
+        )
+        self._cephfilesystem_obj = None
+        self._storagecluster_obj = None
+
+    @classmethod
+    def resolve_cephx_key_config(cls, key):
+        """
+        Map a ``cephx_keys`` config entry to a rotation component.
+
+        ``rook_daemon`` (preferred) and legacy ``daemon`` both resolve to the
+        daemon component (mon/mgr/osd/mds) driven via StorageCluster.
+        """
+        component = cls.CEPHX_KEY_CONFIG_ALIASES.get(key, key)
+        cls._validate_component(component)
+        return component
+
+    def get_ceph_cli_pod(self):
+        """Return the rook-ceph-tools pod used for Ceph CLI commands."""
+        return get_ceph_tools_pod(namespace=self.namespace)
+
+    def _reload(self):
+        self.cephcluster_obj.reload_data()
+
+    def _get_cluster_dict(self):
+        self._reload()
+        return self.cephcluster_obj.data
+
+    def _get_storage_cluster_dict(self):
+        if self._storagecluster_obj is None:
+            self._storagecluster_obj = OCP(
+                kind=constants.STORAGECLUSTER,
+                resource_name=constants.DEFAULT_CLUSTERNAME,
+                namespace=self.namespace,
+            )
+        self._storagecluster_obj.reload_data()
+        return self._storagecluster_obj.data
+
+    def get_storagecluster_managed_resource(self, managed_resource):
+        """Return ``spec.managedResources.<managed_resource>`` from StorageCluster."""
+        sc = self._get_storage_cluster_dict()
+        managed = (sc.get("spec", {}) or {}).get("managedResources") or {}
+        return managed.get(managed_resource) or {}
+
+    def get_storagecluster_managed_cephcluster(self):
+        """Return ``spec.managedResources.cephCluster`` from the StorageCluster."""
+        return self.get_storagecluster_managed_resource("cephCluster")
+
+    def get_storagecluster_managed_cephrbdmirror(self):
+        """Return ``spec.managedResources.cephRBDMirror`` from the StorageCluster."""
+        return self.get_storagecluster_managed_resource("cephRBDMirror")
+
+    def get_cephcluster_reconcile_strategy(self):
+        """Return StorageCluster ``managedResources.cephCluster.reconcileStrategy``."""
+        return self.get_storagecluster_managed_cephcluster().get("reconcileStrategy")
+
+    def patch_storagecluster_cephcluster_reconcile_strategy(self, strategy):
+        """Patch ``managedResources.cephCluster.reconcileStrategy`` on StorageCluster."""
+        cc_spec = self.get_storagecluster_managed_cephcluster()
+        patch_ops = []
+        strategy_path = "/spec/managedResources/cephCluster/reconcileStrategy"
+
+        if not cc_spec:
+            patch_ops.append(
+                {
+                    "op": "add",
+                    "path": "/spec/managedResources/cephCluster",
+                    "value": {"reconcileStrategy": strategy},
+                }
+            )
+        elif "reconcileStrategy" in cc_spec:
+            patch_ops.append(
+                {"op": "replace", "path": strategy_path, "value": strategy}
+            )
+        else:
+            patch_ops.append({"op": "add", "path": strategy_path, "value": strategy})
+
+        log.info(
+            "Patching StorageCluster managedResources.cephCluster.reconcileStrategy "
+            f"to {strategy}"
+        )
+        sc_obj = OCP(
+            kind=constants.STORAGECLUSTER,
+            resource_name=constants.DEFAULT_CLUSTERNAME,
+            namespace=self.namespace,
+        )
+        sc_obj.patch(params=json.dumps(patch_ops), format_type="json")
+        self._storagecluster_obj = None
+
+    @classmethod
+    def uses_storagecluster_for_cephx(cls, component):
+        """Return True when *component* CephX rotation is StorageCluster-driven."""
+        return component in cls.STORAGECLUSTER_CEPHX_MANAGED_RESOURCES
+
+    def get_storagecluster_cephx_managed_resource_name(self, component):
+        """Return managedResources key used for *component* CephX rotation."""
+        self._validate_component(component)
+        managed = self.STORAGECLUSTER_CEPHX_MANAGED_RESOURCES.get(component)
+        if not managed:
+            raise UnexpectedBehaviour(
+                f"Component {component} does not use StorageCluster for CephX rotation"
+            )
+        return managed
+
+    def get_storagecluster_spec_cephx(self, component=None):
+        """
+        Return StorageCluster ``managedResources.<resource>.security.cephx``.
+
+        Args:
+            component (str): Rotation component; defaults to daemon (cephCluster).
+        """
+        component = component or self.COMPONENT_DAEMON
+        managed_name = self.get_storagecluster_cephx_managed_resource_name(component)
+        managed_spec = self.get_storagecluster_managed_resource(managed_name)
+        security = managed_spec.get("security") or {}
+        return security.get("cephx") or {}
+
+    def get_storagecluster_component_spec(self, component):
+        """Return StorageCluster security.cephx.<component> (may be empty)."""
+        return self.get_storagecluster_spec_cephx(component).get(component) or {}
+
+    def _get_storagecluster_ocp(self):
+        """Return an OCP handle for the StorageCluster resource."""
+        return OCP(
+            kind=constants.STORAGECLUSTER,
+            resource_name=constants.DEFAULT_CLUSTERNAME,
+            namespace=self.namespace,
+        )
+
+    def patch_storagecluster_cephx_component(self, component, component_config):
+        """
+        Patch StorageCluster managedResources.cephCluster.security.cephx.<component>.
+
+        Applies to daemon, csi, and rbdMirrorPeer. Preserves sibling fields such
+        as allowedCiphers and other cephx components. Writes the provided
+        component_config as-is (including an explicit lower keyGeneration for
+        negative tests).
+        """
+        managed_name = self.get_storagecluster_cephx_managed_resource_name(component)
+        patch_ops = self._build_storagecluster_cephx_component_patch_ops(
+            component, component_config
+        )
+        log.info(
+            "Patching StorageCluster managedResources."
+            f"{managed_name}.security.cephx.{component} to {component_config}"
+        )
+        self._get_storagecluster_ocp().patch(
+            params=json.dumps(patch_ops), format_type="json"
+        )
+        self._storagecluster_obj = None
+
+    def get_status_cephx(self):
+        """
+        Return ``status.cephx`` from the CephCluster (may be empty).
+
+        Status verification for daemon, CSI, and rbdMirrorPeer generations is
+        still read from CephCluster even when rotation was triggered via
+        StorageCluster.
+        """
+        cluster = self._get_cluster_dict()
+        return cluster.get("status", {}).get("cephx", {}) or {}
+
+    def get_spec_key_generation(self, component):
+        """
+        Read configured key generation for a rotation component from
+        StorageCluster ``managedResources.cephCluster.security.cephx``.
+
+        Args:
+            component (str): One of ``daemon``, ``csi``, ``rbdMirrorPeer``.
+
+        Returns:
+            int: Configured generation, or 0 if unset.
+        """
+        self._validate_component(component)
+        value = self.get_storagecluster_component_spec(component).get(
+            "keyGeneration", 0
+        )
+        return int(value or 0)
+
+    def get_status_key_generation(self, entity):
+        """
+        Read reported key generation for a status.cephx entity.
+
+        Args:
+            entity (str): e.g. ``osd``, ``csi``, ``rbdMirrorPeer``, ``mgr``.
+
+        Returns:
+            int: Reported generation, or 0 if unset / unsupported (e.g. mon).
+        """
+        status_entry = self.get_status_cephx().get(entity) or {}
+        if not status_entry:
+            return 0
+        return int(status_entry.get("keyGeneration", 0) or 0)
+
+    def get_next_key_generation(self, component):
+        """
+        Return a generation value high enough to trigger rotation.
+
+        Uses max(spec, relevant status, DESIRED_CEPHX_KEY_GEN) + 1 so a bare
+        ``rotate_*_keys()`` call advances past the operator desired baseline
+        (writing only the baseline does not rotate CephCluster).
+        """
+        self._validate_component(component)
+        current = self.get_spec_key_generation(component)
+
+        if component == self.COMPONENT_DAEMON:
+            for entity in self.DAEMON_STATUS_ENTITIES:
+                current = max(current, self.get_status_key_generation(entity))
+            # MDS (and other CR-backed daemon) generation lives on CephFilesystem,
+            # not CephCluster.status.cephx; fold it in to avoid no-op rotations.
+            current = max(current, self.get_filesystem_daemon_key_generation())
+            current = max(current, self.get_desired_cephx_key_gen())
+        elif component == self.COMPONENT_CSI:
+            current = max(current, self.get_status_key_generation("csi"))
+        elif component == self.COMPONENT_RBD_MIRROR_PEER:
+            current = max(current, self.get_status_key_generation("rbdMirrorPeer"))
+
+        return current + 1
+
+    def get_component_status_key_generation(self, component):
+        """
+        Return the highest reported status keyGeneration for *component*.
+
+        Used to decide whether a StorageCluster write will trigger an actual
+        CephX rotation (Progressing) versus a no-op / policy-only update.
+        """
+        self._validate_component(component)
+        if component == self.COMPONENT_DAEMON:
+            current = 0
+            for entity in self.ROOK_DAEMON_STATUS_ENTITIES:
+                current = max(current, self.get_status_key_generation(entity))
+            return max(current, self.get_filesystem_daemon_key_generation())
+        if component == self.COMPONENT_CSI:
+            return self.get_status_key_generation("csi")
+        return self.get_status_key_generation("rbdMirrorPeer")
+
+    def get_desired_cephx_key_gen(self):
+        """
+        Return ocs-operator ``DESIRED_CEPHX_KEY_GEN``, or the framework default.
+
+        Greenfield clusters already reconcile to this baseline. Patching
+        StorageCluster ``keyGeneration`` to the same value does not make
+        CephCluster enter Progressing.
+        """
+        try:
+            deploy = OCP(
+                kind=constants.DEPLOYMENT,
+                namespace=self.namespace,
+                resource_name="ocs-operator",
+            ).get()
+            containers = (
+                deploy.get("spec", {})
+                .get("template", {})
+                .get("spec", {})
+                .get("containers")
+                or []
+            )
+            for item in (containers[0].get("env") or []) if containers else []:
+                if item.get("name") == constants.DESIRED_CEPHX_KEY_GEN_ENV:
+                    return int(item.get("value") or 0) or (
+                        constants.DEFAULT_DESIRED_CEPHX_KEY_GEN
+                    )
+        except Exception as exc:
+            log.debug(
+                "Could not read %s from ocs-operator: %s",
+                constants.DESIRED_CEPHX_KEY_GEN_ENV,
+                exc,
+            )
+        return constants.DEFAULT_DESIRED_CEPHX_KEY_GEN
+
+    def will_storagecluster_key_generation_trigger_rotation(
+        self, component, key_generation
+    ):
+        """
+        Return True when writing *key_generation* should start a CephX rotation.
+
+        CephCluster Progressing is expected only when the written generation is
+        greater than the current StorageCluster spec keyGeneration, the current
+        status keyGeneration, and the ocs-operator DESIRED_CEPHX_KEY_GEN baseline.
+
+        Writing the desired baseline (commonly 2) onto StorageCluster is a no-op
+        for CephCluster reconcile — keys are already at that desired level even
+        when status.keyGeneration still reports 1.
+        """
+        self._validate_component(component)
+        key_generation = int(key_generation)
+        pre_spec = self.get_spec_key_generation(component)
+        pre_status = self.get_component_status_key_generation(component)
+        desired_baseline = self.get_desired_cephx_key_gen()
+        threshold = max(pre_spec, pre_status, desired_baseline)
+        will_rotate = key_generation > threshold
+        log.info(
+            "CephX rotation trigger check for %s: written=%s "
+            "pre_spec=%s pre_status=%s desired_baseline=%s threshold=%s "
+            "will_rotate=%s",
+            component,
+            key_generation,
+            pre_spec,
+            pre_status,
+            desired_baseline,
+            threshold,
+            will_rotate,
+        )
+        return will_rotate
+
+    def rotate_component_keys(
+        self,
+        component,
+        key_generation=None,
+        keep_prior_key_count_max=None,
+        wait_for_rotation=True,
+    ):
+        """
+        Initiate a one-off CephX key rotation for a cephx component.
+
+        All components patch StorageCluster
+        ``managedResources.cephCluster.security.cephx.<component>``.
+
+        Waits for CephCluster Progressing→Ready only when *key_generation*
+        will actually trigger rotation (above StorageCluster spec, status,
+        and DESIRED_CEPHX_KEY_GEN). Policy enable / same-as-desired writes
+        skip that wait so setup paths do not hang on Ready forever.
+
+        Args:
+            component (str): ``daemon``, ``csi``, or ``rbdMirrorPeer``.
+            key_generation (int): Desired generation. When omitted, computed as
+                max(spec, status) + 1. Explicit values (including lower than
+                current) are written as-is for negative testing.
+            keep_prior_key_count_max (int): CSI only — number of prior CSI key
+                generations to retain for existing PVC connections.
+            wait_for_rotation (bool): When False, patch only and return without
+                waiting for CephCluster/StorageCluster Ready. Use for mid-
+                rotation fault injection.
+
+        Returns:
+            int: The key generation written to the component spec.
+        """
+        self._validate_component(component)
+        if key_generation is None:
+            key_generation = self.get_next_key_generation(component)
+        key_generation = int(key_generation)
+        will_rotate = self.will_storagecluster_key_generation_trigger_rotation(
+            component, key_generation
+        )
+
+        # Preserve sibling fields (e.g. keyType) already set on StorageCluster.
+        component_config = dict(self.get_storagecluster_component_spec(component))
+        component_config["keyRotationPolicy"] = self.KEY_ROTATION_POLICY_KEY_GENERATION
+        component_config["keyGeneration"] = key_generation
+        if component == self.COMPONENT_CSI and keep_prior_key_count_max is not None:
+            component_config["keepPriorKeyCountMax"] = int(keep_prior_key_count_max)
+
+        managed_name = self.get_storagecluster_cephx_managed_resource_name(component)
+        log.info(
+            f"Initiating CephX key rotation for {component} "
+            f"(generation={key_generation}) via StorageCluster "
+            f"managedResources.{managed_name} "
+            f"{self.namespace}/{constants.DEFAULT_CLUSTERNAME}"
+        )
+        self.patch_storagecluster_cephx_component(component, component_config)
+        if not wait_for_rotation:
+            log.info(
+                f"Triggered {component} rotation generation={key_generation} "
+                "without waiting for Ready (async)"
+            )
+            return key_generation
+        if will_rotate:
+            log.info(
+                f"Generation {key_generation} for {component} should trigger "
+                "rotation; waiting for CephCluster Progressing→Ready"
+            )
+            # Daemon rotation restarts MON/MGR/OSD/MDS serially; encrypted
+            # multi-OSD clusters commonly need >15m to reach Ready again.
+            self.wait_for_cephcluster_rotation(timeout=1500, sleep=15)
+        else:
+            log.info(
+                f"Generation {key_generation} for {component} does not exceed "
+                "spec/status/DESIRED_CEPHX_KEY_GEN; skipping CephCluster "
+                "Progressing wait"
+            )
+        self.wait_for_storagecluster_reconciliation(timeout=600, sleep=10)
+        return key_generation
+
+    def rotate_daemon_keys(self, key_generation=None, wait_for_rotation=True):
+        """Rotate internal Ceph daemon CephX keys."""
+        return self.rotate_component_keys(
+            self.COMPONENT_DAEMON,
+            key_generation,
+            wait_for_rotation=wait_for_rotation,
+        )
+
+    def rotate_csi_keys(self, key_generation=None, keep_prior_key_count_max=1):
+        """Rotate CSI CephX keys."""
+        return self.rotate_component_keys(
+            self.COMPONENT_CSI,
+            key_generation,
+            keep_prior_key_count_max=keep_prior_key_count_max,
+        )
+
+    def rotate_rbd_mirror_peer_keys(self, key_generation=None):
+        """Rotate RBD mirror peer CephX keys."""
+        return self.rotate_component_keys(
+            self.COMPONENT_RBD_MIRROR_PEER, key_generation
+        )
+
+    def rotate_all_keys(self, keep_prior_key_count_max=1):
+        """
+        Rotate daemon, CSI, and RBD mirror peer keys in one sequence.
+
+        Returns:
+            dict: Component name to generation applied.
+        """
+        generations = {}
+        for component in self.ROTATION_COMPONENTS:
+            kwargs = {}
+            if component == self.COMPONENT_CSI:
+                kwargs["keep_prior_key_count_max"] = keep_prior_key_count_max
+            generations[component] = self.rotate_component_keys(component, **kwargs)
+        return generations
+
+    def wait_for_daemon_rotation(self, expected_generation, timeout=900, sleep=15):
+        """
+        Wait until daemon-related ``status.cephx`` entries reach *expected_generation*.
+
+        MON key rotation is not supported and is not checked.
+        """
+        return self._wait_for_status_entities(
+            self.DAEMON_STATUS_ENTITIES,
+            expected_generation,
+            timeout,
+            sleep,
+            label="daemon",
+        )
+
+    def wait_for_csi_rotation(self, expected_generation, timeout=900, sleep=15):
+        """Wait until ``status.cephx.csi.keyGeneration`` matches *expected_generation*."""
+        return self._wait_for_status_entities(
+            ["csi"],
+            expected_generation,
+            timeout,
+            sleep,
+            label="csi",
+        )
+
+    def wait_for_rbd_mirror_peer_rotation(
+        self, expected_generation, timeout=900, sleep=15
+    ):
+        """Wait until ``status.cephx.rbdMirrorPeer.keyGeneration`` matches."""
+        return self._wait_for_status_entities(
+            ["rbdMirrorPeer"],
+            expected_generation,
+            timeout,
+            sleep,
+            label="rbdMirrorPeer",
+        )
+
+    def wait_for_rotation(self, component, expected_generation, timeout=900, sleep=15):
+        """
+        Wait for rotation completion for a cephx component.
+
+        Args:
+            component (str): ``daemon``, ``csi``, or ``rbdMirrorPeer``.
+            expected_generation (int): Generation requested in spec.
+        """
+        self._validate_component(component)
+        if component == self.COMPONENT_DAEMON:
+            return self.wait_for_rook_daemon_rotation(
+                expected_generation, timeout, sleep
+            )
+        if component == self.COMPONENT_CSI:
+            return self.wait_for_csi_rotation(expected_generation, timeout, sleep)
+        return self.wait_for_rbd_mirror_peer_rotation(
+            expected_generation, timeout, sleep
+        )
+
+    def wait_for_all_key_rotations(self, generations, timeout=1500, sleep=15):
+        """
+        Wait for daemon, CSI, and RBD mirror peer key rotations to complete.
+
+        Args:
+            generations (dict): Component name to generation from
+                :meth:`rotate_all_keys`.
+            timeout (int): Timeout in seconds for each wait phase.
+            sleep (int): Poll interval in seconds.
+        """
+        self.wait_for_rook_daemon_rotation(
+            generations[self.COMPONENT_DAEMON], timeout, sleep
+        )
+        self.wait_for_csi_rotation(generations[self.COMPONENT_CSI], timeout, sleep)
+        self.wait_for_rbd_mirror_peer_rotation(
+            generations[self.COMPONENT_RBD_MIRROR_PEER], timeout, sleep
+        )
+        self.wait_for_pgs_active_clean(timeout=timeout, sleep=sleep)
+        self.wait_for_cluster_ready(timeout=timeout)
+
+    def get_spec_rotation_policy(self, component):
+        """Return configured keyRotationPolicy for a cephx component."""
+        self._validate_component(component)
+        return (
+            self.get_storagecluster_component_spec(component).get("keyRotationPolicy")
+            or ""
+        )
+
+    def is_rotation_policy_disabled(self, component):
+        """Return True when *component* rotation policy is Disabled or unset."""
+        policy = self.get_spec_rotation_policy(component)
+        return policy in ("", self.KEY_ROTATION_POLICY_DISABLED)
+
+    def disable_component_key_rotation(self, component):
+        """Set ``keyRotationPolicy: Disabled`` for a cephx component on StorageCluster."""
+        self._validate_component(component)
+        component_spec = dict(self.get_storagecluster_component_spec(component))
+
+        if component_spec.get("keyRotationPolicy") == self.KEY_ROTATION_POLICY_DISABLED:
+            log.info(f"CephX key rotation already Disabled for {component}")
+            return
+
+        component_spec["keyRotationPolicy"] = self.KEY_ROTATION_POLICY_DISABLED
+        log.info(f"Disabling CephX key rotation policy for {component}")
+        self.patch_storagecluster_cephx_component(component, component_spec)
+
+    def ensure_key_rotation_disabled(self):
+        """Ensure daemon, CSI, and RBD mirror peer rotation policies are Disabled."""
+        for component in self.ROTATION_COMPONENTS:
+            self.disable_component_key_rotation(component)
+
+    def assert_key_rotation_disabled(self):
+        """Assert all cephx rotation components use Disabled policy."""
+        enabled = [
+            component
+            for component in self.ROTATION_COMPONENTS
+            if not self.is_rotation_policy_disabled(component)
+        ]
+        if enabled:
+            raise UnexpectedBehaviour(
+                "CephX key rotation is not Disabled for: " f"{', '.join(enabled)}"
+            )
+        log.info(
+            "CephX keyRotationPolicy is Disabled for daemon, csi, and rbdMirrorPeer"
+        )
+
+    def _wait_for_status_entities(
+        self, entities, expected_generation, timeout, sleep, label
+    ):
+        log.info(
+            f"Waiting for CephX {label} rotation to reach generation "
+            f"{expected_generation} (timeout={timeout}s)"
+        )
+
+        def _entities_ready():
+            pending = []
+            for entity in entities:
+                generation = self.get_status_key_generation(entity)
+                if generation < expected_generation:
+                    pending.append(f"{entity}={generation}")
+            if pending:
+                log.debug(
+                    f"CephX {label} rotation pending for: {', '.join(pending)} "
+                    f"(want >= {expected_generation})"
+                )
+                return False
+            return True
+
+        for ready in TimeoutSampler(timeout, sleep, _entities_ready):
+            if ready:
+                log.info(
+                    f"CephX {label} rotation reached generation {expected_generation}"
+                )
+                return True
+
+        raise UnexpectedBehaviour(
+            f"CephX {label} rotation did not reach generation {expected_generation} "
+            f"within {timeout}s"
+        )
+
+    def _build_storagecluster_cephx_component_patch_ops(
+        self, component, component_config
+    ):
+        """
+        Build JSON patch ops for StorageCluster
+        managedResources.<resource>.security.cephx.<component>.
+        """
+        managed_name = self.get_storagecluster_cephx_managed_resource_name(component)
+        managed_spec = self.get_storagecluster_managed_resource(managed_name)
+        security = managed_spec.get("security") or {}
+        cephx = security.get("cephx") or {}
+        base = f"/spec/managedResources/{managed_name}"
+        ops = []
+
+        if not managed_spec:
+            ops.append(
+                {
+                    "op": "add",
+                    "path": base,
+                    "value": {"security": {"cephx": {component: component_config}}},
+                }
+            )
+            return ops
+
+        if not security:
+            ops.append(
+                {
+                    "op": "add",
+                    "path": f"{base}/security",
+                    "value": {"cephx": {component: component_config}},
+                }
+            )
+            return ops
+
+        if not cephx:
+            ops.append(
+                {
+                    "op": "add",
+                    "path": f"{base}/security/cephx",
+                    "value": {component: component_config},
+                }
+            )
+            return ops
+
+        component_path = f"{base}/security/cephx/{component}"
+        if component in cephx:
+            ops.append(
+                {
+                    "op": "replace",
+                    "path": component_path,
+                    "value": component_config,
+                }
+            )
+        else:
+            ops.append(
+                {
+                    "op": "add",
+                    "path": component_path,
+                    "value": component_config,
+                }
+            )
+        return ops
+
+    @staticmethod
+    def _validate_component(component):
+        if component not in CephXKeyRotationCore.ROTATION_COMPONENTS:
+            raise ValueError(
+                f"Invalid cephx component '{component}'. "
+                f"Expected one of: {', '.join(CephXKeyRotationCore.ROTATION_COMPONENTS)}"
+            )

--- a/ocs_ci/helpers/cephx_keyrotation/daemon.py
+++ b/ocs_ci/helpers/cephx_keyrotation/daemon.py
@@ -1,0 +1,751 @@
+"""Daemon-focused CephX rotation, waits, discovery, and bootstrap helpers."""
+
+import logging
+import time
+
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.exceptions import UnexpectedBehaviour
+from ocs_ci.ocs.ocp import OCP
+from ocs_ci.ocs.resources.pod import (
+    get_pods_having_label,
+)
+from ocs_ci.utility.utils import TimeoutSampler
+
+log = logging.getLogger(__name__)
+
+
+class CephXDaemonRotation:
+    """Daemon-specific CephX rotation, waits, pod state, and bootstrap logic."""
+
+    def get_current_rook_daemon_key_generation(self):
+        """
+        Return the highest daemon keyGeneration across spec, status, and desired.
+
+        Includes MON, MGR, and OSD on CephCluster plus MDS on CephFilesystem,
+        and ocs-operator DESIRED_CEPHX_KEY_GEN (greenfield baseline).
+        """
+        current = self.get_spec_key_generation(self.COMPONENT_DAEMON)
+        for entity in self.ROOK_DAEMON_STATUS_ENTITIES:
+            current = max(current, self.get_status_key_generation(entity))
+        current = max(current, self.get_filesystem_daemon_key_generation())
+        return max(current, self.get_desired_cephx_key_gen())
+
+    def get_next_rook_daemon_key_generation(self):
+        """
+        Return a generation value to trigger rotation for Rook daemons only.
+
+        Considers MON, MGR, and OSD on CephCluster plus MDS on CephFilesystem
+        and DESIRED_CEPHX_KEY_GEN.
+        """
+        return self.get_current_rook_daemon_key_generation() + 1
+
+    def rotate_rook_daemon_keys(self, key_generation=None, wait_for_rotation=True):
+        """
+        Rotate CephX keys for Rook-managed daemons: MON, MGR, OSD, and MDS.
+
+        Triggers StorageCluster ``security.cephx.daemon`` reconciliation;
+        generation calculation and completion checks use only those four
+        daemon types (not admin, crashCollector, or cephExporter).
+
+        Args:
+            key_generation (int): Desired generation. When omitted, computed via
+                :meth:`get_next_rook_daemon_key_generation`.
+            wait_for_rotation (bool): When False, patch only and return without
+                waiting for CephCluster/StorageCluster Ready.
+        """
+        if key_generation is None:
+            key_generation = self.get_next_rook_daemon_key_generation()
+        return self.rotate_component_keys(
+            self.COMPONENT_DAEMON,
+            key_generation=key_generation,
+            wait_for_rotation=wait_for_rotation,
+        )
+
+    def wait_for_filesystem_daemon_rotation(
+        self, expected_generation, timeout=900, sleep=15
+    ):
+        """Wait until CephFilesystem ``status.cephx.daemon.keyGeneration`` matches."""
+        return self._wait_for_cr_daemon_rotation(
+            self._get_cephfilesystem_obj(),
+            expected_generation,
+            timeout,
+            sleep,
+            label=f"CephFilesystem/{self.cephfilesystem_name}",
+        )
+
+    def wait_for_rook_daemon_rotation(
+        self, expected_generation, timeout=1200, sleep=15
+    ):
+        """
+        Wait for Rook daemon CephX rotation: MON, MGR, OSD, and MDS only.
+
+        MON/MGR/OSD are tracked on CephCluster ``status.cephx``; MDS is tracked
+        on CephFilesystem ``status.cephx.daemon``.
+        """
+        self._wait_for_status_entities(
+            ["mgr", "osd"],
+            expected_generation,
+            timeout,
+            sleep,
+            label="CephCluster mgr/osd",
+        )
+        self.wait_for_mon_rotation(expected_generation, timeout, sleep)
+        self.wait_for_filesystem_daemon_rotation(expected_generation, timeout, sleep)
+
+    def get_filesystem_status_cephx(self):
+        """Return ``status.cephx`` from the CephFilesystem CR."""
+        fs_obj = self._get_cephfilesystem_obj()
+        fs_obj.reload_data()
+        return fs_obj.data.get("status", {}).get("cephx", {}) or {}
+
+    def get_filesystem_daemon_key_generation(self):
+        """Return ``status.cephx.daemon.keyGeneration`` from CephFilesystem."""
+        daemon_status = self.get_filesystem_status_cephx().get("daemon") or {}
+        return int(daemon_status.get("keyGeneration", 0) or 0)
+
+    def ensure_daemon_key_rotation_enabled(self, key_generation=None):
+        """
+        Ensure StorageCluster daemon CephX uses KeyGeneration policy.
+
+        On a fresh cluster (no security block), the default first generation
+        is :attr:`DEFAULT_DAEMON_KEY_GENERATION` (2), matching
+        ``DESIRED_CEPHX_KEY_GEN``. Enabling at that baseline only updates
+        StorageCluster; CephCluster does not Progress (already at desired).
+
+        Happy-path enable never decreases generation; pass an explicit lower
+        value through :meth:`rotate_component_keys` for negative tests.
+
+        Args:
+            key_generation (int): Minimum desired generation in spec. Defaults
+                to :attr:`DEFAULT_DAEMON_KEY_GENERATION`. When the cluster
+                already has a higher generation, the existing generation is
+                preserved.
+
+        Returns:
+            int: Generation configured in StorageCluster spec.
+        """
+        if key_generation is None:
+            key_generation = self.DEFAULT_DAEMON_KEY_GENERATION
+
+        spec_generation = self.get_spec_key_generation(self.COMPONENT_DAEMON)
+        desired_baseline = self.get_desired_cephx_key_gen()
+        daemon_spec = self.get_storagecluster_component_spec(self.COMPONENT_DAEMON)
+        policy = daemon_spec.get("keyRotationPolicy")
+
+        # Spec (not status) decides whether StorageCluster already has the
+        # policy/generation. Status may remain 1 while desired/spec is 2.
+        if (
+            policy == self.KEY_ROTATION_POLICY_KEY_GENERATION
+            and spec_generation >= key_generation
+        ):
+            log.info(
+                "Daemon CephX key rotation already enabled at generation "
+                f"{spec_generation}"
+            )
+            return spec_generation
+
+        effective_generation = max(key_generation, spec_generation, desired_baseline)
+        if effective_generation > key_generation:
+            log.info(
+                "Preserving daemon keyGeneration %s (requested minimum %s); "
+                "happy-path enable does not decrease keyGeneration",
+                effective_generation,
+                key_generation,
+            )
+
+        log.info(
+            "Enabling daemon CephX KeyGeneration policy at generation "
+            f"{effective_generation} via StorageCluster"
+        )
+        return self.rotate_component_keys(
+            self.COMPONENT_DAEMON, key_generation=effective_generation
+        )
+
+    def assert_all_daemon_pod_states_unchanged(
+        self, before_states, settle_time=30, context="while key rotation is Disabled"
+    ):
+        """Assert MON/MGR/OSD/MDS pods were not restarted for key rotation."""
+        if settle_time:
+            time.sleep(settle_time)
+        after_states = self.capture_all_daemon_pod_states()
+        restarted = []
+        for daemon, before in before_states.items():
+            after = after_states.get(daemon, {})
+            if before != after:
+                restarted.append(daemon)
+        if restarted:
+            raise UnexpectedBehaviour(
+                f"Daemon pods changed {context} "
+                f"(possible rotation restart): {', '.join(restarted)}"
+            )
+        log.info("Daemon pod names and cephx-key-identifier annotations unchanged")
+
+    def assert_bootstrap_keys_unchanged(self, pre_bootstrap_entities):
+        """Assert bootstrap keys were not prematurely deleted."""
+        pre = set(pre_bootstrap_entities)
+        post = set(self.discover_bootstrap_auth_entities())
+        deleted = sorted(pre - post)
+        if deleted:
+            raise UnexpectedBehaviour(
+                "Bootstrap CephX keys prematurely deleted while rotation is "
+                f"Disabled: {', '.join(deleted)}"
+            )
+        log.info("Bootstrap CephX keys unchanged")
+
+    def wait_for_rook_daemon_pods_ready(self, timeout=600):
+        """Wait until MON, MGR, OSD, and MDS pods are Running."""
+        for daemon, label in constants.ROOK_CEPHX_KEYROTATION_DAEMON_LABELS.items():
+            log.info(f"Waiting for {daemon} pods ({label}) to be Running")
+
+            def _pods_running(lbl=label):
+                pods = get_pods_having_label(
+                    lbl, namespace=self.namespace, statuses=[constants.STATUS_RUNNING]
+                )
+                return bool(pods)
+
+            for _ in TimeoutSampler(timeout, 15, _pods_running):
+                break
+
+    def _discover_mgr_auth_entities(self, toolbox_pod=None):
+        """Discover MGR auth entities, falling back to ``ceph mgr dump``."""
+        entities = self.list_auth_entities("mgr.", toolbox_pod)
+        if entities:
+            return entities
+
+        toolbox = toolbox_pod or self.get_ceph_cli_pod()
+        mgr_dump = toolbox.exec_ceph_cmd("ceph mgr dump")
+        discovered = []
+        active = mgr_dump.get("active_name")
+        if active:
+            entity = f"mgr.{active}"
+            if self._auth_entity_exists(entity, toolbox_pod):
+                discovered.append(entity)
+        for standby in mgr_dump.get("standbys", []) or []:
+            standby_name = standby.get("name") if isinstance(standby, dict) else standby
+            if not standby_name:
+                continue
+            entity = f"mgr.{standby_name}"
+            if self._auth_entity_exists(entity, toolbox_pod):
+                discovered.append(entity)
+        return sorted(set(discovered))
+
+    def _discover_mds_auth_entities(self, toolbox_pod=None):
+        """Discover MDS auth entities for the configured CephFilesystem."""
+        mds_prefix = f"mds.{self.cephfilesystem_name}"
+        entities = self.list_auth_entities(mds_prefix, toolbox_pod)
+        if entities:
+            return entities
+
+        discovered = []
+        for suffix in ("a", "b"):
+            entity = f"{mds_prefix}-{suffix}"
+            if self._auth_entity_exists(entity, toolbox_pod):
+                discovered.append(entity)
+        return sorted(discovered)
+
+    def discover_rook_daemon_auth_entities(self, toolbox_pod=None):
+        """
+        Discover MON, MGR, OSD, and MDS auth entities for TC-01.
+
+        Returns:
+            dict: daemon type to list of entity names.
+        """
+        return {
+            "mon": self._discover_mon_auth_entities(toolbox_pod),
+            "mgr": self._discover_mgr_auth_entities(toolbox_pod),
+            "osd": self._discover_osd_auth_entities(toolbox_pod),
+            "mds": self._discover_mds_auth_entities(toolbox_pod),
+        }
+
+    @staticmethod
+    def flatten_daemon_auth_entities(auth_entities):
+        """
+        Return auth entity names for all daemons with discoverable entities.
+
+        Args:
+            auth_entities (dict): Output of :meth:`discover_rook_daemon_auth_entities`.
+
+        Returns:
+            list[str]: Flat list of Ceph auth entity names.
+        """
+        return [
+            entity
+            for daemon, entities in auth_entities.items()
+            for entity in entities
+            if not (daemon == "mon" and not entities)
+        ]
+
+    def record_daemon_generations(self):
+        """
+        Snapshot current rook daemon keyGeneration values from status.
+
+        Returns:
+            dict: mon, mgr, osd, and mds (CephFilesystem) generations.
+        """
+        return {
+            "mon": self.get_status_key_generation("mon"),
+            "mgr": self.get_status_key_generation("mgr"),
+            "osd": self.get_status_key_generation("osd"),
+            "mds": self.get_filesystem_daemon_key_generation(),
+        }
+
+    def log_generation_status(self, label):
+        """Log mon/mgr/osd/mds keyGeneration values under *label*."""
+        generations = self.record_daemon_generations()
+        log.info(
+            f"{label} keyGeneration: mon={generations['mon']} "
+            f"mgr={generations['mgr']} osd={generations['osd']} "
+            f"mds={generations['mds']}"
+        )
+
+    def assert_rook_daemon_generations(
+        self, target_generation, mon_rotation_supported=None
+    ):
+        """
+        Assert CephCluster and CephFilesystem daemon keyGeneration reached target.
+
+        Args:
+            target_generation (int): Expected minimum generation.
+            mon_rotation_supported (bool): When True, also assert MON generation.
+                Auto-detected when omitted.
+        """
+        if mon_rotation_supported is None:
+            mon_rotation_supported = self.is_mon_key_rotation_supported()
+        assert (
+            self.get_status_key_generation("mgr") >= target_generation
+        ), "MGR keyGeneration did not reach target"
+        assert (
+            self.get_status_key_generation("osd") >= target_generation
+        ), "OSD keyGeneration did not reach target"
+        if mon_rotation_supported:
+            assert (
+                self.get_status_key_generation("mon") >= target_generation
+            ), "MON keyGeneration did not reach target"
+        assert (
+            self.get_filesystem_daemon_key_generation() >= target_generation
+        ), "MDS (CephFilesystem) keyGeneration did not reach target"
+
+    def assert_generations_increased(self, before, mon_rotation_supported=None):
+        """
+        Assert each daemon type keyGeneration increased after a rotation.
+
+        Args:
+            before (dict): Output of :meth:`record_daemon_generations`.
+            mon_rotation_supported (bool): When True, also assert MON increased.
+                Auto-detected when omitted.
+        """
+        if mon_rotation_supported is None:
+            mon_rotation_supported = self.is_mon_key_rotation_supported()
+        assert (
+            self.get_status_key_generation("mgr") > before["mgr"]
+        ), "MGR keyGeneration did not increase"
+        assert (
+            self.get_status_key_generation("osd") > before["osd"]
+        ), "OSD keyGeneration did not increase"
+        if mon_rotation_supported:
+            assert (
+                self.get_status_key_generation("mon") > before["mon"]
+            ), "MON keyGeneration did not increase"
+        assert (
+            self.get_filesystem_daemon_key_generation() > before["mds"]
+        ), "MDS keyGeneration did not increase"
+
+    def verify_bootstrap_deletion_idempotent_after_operator_restart(self, timeout=600):
+        """Restart operator and verify bootstrap cleanup is idempotent."""
+        self.assert_bootstrap_keys_absent(constants.CEPHX_BOOTSTRAP_KEYS_TO_CLEANUP)
+        operator_log_marker = None
+        from ocs_ci.helpers.helpers import get_last_log_time_date
+
+        operator_log_marker = get_last_log_time_date()
+        previous_operator = self.restart_rook_ceph_operator()
+        self.wait_for_rook_ceph_operator_ready(previous_pod_name=previous_operator)
+        self.wait_for_cluster_ready(timeout=timeout)
+        self.assert_bootstrap_keys_absent(constants.CEPHX_BOOTSTRAP_KEYS_TO_CLEANUP)
+        self.verify_no_bootstrap_deletion_errors()
+        self.verify_operator_logs_do_not_contain_warnings(
+            constants.CEPHX_BOOTSTRAP_DELETION_WARNING_PATTERNS,
+            since_time=operator_log_marker,
+            require_match=False,
+        )
+        log.info(
+            "Bootstrap key deletion is idempotent after operator restart "
+            f"(restarted pod {previous_operator})"
+        )
+
+    def verify_daemon_rotation_idempotent(
+        self,
+        current_generation,
+        auth_keys,
+        pod_states,
+        entities,
+        settle_timeout=120,
+    ):
+        """
+        Reconcile the same daemon keyGeneration and verify no further rotation occurs.
+
+        Args:
+            current_generation (int): Generation already applied in spec/status.
+            auth_keys (dict): Entity to key mapping after rotation.
+            pod_states (dict): OSD pod name to annotation map from
+                :meth:`capture_daemon_pod_state` (OSD pods do not use
+                cephx-key-identifier; restart detection is by pod name).
+            entities (list): Auth entities to re-check.
+            settle_timeout (int): Seconds to wait for a spurious reconcile.
+        """
+        log.info(
+            f"Verifying idempotent reconcile at daemon keyGeneration "
+            f"{current_generation}"
+        )
+        self.rotate_component_keys(
+            self.COMPONENT_DAEMON, key_generation=current_generation
+        )
+        time.sleep(settle_timeout)
+
+        new_keys = self.capture_auth_keys(entities)
+        unchanged_keys = [
+            entity
+            for entity in entities
+            if auth_keys.get(entity) and auth_keys[entity] == new_keys.get(entity)
+        ]
+        if len(unchanged_keys) != len(
+            [entity for entity in entities if auth_keys.get(entity)]
+        ):
+            changed = [
+                entity
+                for entity in entities
+                if auth_keys.get(entity) != new_keys.get(entity)
+            ]
+            raise UnexpectedBehaviour(
+                f"Re-reconcile changed CephX keys for: {', '.join(changed)}"
+            )
+
+        if self.get_status_key_generation("osd") != current_generation:
+            raise UnexpectedBehaviour(
+                f"Re-reconcile changed OSD keyGeneration "
+                f"(expected {current_generation}, "
+                f"got {self.get_status_key_generation('osd')})"
+            )
+
+        current_pod_states = self.capture_daemon_pod_state(constants.OSD_APP_LABEL)
+        if current_pod_states != pod_states:
+            raise UnexpectedBehaviour(
+                "Re-reconcile triggered OSD pod restarts or annotation changes"
+            )
+        log.info(f"Daemon keyGeneration {current_generation} reconcile is idempotent")
+
+    def discover_bootstrap_auth_entities(self, toolbox_pod=None):
+        """Return sorted ``client.bootstrap-*`` auth entity names."""
+        return self.list_auth_entities(
+            constants.CEPHX_BOOTSTRAP_AUTH_PREFIX, toolbox_pod
+        )
+
+    def assert_bootstrap_keys_absent(self, entities=None, toolbox_pod=None):
+        """
+        Assert bootstrap CephX keys are not present in the auth store.
+
+        Args:
+            entities (list): Bootstrap entities to check (defaults to all known).
+        """
+        entities = entities or list(constants.CEPHX_BOOTSTRAP_KEYS_TO_CLEANUP)
+        present = [
+            entity
+            for entity in entities
+            if self._auth_entity_exists(entity, toolbox_pod)
+        ]
+        if present:
+            raise UnexpectedBehaviour(
+                f"Bootstrap CephX keys still present: {', '.join(present)}"
+            )
+        log.info(f"Bootstrap CephX keys absent as expected: {', '.join(entities)}")
+
+    def wait_for_bootstrap_keys_absent(
+        self, entities=None, timeout=600, sleep=15, toolbox_pod=None
+    ):
+        """Wait until bootstrap auth entities are removed from the auth store."""
+        entities = entities or list(constants.CEPHX_BOOTSTRAP_KEYS_TO_CLEANUP)
+        log.info(
+            f"Waiting for bootstrap keys to be absent: {', '.join(entities)} "
+            f"(timeout={timeout}s)"
+        )
+
+        def _keys_absent():
+            present = [
+                entity
+                for entity in entities
+                if self._auth_entity_exists(entity, toolbox_pod)
+            ]
+            if present:
+                log.debug(f"Bootstrap keys still present: {', '.join(present)}")
+                return False
+            return True
+
+        for absent in TimeoutSampler(timeout, sleep, _keys_absent):
+            if absent:
+                log.info("Bootstrap CephX keys are absent")
+                return True
+
+        raise UnexpectedBehaviour(f"Bootstrap CephX keys not removed within {timeout}s")
+
+    def wait_for_bootstrap_key_present(
+        self, entity, timeout=300, sleep=10, toolbox_pod=None
+    ):
+        """Wait until a bootstrap auth entity appears (e.g. during OSD provisioning)."""
+        log.info(f"Waiting for bootstrap auth entity {entity} to appear")
+
+        def _key_present():
+            return self._auth_entity_exists(entity, toolbox_pod)
+
+        for present in TimeoutSampler(timeout, sleep, _key_present):
+            if present:
+                log.info(f"Bootstrap auth entity {entity} is present")
+                return True
+
+        log.info(f"Bootstrap auth entity {entity} did not appear within {timeout}s")
+        return False
+
+    def verify_key_rotation_idempotent_after_operator_restart(
+        self,
+        baseline_generations,
+        auth_keys,
+        auth_entities,
+        pod_states,
+        osd_cephx_status=None,
+        operator_log_since=None,
+        previous_operator_pod_name=None,
+        settle_timeout=120,
+    ):
+        """
+        Verify CephX state is unchanged after rook-ceph-operator re-reconcile.
+
+        Args:
+            baseline_generations (dict): From :meth:`record_all_cephx_status_generations`.
+            auth_keys (dict): Entity to key mapping captured after rotation.
+            auth_entities (list): Auth entities to re-check.
+            pod_states (dict): From :meth:`capture_all_daemon_pod_states`.
+            osd_cephx_status (dict): From :meth:`capture_osd_deployment_cephx_status`.
+            operator_log_since (datetime): Scan operator logs after this timestamp.
+            previous_operator_pod_name (str): Deleted operator pod name.
+            settle_timeout (int): Seconds to wait before post-reconcile checks.
+        """
+        idempotency_context = "after operator re-reconcile"
+        log.info("Verifying CephX key rotation idempotency after operator restart")
+        if settle_timeout:
+            time.sleep(settle_timeout)
+
+        self.wait_for_rook_ceph_operator_ready(
+            previous_pod_name=previous_operator_pod_name
+        )
+        self.wait_for_cluster_ready()
+        self.assert_cephx_status_generations_unchanged(
+            baseline_generations, context=idempotency_context
+        )
+        self.assert_auth_keys_unchanged(
+            auth_keys,
+            entities=auth_entities,
+            context=idempotency_context,
+        )
+        self.assert_all_daemon_pod_states_unchanged(
+            pod_states,
+            settle_time=0,
+            context=idempotency_context,
+        )
+        if osd_cephx_status is not None:
+            self.assert_osd_deployment_cephx_status_unchanged(osd_cephx_status)
+        if operator_log_since is not None:
+            self.verify_operator_no_key_rotation_logs(operator_log_since)
+        log.info("CephX key rotation is idempotent after operator re-reconcile")
+
+    def wait_for_post_mon_startup_bootstrap_cleanup(self, timeout=900, sleep=15):
+        """
+        Wait for post-mon-startup bootstrap key cleanup to finish.
+
+        Non-OSD bootstrap keys are removed by Rook after cluster startup actions.
+        """
+        return self.wait_for_bootstrap_keys_absent(
+            constants.CEPHX_BOOTSTRAP_NON_OSD_KEYS,
+            timeout=timeout,
+            sleep=sleep,
+        )
+
+    def wait_for_bootstrap_osd_key_absent(self, timeout=900, sleep=15):
+        """Wait until ``client.bootstrap-osd`` is removed after OSD provisioning."""
+        return self.wait_for_bootstrap_keys_absent(
+            ["client.bootstrap-osd"],
+            timeout=timeout,
+            sleep=sleep,
+        )
+
+    def verify_operator_bootstrap_deletion_logs(self, bootstrap_entities):
+        """
+        Verify rook-ceph-operator logged successful bootstrap key deletion.
+
+        Args:
+            bootstrap_entities (list): Entity names expected to have deletion logs.
+        """
+        if not bootstrap_entities:
+            log.info(
+                "No bootstrap keys were present before cleanup; "
+                "skipping operator deletion log verification"
+            )
+            return
+
+        from ocs_ci.helpers.helpers import get_logs_rook_ceph_operator
+
+        operator_logs = get_logs_rook_ceph_operator()
+        missing = []
+        for entity in bootstrap_entities:
+            if any(
+                entity in line
+                and constants.CEPHX_BOOTSTRAP_DELETED_OPERATOR_LOG in line
+                and constants.CEPHX_BOOTSTRAP_OPERATOR_LOG_TOKEN in line
+                for line in operator_logs.splitlines()
+            ):
+                log.info(f"Operator log confirms deletion of {entity}")
+                continue
+            missing.append(entity)
+
+        if missing:
+            raise UnexpectedBehaviour(
+                "Operator logs missing successful bootstrap key deletion for: "
+                f"{', '.join(missing)}"
+            )
+
+    def verify_no_bootstrap_deletion_errors(self):
+        """
+        Verify operator did not log non-idempotent bootstrap key deletion errors.
+
+        ENOENT/not-found style failures are acceptable when keys are already gone.
+        """
+        from ocs_ci.helpers.helpers import get_logs_rook_ceph_operator
+
+        operator_logs = get_logs_rook_ceph_operator()
+        errors = []
+        for line in operator_logs.splitlines():
+            lower_line = line.lower()
+            if "bootstrap" not in lower_line or "failed to delete" not in lower_line:
+                continue
+            if "enoent" in lower_line or "not found" in lower_line:
+                continue
+            errors.append(line.strip())
+
+        if errors:
+            raise UnexpectedBehaviour(
+                "Unexpected bootstrap key deletion errors in operator logs: "
+                f"{'; '.join(errors[:5])}"
+            )
+        log.info("No unexpected bootstrap key deletion errors in operator logs")
+
+    def capture_daemon_pod_state(self, label):
+        """
+        Record Running pod names and cephx-key-identifier annotations for *label*.
+
+        Note:
+            OSD pods do not carry ``cephx-key-identifier`` (Rook uses Deployment
+            ``cephx-status`` plus the ``cephx-keyring-update`` init container).
+            For OSDs the annotation value is typically ``None``.
+
+        Returns:
+            dict: pod name to annotation value (may be None).
+        """
+        pods = get_pods_having_label(
+            label, namespace=self.namespace, statuses=[constants.STATUS_RUNNING]
+        )
+        state = {}
+        for pod in pods:
+            name = pod["metadata"]["name"]
+            annotations = pod["metadata"].get("annotations") or {}
+            state[name] = annotations.get(constants.CEPHX_KEY_IDENTIFIER_ANNOTATION)
+        return state
+
+    def capture_all_daemon_pod_states(self):
+        """Capture pod state for MON, MGR, OSD, and MDS daemons."""
+        return {
+            daemon: self.capture_daemon_pod_state(label)
+            for daemon, label in constants.ROOK_CEPHX_KEYROTATION_DAEMON_LABELS.items()
+        }
+
+    def wait_for_pod_restarts(self, before_state, label, timeout=900, sleep=15):
+        """
+        Wait until all Running pods for *label* have new names or annotations.
+
+        Args:
+            before_state (dict): Output of :meth:`capture_daemon_pod_state`.
+        """
+        log.info(
+            f"Waiting for pod restarts (label={label}, "
+            f"prior pods={', '.join(before_state) or 'none'})"
+        )
+
+        def _pods_restarted():
+            current = self.capture_daemon_pod_state(label)
+            if not current:
+                return False
+            # Require every currently Running pod to be new or annotation-changed;
+            # a single restarted peer must not short-circuit the wait.
+            for pod_name, annotation in current.items():
+                if pod_name in before_state and before_state[pod_name] == annotation:
+                    return False
+            return True
+
+        for restarted in TimeoutSampler(timeout, sleep, _pods_restarted):
+            if restarted:
+                log.info(f"Pods restarted for label {label}")
+                return self.capture_daemon_pod_state(label)
+
+        raise UnexpectedBehaviour(
+            f"Pods with label {label} did not restart within {timeout}s"
+        )
+
+    def wait_for_all_daemon_pod_restarts(self, before_states, timeout=900, sleep=15):
+        """Wait for MON, MGR, OSD, and MDS pod restarts."""
+        after_states = {}
+        for daemon, label in constants.ROOK_CEPHX_KEYROTATION_DAEMON_LABELS.items():
+            after_states[daemon] = self.wait_for_pod_restarts(
+                before_states.get(daemon, {}),
+                label,
+                timeout=timeout,
+                sleep=sleep,
+            )
+        return after_states
+
+    def _get_cephfilesystem_obj(self):
+        if self._cephfilesystem_obj is None:
+            self._cephfilesystem_obj = OCP(
+                kind=constants.CEPHFILESYSTEM,
+                resource_name=self.cephfilesystem_name,
+                namespace=self.namespace,
+            )
+        return self._cephfilesystem_obj
+
+    def _wait_for_cr_daemon_rotation(
+        self, cr_obj, expected_generation, timeout, sleep, label
+    ):
+        log.info(
+            f"Waiting for CephX daemon rotation on {label} to reach "
+            f"generation {expected_generation}"
+        )
+
+        def _daemon_ready():
+            cr_obj.reload_data()
+            cephx = cr_obj.data.get("status", {}).get("cephx", {}) or {}
+            generation = int((cephx.get("daemon") or {}).get("keyGeneration", 0) or 0)
+            if generation < expected_generation:
+                log.debug(
+                    f"{label} daemon keyGeneration={generation} "
+                    f"(want >= {expected_generation})"
+                )
+                return False
+            return True
+
+        for ready in TimeoutSampler(timeout, sleep, _daemon_ready):
+            if ready:
+                log.info(
+                    f"CephX daemon rotation on {label} reached "
+                    f"generation {expected_generation}"
+                )
+                return True
+
+        raise UnexpectedBehaviour(
+            f"CephX daemon rotation on {label} did not reach generation "
+            f"{expected_generation} within {timeout}s"
+        )

--- a/ocs_ci/helpers/cephx_keyrotation/facade.py
+++ b/ocs_ci/helpers/cephx_keyrotation/facade.py
@@ -1,0 +1,31 @@
+"""Facade composing focused CephX key-rotation helper mixins."""
+
+from ocs_ci.helpers.cephx_keyrotation.auth import CephXAuthHelper
+from ocs_ci.helpers.cephx_keyrotation.cluster import CephXClusterHelper
+from ocs_ci.helpers.cephx_keyrotation.core import CephXKeyRotationCore
+from ocs_ci.helpers.cephx_keyrotation.daemon import CephXDaemonRotation
+from ocs_ci.helpers.cephx_keyrotation.io import CephXIOHelper
+from ocs_ci.helpers.cephx_keyrotation.metrics import CephXMetricsHelper
+from ocs_ci.helpers.cephx_keyrotation.mon import CephXMONHelper
+from ocs_ci.helpers.cephx_keyrotation.osd import CephXOSDHelper
+from ocs_ci.helpers.cephx_keyrotation.security import CephXSecurityHelper
+
+
+class CephXKeyRotation(
+    CephXKeyRotationCore,
+    CephXAuthHelper,
+    CephXSecurityHelper,
+    CephXClusterHelper,
+    CephXDaemonRotation,
+    CephXOSDHelper,
+    CephXMONHelper,
+    CephXMetricsHelper,
+    CephXIOHelper,
+):
+    """
+    Rotate CephX keys via StorageCluster
+    ``managedResources.cephCluster.security.cephx``.
+
+    Implementation is split across focused mixins; this class preserves the
+    historical single-entry API used by tests and background operations.
+    """

--- a/ocs_ci/helpers/cephx_keyrotation/io.py
+++ b/ocs_ci/helpers/cephx_keyrotation/io.py
@@ -1,0 +1,139 @@
+"""Background dd I/O helpers used by CephX CSI rotation tests."""
+
+import logging
+import shlex
+import time
+from threading import Thread
+
+from ocs_ci.ocs.exceptions import CommandFailed
+
+log = logging.getLogger(__name__)
+
+
+class CephXIOHelper:
+    """Background dd I/O helpers for CSI CephX rotation tests."""
+
+    @staticmethod
+    def _dd_io_stop_flag(file_path):
+        """Return a pod-local stop-flag path for background dd I/O."""
+        safe = file_path.strip("/").replace("/", "-")
+        return f"/tmp/ocs-ci-stop-dd-{safe}"
+
+    def start_dd_io_in_background(
+        self, pod_obj, file_path, bs="4k", count=10000, loop=True
+    ):
+        """
+        Start continuous ``dd`` I/O on a pod mount path in a background thread.
+
+        Args:
+            pod_obj: Pod object with ``exec_cmd_on_pod``.
+            file_path (str): Destination file path on the mounted volume.
+            bs (str): Block size for ``dd``.
+            count (int): Block count per ``dd`` invocation.
+            loop (bool): When True, repeat ``dd`` until stopped.
+
+        Returns:
+            Thread: Background I/O thread.
+        """
+        mount_dir = file_path.rsplit("/", 1)[0]
+        stop_flag = self._dd_io_stop_flag(file_path)
+        pod_obj.exec_cmd_on_pod(f"mkdir -p {mount_dir}", out_yaml_format=False)
+        pod_obj.exec_cmd_on_pod(f"rm -f {stop_flag}", out_yaml_format=False)
+
+        if loop:
+            # Stop via stop-flag file — workload images often lack pkill/procps.
+            dd_cmd = (
+                f"while [ ! -f {stop_flag} ]; do "
+                f"dd if=/dev/urandom of={file_path} bs={bs} count={count} "
+                f"status=none conv=notrunc; "
+                f"done; "
+                f"rm -f {stop_flag}"
+            )
+        else:
+            dd_cmd = (
+                f"dd if=/dev/urandom of={file_path} bs={bs} count={count} "
+                f"status=none"
+            )
+
+        def _run_dd():
+            try:
+                pod_obj.exec_cmd_on_pod(
+                    command=f"bash -c '{dd_cmd}'",
+                    timeout=7200,
+                    out_yaml_format=False,
+                )
+            except Exception as exc:
+                # Expected when stop_dd_io kills the in-flight dd/shell.
+                log.info(
+                    "Background dd I/O on %s:%s ended: %s",
+                    pod_obj.name,
+                    file_path,
+                    exc,
+                )
+
+        thread = Thread(target=_run_dd, name=f"dd-io-{pod_obj.name}")
+        thread.daemon = True
+        thread.start()
+        time.sleep(2)
+        log.info(f"Started background dd I/O on {pod_obj.name}:{file_path}")
+        return thread
+
+    def stop_dd_io(self, pod_obj, file_path):
+        """
+        Stop background ``dd`` I/O started by :meth:`start_dd_io_in_background`.
+
+        Uses a stop-flag file plus ``/proc`` cmdline matching so it works in
+        minimal workload images that do not ship ``pkill``/``procps``.
+
+        Skips the stop script's own PID when scanning ``/proc`` — the script
+        text itself contains ``of=<file_path>``, so a naive match would
+        SIGTERM the ``oc rsh`` shell (exit 143). Exit 143 from the stop
+        command is still tolerated as a race with the background dd session.
+        """
+        stop_flag = self._dd_io_stop_flag(file_path)
+        # shlex.quote keeps $pid expansion inside bash -c intact.
+        # Exclude $$ so the stop shell does not match its own cmdline.
+        stop_script = (
+            f"touch {stop_flag}; "
+            "self=$$; "
+            "for pid in /proc/[0-9]*; do "
+            "pidnum=${pid##*/}; "
+            '[ "$pidnum" = "$self" ] && continue; '
+            'cmd=$(tr "\\0" " " < "$pid/cmdline" 2>/dev/null) || continue; '
+            f'case "$cmd" in '
+            f'*dd*of={file_path}*) kill "$pidnum" 2>/dev/null || true ;; '
+            "esac; "
+            "done; "
+            "true"
+        )
+        try:
+            pod_obj.exec_cmd_on_pod(
+                command=f"bash -c {shlex.quote(stop_script)}",
+                out_yaml_format=False,
+                timeout=60,
+            )
+        except CommandFailed as exc:
+            # 143 = 128 + SIGTERM; expected if the stop rsh is terminated
+            # while tearing down the background dd session.
+            if "exit code 143" not in str(exc):
+                raise
+            log.info(
+                "stop_dd_io on %s:%s returned exit 143 (SIGTERM); "
+                "treating background dd as stopped",
+                pod_obj.name,
+                file_path,
+            )
+        log.info(f"Stopped background dd I/O on {pod_obj.name}:{file_path}")
+
+    def verify_io_file_readable(self, pod_obj, file_path):
+        """Assert *file_path* exists on the pod volume and is readable."""
+        # oc rsh does not invoke a shell, so compound commands need bash -c.
+        verify_script = (
+            f"test -s {shlex.quote(file_path)} && "
+            f"dd if={shlex.quote(file_path)} of=/dev/null bs=4k count=1 status=none"
+        )
+        pod_obj.exec_cmd_on_pod(
+            command=f"bash -c {shlex.quote(verify_script)}",
+            out_yaml_format=False,
+        )
+        log.info(f"Verified I/O file is readable on {pod_obj.name}:{file_path}")

--- a/ocs_ci/helpers/cephx_keyrotation/metrics.py
+++ b/ocs_ci/helpers/cephx_keyrotation/metrics.py
@@ -1,0 +1,377 @@
+"""Metrics-exporter verification helpers for CephX key rotation."""
+
+import logging
+
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.exceptions import UnexpectedBehaviour
+from ocs_ci.ocs.ocp import OCP
+from ocs_ci.ocs.resources.pod import (
+    get_ceph_tools_pod,
+    get_pod_ip,
+    get_pod_logs,
+    get_pod_obj,
+    get_pods_having_label,
+)
+from ocs_ci.utility.utils import TimeoutSampler
+
+log = logging.getLogger(__name__)
+
+_PROMETHEUS_SA = "prometheus-k8s"
+_PROMETHEUS_NS = "openshift-monitoring"
+
+
+class CephXMetricsHelper:
+    """ocs-metrics-exporter verification for CephX rotations."""
+
+    def get_metrics_exporter_pods(self):
+        """Return Running ocs-metrics-exporter pod resource dicts."""
+        return get_pods_having_label(
+            constants.OCS_METRICS_EXPORTER,
+            namespace=self.namespace,
+            statuses=[constants.STATUS_RUNNING],
+        )
+
+    def assert_metrics_exporter_running(self):
+        """Assert a Running ocs-metrics-exporter pod exists."""
+        pods = self.get_metrics_exporter_pods()
+        if not pods:
+            raise UnexpectedBehaviour("No Running ocs-metrics-exporter pods found")
+        pod_name = pods[0]["metadata"]["name"]
+        log.info(f"ocs-metrics-exporter pod is Running: {pod_name}")
+        return pods[0]
+
+    def _get_metrics_exporter_deployment(self):
+        """Return the ocs-metrics-exporter Deployment dict."""
+        return OCP(
+            kind=constants.DEPLOYMENT,
+            namespace=self.namespace,
+            resource_name="ocs-metrics-exporter",
+        ).get()
+
+    def _discover_metrics_exporter_scrape_port(self):
+        """
+        Resolve the HTTPS port that serves OCS/Ceph /metrics.
+
+        Preference order:
+            1. Service port named ``https-main`` (kube-rbac-proxy layout)
+            2. Any other Service HTTPS port except ``https-self``
+            3. Deployment containerPort named ``https-main``
+            4. Fallback constants (8443 modern, then 9443 legacy)
+        """
+        cached = getattr(self, "_metrics_scrape_port", None)
+        if cached:
+            return cached
+
+        port = None
+        source = "fallback"
+
+        try:
+            service = OCP(
+                kind=constants.SERVICE,
+                namespace=self.namespace,
+                resource_name="ocs-metrics-exporter",
+            ).get()
+            ports = service.get("spec", {}).get("ports", []) or []
+            by_name = {
+                p.get("name"): p.get("port")
+                for p in ports
+                if p.get("name") and p.get("port") is not None
+            }
+            if constants.OCS_METRICS_EXPORTER_HTTPS_MAIN_PORT_NAME in by_name:
+                port = by_name[constants.OCS_METRICS_EXPORTER_HTTPS_MAIN_PORT_NAME]
+                source = "service/https-main"
+            else:
+                for name, value in by_name.items():
+                    if name == constants.OCS_METRICS_EXPORTER_HTTPS_SELF_PORT_NAME:
+                        continue
+                    port = value
+                    source = f"service/{name}"
+                    break
+        except Exception as exc:
+            log.debug(f"Could not read ocs-metrics-exporter Service ports: {exc}")
+
+        if port is None:
+            try:
+                deploy = self._get_metrics_exporter_deployment()
+                for container in (
+                    deploy.get("spec", {})
+                    .get("template", {})
+                    .get("spec", {})
+                    .get("containers", [])
+                    or []
+                ):
+                    for cport in container.get("ports", []) or []:
+                        if (
+                            cport.get("name")
+                            == constants.OCS_METRICS_EXPORTER_HTTPS_MAIN_PORT_NAME
+                            and cport.get("containerPort") is not None
+                        ):
+                            port = cport["containerPort"]
+                            source = "deployment/https-main"
+                            break
+                    if port is not None:
+                        break
+            except Exception as exc:
+                log.debug(
+                    f"Could not read ocs-metrics-exporter Deployment ports: {exc}"
+                )
+
+        if port is None:
+            port = constants.OCS_METRICS_EXPORTER_PORT
+            source = "constant/OCS_METRICS_EXPORTER_PORT"
+
+        self._metrics_scrape_port = int(port)
+        log.info(
+            "ocs-metrics-exporter scrape port=%s (source=%s)",
+            self._metrics_scrape_port,
+            source,
+        )
+        return self._metrics_scrape_port
+
+    def _metrics_exporter_local_url(self):
+        """HTTPS /metrics URL on the exporter pod loopback interface."""
+        port = self._discover_metrics_exporter_scrape_port()
+        return (
+            f"https://127.0.0.1:{port}" f"{constants.OCS_METRICS_EXPORTER_METRICS_PATH}"
+        )
+
+    def _metrics_exporter_requires_auth(self):
+        """
+        Return True when /metrics is fronted by auth (kube-rbac-proxy or
+        legacy ``--secure-serving=true`` on the exporter container).
+
+        Current ODF deployments put kube-rbac-proxy sidecars first in the
+        container list; checking only containers[0] misses that layout.
+        """
+        try:
+            deploy = self._get_metrics_exporter_deployment()
+            containers = (
+                deploy.get("spec", {})
+                .get("template", {})
+                .get("spec", {})
+                .get("containers", [])
+                or []
+            )
+            for container in containers:
+                name = container.get("name") or ""
+                if name.startswith("kube-rbac-proxy"):
+                    return True
+                args = container.get("args") or []
+                if "--secure-serving=true" in args:
+                    return True
+            return False
+        except Exception as exc:
+            log.debug(f"Could not inspect ocs-metrics-exporter deployment: {exc}")
+            return False
+
+    # Backward-compatible alias used by older call sites / tests.
+    _is_metrics_exporter_secure_serving = _metrics_exporter_requires_auth
+
+    def _get_metrics_bearer_token(self):
+        """Create a short-lived bearer token for scraping authenticated /metrics."""
+        ocp = OCP(namespace=_PROMETHEUS_NS)
+        token = ocp.exec_oc_cmd(
+            f"create token {_PROMETHEUS_SA} --duration=600s",
+            out_yaml_format=False,
+        )
+        return token.strip()
+
+    def _curl_metrics_from_pod(
+        self, pod_obj, metrics_url, container_name=None, bearer_token=None
+    ):
+        """Run curl against *metrics_url* inside *pod_obj*."""
+        auth_header = ""
+        if bearer_token:
+            auth_header = f" -H 'Authorization: Bearer {bearer_token}'"
+        return pod_obj.exec_cmd_on_pod(
+            f"curl -sk --connect-timeout 15{auth_header} {metrics_url}",
+            out_yaml_format=False,
+            container_name=container_name,
+        )
+
+    def _metrics_output_is_valid(self, metrics_output):
+        """Return True when *metrics_output* looks like a Prometheus scrape."""
+        if not metrics_output or "# TYPE" not in metrics_output:
+            return False
+        return any(
+            prefix in metrics_output
+            for prefix in constants.OCS_METRICS_EXPORTER_METRIC_PREFIXES
+        )
+
+    def fetch_metrics_exporter_metrics(self, metrics_pod=None):
+        """
+        Fetch the ocs-metrics-exporter /metrics payload.
+
+        When metrics are behind kube-rbac-proxy (or legacy
+        ``--secure-serving=true``), a short-lived ``prometheus-k8s`` bearer
+        token is included in the request. The scrape port is discovered from
+        the live Service (prefer ``https-main``); ``https-self`` is skipped
+        because it only exposes process metrics.
+
+        Prefer curl from the exporter pod itself (works on baremetal where
+        toolbox-to-pod-IP routing may fail). Fall back to the toolbox pod
+        curling the exporter pod IP.
+        """
+        metrics_pod = metrics_pod or self.assert_metrics_exporter_running()
+        pod_name = metrics_pod["metadata"]["name"]
+        scrape_port = self._discover_metrics_exporter_scrape_port()
+        local_url = self._metrics_exporter_local_url()
+
+        bearer_token = None
+        if self._metrics_exporter_requires_auth():
+            log.info(
+                "ocs-metrics-exporter /metrics requires auth "
+                "(kube-rbac-proxy or secure-serving); "
+                "fetching prometheus-k8s bearer token"
+            )
+            try:
+                bearer_token = self._get_metrics_bearer_token()
+            except Exception as exc:
+                log.warning(f"Failed to create metrics bearer token: {exc}")
+
+        log.info(f"Fetching ocs-metrics-exporter metrics from {pod_name} ({local_url})")
+        try:
+            local_output = self._curl_metrics_from_pod(
+                get_pod_obj(pod_name, namespace=self.namespace),
+                local_url,
+                container_name=constants.OCS_METRICS_EXPORTER_CONTAINER,
+                bearer_token=bearer_token,
+            )
+            if self._metrics_output_is_valid(local_output):
+                return local_output
+            log.debug(
+                "ocs-metrics-exporter local /metrics response was empty or invalid"
+            )
+        except Exception as exc:
+            log.debug(f"ocs-metrics-exporter local metrics fetch failed: {exc}")
+
+        pod_ip = get_pod_ip(
+            OCP(
+                kind=constants.POD,
+                namespace=self.namespace,
+                resource_name=pod_name,
+            )
+        )
+        if not pod_ip:
+            raise UnexpectedBehaviour("ocs-metrics-exporter pod IP is not assigned")
+
+        remote_url = (
+            f"https://{pod_ip}:{scrape_port}"
+            f"{constants.OCS_METRICS_EXPORTER_METRICS_PATH}"
+        )
+        log.info(f"Fetching ocs-metrics-exporter metrics via toolbox ({remote_url})")
+        toolbox = get_ceph_tools_pod()
+        return self._curl_metrics_from_pod(
+            toolbox, remote_url, bearer_token=bearer_token
+        )
+
+    def assert_metrics_exporter_metrics(self, metrics_output=None, metrics_pod=None):
+        """
+        Assert ocs-metrics-exporter exposes Prometheus metrics from Ceph/OCS.
+
+        Args:
+            metrics_output (str): Pre-fetched /metrics payload.
+            metrics_pod (dict): Optional exporter pod resource dict.
+        """
+        metrics_output = metrics_output or self.fetch_metrics_exporter_metrics(
+            metrics_pod
+        )
+        if not metrics_output or "# TYPE" not in metrics_output:
+            raise UnexpectedBehaviour(
+                "ocs-metrics-exporter /metrics response is empty or invalid"
+            )
+        if not any(
+            prefix in metrics_output
+            for prefix in constants.OCS_METRICS_EXPORTER_METRIC_PREFIXES
+        ):
+            raise UnexpectedBehaviour(
+                "ocs-metrics-exporter /metrics missing expected OCS/Ceph metric names"
+            )
+        log.info("ocs-metrics-exporter metrics export verified successfully")
+
+    def verify_metrics_exporter_no_auth_bad_key(self, metrics_pod=None, tail=500):
+        """Assert ocs-metrics-exporter logs do not contain AUTH_BAD_KEY errors."""
+        metrics_pod = metrics_pod or self.assert_metrics_exporter_running()
+        pod_name = metrics_pod["metadata"]["name"]
+        auth_errors = get_pod_logs(
+            pod_name=pod_name,
+            container=constants.OCS_METRICS_EXPORTER_CONTAINER,
+            namespace=self.namespace,
+            tail=str(tail),
+            grep=constants.AUTH_BAD_KEY_LOG,
+            return_empty_string=True,
+        )
+        if auth_errors and constants.AUTH_BAD_KEY_LOG in auth_errors:
+            raise UnexpectedBehaviour(
+                f"AUTH_BAD_KEY errors found in ocs-metrics-exporter logs: "
+                f"{auth_errors.strip()}"
+            )
+        log.info("No AUTH_BAD_KEY errors in ocs-metrics-exporter logs")
+
+    def wait_for_metrics_exporter_metrics(
+        self, timeout=600, sleep=15, metrics_pod=None
+    ):
+        """Wait until ocs-metrics-exporter exports valid metrics."""
+        log.info(
+            f"Waiting for ocs-metrics-exporter metrics export (timeout={timeout}s)"
+        )
+
+        def _metrics_ready():
+            try:
+                self.assert_metrics_exporter_metrics(metrics_pod=metrics_pod)
+                self.verify_metrics_exporter_no_auth_bad_key(metrics_pod=metrics_pod)
+                return True
+            except UnexpectedBehaviour as exc:
+                log.debug(f"ocs-metrics-exporter metrics not ready yet: {exc}")
+                return False
+
+        for ready in TimeoutSampler(timeout, sleep, _metrics_ready):
+            if ready:
+                log.info("ocs-metrics-exporter metrics export is healthy")
+                return True
+
+        raise UnexpectedBehaviour(
+            f"ocs-metrics-exporter did not export metrics within {timeout}s"
+        )
+
+    def wait_for_metrics_exporter_after_rotation(
+        self, previous_pod_name=None, timeout=900, sleep=15
+    ):
+        """
+        Wait for ocs-metrics-exporter to recover after CephX key rotation.
+
+        The exporter may restart or reload its Ceph keyring; metrics export and
+        logs are polled until healthy.
+        """
+        log.info(
+            "Waiting for ocs-metrics-exporter to use rotated CephX key "
+            f"(previous pod={previous_pod_name or 'unknown'})"
+        )
+
+        def _exporter_ready():
+            pods = self.get_metrics_exporter_pods()
+            if not pods:
+                log.debug("ocs-metrics-exporter pod is not Running yet")
+                return False
+            pod_name = pods[0]["metadata"]["name"]
+            if previous_pod_name and pod_name != previous_pod_name:
+                log.info(
+                    f"ocs-metrics-exporter pod restarted: "
+                    f"{previous_pod_name} -> {pod_name}"
+                )
+            try:
+                self.assert_metrics_exporter_metrics(metrics_pod=pods[0])
+                self.verify_metrics_exporter_no_auth_bad_key(pods[0])
+                return True
+            except UnexpectedBehaviour as exc:
+                log.debug(f"ocs-metrics-exporter not ready after rotation: {exc}")
+                return False
+
+        for ready in TimeoutSampler(timeout, sleep, _exporter_ready):
+            if ready:
+                log.info("ocs-metrics-exporter is healthy after CephX key rotation")
+                return True
+
+        raise UnexpectedBehaviour(
+            f"ocs-metrics-exporter did not recover within {timeout}s after rotation"
+        )

--- a/ocs_ci/helpers/cephx_keyrotation/mon.py
+++ b/ocs_ci/helpers/cephx_keyrotation/mon.py
@@ -1,0 +1,364 @@
+"""MON CephX helpers: quorum, secrets, and operator crash recovery."""
+
+import logging
+import re
+
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.exceptions import UnexpectedBehaviour
+from ocs_ci.ocs.ocp import OCP
+from ocs_ci.ocs.resources.pod import (
+    get_deployments_having_label,
+    get_mon_pods,
+    get_operator_pods,
+)
+from ocs_ci.utility.retry import retry
+from ocs_ci.utility.utils import TimeoutSampler
+
+log = logging.getLogger(__name__)
+
+
+class CephXMONHelper:
+    """MON quorum, secret, and operator-crash recovery helpers."""
+
+    def wait_for_mon_rotation(self, expected_generation, timeout=900, sleep=15):
+        """Wait until ``status.cephx.mon.keyGeneration`` matches (when supported)."""
+        if not self.is_mon_key_rotation_supported():
+            log.info("MON CephX key rotation status not reported; skipping wait")
+            return False
+        return self._wait_for_status_entities(
+            ["mon"],
+            expected_generation,
+            timeout,
+            sleep,
+            label="mon",
+        )
+
+    @retry(UnexpectedBehaviour, tries=5, delay=20)
+    def is_mon_key_rotation_supported(self):
+        """
+        Return True when CephCluster reports MON ``status.cephx.mon.keyGeneration``.
+
+        Raises ``UnexpectedBehaviour`` while ``status.cephx.mon`` is absent so the
+        retry decorator can wait for CephCluster to report MON status. Returns
+        False only when ``mon`` is present but has no ``keyGeneration`` (Rook
+        reports ``mon: {}`` when MON rotation is unsupported).
+
+        Note: Prefer verifying keys via the shared ``mon.`` entity
+        (``ceph auth get-key mon.``). Use :meth:`is_mon_auth_verifiable` before
+        asserting on MON auth keys.
+        """
+        status_cephx = self.get_status_cephx()
+        if "mon" not in status_cephx:
+            raise UnexpectedBehaviour("CephCluster status.cephx.mon not yet reported")
+        mon_status = status_cephx.get("mon") or {}
+        return bool(mon_status.get("keyGeneration"))
+
+    def is_mon_auth_verifiable(self, toolbox_pod=None):
+        """Return True when MON auth entities are readable from the auth store."""
+        return bool(self._discover_mon_auth_entities(toolbox_pod))
+
+    def _discover_mon_auth_entities(self, toolbox_pod=None):
+        """
+        Discover MON auth entities.
+
+        Prefer the shared ``mon.`` entity (``ceph auth get-key mon.``), which is
+        the CephX key used by monitors on current ODF clusters. Fall back to
+        per-mon entities from ``ceph auth ls`` / ``ceph mon dump`` when ``mon.``
+        is absent.
+        """
+        if self._auth_entity_exists("mon.", toolbox_pod):
+            return ["mon."]
+
+        entities = self.list_auth_entities("mon.", toolbox_pod)
+        if entities:
+            return entities
+
+        toolbox = toolbox_pod or self.get_ceph_cli_pod()
+        mon_dump = toolbox.exec_ceph_cmd("ceph mon dump")
+        discovered = []
+        for mon in mon_dump.get("mons", []):
+            name = mon.get("name")
+            if not name:
+                continue
+            entity = f"mon.{name}"
+            if self._auth_entity_exists(entity, toolbox_pod):
+                discovered.append(entity)
+        return sorted(discovered)
+
+    def get_mon_deployment_names(self):
+        """Return sorted rook-ceph-mon deployment names."""
+        deployments = get_deployments_having_label(
+            constants.MON_APP_LABEL, self.namespace
+        )
+        return sorted(dep["metadata"]["name"] for dep in deployments)
+
+    def scale_mon_deployments(self, deployment_names, replicas):
+        """Scale mon deployments to *replicas*."""
+        from ocs_ci.helpers.helpers import modify_deployment_replica_count
+
+        for deployment_name in deployment_names:
+            log.info(f"Scaling {deployment_name} to {replicas} replicas")
+            assert modify_deployment_replica_count(
+                deployment_name, replicas, namespace=self.namespace
+            ), f"Failed to scale {deployment_name} to {replicas}"
+
+    def restore_mon_deployments(self, deployment_names=None):
+        """Scale mon deployments back to one replica and wait for quorum."""
+        from ocs_ci.helpers.ceph_helpers import wait_for_mons_in_quorum
+
+        deployment_names = deployment_names or self.get_mon_deployment_names()
+        self.scale_mon_deployments(deployment_names, 1)
+        wait_for_mons_in_quorum(len(deployment_names), timeout=600)
+
+    def break_mon_quorum(self, mons_to_stop=2):
+        """
+        Scale down *mons_to_stop* mon deployments to break quorum.
+
+        Returns:
+            list: Mon deployment names scaled to zero (keeps the first mon up).
+        """
+        mon_deployments = self.get_mon_deployment_names()
+        if len(mon_deployments) < mons_to_stop + 1:
+            raise UnexpectedBehaviour(
+                f"Need at least {mons_to_stop + 1} mon deployments; "
+                f"found {len(mon_deployments)}"
+            )
+        scaled_down = mon_deployments[1 : mons_to_stop + 1]
+        self.scale_mon_deployments(scaled_down, 0)
+        return scaled_down
+
+    def get_running_mon_pod_count(self):
+        """
+        Return the number of mon pods currently in Running state.
+
+        Prefer this over ``ceph mon stat`` when quorum may already be broken:
+        Ceph CLI against the tools pod hangs without mon majority.
+        """
+        running = [
+            mon_pod
+            for mon_pod in get_mon_pods(namespace=self.namespace)
+            if mon_pod.status() == constants.STATUS_RUNNING
+        ]
+        log.info(
+            f"Running mon pods ({len(running)}): "
+            f"{[mon_pod.name for mon_pod in running]}"
+        )
+        return len(running)
+
+    def wait_for_mon_quorum_count_at_most(self, max_count, timeout=300, sleep=15):
+        """
+        Wait until at most *max_count* mon pods are Running.
+
+        Uses the Kubernetes API rather than ``ceph mon stat``. After scaling
+        mons below majority, Ceph CLI hangs, so running-pod count is the
+        reliable signal that quorum has been broken for negative tests.
+        """
+        log.info(f"Waiting for running mon pod count <= {max_count}")
+
+        def _running_mons_reduced():
+            count = self.get_running_mon_pod_count()
+            return count <= max_count
+
+        for ready in TimeoutSampler(timeout, sleep, _running_mons_reduced):
+            if ready:
+                return self.get_running_mon_pod_count()
+
+        raise UnexpectedBehaviour(
+            f"Running mon pod count did not drop to {max_count} within {timeout}s"
+        )
+
+    def assert_mon_pods_not_crashlooping(self):
+        """Assert no mon pods are in CrashLoopBackOff."""
+        crashloop_pods = []
+        for mon_pod in get_mon_pods(namespace=self.namespace):
+            pod_data = mon_pod.get()
+            for container_status in (
+                pod_data.get("status", {}).get("containerStatuses", []) or []
+            ):
+                waiting = container_status.get("state", {}).get("waiting", {})
+                if waiting.get("reason") == constants.STATUS_CLBO:
+                    crashloop_pods.append(mon_pod.name)
+        if crashloop_pods:
+            raise UnexpectedBehaviour(
+                f"Mon pods in CrashLoopBackOff: {', '.join(crashloop_pods)}"
+            )
+        log.info("No mon pods are in CrashLoopBackOff")
+
+    def _parse_mon_keys_from_keyring(self, keyring_text):
+        """Return mon entity to key mapping parsed from a Ceph keyring."""
+        keys = {}
+        current_entity = None
+        for line in keyring_text.splitlines():
+            # Any section header ends the previous entity scope. Only ``mon.*``
+            # sections (shared ``[mon.]`` or per-mon ``[mon.a]``) stay active so
+            # later sections like ``[client.admin]`` cannot overwrite mon keys.
+            section_match = re.match(r"\[([^\]]+)\]", line.strip())
+            if section_match:
+                entity = section_match.group(1)
+                current_entity = entity if entity.startswith("mon.") else None
+                continue
+            if current_entity and "key" in line:
+                key_match = re.search(r"key\s*=\s*(\S+)", line)
+                if key_match:
+                    keys[current_entity] = key_match.group(1)
+        return keys
+
+    def get_mon_keys_from_secrets(self):
+        """Return mon entity to key mapping from rook mon Kubernetes secrets."""
+        import base64
+
+        secret_keys = {}
+        for secret_name in (
+            constants.MANAGED_MON_SECRET,
+            constants.MANAGED_MONS_KEYRING_SECRET,
+        ):
+            secret_obj = OCP(
+                kind=constants.SECRET,
+                resource_name=secret_name,
+                namespace=self.namespace,
+            )
+            secret_data = secret_obj.get().get("data", {})
+            keyring_b64 = secret_data.get("keyring") or secret_data.get("adminKeyring")
+            if not keyring_b64:
+                continue
+            keyring_text = base64.b64decode(keyring_b64).decode()
+            secret_keys.update(self._parse_mon_keys_from_keyring(keyring_text))
+        return secret_keys
+
+    def assert_mon_secret_keys_unchanged(
+        self, old_keys, context="while mon quorum is broken"
+    ):
+        """
+        Assert rook mon Kubernetes secret keys did not change.
+
+        Prefer this over :meth:`assert_auth_keys_unchanged` when mon quorum is
+        broken: ``ceph auth get-key`` cannot reach the cluster without quorum.
+        """
+        new_keys = self.get_mon_keys_from_secrets()
+        self.log_auth_key_comparison(old_keys, new_keys)
+        entities = sorted(set(old_keys) | set(new_keys))
+        changed = [
+            entity
+            for entity in entities
+            if old_keys.get(entity) != new_keys.get(entity)
+        ]
+        if changed:
+            raise UnexpectedBehaviour(
+                f"Mon Kubernetes secret keys changed {context}: {', '.join(changed)}"
+            )
+        log.info(
+            f"Mon Kubernetes secret keys unchanged for entities: "
+            f"{', '.join(entities) if entities else '<none>'}"
+        )
+
+    def get_mon_keys_from_ceph_auth(self, toolbox_pod=None):
+        """Return mon entity to key mapping from the Ceph auth store."""
+        toolbox = toolbox_pod or self.get_ceph_cli_pod()
+        mon_entities = self.discover_rook_daemon_auth_entities(toolbox).get("mon", [])
+        if not mon_entities:
+            mon_entities = [
+                line.split()[0]
+                for line in toolbox.exec_cmd_on_pod(
+                    "ceph auth ls", out_yaml_format=False
+                ).splitlines()
+                if line.startswith("mon.")
+            ]
+        return self.capture_auth_keys(mon_entities, toolbox_pod=toolbox)
+
+    def verify_mon_secrets_match_ceph_auth(self, toolbox_pod=None):
+        """Assert Kubernetes mon secrets match Ceph auth store mon keys."""
+        ceph_keys = self.get_mon_keys_from_ceph_auth(toolbox_pod)
+        secret_keys = self.get_mon_keys_from_secrets()
+        if not ceph_keys:
+            log.warning(
+                "No mon auth entities found in Ceph; skipping secret comparison"
+            )
+            return
+        mismatched = []
+        for entity, ceph_key in ceph_keys.items():
+            secret_key = secret_keys.get(entity)
+            if not secret_key:
+                mismatched.append(f"{entity}=<missing in secret>")
+            elif secret_key != ceph_key:
+                mismatched.append(f"{entity}=<mismatch>")
+        if mismatched:
+            raise UnexpectedBehaviour(
+                "Mon Kubernetes secrets do not match Ceph auth store: "
+                f"{', '.join(mismatched)}"
+            )
+        log.info("Mon Kubernetes secrets match Ceph auth store")
+
+    def kill_operator_during_mon_rotation(self, timeout=900, poll_interval=2):
+        """
+        Trigger daemon rotation and kill rook-ceph-operator while mon rotation
+        is in progress.
+
+        Patches StorageCluster without waiting for Ready, then force-deletes the
+        operator once CephCluster is Progressing and mon auth rotation appears
+        in operator logs since the trigger.
+
+        Returns:
+            int: Requested daemon key generation.
+        """
+        from ocs_ci.helpers.helpers import get_last_log_time_date
+
+        operator_log_marker = get_last_log_time_date()
+        target_generation = self.rotate_daemon_keys(wait_for_rotation=False)
+        operator_pods = get_operator_pods(namespace=self.namespace)
+        if not operator_pods:
+            raise UnexpectedBehaviour("rook-ceph-operator pod not found")
+        operator_pod = operator_pods[0]
+        operator_ocp = OCP(kind=constants.POD, namespace=self.namespace)
+
+        log.info(
+            "Waiting to kill rook-ceph-operator while mon key rotation is in progress"
+        )
+
+        def _kill_when_mon_rotating():
+            phase = self.get_cephcluster_phase()
+            logs = self.get_operator_logs_since(operator_log_marker)
+            logs_text = "\n".join(logs)
+            mon_rotating = bool(
+                re.search(
+                    constants.CEPHX_MON_AUTH_ROTATION_LOG_PATTERN, logs_text, re.I
+                )
+            )
+            if phase == constants.STATUS_PROGRESSING and mon_rotating:
+                log.info(
+                    f"Killing rook-ceph-operator pod {operator_pod.name} during "
+                    f"mon key rotation (CephCluster phase={phase})"
+                )
+                operator_ocp.delete(
+                    resource_name=operator_pod.name, force=True, wait=False
+                )
+                return True
+            log.debug(
+                f"Mon rotation kill gate: phase={phase}, "
+                f"mon_auth_log={mon_rotating}"
+            )
+            return False
+
+        for done in TimeoutSampler(timeout, poll_interval, _kill_when_mon_rotating):
+            if done:
+                return target_generation
+
+        raise UnexpectedBehaviour(
+            "Timed out waiting for mon key rotation in progress before "
+            "killing rook-ceph-operator"
+        )
+
+    def recover_after_operator_crash_during_mon_rotation(self, timeout=1500):
+        """
+        Wait for operator and cluster recovery after a mid-mon-rotation crash.
+
+        Does not gate on operator log patterns; callers should verify daemon
+        key rotation separately via status generation and auth key comparison.
+        """
+        self.wait_for_rook_ceph_operator_ready()
+        self.assert_mon_pods_not_crashlooping()
+        from ocs_ci.helpers.ceph_helpers import wait_for_mons_in_quorum
+
+        wait_for_mons_in_quorum(len(self.get_mon_deployment_names()), timeout=timeout)
+        self.wait_for_cluster_ready(timeout=timeout)
+        self.wait_for_pgs_active_clean(timeout=timeout)
+        self.verify_mon_secrets_match_ceph_auth()

--- a/ocs_ci/helpers/cephx_keyrotation/osd.py
+++ b/ocs_ci/helpers/cephx_keyrotation/osd.py
@@ -1,0 +1,909 @@
+"""OSD CephX helpers: deployment cephx-status, lockbox, auth inject/restore."""
+
+import json
+import logging
+import re
+import shlex
+
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.exceptions import CommandFailed, UnexpectedBehaviour
+from ocs_ci.ocs.ocp import OCP
+from ocs_ci.ocs.resources.pod import (
+    get_operator_pods,
+    get_osd_deployments,
+    get_osd_pods,
+    get_osd_pods_having_ids,
+    get_pod_logs,
+)
+from ocs_ci.utility.utils import TimeoutSampler
+
+log = logging.getLogger(__name__)
+
+
+class CephXOSDHelper:
+    """OSD deployment, lockbox, and OSD auth failure/recovery helpers."""
+
+    def wait_for_osd_rotation(self, expected_generation, timeout=900, sleep=15):
+        """Wait until ``status.cephx.osd.keyGeneration`` reaches *expected_generation*."""
+        return self._wait_for_status_entities(
+            ["osd"],
+            expected_generation,
+            timeout,
+            sleep,
+            label="osd",
+        )
+
+    def _discover_osd_auth_entities(self, toolbox_pod=None):
+        """Discover OSD auth entities, falling back to ``ceph osd dump``."""
+        entities = self.list_auth_entities("osd.", toolbox_pod)
+        if entities:
+            return entities
+
+        toolbox = toolbox_pod or self.get_ceph_cli_pod()
+        osd_dump = toolbox.exec_ceph_cmd("ceph osd dump")
+        discovered = []
+        for osd in osd_dump.get("osds", []):
+            osd_id = osd.get("osd")
+            if osd_id is None:
+                continue
+            entity = f"osd.{osd_id}"
+            if self._auth_entity_exists(entity, toolbox_pod):
+                discovered.append(entity)
+        return sorted(discovered, key=lambda name: int(name.split(".", 1)[1]))
+
+    def discover_osd_auth_entities(self, toolbox_pod=None):
+        """Return sorted OSD auth entity names (e.g. osd.0, osd.1)."""
+        return self._discover_osd_auth_entities(toolbox_pod)
+
+    def capture_osd_deployment_cephx_status(self):
+        """
+        Snapshot ``cephx-status`` deployment template annotations for OSDs.
+
+        Returns:
+            dict: deployment name to parsed CephxStatus JSON (may be empty).
+        """
+        statuses = {}
+        for deployment in get_osd_deployments(namespace=self.namespace):
+            deployment_data = deployment.get()
+            annotation = (
+                deployment_data.get("spec", {})
+                .get("template", {})
+                .get("metadata", {})
+                .get("annotations", {})
+                .get(constants.CEPHX_STATUS_ANNOTATION)
+            )
+            if annotation:
+                statuses[deployment.name] = json.loads(annotation)
+            else:
+                statuses[deployment.name] = {}
+        return statuses
+
+    def clear_osd_deployment_cephx_status_annotations(self):
+        """
+        Remove ``cephx-status`` from OSD deployment templates.
+
+        Simulates brownfield OSD deployments that pre-date cephx rotation support.
+        """
+        annotation_key = constants.CEPHX_STATUS_ANNOTATION
+        cleared = []
+        for deployment in get_osd_deployments(namespace=self.namespace):
+            deployment_data = deployment.get()
+            annotations = (
+                deployment_data.get("spec", {})
+                .get("template", {})
+                .get("metadata", {})
+                .get("annotations", {})
+                or {}
+            )
+            if annotation_key not in annotations:
+                continue
+            patch_ops = [
+                {
+                    "op": "remove",
+                    "path": (
+                        "/spec/template/metadata/annotations/" f"{annotation_key}"
+                    ),
+                }
+            ]
+            deployment.ocp.patch(
+                resource_name=deployment.name,
+                params=json.dumps(patch_ops),
+                format_type="json",
+            )
+            cleared.append(deployment.name)
+        if cleared:
+            log.info(
+                "Cleared cephx-status annotation from OSD deployments: "
+                f"{', '.join(cleared)}"
+            )
+        return cleared
+
+    def restore_osd_deployment_cephx_status_annotations(self, statuses):
+        """
+        Restore OSD deployment ``cephx-status`` annotations from a snapshot.
+
+        Args:
+            statuses (dict): deployment name to parsed CephxStatus JSON (may be
+                empty). Empty values remove the annotation.
+        """
+        annotation_key = constants.CEPHX_STATUS_ANNOTATION
+        restored = []
+        for deployment in get_osd_deployments(namespace=self.namespace):
+            if deployment.name not in statuses:
+                continue
+            status = statuses[deployment.name] or {}
+            deployment_data = deployment.get()
+            annotations = (
+                deployment_data.get("spec", {})
+                .get("template", {})
+                .get("metadata", {})
+                .get("annotations", {})
+                or {}
+            )
+            path = f"/spec/template/metadata/annotations/{annotation_key}"
+            if not status:
+                if annotation_key not in annotations:
+                    continue
+                patch_ops = [{"op": "remove", "path": path}]
+            elif annotation_key in annotations:
+                patch_ops = [
+                    {"op": "replace", "path": path, "value": json.dumps(status)}
+                ]
+            else:
+                patch_ops = [{"op": "add", "path": path, "value": json.dumps(status)}]
+            deployment.ocp.patch(
+                resource_name=deployment.name,
+                params=json.dumps(patch_ops),
+                format_type="json",
+            )
+            restored.append(deployment.name)
+        if restored:
+            log.info(
+                "Restored cephx-status annotation on OSD deployments: "
+                f"{', '.join(restored)}"
+            )
+        return restored
+
+    def assert_osd_deployments_have_empty_cephx_status(self):
+        """Assert all OSD deployments lack populated cephx-status annotations."""
+        statuses = self.capture_osd_deployment_cephx_status()
+        assert statuses, "No OSD deployments found for cephx-status verification"
+        populated = {name: status for name, status in statuses.items() if status}
+        if populated:
+            raise UnexpectedBehaviour(
+                "Expected empty cephx-status on brownfield OSD deployments; "
+                f"populated: {populated}"
+            )
+        log.info("All OSD deployments have empty cephx-status annotations")
+
+    def assert_all_osd_deployments_cephx_status_at_generation(
+        self, expected_generation
+    ):
+        """Assert every OSD deployment cephx-status reached *expected_generation*."""
+        statuses = self.capture_osd_deployment_cephx_status()
+        assert statuses, "No OSD deployments found for cephx-status verification"
+        behind = {
+            name: int(status.get("keyGeneration", 0) or 0)
+            for name, status in statuses.items()
+            if int(status.get("keyGeneration", 0) or 0) < expected_generation
+        }
+        if behind:
+            raise UnexpectedBehaviour(
+                f"OSD deployments below cephx-status keyGeneration "
+                f"{expected_generation}: {behind}"
+            )
+        log.info(
+            f"All OSD deployments report cephx-status keyGeneration "
+            f">= {expected_generation}"
+        )
+
+    def assert_osd_deployment_cephx_status_unchanged_for(
+        self, deployment_names, baseline_status
+    ):
+        """Assert cephx-status for *deployment_names* matches *baseline_status*."""
+        current = self.capture_osd_deployment_cephx_status()
+        changed = {
+            name: {
+                "before": baseline_status.get(name),
+                "after": current.get(name),
+            }
+            for name in deployment_names
+            if baseline_status.get(name) != current.get(name)
+        }
+        if changed:
+            raise UnexpectedBehaviour(
+                "cephx-status changed for OSD deployments that should be "
+                f"checkpoint-frozen: {changed}"
+            )
+        log.info(
+            "cephx-status unchanged for checkpoint OSD deployments: "
+            f"{', '.join(deployment_names)}"
+        )
+
+    def assert_auth_keys_unchanged_for(self, baseline_keys, entities=None):
+        """Assert a subset of auth keys did not change."""
+        entities = entities or list(baseline_keys.keys())
+        self.assert_auth_keys_unchanged(
+            baseline_keys,
+            entities=entities,
+            context="for checkpoint OSDs after operator restart",
+        )
+
+    def get_disk_based_encrypted_osd_deployments(self):
+        """Return encrypted OSD deployments backed by host/disk store."""
+        return {
+            name: info
+            for name, info in self.capture_encrypted_osd_deployments().items()
+            if info.get("store_type") == "host"
+        }
+
+    def assert_lockbox_auth_keys_present(self, entities, toolbox_pod=None):
+        """Assert lockbox auth entities still exist in the Ceph auth store."""
+        missing = [
+            entity
+            for entity in entities
+            if not self.get_auth_key(entity, toolbox_pod=toolbox_pod)
+        ]
+        if missing:
+            raise UnexpectedBehaviour(
+                f"Lockbox auth keys missing after rotation disruption: "
+                f"{', '.join(missing)}"
+            )
+        log.info(f"Lockbox auth keys present for: {', '.join(entities)}")
+
+    def get_osd_auth_entity_for_deployment(self, deployment_name):
+        """Map an OSD deployment name to its ``osd.<id>`` auth entity."""
+        deployment = OCP(
+            kind=constants.DEPLOYMENT,
+            namespace=self.namespace,
+            resource_name=deployment_name,
+        )
+        osd_id = (
+            deployment.get().get("metadata", {}).get("labels", {}).get("ceph-osd-id")
+        )
+        if osd_id is None:
+            raise UnexpectedBehaviour(
+                f"OSD deployment {deployment_name} missing ceph-osd-id label"
+            )
+        return f"osd.{osd_id}"
+
+    def map_osd_deployments_to_auth_entities(self, deployment_names):
+        """Return ``osd.<id>`` auth entities for OSD deployment names."""
+        return [
+            self.get_osd_auth_entity_for_deployment(name) for name in deployment_names
+        ]
+
+    def break_mon_quorum_during_lockbox_rotation(self, mons_to_stop=2, timeout=600):
+        """
+        Start daemon rotation and break mon quorum while lockbox rotation runs.
+
+        Returns:
+            tuple: ``(target_generation, scaled_mon_deployments)`` where
+            ``scaled_mon_deployments`` is the list of mon deployment names
+            scaled down for later restoration.
+        """
+        from ocs_ci.helpers.helpers import get_last_log_time_date
+
+        operator_log_marker = get_last_log_time_date()
+        target_generation = self.rotate_daemon_keys()
+
+        def _lockbox_rotation_started():
+            logs = self.get_operator_logs_since(operator_log_marker)
+            return any(constants.OSD_LOCKBOX_OPERATOR_LOG in line for line in logs)
+
+        for started in TimeoutSampler(timeout, 5, _lockbox_rotation_started):
+            if started:
+                log.info("Encrypted OSD lockbox rotation started; breaking mon quorum")
+                scaled = self.break_mon_quorum(mons_to_stop=mons_to_stop)
+                return target_generation, scaled
+
+        raise UnexpectedBehaviour(f"Lockbox rotation did not start within {timeout}s")
+
+    def verify_osd_lockbox_init_container_disruption_logs(self, osd_pods=None):
+        """
+        Verify encrypted OSD init containers logged failures during disruption.
+
+        At least one encrypted OSD pod should report a failure pattern in an
+        init container involved in lockbox key load.
+        """
+        osd_pods = osd_pods or self.get_encrypted_osd_pods()
+        if not osd_pods:
+            raise UnexpectedBehaviour(
+                "No encrypted OSD pods found for lockbox disruption logs"
+            )
+
+        init_containers = list(constants.OSD_CEPHX_INIT_CONTAINER_NAMES) + [
+            constants.OSD_ACTIVATE_INIT_CONTAINER
+        ]
+        failure_patterns = constants.CEPHX_LOCKBOX_ROTATION_FAILURE_LOG_PATTERNS
+        pods_with_failures = []
+
+        for osd_pod in osd_pods:
+            for container_name in init_containers:
+                try:
+                    logs = get_pod_logs(
+                        pod_name=osd_pod.name,
+                        container=container_name,
+                        namespace=self.namespace,
+                    )
+                except CommandFailed:
+                    continue
+                lower_logs = logs.lower()
+                if any(pattern in lower_logs for pattern in failure_patterns):
+                    pods_with_failures.append((osd_pod.name, container_name))
+                    log.info(
+                        f"OSD pod {osd_pod.name} init container {container_name} "
+                        "logged lockbox rotation disruption"
+                    )
+                    break
+
+        if not pods_with_failures:
+            raise UnexpectedBehaviour(
+                "No encrypted OSD init containers logged lockbox rotation failures"
+            )
+
+    def kill_operator_during_partial_osd_rotation(
+        self,
+        baseline_cephx_status,
+        min_rotated,
+        timeout=900,
+        poll_interval=5,
+    ):
+        """
+        Trigger OSD rotation and kill the operator after partial completion.
+
+        Returns:
+            tuple: (target_generation, list of deployment names rotated before kill)
+        """
+        target_generation = self.rotate_daemon_keys(wait_for_rotation=False)
+        operator_pods = get_operator_pods(namespace=self.namespace)
+        if not operator_pods:
+            raise UnexpectedBehaviour("rook-ceph-operator pod not found")
+        operator_pod = operator_pods[0]
+        operator_ocp = OCP(kind=constants.POD, namespace=self.namespace)
+        rotated_before_kill = []
+
+        log.info(
+            f"Waiting to kill operator after >= {min_rotated} OSD cephx-status "
+            "updates and before all OSDs complete"
+        )
+
+        def _partial_rotation_ready():
+            nonlocal rotated_before_kill
+            current = self.capture_osd_deployment_cephx_status()
+            rotated_before_kill = [
+                deployment_name
+                for deployment_name, prior in baseline_cephx_status.items()
+                if current.get(deployment_name) != prior
+                and int(current.get(deployment_name, {}).get("keyGeneration", 0) or 0)
+                >= target_generation
+            ]
+            total = len(baseline_cephx_status)
+            if (
+                len(rotated_before_kill) >= min_rotated
+                and len(rotated_before_kill) < total
+            ):
+                log.info(
+                    f"Killing rook-ceph-operator after partial OSD rotation; "
+                    f"rotated={rotated_before_kill}"
+                )
+                operator_ocp.delete(
+                    resource_name=operator_pod.name, force=True, wait=False
+                )
+                return True
+            return False
+
+        for ready in TimeoutSampler(timeout, poll_interval, _partial_rotation_ready):
+            if ready:
+                return target_generation, list(rotated_before_kill)
+
+        raise UnexpectedBehaviour(
+            f"Partial OSD rotation checkpoint not reached within {timeout}s "
+            f"(min_rotated={min_rotated})"
+        )
+
+    def capture_osd_store_types(self):
+        """
+        Classify OSD deployments by backing store (PVC-based vs host-based).
+
+        Returns:
+            dict: deployment name to ``pvc`` or ``host``.
+        """
+        store_types = {}
+        for deployment in get_osd_deployments(namespace=self.namespace):
+            deployment_data = deployment.get()
+            labels = deployment_data.get("metadata", {}).get("labels", {})
+            if labels.get(constants.OSD_STORE_LABEL):
+                store_label = labels[constants.OSD_STORE_LABEL]
+                store_types[deployment.name] = (
+                    "pvc" if "pvc" in store_label.lower() else "host"
+                )
+                continue
+
+            volumes = (
+                deployment_data.get("spec", {})
+                .get("template", {})
+                .get("spec", {})
+                .get("volumes", [])
+            )
+            if any(volume.get("persistentVolumeClaim") for volume in volumes):
+                store_types[deployment.name] = "pvc"
+            else:
+                store_types[deployment.name] = "host"
+        return store_types
+
+    @staticmethod
+    def get_osd_cephx_init_container_name(pod_data):
+        """Return the CephX key init container name from an OSD pod spec."""
+        init_containers = pod_data.get("spec", {}).get("initContainers", []) or []
+        container_names = {container.get("name") for container in init_containers}
+        for name in constants.OSD_CEPHX_INIT_CONTAINER_NAMES:
+            if name in container_names:
+                return name
+        return None
+
+    def verify_osd_cephx_init_container_logs(self, osd_pods=None):
+        """
+        Verify CephX init containers completed and loaded keys from the mon cluster.
+
+        Args:
+            osd_pods (list): Optional OSD pod objects; discovered when omitted.
+
+        Raises:
+            UnexpectedBehaviour: When init container is missing or logs indicate failure.
+        """
+        osd_pods = osd_pods or get_osd_pods(namespace=self.namespace)
+        for osd_pod in osd_pods:
+            pod_data = osd_pod.get()
+            container_name = self.get_osd_cephx_init_container_name(pod_data)
+            if not container_name:
+                raise UnexpectedBehaviour(
+                    f"OSD pod {osd_pod.name} is missing a CephX key init container"
+                )
+            logs = get_pod_logs(
+                pod_name=osd_pod.name,
+                container=container_name,
+                namespace=self.namespace,
+            )
+            log.info(
+                f"OSD pod {osd_pod.name} init container {container_name} logs:\n"
+                f"{logs}"
+            )
+            if constants.OSD_CEPHX_INIT_SUCCESS_LOG not in logs:
+                raise UnexpectedBehaviour(
+                    f"OSD pod {osd_pod.name} init container {container_name} "
+                    f"did not report successful CephX key load"
+                )
+            if constants.OSD_CEPHX_GET_OR_CREATE_LOG not in logs:
+                raise UnexpectedBehaviour(
+                    f"OSD pod {osd_pod.name} init container {container_name} "
+                    f"did not use ceph auth get-or-create"
+                )
+
+    def assert_osd_deployment_cephx_status_updated(
+        self, before_status, expected_generation
+    ):
+        """Assert OSD deployment cephx-status annotations reached *expected_generation*."""
+        after_status = self.capture_osd_deployment_cephx_status()
+        assert after_status, "No OSD deployments found for cephx-status verification"
+        for deployment_name, prior in before_status.items():
+            current = after_status.get(deployment_name, {})
+            current_generation = int(current.get("keyGeneration", 0) or 0)
+            assert current_generation >= expected_generation, (
+                f"OSD deployment {deployment_name} cephx-status keyGeneration "
+                f"{current_generation} did not reach {expected_generation}"
+            )
+            if prior.get("keyGeneration") is not None:
+                assert current_generation >= int(prior.get("keyGeneration", 0) or 0), (
+                    f"OSD deployment {deployment_name} cephx-status keyGeneration "
+                    "did not increase after rotation"
+                )
+            if prior.get("keyCephVersion"):
+                assert current.get("keyCephVersion"), (
+                    f"OSD deployment {deployment_name} missing keyCephVersion "
+                    "in cephx-status annotation"
+                )
+
+    def assert_osd_deployment_cephx_status_unchanged(self, baseline):
+        """Assert OSD deployment ``cephx-status`` annotations did not change."""
+        current = self.capture_osd_deployment_cephx_status()
+        changed = {
+            deployment_name: {
+                "before": baseline[deployment_name],
+                "after": current.get(deployment_name),
+            }
+            for deployment_name in baseline
+            if baseline[deployment_name] != current.get(deployment_name)
+        }
+        if changed:
+            raise UnexpectedBehaviour(
+                "OSD deployment cephx-status annotations changed after "
+                f"re-reconcile: {changed}"
+            )
+        log.info("OSD deployment cephx-status annotations unchanged")
+
+    def set_osd_out(self, osd_id):
+        """Mark an OSD out via ``ceph osd out``."""
+        toolbox = self.get_ceph_cli_pod()
+        toolbox.exec_cmd_on_pod(
+            f"ceph osd out osd.{osd_id}",
+            out_yaml_format=False,
+        )
+        log.info(f"Marked osd.{osd_id} out")
+
+    def set_osd_in(self, osd_id):
+        """Mark an OSD back in via ``ceph osd in``."""
+        toolbox = self.get_ceph_cli_pod()
+        toolbox.exec_cmd_on_pod(
+            f"ceph osd in osd.{osd_id}",
+            out_yaml_format=False,
+        )
+        log.info(f"Marked osd.{osd_id} in")
+
+    def restore_osd_and_wait_for_recovery(self, osd_id, timeout=1500, sleep=15):
+        """
+        Mark an intentionally out OSD back in and wait for full recovery.
+
+        Args:
+            osd_id (int): OSD id previously marked out.
+            timeout (int): Max seconds to wait for PGs and Ready state.
+            sleep (int): Poll interval in seconds.
+        """
+        log.info(
+            f"Restoring osd.{osd_id} and waiting for cluster recovery "
+            f"(timeout={timeout}s)"
+        )
+        self.set_osd_in(osd_id)
+        self.wait_for_cluster_fully_recovered(timeout=timeout, sleep=sleep)
+
+    def wait_for_pgs_not_clean(self, timeout=300, sleep=15):
+        """Wait until not all PGs are active+clean."""
+        from ocs_ci.ocs.cluster import CephCluster
+
+        ceph_cluster = CephCluster()
+        log.info("Waiting for PGs to leave active+clean state")
+
+        def _pgs_not_clean():
+            return not ceph_cluster.get_rebalance_status()
+
+        for ready in TimeoutSampler(timeout, sleep, _pgs_not_clean):
+            if ready:
+                log.info("PGs are not fully active+clean")
+                return True
+
+        raise UnexpectedBehaviour(
+            f"PGs remained active+clean within {timeout}s after inducing degradation"
+        )
+
+    def delete_auth_entity(self, entity, toolbox_pod=None):
+        """Delete a Ceph auth entity from the auth store."""
+        toolbox = toolbox_pod or self.get_ceph_cli_pod()
+        toolbox.exec_cmd_on_pod(
+            f"ceph auth del {entity}",
+            out_yaml_format=False,
+        )
+        log.info(f"Deleted Ceph auth entity {entity}")
+
+    def get_osd_keyring_key_from_pod(self, osd_id):
+        """
+        Read the OSD CephX key from the running OSD pod keyring file.
+
+        Args:
+            osd_id (int): OSD id.
+
+        Returns:
+            str: Base64 CephX key for ``osd.<id>``.
+        """
+        # get_osd_pod_id returns string labels; keep public callers on int osd_id.
+        osd_pods = get_osd_pods_having_ids([str(osd_id)])
+        if not osd_pods:
+            raise UnexpectedBehaviour(f"No running OSD pod found for osd.{osd_id}")
+        osd_pod = osd_pods[0]
+        keyring = osd_pod.exec_cmd_on_pod(
+            f"cat /var/lib/ceph/osd/ceph-{osd_id}/keyring",
+            out_yaml_format=False,
+            container_name="osd",
+        )
+        match = re.search(r"key\s*=\s*(\S+)", keyring or "")
+        if not match:
+            raise UnexpectedBehaviour(
+                f"Could not parse key from osd.{osd_id} pod keyring: {keyring!r}"
+            )
+        return match.group(1)
+
+    def restore_osd_auth_entity_from_pod_keyring(self, entity, toolbox_pod=None):
+        """
+        Recreate a deleted OSD auth entity using the key from the OSD pod.
+
+        Needed because Rook ``ceph auth rotate`` fails when the entity is missing
+        and does not recreate it from the on-disk keyring.
+        """
+        if not entity.startswith("osd."):
+            raise UnexpectedBehaviour(
+                f"restore_osd_auth_entity_from_pod_keyring expects osd.* entity, "
+                f"got {entity}"
+            )
+        osd_id = int(entity.split(".")[-1])
+        key = self.get_osd_keyring_key_from_pod(osd_id)
+        toolbox = toolbox_pod or self.get_ceph_cli_pod()
+        # Pipe a minimal keyring into ceph auth add (entity must exist for rotate).
+        # oc rsh does not invoke a shell, so compound printf|ceph needs bash -c.
+        # Pass the CephX key via secrets so it is masked in logs.
+        keyring_script = (
+            f"printf '%s\\n' '[osd.{osd_id}]' ' key = {key}' | "
+            f"ceph auth add osd.{osd_id} osd 'allow *' mon 'allow profile osd' "
+            f"mgr 'allow profile osd' -i -"
+        )
+        toolbox.exec_cmd_on_pod(
+            command=f"bash -c {shlex.quote(keyring_script)}",
+            out_yaml_format=False,
+            secrets=[key],
+        )
+        log.info(f"Restored Ceph auth entity {entity} from OSD pod keyring")
+
+    def ensure_osd_auth_entity_restored(self, entity, toolbox_pod=None):
+        """Restore *entity* from the OSD pod keyring if it is missing."""
+        if self.auth_entity_exists(entity, toolbox_pod=toolbox_pod):
+            log.info(f"Ceph auth entity {entity} already present; no restore needed")
+            return False
+        self.restore_osd_auth_entity_from_pod_keyring(entity, toolbox_pod=toolbox_pod)
+        return True
+
+    def wait_for_partial_osd_key_rotation(self, pre_keys, timeout=900, sleep=5):
+        """
+        Wait until at least one OSD auth key differs from *pre_keys*.
+
+        Returns the key snapshot from the poll that first observed a change so
+        callers can inject failure against still-pending OSDs without a second
+        capture race on small/fast clusters.
+        """
+        entities = list(pre_keys.keys())
+
+        def _partial_rotation():
+            current_keys = self.capture_auth_keys(entities)
+            changed = [
+                entity
+                for entity in entities
+                if pre_keys.get(entity)
+                and pre_keys.get(entity) != current_keys.get(entity)
+            ]
+            pending = [
+                entity
+                for entity in entities
+                if pre_keys.get(entity)
+                and pre_keys.get(entity) == current_keys.get(entity)
+            ]
+            # Prefer a true partial snapshot; skip all-rotated samples so the
+            # next poll can catch mid-rotation on fast clusters.
+            if changed and pending:
+                return current_keys
+            if changed and not pending:
+                log.debug(
+                    "OSD rotation already complete for all entities; "
+                    "continuing to look for a mid-rotation window"
+                )
+                return False
+            return False
+
+        for current_keys in TimeoutSampler(timeout, sleep, _partial_rotation):
+            if current_keys:
+                log.info(
+                    "Detected partial OSD key rotation "
+                    f"(changed={[e for e in entities if pre_keys.get(e) != current_keys.get(e)]}, "
+                    f"pending={[e for e in entities if pre_keys.get(e) == current_keys.get(e)]})"
+                )
+                return current_keys
+
+        raise UnexpectedBehaviour(
+            f"No partial OSD key rotation window within {timeout}s "
+            "(rotation may have completed too quickly to inject failure)"
+        )
+
+    def inject_osd_auth_rotation_failure(self, pre_keys, timeout=900):
+        """
+        During OSD rotation, delete auth for an OSD that has not rotated yet.
+
+        Returns:
+            tuple: ``(failed_entity, operator_log_marker)`` where the marker is
+            captured immediately before the auth delete so callers can search
+            operator logs for the OSD rotate failure without matching earlier
+            admin-rotate restart noise from the same rotation.
+        """
+        from ocs_ci.helpers.helpers import get_last_log_time_date
+
+        current_keys = self.wait_for_partial_osd_key_rotation(pre_keys, timeout=timeout)
+        pending_entities = [
+            entity
+            for entity in pre_keys
+            if pre_keys.get(entity) and pre_keys.get(entity) == current_keys.get(entity)
+        ]
+        if not pending_entities:
+            raise UnexpectedBehaviour(
+                "All OSD auth keys rotated before failure could be injected"
+            )
+        # Delete the next OSD Rook is likely to rotate (first pending), not the
+        # last. Deleting the last pending entity lets Rook spend a long time on
+        # earlier OSDs/mons before the missing-auth failure surfaces.
+        failed_entity = sorted(pending_entities)[0]
+        # Record before delete so callers can restore if a later step raises.
+        self.last_deleted_osd_auth_entity = failed_entity
+        operator_log_marker = get_last_log_time_date()
+        self.delete_auth_entity(failed_entity)
+        return failed_entity, operator_log_marker
+
+    def discover_lockbox_auth_entities(self, toolbox_pod=None):
+        """Return sorted ``client.osd-lockbox.*`` auth entity names."""
+        return self.list_auth_entities(constants.OSD_LOCKBOX_AUTH_PREFIX, toolbox_pod)
+
+    def capture_encrypted_osd_deployments(self):
+        """
+        Return OSD deployments labeled as encrypted.
+
+        Returns:
+            dict: deployment name to osd_id and store_type metadata.
+        """
+        store_types = self.capture_osd_store_types()
+        encrypted = {}
+        for deployment in get_osd_deployments(namespace=self.namespace):
+            deployment_data = deployment.get()
+            labels = deployment_data.get("metadata", {}).get("labels", {})
+            if labels.get(constants.OSD_ENCRYPTED_LABEL) != "true":
+                continue
+            encrypted[deployment.name] = {
+                "osd_id": labels.get("ceph-osd-id"),
+                "store_type": store_types.get(deployment.name, "unknown"),
+            }
+        return encrypted
+
+    def assert_encrypted_osd_labels(self, encrypted_deployments):
+        """Assert encrypted OSD deployments carry ``encrypted=true``."""
+        for deployment_name in encrypted_deployments:
+            deployment = OCP(
+                kind=constants.DEPLOYMENT,
+                namespace=self.namespace,
+                resource_name=deployment_name,
+            )
+            labels = deployment.get().get("metadata", {}).get("labels", {})
+            assert (
+                labels.get(constants.OSD_ENCRYPTED_LABEL) == "true"
+            ), f"OSD deployment {deployment_name} is not labeled encrypted=true"
+
+    @staticmethod
+    def _get_pod_env_value(pod_data, env_name):
+        """Read an environment variable from pod init/main container specs."""
+        for container_key in ("initContainers", "containers"):
+            for container in pod_data.get("spec", {}).get(container_key, []) or []:
+                for env in container.get("env", []) or []:
+                    if env.get("name") == env_name:
+                        return env.get("value")
+        return None
+
+    def get_encrypted_osd_pods(self):
+        """Return Running OSD pod objects for encrypted deployments."""
+        encrypted_ids = {
+            info["osd_id"]
+            for info in self.capture_encrypted_osd_deployments().values()
+            if info.get("osd_id") is not None
+        }
+        if not encrypted_ids:
+            return []
+
+        encrypted_pods = []
+        for osd_pod in get_osd_pods(namespace=self.namespace):
+            osd_id = (
+                osd_pod.get().get("metadata", {}).get("labels", {}).get("ceph-osd-id")
+            )
+            if osd_id in encrypted_ids:
+                encrypted_pods.append(osd_pod)
+        return encrypted_pods
+
+    @staticmethod
+    def lockbox_entity_for_uuid(osd_uuid):
+        """Return the lockbox auth entity name for an OSD UUID."""
+        return f"{constants.OSD_LOCKBOX_AUTH_PREFIX}{osd_uuid}"
+
+    def map_lockbox_entities_to_osd_uuids(self, lockbox_entities):
+        """
+        Map lockbox auth entities to OSD UUIDs.
+
+        Returns:
+            dict: entity name to UUID string.
+        """
+        prefix = constants.OSD_LOCKBOX_AUTH_PREFIX
+        mapping = {}
+        for entity in lockbox_entities:
+            if not entity.startswith(prefix):
+                continue
+            mapping[entity] = entity[len(prefix) :]
+        return mapping
+
+    def verify_osd_activate_lockbox_logs(self, osd_pods=None):
+        """
+        Verify the activate init container loaded lockbox keys for encrypted OSDs.
+
+        Args:
+            osd_pods (list): Encrypted OSD pods; discovered when omitted.
+        """
+        osd_pods = osd_pods or self.get_encrypted_osd_pods()
+        if not osd_pods:
+            raise UnexpectedBehaviour("No encrypted OSD pods found for activate logs")
+
+        for osd_pod in osd_pods:
+            pod_data = osd_pod.get()
+            logs = get_pod_logs(
+                pod_name=osd_pod.name,
+                container=constants.OSD_ACTIVATE_INIT_CONTAINER,
+                namespace=self.namespace,
+            )
+            osd_uuid = self._get_pod_env_value(pod_data, constants.ROOK_OSD_UUID_ENV)
+            log.info(
+                f"OSD pod {osd_pod.name} (uuid={osd_uuid}) activate container logs:\n"
+                f"{logs}"
+            )
+            if constants.OSD_LOCKBOX_INIT_SUCCESS_LOG not in logs:
+                raise UnexpectedBehaviour(
+                    f"OSD pod {osd_pod.name} activate container did not report "
+                    "successful lockbox key load"
+                )
+            if constants.OSD_LOCKBOX_GET_OR_CREATE_LOG not in logs:
+                raise UnexpectedBehaviour(
+                    f"OSD pod {osd_pod.name} activate container did not use "
+                    "ceph auth get-or-create for lockbox key"
+                )
+
+    def verify_operator_lockbox_rotation_logs(self, expected_count, since_time=None):
+        """
+        Verify rook-ceph-operator logged lockbox key rotation for encrypted OSDs.
+
+        Args:
+            expected_count (int): Minimum number of lockbox rotation log lines.
+            since_time: Optional marker from ``get_last_log_time_date``; when set,
+                only logs newer than the marker are considered.
+        """
+        from ocs_ci.helpers.helpers import get_logs_rook_ceph_operator
+
+        if since_time:
+            log_lines = self.get_operator_logs_since(since_time)
+        else:
+            log_lines = get_logs_rook_ceph_operator().splitlines()
+        matches = [
+            line for line in log_lines if constants.OSD_LOCKBOX_OPERATOR_LOG in line
+        ]
+        log.info(
+            f"Found {len(matches)} operator log lines for encrypted OSD lockbox "
+            f"rotation (expected >= {expected_count})"
+        )
+        for line in matches:
+            log.info(f"  operator: {line}")
+        if len(matches) < expected_count:
+            raise UnexpectedBehaviour(
+                f"Expected at least {expected_count} operator log lines containing "
+                f"'{constants.OSD_LOCKBOX_OPERATOR_LOG}', found {len(matches)}"
+            )
+
+    def verify_encrypted_osd_pods_running(self, osd_pods=None):
+        """Assert encrypted OSD pods are Running with ready containers."""
+        osd_pods = osd_pods or self.get_encrypted_osd_pods()
+        if not osd_pods:
+            raise UnexpectedBehaviour("No encrypted OSD pods found")
+
+        for osd_pod in osd_pods:
+            pod_data = osd_pod.get()
+            phase = pod_data.get("status", {}).get("phase")
+            if phase != constants.STATUS_RUNNING:
+                raise UnexpectedBehaviour(
+                    f"Encrypted OSD pod {osd_pod.name} is not Running (phase={phase})"
+                )
+            container_statuses = (
+                pod_data.get("status", {}).get("containerStatuses", []) or []
+            )
+            not_ready = [
+                status.get("name")
+                for status in container_statuses
+                if not status.get("ready")
+            ]
+            if not_ready:
+                raise UnexpectedBehaviour(
+                    f"Encrypted OSD pod {osd_pod.name} has containers not ready: "
+                    f"{', '.join(not_ready)}"
+                )

--- a/ocs_ci/helpers/cephx_keyrotation/security.py
+++ b/ocs_ci/helpers/cephx_keyrotation/security.py
@@ -1,0 +1,406 @@
+"""CephX security helpers: allowed ciphers, key types, AUTH_INSECURE checks."""
+
+import json
+import logging
+import re
+
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.exceptions import UnexpectedBehaviour
+from ocs_ci.ocs.ocp import OCP
+from ocs_ci.utility.utils import TimeoutSampler
+
+log = logging.getLogger(__name__)
+
+
+class CephXSecurityHelper:
+    """Allowed ciphers, keyType, and AUTH_INSECURE health helpers."""
+
+    def get_spec_cephx(self):
+        """Return ``spec.security.cephx`` from the CephCluster (may be empty)."""
+        cluster = self._get_cluster_dict()
+        return cluster.get("spec", {}).get("security", {}).get("cephx", {}) or {}
+
+    def get_spec_security(self):
+        """Return ``spec.security`` from the CephCluster (may be empty)."""
+        cluster = self._get_cluster_dict()
+        return cluster.get("spec", {}).get("security", {}) or {}
+
+    def get_allowed_ciphers(self):
+        """Return ``spec.security.cephx.allowedCiphers`` from the CephCluster."""
+        return self.get_spec_cephx().get("allowedCiphers")
+
+    def get_storagecluster_allowed_ciphers(self):
+        """Return allowedCiphers from StorageCluster managedResources.cephCluster."""
+        cc_spec = self.get_storagecluster_managed_cephcluster()
+        security = cc_spec.get("security") or {}
+        cephx = security.get("cephx") or {}
+        return cephx.get("allowedCiphers")
+
+    def assert_allowed_ciphers(self, expected, source="cephcluster"):
+        """
+        Assert allowedCiphers match *expected* on CephCluster or StorageCluster.
+
+        Args:
+            expected (list|tuple): Expected cipher names.
+            source (str): ``cephcluster`` or ``storagecluster``.
+        """
+        expected_list = list(expected)
+        if source == "storagecluster":
+            actual = self.get_storagecluster_allowed_ciphers()
+            label = "StorageCluster"
+        else:
+            actual = self.get_allowed_ciphers()
+            label = "CephCluster"
+        if actual != expected_list:
+            raise UnexpectedBehaviour(
+                f"{label} allowedCiphers mismatch: expected {expected_list}, got {actual}"
+            )
+        log.info(f"{label} allowedCiphers matches expected: {expected_list}")
+
+    def assert_cephcluster_security_populated(self):
+        """Assert CephCluster ``spec.security.cephx`` includes allowedCiphers."""
+        security = self.get_spec_security()
+        if not security:
+            raise UnexpectedBehaviour("CephCluster spec.security is empty or missing")
+        cephx = security.get("cephx")
+        if not cephx:
+            raise UnexpectedBehaviour(
+                "CephCluster spec.security.cephx is empty or missing"
+            )
+        if "allowedCiphers" not in cephx:
+            raise UnexpectedBehaviour(
+                "CephCluster spec.security.cephx.allowedCiphers is missing"
+            )
+        log.info(
+            "CephCluster spec.security.cephx populated: "
+            f"allowedCiphers={cephx.get('allowedCiphers')}"
+        )
+
+    def wait_for_allowed_ciphers(
+        self, expected, timeout=600, sleep=10, source="cephcluster"
+    ):
+        """Wait until allowedCiphers on CephCluster or StorageCluster match *expected*."""
+        expected_list = list(expected)
+        log.info(f"Waiting for {source} allowedCiphers={expected_list}")
+
+        def _matches():
+            if source == "storagecluster":
+                actual = self.get_storagecluster_allowed_ciphers()
+            else:
+                actual = self.get_allowed_ciphers()
+            if actual == expected_list:
+                return True
+            log.debug(f"{source} allowedCiphers={actual}, want {expected_list}")
+            return False
+
+        for matched in TimeoutSampler(timeout, sleep, _matches):
+            if matched:
+                log.info(f"{source} allowedCiphers reached {expected_list}")
+                return True
+
+        raise UnexpectedBehaviour(
+            f"Timed out waiting for {source} allowedCiphers={expected_list}"
+        )
+
+    def get_spec_key_type(self, component=None):
+        """
+        Return ``keyType`` for *component* from StorageCluster cephx config.
+
+        Path: managedResources.cephCluster.security.cephx.<component>.keyType
+        """
+        component = component or self.COMPONENT_DAEMON
+        return self.get_storagecluster_component_spec(component).get("keyType")
+
+    def get_cephcluster_key_type(self, component=None):
+        """Return ``spec.security.cephx.<component>.keyType`` from the CephCluster."""
+        component = component or self.COMPONENT_DAEMON
+        return (self.get_spec_cephx().get(component) or {}).get("keyType")
+
+    def patch_cephcluster_key_type(self, key_type, component=None):
+        """
+        Set ``keyType`` for *component* on StorageCluster (ODF passthrough to Rook).
+
+        Patches managedResources.cephCluster.security.cephx.<component>.keyType
+        while preserving sibling fields such as keyGeneration / keyRotationPolicy.
+        """
+        component = component or self.COMPONENT_DAEMON
+        component_spec = dict(self.get_storagecluster_component_spec(component))
+        component_spec["keyType"] = key_type
+        log.info(
+            "Patching StorageCluster managedResources.cephCluster.security.cephx."
+            f"{component}.keyType to {key_type}"
+        )
+        self.patch_storagecluster_cephx_component(component, component_spec)
+        self.wait_for_storagecluster_reconciliation(timeout=600, sleep=10)
+
+    def remove_cephcluster_key_type(self, component=None):
+        """
+        Remove ``keyType`` for *component* from StorageCluster cephx config.
+
+        Preserves other fields on the component (keyGeneration, keyRotationPolicy).
+        """
+        component = component or self.COMPONENT_DAEMON
+        component_spec = dict(self.get_storagecluster_component_spec(component))
+        if "keyType" not in component_spec:
+            log.info(
+                "StorageCluster managedResources.cephCluster.security.cephx."
+                f"{component}.keyType not set; nothing to remove"
+            )
+            return
+
+        component_spec.pop("keyType", None)
+        log.info(
+            "Removing StorageCluster managedResources.cephCluster.security.cephx."
+            f"{component}.keyType"
+        )
+        if component_spec:
+            self.patch_storagecluster_cephx_component(component, component_spec)
+        else:
+            # No remaining fields — replace with empty object via full component patch
+            self.patch_storagecluster_cephx_component(component, {})
+        self.wait_for_storagecluster_reconciliation(timeout=600, sleep=10)
+
+    def wait_for_cephcluster_key_type(
+        self, key_type, timeout=300, sleep=10, component=None
+    ):
+        """
+        Wait until StorageCluster and CephCluster report *key_type* for *component*.
+
+        StorageCluster is the write target; CephCluster confirms ODF passthrough.
+        """
+        component = component or self.COMPONENT_DAEMON
+        log.info(
+            f"Waiting for StorageCluster/CephCluster security.cephx.{component}."
+            f"keyType={key_type}"
+        )
+
+        def _matches():
+            sc_actual = self.get_spec_key_type(component=component)
+            cc_actual = self.get_cephcluster_key_type(component=component)
+            if sc_actual == key_type and cc_actual == key_type:
+                return True
+            log.debug(
+                f"keyType pending for {component}: StorageCluster={sc_actual}, "
+                f"CephCluster={cc_actual}, want {key_type}"
+            )
+            return False
+
+        for matched in TimeoutSampler(timeout, sleep, _matches):
+            if matched:
+                log.info(
+                    f"StorageCluster and CephCluster security.cephx.{component}."
+                    f"keyType is {key_type}"
+                )
+                return True
+
+        raise UnexpectedBehaviour(
+            f"Timed out waiting for security.cephx.{component}.keyType={key_type} "
+            f"(StorageCluster={self.get_spec_key_type(component=component)}, "
+            f"CephCluster={self.get_cephcluster_key_type(component=component)})"
+        )
+
+    def get_ceph_health_detail(self, toolbox_pod=None):
+        """Return output of ``ceph health detail``."""
+        toolbox = toolbox_pod or self.get_ceph_cli_pod()
+        return toolbox.exec_cmd_on_pod(
+            "ceph health detail",
+            out_yaml_format=False,
+        )
+
+    def has_auth_insecure_service_key_type_warning(self, toolbox_pod=None):
+        """Return True when AUTH_INSECURE_SERVICE_KEY_TYPE is present in health detail."""
+        detail = self.get_ceph_health_detail(toolbox_pod)
+        return constants.CEPHX_INSECURE_SERVICE_KEY_TYPE_WARN in detail
+
+    def get_insecure_service_key_type_entities(self, toolbox_pod=None):
+        """
+        Parse entities still using insecure key types from health detail.
+
+        Returns:
+            list[tuple[str, str]]: (entity, key_type) pairs.
+        """
+        detail = self.get_ceph_health_detail(toolbox_pod)
+        return re.findall(
+            r"entity (\S+) using insecure key type: (\S+)",
+            detail,
+        )
+
+    def wait_for_auth_insecure_service_key_type_cleared(
+        self, timeout=1200, sleep=15, toolbox_pod=None
+    ):
+        """Wait until AUTH_INSECURE_SERVICE_KEY_TYPE is reconciled away."""
+        log.info(
+            "Waiting for AUTH_INSECURE_SERVICE_KEY_TYPE health warning to clear "
+            f"(timeout={timeout}s)"
+        )
+
+        def _cleared():
+            if not self.has_auth_insecure_service_key_type_warning(toolbox_pod):
+                return True
+            insecure = self.get_insecure_service_key_type_entities(toolbox_pod)
+            log.debug(
+                "AUTH_INSECURE_SERVICE_KEY_TYPE still present for: "
+                f"{', '.join(f'{entity}={key_type}' for entity, key_type in insecure)}"
+            )
+            return False
+
+        for cleared in TimeoutSampler(timeout, sleep, _cleared):
+            if cleared:
+                log.info("AUTH_INSECURE_SERVICE_KEY_TYPE health warning cleared")
+                return True
+
+        insecure = self.get_insecure_service_key_type_entities(toolbox_pod)
+        raise UnexpectedBehaviour(
+            "AUTH_INSECURE_SERVICE_KEY_TYPE not reconciled within "
+            f"{timeout}s; remaining entities: {insecure}"
+        )
+
+    def verify_operator_auth_rotate_key_type_logs(self, key_type):
+        """Verify rook-ceph-operator invoked ceph auth rotate with --key-type."""
+        from ocs_ci.helpers.helpers import get_logs_rook_ceph_operator
+
+        operator_logs = get_logs_rook_ceph_operator()
+        key_type_lower = key_type.lower()
+        for line in operator_logs.splitlines():
+            lower_line = line.lower()
+            if "auth rotate" not in lower_line:
+                continue
+            if constants.CEPHX_AUTH_ROTATE_KEY_TYPE_OPERATOR_LOG not in lower_line:
+                continue
+            if key_type_lower in lower_line:
+                log.info(
+                    "Operator log confirms ceph auth rotate with key type "
+                    f"{key_type}: {line.strip()}"
+                )
+                return
+
+        raise UnexpectedBehaviour(
+            "Operator logs missing ceph auth rotate invocation with "
+            f"{constants.CEPHX_AUTH_ROTATE_KEY_TYPE_OPERATOR_LOG} {key_type}"
+        )
+
+    def patch_storagecluster_allowed_ciphers(self, ciphers):
+        """Patch StorageCluster managedResources.cephCluster.security.cephx.allowedCiphers."""
+        ciphers = list(ciphers)
+        sc_obj = OCP(
+            kind=constants.STORAGECLUSTER,
+            resource_name=constants.DEFAULT_CLUSTERNAME,
+            namespace=self.namespace,
+        )
+        cc_spec = self.get_storagecluster_managed_cephcluster()
+        security = cc_spec.get("security") or {}
+        cephx = security.get("cephx") or {}
+        patch_ops = []
+
+        if not cc_spec:
+            patch_ops.append(
+                {
+                    "op": "add",
+                    "path": "/spec/managedResources/cephCluster",
+                    "value": {"security": {"cephx": {"allowedCiphers": ciphers}}},
+                }
+            )
+        elif not security:
+            patch_ops.append(
+                {
+                    "op": "add",
+                    "path": "/spec/managedResources/cephCluster/security",
+                    "value": {"cephx": {"allowedCiphers": ciphers}},
+                }
+            )
+        elif not cephx:
+            patch_ops.append(
+                {
+                    "op": "add",
+                    "path": "/spec/managedResources/cephCluster/security/cephx",
+                    "value": {"allowedCiphers": ciphers},
+                }
+            )
+        elif "allowedCiphers" in cephx:
+            patch_ops.append(
+                {
+                    "op": "replace",
+                    "path": "/spec/managedResources/cephCluster/security/cephx/allowedCiphers",
+                    "value": ciphers,
+                }
+            )
+        else:
+            patch_ops.append(
+                {
+                    "op": "add",
+                    "path": "/spec/managedResources/cephCluster/security/cephx/allowedCiphers",
+                    "value": ciphers,
+                }
+            )
+
+        log.info(f"Patching StorageCluster allowedCiphers to {ciphers}")
+        sc_obj.patch(params=json.dumps(patch_ops), format_type="json")
+        self._storagecluster_obj = None
+
+    def remove_storagecluster_cephcluster_security(self):
+        """Remove security block from StorageCluster managedResources.cephCluster."""
+        cc_spec = self.get_storagecluster_managed_cephcluster()
+        if not cc_spec.get("security"):
+            log.info(
+                "StorageCluster managedResources.cephCluster.security not present; "
+                "nothing to remove"
+            )
+            return
+
+        sc_obj = OCP(
+            kind=constants.STORAGECLUSTER,
+            resource_name=constants.DEFAULT_CLUSTERNAME,
+            namespace=self.namespace,
+        )
+        log.info("Removing StorageCluster managedResources.cephCluster.security block")
+        sc_obj.patch(
+            params=json.dumps(
+                [
+                    {
+                        "op": "remove",
+                        "path": "/spec/managedResources/cephCluster/security",
+                    }
+                ]
+            ),
+            format_type="json",
+        )
+        self._storagecluster_obj = None
+
+    def restore_storagecluster_cephcluster_security(self, security):
+        """
+        Restore ``managedResources.cephCluster.security`` on StorageCluster.
+
+        Args:
+            security (dict | None): Pre-test security block. When None, removes
+                the security path if present (pre-test absent state).
+        """
+        if security is None:
+            self.remove_storagecluster_cephcluster_security()
+            return
+
+        cc_spec = self.get_storagecluster_managed_cephcluster()
+        sc_obj = OCP(
+            kind=constants.STORAGECLUSTER,
+            resource_name=constants.DEFAULT_CLUSTERNAME,
+            namespace=self.namespace,
+        )
+        path = "/spec/managedResources/cephCluster/security"
+        if not cc_spec:
+            patch_ops = [
+                {
+                    "op": "add",
+                    "path": "/spec/managedResources/cephCluster",
+                    "value": {"security": security},
+                }
+            ]
+        elif "security" in cc_spec:
+            patch_ops = [{"op": "replace", "path": path, "value": security}]
+        else:
+            patch_ops = [{"op": "add", "path": path, "value": security}]
+
+        log.info(
+            "Restoring StorageCluster managedResources.cephCluster.security "
+            f"to pre-test state: {security}"
+        )
+        sc_obj.patch(params=json.dumps(patch_ops), format_type="json")
+        self._storagecluster_obj = None

--- a/ocs_ci/helpers/cephx_keyrotation_helper.py
+++ b/ocs_ci/helpers/cephx_keyrotation_helper.py
@@ -1,0 +1,12 @@
+"""
+Backward-compatible import path for CephX key rotation helpers.
+
+Implementation lives in ``ocs_ci.helpers.cephx_keyrotation`` (focused mixins +
+facade). Prefer::
+
+    from ocs_ci.helpers.cephx_keyrotation import CephXKeyRotation
+"""
+
+from ocs_ci.helpers.cephx_keyrotation import CephXKeyRotation
+
+__all__ = ["CephXKeyRotation"]

--- a/ocs_ci/krkn_chaos/background_cluster_operations.py
+++ b/ocs_ci/krkn_chaos/background_cluster_operations.py
@@ -27,6 +27,7 @@ from contextlib import suppress
 from typing import List, Dict, Any, Optional
 from collections import defaultdict
 
+from ocs_ci.framework import config
 from ocs_ci.ocs import constants, ocp
 from ocs_ci.ocs.resources import pod as pod_helpers
 from ocs_ci.ocs.resources import pvc as pvc_helpers
@@ -131,6 +132,8 @@ class BackgroundClusterOperations:
 
         # Feature availability tracking
         self._csi_addons_available = True  # Assume available until proven otherwise
+        self._cephx_rotator = None
+        self._last_cephx_rotation_time = 0.0
 
         # Available operations
         self.available_operations = {
@@ -143,6 +146,7 @@ class BackgroundClusterOperations:
             "reclaim_space": self._reclaim_space_operation,
             "volume_replication": self._volume_replication_operation,
             "longevity_operations": self._longevity_operations,
+            "cephx_keyrotation": self._cephx_keyrotation_operation,
         }
 
         # Filter enabled operations
@@ -155,11 +159,72 @@ class BackgroundClusterOperations:
         else:
             self.enabled_operations = self.available_operations
 
+        self._apply_cephx_keyrotation_config()
+
         log.info(
             f"Initialized BackgroundClusterOperations with "
             f"{len(self.enabled_operations)} operation types: "
             f"{list(self.enabled_operations.keys())}"
         )
+
+    def _get_background_ops_config(self) -> Dict[str, Any]:
+        """Return background_cluster_operations from krkn or resiliency config."""
+        env_data = config.ENV_DATA
+        krkn_config = env_data.get("krkn_config") or {}
+        if "background_cluster_operations" in krkn_config:
+            return krkn_config.get("background_cluster_operations", {})
+        resiliency_config = env_data.get("resiliency_config") or {}
+        if "background_cluster_operations" in resiliency_config:
+            return resiliency_config.get("background_cluster_operations", {})
+        return {}
+
+    def _apply_cephx_keyrotation_config(self):
+        """Enable or disable cephx_keyrotation based on config flags."""
+        from ocs_ci.helpers.cephx_bg_ops_config import is_cephx_keyrotation_enabled
+
+        bg_ops_config = self._get_background_ops_config()
+        cephx_enabled = is_cephx_keyrotation_enabled(bg_ops_config)
+        operation = self.available_operations["cephx_keyrotation"]
+
+        if cephx_enabled:
+            if "cephx_keyrotation" not in self.enabled_operations:
+                self.enabled_operations["cephx_keyrotation"] = operation
+        else:
+            self.enabled_operations.pop("cephx_keyrotation", None)
+
+    def _resolve_cephx_key_config(self, key: str) -> str:
+        from ocs_ci.helpers.cephx_keyrotation import CephXKeyRotation
+
+        if key == "daemon":
+            log.debug(
+                "cephx_keys entry 'daemon' is deprecated; use 'rook_daemon' instead"
+            )
+        return CephXKeyRotation.resolve_cephx_key_config(key)
+
+    def _get_cephx_rotation_timeout(self) -> int:
+        bg_ops_config = self._get_background_ops_config()
+        cephx_keys = bg_ops_config.get("cephx_keys", {})
+        if isinstance(cephx_keys, dict):
+            return int(cephx_keys.get("rotation_timeout", 1200))
+        return int(bg_ops_config.get("cephx_rotation_timeout", 1200))
+
+    def _get_cephx_keep_prior_key_count_max(self) -> int:
+        cephx_keys = self._get_background_ops_config().get("cephx_keys", {})
+        if isinstance(cephx_keys, dict):
+            return int(cephx_keys.get("keep_prior_key_count_max", 1))
+        return 1
+
+    def _is_cephx_keyrotation_supported(self) -> bool:
+        if config.DEPLOYMENT.get("external_mode"):
+            return False
+        try:
+            from ocs_ci.utility import version
+
+            return (
+                version.get_semantic_ocs_version_from_config() >= version.VERSION_4_19
+            )
+        except Exception:
+            return False
 
     def start(self):
         """Start background cluster operations."""
@@ -1064,6 +1129,103 @@ class BackgroundClusterOperations:
             log.error(f"Longevity operations failed: {e}", exc_info=True)
             # Don't raise - allow other background operations to continue
             return
+
+    # ==========================================================================
+    # CephX Key Rotation Operations
+    # ==========================================================================
+
+    def _cephx_keyrotation_operation(self):
+        """
+        Rotate configured CephX key types while workloads and chaos run.
+
+        Picks one component from ``cephx_keys`` per invocation. Use
+        ``rook_daemon`` for MON/MGR/OSD/MDS rotation (legacy alias: ``daemon``).
+        No Ceph health gate — rotation must proceed under chaos/resiliency.
+        """
+        log.info("Executing CephX key rotation background operation")
+
+        if not self._namespace_exists():
+            return
+
+        from ocs_ci.helpers.cephx_bg_ops_config import (
+            get_cephx_keys,
+            get_cephx_keyrotation_interval,
+            is_cephx_keyrotation_enabled,
+        )
+
+        bg_ops_config = self._get_background_ops_config()
+        if not is_cephx_keyrotation_enabled(bg_ops_config):
+            log.debug("CephX key rotation disabled in config, skipping")
+            return
+
+        if not self._is_cephx_keyrotation_supported():
+            log.info("CephX key rotation not supported on this cluster, skipping")
+            return
+
+        interval = get_cephx_keyrotation_interval(bg_ops_config)
+        elapsed = time.time() - self._last_cephx_rotation_time
+        if self._last_cephx_rotation_time and elapsed < interval:
+            log.info(
+                f"Skipping CephX key rotation; {elapsed:.0f}s elapsed, "
+                f"interval is {interval}s"
+            )
+            return
+
+        from ocs_ci.helpers.cephx_keyrotation import CephXKeyRotation
+
+        cephx_keys = get_cephx_keys(bg_ops_config)
+        valid_keys = CephXKeyRotation.CEPHX_KEY_CONFIG_NAMES
+        cephx_keys = [key for key in cephx_keys if key in valid_keys]
+        if not cephx_keys:
+            log.warning(
+                "No valid cephx_keys configured "
+                f"(expected one of: {', '.join(sorted(valid_keys))})"
+            )
+            return
+
+        config_key = random.choice(cephx_keys)
+        component = self._resolve_cephx_key_config(config_key)
+        timeout = self._get_cephx_rotation_timeout()
+        cluster_namespace = config.ENV_DATA["cluster_namespace"]
+
+        if self._cephx_rotator is None:
+            self._cephx_rotator = CephXKeyRotation(namespace=cluster_namespace)
+        rotator = self._cephx_rotator
+
+        # Patch asynchronously. rotate_* defaults wait for CephCluster Ready,
+        # which often never happens while chaos/resiliency faults are active.
+        rotate_kwargs = {"wait_for_rotation": False}
+        if component == rotator.COMPONENT_DAEMON:
+            target = rotator.rotate_rook_daemon_keys(**rotate_kwargs)
+            # Throttle only after the StorageCluster patch is applied.
+            self._last_cephx_rotation_time = time.time()
+            log.info(
+                f"Triggered CephX key rotation for Rook daemons "
+                f"(mon/mgr/osd/mds, target generation={target}, timeout={timeout}s)"
+            )
+            if not self._running:
+                log.info("CephX rotation stopping before rook daemon wait")
+                return
+            rotator.wait_for_rook_daemon_rotation(target, timeout=timeout)
+            rotator.assert_rook_daemon_generations(target)
+            rotator.log_generation_status("post-rotation Rook daemons")
+        else:
+            if component == rotator.COMPONENT_CSI:
+                rotate_kwargs["keep_prior_key_count_max"] = (
+                    self._get_cephx_keep_prior_key_count_max()
+                )
+            target = rotator.rotate_component_keys(component, **rotate_kwargs)
+            self._last_cephx_rotation_time = time.time()
+            log.info(
+                f"Triggered CephX key rotation for {component} "
+                f"(target generation={target}, timeout={timeout}s)"
+            )
+            if not self._running:
+                log.info("CephX rotation stopping before component wait")
+                return
+            rotator.wait_for_rotation(component, target, timeout=timeout)
+
+        log.info(f"CephX key rotation background operation completed for {config_key}")
 
     # ==========================================================================
     # Helper Methods

--- a/ocs_ci/krkn_chaos/krkn_workload_config.py
+++ b/ocs_ci/krkn_chaos/krkn_workload_config.py
@@ -149,6 +149,43 @@ class KrknWorkloadConfig:
         bg_ops_config = self.get_background_cluster_operations_config()
         return bg_ops_config.get("enabled_operations", [])
 
+    def is_cephx_keyrotation_enabled(self) -> bool:
+        """
+        Check if CephX key rotation background operations are enabled.
+
+        Returns:
+            bool: True if CephX key rotation is enabled in config
+        """
+        from ocs_ci.helpers.cephx_bg_ops_config import is_cephx_keyrotation_enabled
+
+        return is_cephx_keyrotation_enabled(
+            self.get_background_cluster_operations_config()
+        )
+
+    def get_cephx_keys(self) -> List[str]:
+        """
+        Get CephX key components to rotate in background operations.
+
+        Returns:
+            list: Component names (rook_daemon, csi, rbdMirrorPeer)
+        """
+        from ocs_ci.helpers.cephx_bg_ops_config import get_cephx_keys
+
+        return get_cephx_keys(self.get_background_cluster_operations_config())
+
+    def get_cephx_keyrotation_interval(self) -> int:
+        """
+        Get minimum interval between CephX key rotation iterations.
+
+        Returns:
+            int: Interval in seconds (default: 180)
+        """
+        from ocs_ci.helpers.cephx_bg_ops_config import get_cephx_keyrotation_interval
+
+        return get_cephx_keyrotation_interval(
+            self.get_background_cluster_operations_config()
+        )
+
     def is_parallel_verification_enabled(self) -> bool:
         """
         Check if parallel verification is enabled.

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -194,6 +194,7 @@ SCRUBBER_INTERVAL = CONFIG_JS_PREFIX + "SCRUBBER_RESTART_DELAY"
 
 # Resources / Kinds
 CEPHFILESYSTEM = "CephFileSystem"
+CEPHCLIENT = "CephClient"
 CEPHBLOCKPOOL = "CephBlockPool"
 CEPHBLOCKPOOLRADOSNS = "cephblockpoolradosnamespaces"
 CEPHBLOCKPOOL_THICK = "CephBlockPoolThick"
@@ -733,6 +734,113 @@ CEPH_DAEMON_LABEL_BY_COMPONENT = {
     "osd": OSD_APP_LABEL,
     "mds": MDS_APP_LABEL,
     "rgw": RGW_APP_LABEL,
+}
+# CephX authentication key rotation (Rook CephCluster spec.security.cephx)
+CEPHX_KEY_IDENTIFIER_ANNOTATION = "cephx-key-identifier"
+CEPHX_STATUS_ANNOTATION = "cephx-status"
+OSD_CEPHX_INIT_CONTAINER_NAMES = ("cephx-keyring-update",)
+OSD_STORE_LABEL = "osd-store"
+OSD_CEPHX_INIT_SUCCESS_LOG = "got latest cephx key for OSD successfully"
+OSD_CEPHX_GET_OR_CREATE_LOG = "auth get-or-create"
+OSD_ENCRYPTED_LABEL = "encrypted"
+OSD_LOCKBOX_AUTH_PREFIX = "client.osd-lockbox."
+OSD_ACTIVATE_INIT_CONTAINER = "activate"
+OSD_LOCKBOX_INIT_SUCCESS_LOG = "got latest cephx lockbox key for OSD successfully"
+# Same get-or-create token as OSD cephx init; alias kept for lockbox call sites.
+OSD_LOCKBOX_GET_OR_CREATE_LOG = OSD_CEPHX_GET_OR_CREATE_LOG
+OSD_LOCKBOX_OPERATOR_LOG = "rotating osd-lockbox cephx key of encrypted OSD"
+ROOK_OSD_UUID_ENV = "ROOK_OSD_UUID"
+CEPHX_BOOTSTRAP_AUTH_PREFIX = "client.bootstrap-"
+CEPHX_BOOTSTRAP_KEYS_TO_CLEANUP = (
+    "client.bootstrap-mds",
+    "client.bootstrap-mgr",
+    "client.bootstrap-rbd",
+    "client.bootstrap-rbd-mirror",
+    "client.bootstrap-rgw",
+    "client.bootstrap-osd",
+)
+CEPHX_BOOTSTRAP_NON_OSD_KEYS = tuple(
+    key for key in CEPHX_BOOTSTRAP_KEYS_TO_CLEANUP if key != "client.bootstrap-osd"
+)
+CEPHX_BOOTSTRAP_DELETED_OPERATOR_LOG = "successfully deleted"
+CEPHX_BOOTSTRAP_OPERATOR_LOG_TOKEN = "bootstrap key"
+CEPHX_BOOTSTRAP_DELETION_WARNING_PATTERNS = (
+    "failed to delete bootstrap",
+    "error deleting bootstrap",
+    "bootstrap key deletion failed",
+)
+CEPHX_LOCKBOX_ROTATION_FAILURE_LOG_PATTERNS = (
+    "failed to rotate cephx lockbox",
+    "failed auth rotate osd-lockbox",
+    "could not",
+    "connection refused",
+    "no route to host",
+    "timed out",
+)
+CEPHX_DEFAULT_ALLOWED_CIPHERS = ("aes", "aes256k")
+CEPHX_CUSTOM_ALLOWED_CIPHERS = ("aes256k",)
+# Scrape-port discovery prefers Service port https-main (kube-rbac-proxy →
+# exporter). https-self is process metrics only. Fallbacks cover modern
+# (8443) and legacy secure-serving (9443) layouts when discovery fails.
+OCS_METRICS_EXPORTER_HTTPS_MAIN_PORT_NAME = "https-main"
+OCS_METRICS_EXPORTER_HTTPS_SELF_PORT_NAME = "https-self"
+OCS_METRICS_EXPORTER_PORT = 8443
+OCS_METRICS_EXPORTER_LEGACY_PORT = 9443
+OCS_METRICS_EXPORTER_METRICS_PATH = "/metrics"
+OCS_METRICS_EXPORTER_CONTAINER = "ocs-metrics-exporter"
+AUTH_BAD_KEY_LOG = "AUTH_BAD_KEY"
+OCS_METRICS_EXPORTER_METRIC_PREFIXES = ("ocs_storagecluster", "ceph_")
+CEPHX_CUSTOM_KEY_TYPE = "aes256k"
+CEPHX_INSECURE_SERVICE_KEY_TYPE_WARN = "AUTH_INSECURE_SERVICE_KEY_TYPE"
+CEPHX_AUTH_ROTATE_KEY_TYPE_OPERATOR_LOG = "--key-type"
+# Substrings that indicate actual CephX auth rotation activity.
+# Do not use broad phrases like "cephx key rotation" — they also match
+# enablement logs such as "enabling cephx key rotation because the cluster
+# is not upgrading" and false-fail idempotency checks.
+CEPHX_KEY_ROTATION_OPERATOR_LOG_PATTERNS = (
+    "auth rotate",
+    "rotating cephx",
+    "rotating ceph auth key",
+)
+CEPHX_MON_AUTH_ROTATION_LOG_PATTERN = r'rotating ceph auth key.*"mon\.'
+CEPHX_MON_SECRET_UPDATE_LOG = "updating mon secret"
+CEPHX_MON_AUTH_GET_LOG_PATTERN = r"auth get mon"
+MANAGED_MONS_KEYRING_SECRET = "rook-ceph-mons-keyring"  # pragma: allowlist secret
+CEPHX_ROTATION_QUORUM_ERROR_PATTERNS = (
+    "quorum",
+    "cannot rotate",
+    "not in quorum",
+    "mon quorum",
+)
+CEPHX_OSD_ROTATION_DEFERRED_PATTERNS = (
+    "not clean",
+    "not healthy",
+    "skipping osd",
+    "waiting for pgs",
+    "deferring osd rotation",
+    "osd rotation deferred",
+)
+CEPHX_OSD_AUTH_ROTATION_LOG_PATTERN = r'rotating ceph auth key.*"osd\.'
+CEPHX_OSD_KEY_ROTATION_LOG_PATTERNS = (
+    'rotating ceph auth key "osd.',
+    "auth rotate osd.",
+)
+CEPHX_RECONCILE_FAILURE_PATTERNS = (
+    "failed to rotate",
+    "error rotating",
+    "reconcile failed",
+)
+# OSD-auth-delete inject: match the OSD rotate failure, not generic admin rotate
+# restart noise or normal Progressing reconcile messages.
+CEPHX_OSD_AUTH_ROTATION_FAILURE_PATTERNS = (
+    "failed to rotate cephx key for osd",
+    "failed auth rotate osd.",
+)
+ROOK_CEPHX_KEYROTATION_DAEMONS = ("mon", "mgr", "osd", "mds")
+CEPHCLUSTER_CEPHX_KEYROTATION_STATUS_ENTITIES = ("mon", "mgr", "osd")
+ROOK_CEPHX_KEYROTATION_DAEMON_LABELS = {
+    daemon: CEPH_DAEMON_LABEL_BY_COMPONENT[daemon]
+    for daemon in ROOK_CEPHX_KEYROTATION_DAEMONS
 }
 EXPORTER_APP_LABEL = "app=rook-ceph-exporter"
 OPERATOR_LABEL = "app=rook-ceph-operator"
@@ -1629,6 +1737,23 @@ ALERT_ODF_NODE_LATENCY_HIGH_OSD_NODES = "ODFNodeLatencyHighOnOSDNodes"
 ALERT_ODF_NODE_LATENCY_HIGH_NON_OSD_NODES = "ODFNodeLatencyHighOnNonOSDNodes"
 ALERT_ODF_NODE_NIC_BANDWIDTH_SATURATION = "ODFNodeNICBandwidthSaturation"
 ALERT_ODF_NODE_MTU_LESS_THAN_9000 = "ODFNodeMTULessThan9000"
+ALERT_CEPHFS_ORPHANED_SNAPSHOT = "CephFSOrphanedSnapshot"
+CEPHFS_SNAPSHOT_STATE_ORPHANED = "orphaned"
+CEPHFS_SNAPSHOT_STATE_BOUND = "bound"
+ALERT_MDSXATTR = "CephXattrSetLatency"
+ALERT_CEPHX_KEY_GENERATION_FAILED = "CephxKeyGenerationFailed"
+OCS_CEPHX_DAEMON_KEY_ROTATION_MISMATCH_METRIC = "ocs_cephx_daemon_key_rotation_mismatch"
+CEPHX_CREATED_WITH_FEATURES_ANNOTATION = "ocs.openshift.io/created-with-cephx-features"
+CEPHX_CREATED_AT_DF_VERSION_ANNOTATION = "ocs.openshift.io/created-at-df-version"
+DESIRED_CEPHX_KEY_GEN_ENV = "DESIRED_CEPHX_KEY_GEN"
+DEFAULT_DESIRED_CEPHX_KEY_GEN = 2
+CEPHX_KEY_GENERATION_DECREASE_ERROR = "keyGeneration cannot be decreased"
+CEPHX_KEY_GENERATION_REMOVE_ERROR = "keyGeneration cannot be removed once set"
+CEPHX_KEY_GENERATION_TYPE_ERROR = "must be of type integer"
+
+# DR Pending Cleanup Alert (OCS 4.22+)
+ALERT_APPLICATION_CLEANUP_PENDING = "ApplicationCleanupPending"
+ALERT_APPLICATION_CLEANUP_PENDING_THRESHOLD = 15 * 60  # 15 minutes in seconds
 
 # OCS Deployment related constants
 OPERATOR_NODE_LABEL = "cluster.ocs.openshift.io/openshift-storage=''"

--- a/ocs_ci/resiliency/resiliency_workload_config.py
+++ b/ocs_ci/resiliency/resiliency_workload_config.py
@@ -122,6 +122,77 @@ class ResiliencyWorkloadConfig:
         resiliency_config = self.config.ENV_DATA.get("resiliency_config", {})
         return resiliency_config.get("background_cluster_operations", {})
 
+    def is_background_cluster_operations_enabled(self) -> bool:
+        """
+        Check if background cluster operations are enabled.
+
+        Returns:
+            bool: True if background cluster operations are enabled
+        """
+        return self.get_background_operations_config().get("enabled", False)
+
+    def get_background_operations_interval(self) -> int:
+        """
+        Get background operations interval in seconds.
+
+        Returns:
+            int: Operation interval in seconds (default: 60)
+        """
+        return self.get_background_operations_config().get("operation_interval", 60)
+
+    def get_background_operations_max_concurrent(self) -> int:
+        """
+        Get maximum concurrent background operations.
+
+        Returns:
+            int: Maximum concurrent operations (default: 3)
+        """
+        return self.get_background_operations_config().get(
+            "max_concurrent_operations", 3
+        )
+
+    def get_enabled_background_operations(self) -> List[str]:
+        """
+        Get list of enabled background operation types.
+
+        Returns:
+            list: List of enabled operation type names
+        """
+        return self.get_background_operations_config().get("enabled_operations", [])
+
+    def is_cephx_keyrotation_enabled(self) -> bool:
+        """
+        Check if CephX key rotation background operations are enabled.
+
+        Returns:
+            bool: True if CephX key rotation is enabled in config
+        """
+        from ocs_ci.helpers.cephx_bg_ops_config import is_cephx_keyrotation_enabled
+
+        return is_cephx_keyrotation_enabled(self.get_background_operations_config())
+
+    def get_cephx_keys(self) -> List[str]:
+        """
+        Get CephX key components to rotate in background operations.
+
+        Returns:
+            list: Component names (daemon, csi, rbdMirrorPeer)
+        """
+        from ocs_ci.helpers.cephx_bg_ops_config import get_cephx_keys
+
+        return get_cephx_keys(self.get_background_operations_config())
+
+    def get_cephx_keyrotation_interval(self) -> int:
+        """
+        Get minimum interval between CephX key rotation iterations.
+
+        Returns:
+            int: Interval in seconds (default: 180)
+        """
+        from ocs_ci.helpers.cephx_bg_ops_config import get_cephx_keyrotation_interval
+
+        return get_cephx_keyrotation_interval(self.get_background_operations_config())
+
     def get_scaling_config(self) -> Dict[str, Any]:
         """
         Get workload scaling configuration.

--- a/ocs_ci/resiliency/resiliency_workload_factory.py
+++ b/ocs_ci/resiliency/resiliency_workload_factory.py
@@ -94,22 +94,33 @@ class ResiliencyWorkloadOps:
 
     def _start_background_cluster_operations(self):
         """Start background cluster operations during workload execution."""
+        workload_config = ResiliencyWorkloadConfig()
+
         try:
             from ocs_ci.krkn_chaos.background_cluster_operations import (
                 BackgroundClusterOperations,
-                BackgroundClusterValidator,
             )
 
-            self.background_cluster_ops = BackgroundClusterOperations()
-            self.background_cluster_ops.start_operations()
-
-            self.background_cluster_validator = BackgroundClusterValidator(
-                self.background_cluster_ops
+            enabled_operations = workload_config.get_enabled_background_operations()
+            self.background_cluster_ops = BackgroundClusterOperations(
+                workload_ops=self,
+                enabled_operations=enabled_operations if enabled_operations else None,
+                operation_interval=workload_config.get_background_operations_interval(),
+                max_concurrent_operations=workload_config.get_background_operations_max_concurrent(),
             )
+            self.background_cluster_ops.start()
 
-            log.info("Background cluster operations started successfully")
+            ops_count = len(enabled_operations) if enabled_operations else "all"
+            log.info(
+                f"Background cluster operations started with {ops_count} "
+                f"operation types (interval: "
+                f"{workload_config.get_background_operations_interval()}s, "
+                f"max concurrent: "
+                f"{workload_config.get_background_operations_max_concurrent()})"
+            )
         except Exception as e:
             log.warning(f"Failed to start background cluster operations: {e}")
+            self.background_cluster_ops = None
 
     def _start_background_scaling(self):
         """Start background scaling operations."""
@@ -167,19 +178,12 @@ class ResiliencyWorkloadOps:
         if self.background_cluster_ops:
             log.info("Stopping background cluster operations")
             try:
-                self.background_cluster_ops.stop_operations()
-
-                # Validate background operations
-                if self.background_cluster_validator:
-                    validation_result = (
-                        self.background_cluster_validator.validate_all_operations()
-                    )
-                    if not validation_result:
-                        validation_errors.append(
-                            "Background cluster operations validation failed"
-                        )
+                self.background_cluster_ops.stop(cleanup=True)
             except Exception as e:
                 log.warning(f"Failed to stop background cluster operations: {e}")
+            finally:
+                self.background_cluster_ops = None
+                self.background_cluster_validator = None
 
         # Validate and cleanup workloads
         for workload in self.workloads:

--- a/ocs_ci/utility/prometheus.py
+++ b/ocs_ci/utility/prometheus.py
@@ -648,7 +648,7 @@ class PrometheusAPI(object):
         # return actual result of the query
         return content["data"]["result"]
 
-    def wait_for_alert(self, name, state=None, timeout=1200, sleep=5):
+    def wait_for_alert(self, name, state=None, timeout=1200, sleep=5, min_count=1):
         """
         Search for alerts that have requested name and state.
 
@@ -689,9 +689,9 @@ class PrometheusAPI(object):
                     ]
                     logger.info(
                         f"Checking for {name} alerts with state {state}... "
-                        f"{len(alerts)} found"
+                        f"{len(alerts)} found (need {min_count})"
                     )
-                    if len(alerts) > 0:
+                    if len(alerts) >= min_count:
                         break
                 else:
                     # search for missing alerts, search is completed when
@@ -797,6 +797,123 @@ class PrometheusAPI(object):
                 )
                 return False
         return True
+
+
+def _validate_alert_instance(
+    alert, alert_name, instance_index, expected_severity, expected_message_substr
+):
+    """
+    Assert that a single alert instance matches the expected criteria.
+
+    Args:
+        alert (dict): A single alert record from the Prometheus API.
+        alert_name (str): Alert name (used in assertion messages).
+        instance_index (int): Instance index (used in assertion messages).
+        expected_severity (str | None): If given, assert that
+            ``alert["labels"]["severity"]`` equals this value.
+        expected_message_substr (str | None): If given, assert that this
+            substring appears (case-insensitive) in
+            ``alert["annotations"]["message"]``.
+
+    Raises:
+        AssertionError: If any validation check fails.
+    """
+    if expected_severity is not None:
+        assert alert["labels"]["severity"] == expected_severity, (
+            f"Alert '{alert_name}' instance {instance_index}: expected severity "
+            f"'{expected_severity}', "
+            f"got '{alert['labels']['severity']}'"
+        )
+    if expected_message_substr is not None:
+        assert expected_message_substr.lower() in (
+            alert["annotations"]["message"].lower()
+        ), (
+            f"Alert '{alert_name}' instance {instance_index}: expected "
+            f"'{expected_message_substr}' in message: "
+            f"{alert['annotations']['message']}"
+        )
+    assert alert["annotations"].get("runbook_url") or alert["annotations"].get(
+        "description"
+    ), (
+        f"Alert '{alert_name}' instance {instance_index} is missing both "
+        f"runbook_url and description"
+    )
+
+
+def wait_for_alert_firing(
+    api,
+    alert_name,
+    timeout=600,
+    expected_severity=None,
+    expected_message_substr=None,
+    min_count=1,
+):
+    """
+    Wait for a Prometheus alert to reach the ``firing`` state and validate it.
+
+    Args:
+        api (PrometheusAPI): Prometheus API instance.
+        alert_name (str): Alert name to wait for.
+        timeout (int): Seconds to wait for the alert to fire.
+        expected_severity (str | None): If given, assert that
+            ``alert["labels"]["severity"]`` equals this value.
+        expected_message_substr (str | None): If given, assert that this
+            substring appears (case-insensitive) in
+            ``alert["annotations"]["message"]``.
+        min_count (int): Minimum number of firing alert instances to
+            wait for. Defaults to 1.
+
+    Returns:
+        list[dict]: All fired alert records (at least ``min_count``).
+
+    Raises:
+        AssertionError: If fewer than ``min_count`` alerts fire, or any
+            validation fails.
+    """
+    alerts = api.wait_for_alert(
+        name=alert_name,
+        state="firing",
+        timeout=timeout,
+        sleep=10,
+        min_count=min_count,
+    )
+    assert len(alerts) >= min_count, (
+        f"Expected at least {min_count} '{alert_name}' alert(s) to fire "
+        f"within {timeout}s, got {len(alerts)}"
+    )
+    for instance_index, alert in enumerate(alerts):
+        _validate_alert_instance(
+            alert,
+            alert_name,
+            instance_index,
+            expected_severity,
+            expected_message_substr,
+        )
+    logger.info(
+        "Alert '%s' fired: %d instance(s), labels=%s message=%s",
+        alert_name,
+        len(alerts),
+        alerts[0]["labels"],
+        alerts[0]["annotations"].get("message"),
+    )
+    return alerts
+
+
+def wait_for_alert_cleared(api, alert_name, timeout=600):
+    """
+    Wait for a Prometheus alert to disappear (no longer firing or pending).
+
+    Args:
+        api (PrometheusAPI): Prometheus API instance.
+        alert_name (str): Alert name to wait for clearing.
+        timeout (int): Seconds to wait for the alert to clear.
+
+    Raises:
+        AssertionError: If the alert is still present after ``timeout``.
+    """
+    alerts = api.wait_for_alert(name=alert_name, timeout=timeout, sleep=10)
+    assert not alerts, f"Alert '{alert_name}' did not clear within {timeout}s"
+    logger.info("Alert '%s' cleared successfully", alert_name)
 
 
 class PrometheusAlertSubscriber(Timer):

--- a/tests/functional/cephx_keyrotation/conftest.py
+++ b/tests/functional/cephx_keyrotation/conftest.py
@@ -1,0 +1,193 @@
+import logging
+
+import pytest
+
+from ocs_ci.framework import config
+from ocs_ci.helpers.cephx_keyrotation import CephXKeyRotation
+from ocs_ci.utility.utils import ceph_health_check
+
+log = logging.getLogger(__name__)
+
+_CEPHX_NEGATIVE_RESTORE_CLASSES = (
+    "TestCephXKeyRotationNegative",
+    "TestCephXKeyRotationNegativeEncryptedCSI",
+)
+
+
+def _align_daemon_key_generations():
+    """Align StorageCluster daemon keyGeneration to CephCluster (teardown)."""
+    try:
+        rotator = CephXKeyRotation()
+        aligned = rotator.ensure_daemon_key_generations_aligned()
+        log.info(
+            "Teardown: StorageCluster/CephCluster daemon keyGeneration aligned "
+            "at %s",
+            aligned,
+        )
+    except Exception as exc:
+        log.warning(
+            "Teardown: failed to align StorageCluster/CephCluster daemon "
+            "keyGeneration: %s",
+            exc,
+        )
+
+
+@pytest.fixture(autouse=True)
+def cephx_align_key_generations_teardown(request):
+    """
+    After every CephX test, ensure StorageCluster and CephCluster daemon
+    keyGeneration values match (CephCluster is the source of truth).
+    """
+    request.addfinalizer(_align_daemon_key_generations)
+
+
+@pytest.fixture(autouse=True)
+def cephx_negative_restore_cluster_state(request):
+    """
+    Shared teardown for disruptive CephX negative tests.
+
+    Restores mon quorum, OSD mark-in, and deleted OSD auth entities, then waits
+    for full cluster recovery and health when any restore ran.
+    """
+    cls = getattr(request, "cls", None)
+    if cls is None or cls.__name__ not in _CEPHX_NEGATIVE_RESTORE_CLASSES:
+        yield
+        return
+
+    instance = request.instance
+    instance._scaled_mon_deployments = []
+    instance._osd_marked_out = None
+    instance._deleted_osd_auth_entity = None
+
+    def finalizer():
+        rotator = CephXKeyRotation()
+        namespace = config.ENV_DATA["cluster_namespace"]
+        restored = False
+        # Full recovery wait for mon/auth restore only. OSD mark-in already
+        # waits inside restore_osd_and_wait_for_recovery.
+        need_full_recovery = False
+        teardown_exc = None
+
+        def _record_teardown_error(exc):
+            nonlocal teardown_exc
+            if teardown_exc is None:
+                teardown_exc = exc
+
+        if instance._scaled_mon_deployments:
+            log.info(
+                "Teardown: restoring mon deployments "
+                f"{instance._scaled_mon_deployments}"
+            )
+            try:
+                rotator.restore_mon_deployments(instance._scaled_mon_deployments)
+                restored = True
+                need_full_recovery = True
+            except Exception as exc:
+                log.warning("Teardown: failed to restore mon deployments: %s", exc)
+                _record_teardown_error(exc)
+            instance._scaled_mon_deployments = []
+        if instance._osd_marked_out is not None:
+            log.info(
+                f"Teardown: marking osd.{instance._osd_marked_out} back in and "
+                "waiting for full cluster recovery"
+            )
+            try:
+                rotator.restore_osd_and_wait_for_recovery(
+                    instance._osd_marked_out, timeout=1500
+                )
+                restored = True
+            except Exception as exc:
+                log.warning(
+                    "Teardown: failed to restore osd.%s: %s",
+                    instance._osd_marked_out,
+                    exc,
+                )
+                _record_teardown_error(exc)
+            instance._osd_marked_out = None
+        if instance._deleted_osd_auth_entity:
+            entity = instance._deleted_osd_auth_entity
+            log.info(f"Teardown: ensuring deleted OSD auth entity {entity} is restored")
+            try:
+                if rotator.ensure_osd_auth_entity_restored(entity):
+                    rotator.trigger_cephcluster_reconcile()
+                    need_full_recovery = True
+                restored = True
+            except Exception as exc:
+                log.warning(
+                    f"Teardown: failed to restore OSD auth entity {entity}: {exc}"
+                )
+                _record_teardown_error(exc)
+            instance._deleted_osd_auth_entity = None
+        if need_full_recovery:
+            try:
+                rotator.wait_for_cluster_fully_recovered(timeout=1500)
+            except Exception as exc:
+                log.warning(
+                    "Teardown: wait_for_cluster_fully_recovered failed: %s", exc
+                )
+                _record_teardown_error(exc)
+        if restored:
+            try:
+                ceph_health_check(namespace=namespace)
+            except Exception as exc:
+                log.warning("Teardown: ceph_health_check failed: %s", exc)
+                _record_teardown_error(exc)
+        try:
+            rotator.ensure_daemon_key_generations_aligned()
+        except Exception as exc:
+            log.warning("Teardown: failed to align daemon keyGeneration: %s", exc)
+            _record_teardown_error(exc)
+        if teardown_exc is not None:
+            raise teardown_exc
+
+    request.addfinalizer(finalizer)
+    yield
+
+
+@pytest.fixture(scope="class")
+def cephx_keyrotation_setup():
+    """
+    Prepare cluster for CephX key rotation TC-01:
+      - enable daemon KeyGeneration policy on StorageCluster
+      - wait for mon/mgr/osd/mds daemons and cluster Ready state
+
+    Enabling at DESIRED_CEPHX_KEY_GEN / DEFAULT_DAEMON_KEY_GENERATION only
+    updates StorageCluster; CephCluster does not Progress and status may stay
+    at keyGeneration 1. Do not wait for status to reach the desired baseline.
+    """
+    rotator = CephXKeyRotation()
+    rotator.ensure_daemon_key_rotation_enabled(
+        key_generation=CephXKeyRotation.DEFAULT_DAEMON_KEY_GENERATION
+    )
+    rotator.wait_for_rook_daemon_pods_ready()
+    rotator.wait_for_cluster_ready()
+    return rotator
+
+
+@pytest.fixture(scope="class")
+def cephx_bootstrap_setup():
+    """
+    Prepare cluster for bootstrap CephX key cleanup verification:
+      - wait for mon/mgr/osd/mds daemons and cluster Ready state
+    """
+    rotator = CephXKeyRotation()
+    rotator.wait_for_rook_daemon_pods_ready()
+    rotator.wait_for_cluster_ready()
+    return rotator
+
+
+@pytest.fixture(scope="class")
+def cephx_rotation_disabled_setup():
+    """
+    Prepare cluster for CephX policy-disabled verification:
+      - disable daemon keyRotationPolicy on StorageCluster cephCluster
+      - disable rbdMirrorPeer keyRotationPolicy on StorageCluster cephRBDMirror
+      - disable csi keyRotationPolicy on CephCluster
+      - wait for mon/mgr/osd/mds daemons and cluster Ready state
+    """
+    rotator = CephXKeyRotation()
+    rotator.ensure_key_rotation_disabled()
+    rotator.assert_key_rotation_disabled()
+    rotator.wait_for_rook_daemon_pods_ready()
+    rotator.wait_for_cluster_ready()
+    return rotator

--- a/tests/functional/cephx_keyrotation/test_cephx_keyrotation_bootstrap_cleanup.py
+++ b/tests/functional/cephx_keyrotation/test_cephx_keyrotation_bootstrap_cleanup.py
@@ -1,0 +1,121 @@
+"""
+Bootstrap CephX Key Cleanup Verification
+
+Verify Rook removes bootstrap CephX keys after they are no longer needed and
+that client.bootstrap-osd is recreated during OSD provisioning then cleaned up.
+"""
+
+import logging
+
+import pytest
+
+from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import (
+    green_squad,
+    skipif_external_mode,
+    skipif_ocs_version,
+    tier1,
+)
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.resources.pod import (
+    get_osd_pods,
+    get_pods_having_label,
+    wait_for_new_osd_pods_to_come_up,
+)
+from ocs_ci.ocs.resources.storage_cluster import add_capacity, get_osd_size
+from ocs_ci.utility.utils import ceph_health_check
+
+log = logging.getLogger(__name__)
+
+pytestmark = pytest.mark.skip(
+    reason="Only daemon CephX key rotation is currently supported"
+)
+
+
+@skipif_external_mode
+@skipif_ocs_version(["<4.21", ">=4.23"])
+@green_squad
+@pytest.mark.order("last")
+class TestCephXBootstrapKeyCleanup:
+    @pytest.mark.polarion_id("OCS-8161")
+    @tier1
+    def test_cephx_bootstrap_key_cleanup(self, cephx_bootstrap_setup):
+        """
+        Verify bootstrap CephX keys are cleaned up and OSD bootstrap is ephemeral.
+
+        Steps:
+            1. Wait for cluster/daemons Ready (fixture).
+            2. Record bootstrap keys, trigger reconcile, wait for non-OSD cleanup.
+            3. Add OSD capacity and verify bootstrap-osd is recreated then removed.
+            4. Verify operator deletion logs and idempotent re-reconcile behavior.
+        """
+        rotator = cephx_bootstrap_setup
+        namespace = config.ENV_DATA["cluster_namespace"]
+
+        ceph_health_check(namespace=namespace)
+
+        pre_bootstrap_entities = rotator.discover_bootstrap_auth_entities()
+        if pre_bootstrap_entities:
+            log.info(
+                "Bootstrap keys before cleanup: " f"{', '.join(pre_bootstrap_entities)}"
+            )
+        else:
+            log.info("No bootstrap keys present before reconcile")
+
+        rotator.trigger_cephcluster_reconcile()
+        rotator.wait_for_post_mon_startup_bootstrap_cleanup(timeout=900)
+        rotator.assert_bootstrap_keys_absent(constants.CEPHX_BOOTSTRAP_NON_OSD_KEYS)
+
+        rotator.verify_operator_bootstrap_deletion_logs(
+            [
+                entity
+                for entity in constants.CEPHX_BOOTSTRAP_NON_OSD_KEYS
+                if entity in pre_bootstrap_entities
+            ]
+        )
+
+        osd_pods_before = get_osd_pods(namespace=namespace)
+        osd_count_before = len(osd_pods_before)
+        log.info(f"OSD pod count before add_capacity: {osd_count_before}")
+
+        try:
+            osd_size = get_osd_size()
+            log.info(f"Adding OSD capacity (device set size={osd_size})")
+            add_capacity(osd_size)
+        except Exception as exc:
+            pytest.skip(f"Cannot add OSD capacity on this cluster: {exc}")
+
+        bootstrap_osd_seen = rotator.wait_for_bootstrap_key_present(
+            "client.bootstrap-osd", timeout=300
+        )
+        wait_for_new_osd_pods_to_come_up(osd_count_before)
+
+        running_osd_count = len(
+            get_pods_having_label(
+                constants.OSD_APP_LABEL,
+                namespace=namespace,
+                statuses=[constants.STATUS_RUNNING],
+            )
+        )
+        assert running_osd_count > osd_count_before, (
+            f"Expected more Running OSD pods after add_capacity; "
+            f"before={osd_count_before} after={running_osd_count}"
+        )
+        log.info(f"OSD pod count after add_capacity: {running_osd_count}")
+
+        rotator.wait_for_bootstrap_osd_key_absent(timeout=1200)
+        rotator.assert_bootstrap_keys_absent()
+
+        if bootstrap_osd_seen:
+            rotator.verify_operator_bootstrap_deletion_logs(["client.bootstrap-osd"])
+
+        rotator.trigger_cephcluster_reconcile()
+        rotator.wait_for_bootstrap_keys_absent(timeout=300)
+        rotator.verify_no_bootstrap_deletion_errors()
+        rotator.assert_bootstrap_keys_absent()
+
+        ceph_health_check(namespace=namespace)
+        rotator.wait_for_cluster_ready()
+        rotator.wait_for_pgs_active_clean()
+
+        log.info("Bootstrap CephX key cleanup verification completed successfully")

--- a/tests/functional/cephx_keyrotation/test_cephx_keyrotation_configuration.py
+++ b/tests/functional/cephx_keyrotation/test_cephx_keyrotation_configuration.py
@@ -1,0 +1,229 @@
+"""
+CephX Key Rotation — Security Configuration
+
+Policy disabled and allowedCiphers defaults/custom StorageCluster config.
+"""
+
+import logging
+
+import pytest
+
+from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import (
+    green_squad,
+    skipif_external_mode,
+    skipif_ocs_version,
+    tier1,
+)
+from ocs_ci.helpers.cephx_keyrotation import CephXKeyRotation
+from ocs_ci.ocs import constants
+from ocs_ci.utility.utils import ceph_health_check
+
+log = logging.getLogger(__name__)
+
+RECONCILE_CYCLES = 3
+RECONCILE_SLEEP_SECONDS = 60
+EXPECTED_INITIAL_GENERATION = 2
+
+
+@skipif_external_mode
+@skipif_ocs_version(["<4.21", ">=4.23"])
+@green_squad
+@pytest.mark.order("first")
+class TestCephXKeyRotationPolicyDisabled:
+    @pytest.mark.polarion_id("OCS-8133")
+    @tier1
+    def test_cephx_key_rotation_policy_disabled_no_rotation(
+        self, cephx_rotation_disabled_setup
+    ):
+        """
+        Verify Disabled keyRotationPolicy prevents CephX key rotation.
+
+        Steps:
+            1. Ensure keyRotationPolicy is Disabled for daemon (and other components).
+            2. Record keyGeneration, daemon auth keys, pod state, and bootstrap keys.
+            3. Trigger multiple CephCluster reconciles.
+            4. Verify generations, daemon auth keys, pods, and bootstrap keys are unchanged.
+        """
+        rotator = cephx_rotation_disabled_setup
+        namespace = config.ENV_DATA["cluster_namespace"]
+
+        ceph_health_check(namespace=namespace)
+        rotator.assert_key_rotation_disabled()
+
+        baseline_generations = rotator.record_all_cephx_status_generations()
+        rotator.log_generation_status("Baseline")
+        log.info(f"Baseline CephX status generations: {baseline_generations}")
+
+        for entity, generation in baseline_generations.items():
+            if entity.startswith("spec_"):
+                continue
+            if generation and generation != EXPECTED_INITIAL_GENERATION:
+                log.warning(
+                    f"Baseline {entity} keyGeneration={generation}; "
+                    f"expected initial creation generation "
+                    f"{EXPECTED_INITIAL_GENERATION} on fresh clusters"
+                )
+
+        auth_entities = rotator.flatten_daemon_auth_entities(
+            rotator.discover_rook_daemon_auth_entities()
+        )
+        if not auth_entities:
+            pytest.skip("No Ceph auth entities found for rotation verification")
+
+        log.info(
+            "Daemon auth entities tracked for no-rotation verification: "
+            f"{', '.join(auth_entities)}"
+        )
+        pre_auth_keys = rotator.capture_auth_keys(
+            auth_entities, label="before reconcile cycles"
+        )
+        pre_pod_states = rotator.capture_all_daemon_pod_states()
+        pre_bootstrap_entities = rotator.discover_bootstrap_auth_entities()
+        if pre_bootstrap_entities:
+            log.info(
+                "Bootstrap keys present before reconcile: "
+                f"{', '.join(pre_bootstrap_entities)}"
+            )
+        else:
+            log.info("No bootstrap keys present before reconcile")
+
+        rotator.trigger_reconciliation_cycles(
+            cycles=RECONCILE_CYCLES,
+            sleep_between=RECONCILE_SLEEP_SECONDS,
+        )
+
+        rotator.assert_cephx_status_generations_unchanged(baseline_generations)
+        rotator.assert_auth_keys_unchanged(pre_auth_keys, entities=auth_entities)
+        rotator.assert_all_daemon_pod_states_unchanged(pre_pod_states, settle_time=30)
+        rotator.assert_bootstrap_keys_unchanged(pre_bootstrap_entities)
+
+        ceph_health_check(namespace=namespace)
+        rotator.wait_for_cluster_ready()
+        rotator.wait_for_pgs_active_clean()
+
+        log.info(
+            "CephX key rotation policy Disabled verification completed successfully"
+        )
+
+
+@skipif_external_mode
+@skipif_ocs_version(["<4.21", ">=4.23"])
+@green_squad
+class TestCephXAllowedCiphers:
+    @pytest.fixture(autouse=True)
+    def _teardown(self, request):
+        """Restore StorageCluster security after custom cipher test."""
+        request.node._cephx_reconcile_strategy_restore = None
+        rotator = CephXKeyRotation()
+        # Capture full pre-test security (including sc_ciphers / other fields).
+        pre_security = rotator.get_storagecluster_managed_cephcluster().get("security")
+
+        def fin():
+            log.info(
+                "Teardown: restoring StorageCluster managedResources.cephCluster.security"
+            )
+            try:
+                rotator.restore_storagecluster_cephcluster_security(pre_security)
+                restore_strategy = getattr(
+                    request.node, "_cephx_reconcile_strategy_restore", None
+                )
+                if restore_strategy is not None:
+                    log.info(
+                        "Teardown: restoring StorageCluster "
+                        f"cephCluster.reconcileStrategy={restore_strategy}"
+                    )
+                    rotator.patch_storagecluster_cephcluster_reconcile_strategy(
+                        restore_strategy
+                    )
+                rotator.wait_for_allowed_ciphers(
+                    constants.CEPHX_DEFAULT_ALLOWED_CIPHERS,
+                    timeout=600,
+                )
+                rotator.ensure_daemon_key_generations_aligned()
+            except Exception as exc:
+                log.warning(
+                    "Teardown restore of default allowedCiphers failed: %s", exc
+                )
+
+        request.addfinalizer(fin)
+
+    @pytest.mark.polarion_id("OCS-8134")
+    @tier1
+    def test_cephx_allowed_ciphers_configuration(self, cephx_bootstrap_setup, request):
+        """
+        Verify default CephCluster allowedCiphers and StorageCluster custom config.
+
+        Part A — Default ciphers:
+            1. Confirm StorageCluster does not specify allowedCiphers.
+            2. Verify CephCluster spec.security.cephx.allowedCiphers defaults to
+               ["aes", "aes256k"].
+
+        Part B — Custom StorageCluster ciphers:
+            3. Patch StorageCluster with custom allowedCiphers (["aes256k"]).
+            4. Verify StorageCluster retains the custom value.
+            5. Verify CephCluster keeps the default ["aes", "aes256k"] (operator
+               does not propagate StorageCluster allowedCiphers overrides).
+        """
+        rotator = cephx_bootstrap_setup
+        namespace = config.ENV_DATA["cluster_namespace"]
+
+        ceph_health_check(namespace=namespace)
+
+        sc_ciphers = rotator.get_storagecluster_allowed_ciphers()
+        if sc_ciphers is not None:
+            log.warning(
+                "StorageCluster already specifies allowedCiphers=%s; "
+                "expected unset for Part A default verification",
+                sc_ciphers,
+            )
+        else:
+            log.info("StorageCluster does not specify allowedCiphers (defaults apply)")
+
+        rotator.wait_for_allowed_ciphers(
+            constants.CEPHX_DEFAULT_ALLOWED_CIPHERS,
+            timeout=600,
+        )
+        rotator.assert_allowed_ciphers(constants.CEPHX_DEFAULT_ALLOWED_CIPHERS)
+        rotator.assert_cephcluster_security_populated()
+
+        log.info(
+            "Part A passed: default allowedCiphers=%s on CephCluster",
+            list(constants.CEPHX_DEFAULT_ALLOWED_CIPHERS),
+        )
+
+        reconcile_strategy = rotator.get_cephcluster_reconcile_strategy()
+        if reconcile_strategy == "ignore":
+            log.info(
+                "StorageCluster cephCluster.reconcileStrategy is ignore; "
+                "temporarily setting manage so reconcile can evaluate custom "
+                "allowedCiphers without changing CephCluster defaults"
+            )
+            request.node._cephx_reconcile_strategy_restore = reconcile_strategy
+            rotator.patch_storagecluster_cephcluster_reconcile_strategy("manage")
+
+        rotator.patch_storagecluster_allowed_ciphers(
+            constants.CEPHX_CUSTOM_ALLOWED_CIPHERS
+        )
+        rotator.wait_for_allowed_ciphers(
+            constants.CEPHX_CUSTOM_ALLOWED_CIPHERS,
+            timeout=600,
+            source="storagecluster",
+        )
+        rotator.assert_allowed_ciphers(
+            constants.CEPHX_CUSTOM_ALLOWED_CIPHERS,
+            source="storagecluster",
+        )
+        rotator.wait_for_storagecluster_reconciliation(timeout=600)
+        # Operator keeps CephCluster on the default cipher list; custom values
+        # on StorageCluster are accepted but not mirrored to CephCluster.
+        rotator.assert_allowed_ciphers(constants.CEPHX_DEFAULT_ALLOWED_CIPHERS)
+        rotator.assert_cephcluster_security_populated()
+
+        ceph_health_check(namespace=namespace)
+        log.info(
+            "Part B passed: StorageCluster allowedCiphers=%s; CephCluster "
+            "remained at defaults %s",
+            list(constants.CEPHX_CUSTOM_ALLOWED_CIPHERS),
+            list(constants.CEPHX_DEFAULT_ALLOWED_CIPHERS),
+        )

--- a/tests/functional/cephx_keyrotation/test_cephx_keyrotation_daemon_rotation.py
+++ b/tests/functional/cephx_keyrotation/test_cephx_keyrotation_daemon_rotation.py
@@ -1,0 +1,563 @@
+"""
+CephX Key Rotation — Daemon Rotation and Cluster Health
+
+TC-01/02/03: Rook daemon rotation, consecutive rotations, OSD init container.
+Idempotency after operator re-reconcile.
+I/O continuity during daemon key rotation.
+"""
+
+import logging
+
+import pytest
+
+from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import (
+    green_squad,
+    skipif_external_mode,
+    skipif_ocs_version,
+    tier1,
+)
+from ocs_ci.helpers.helpers import get_last_log_time_date
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.exceptions import UnexpectedBehaviour
+from ocs_ci.ocs.resources.pod import (
+    get_mgr_pods,
+    get_mon_pods,
+    get_osd_pods,
+)
+from ocs_ci.utility.utils import ceph_health_check
+
+log = logging.getLogger(__name__)
+
+CONSECUTIVE_ROTATION_COUNT = 3
+MIN_OSD_COUNT = 2
+IDEMPOTENCY_SETTLE_SECONDS = 120
+RBD_IO_FILE = "/mnt/testfile"
+CEPHFS_IO_FILE = "/mnt/testfile"
+DD_BS = "4k"
+DD_COUNT = 10000
+WORKLOAD_PVC_SIZE = 10
+POST_ROTATION_PVC_SIZE = 5
+
+
+@skipif_external_mode
+@skipif_ocs_version(["<4.21", ">=4.23"])
+@green_squad
+class TestCephXKeyRotation:
+    @pytest.mark.polarion_id("OCS-8128")
+    @tier1
+    def test_cephx_key_rotation_all_rook_daemons(self, cephx_keyrotation_setup):
+        """
+        TC-01: Rotate CephX keys for MON, MGR, OSD, and MDS daemons.
+
+        Steps:
+            1. Record keyGeneration, auth keys, pod names, and cephx-key-identifier
+               annotations for MON, MGR, and MDS (OSDs use Deployment cephx-status).
+            2. Trigger daemon key rotation (increment desired key generation).
+            3. Wait for status.cephx updates on CephCluster and CephFilesystem;
+               wait for daemon pod restarts.
+            4. Verify new keys, updated annotations (non-OSD), OSD cephx-status,
+               unchanged capabilities, and cluster health (HEALTH_OK, Ready).
+        """
+        rotator = cephx_keyrotation_setup
+        namespace = config.ENV_DATA["cluster_namespace"]
+
+        log.info("Recording pre-rotation CephX key generation values")
+        pre_mgr_generation = rotator.get_status_key_generation("mgr")
+        pre_mon_generation = rotator.get_status_key_generation("mon")
+        pre_osd_generation = rotator.get_status_key_generation("osd")
+        pre_mds_generation = rotator.get_filesystem_daemon_key_generation()
+        mon_rotation_supported = rotator.is_mon_key_rotation_supported()
+        mon_auth_verifiable = rotator.is_mon_auth_verifiable()
+        log.info(
+            f"Pre-rotation keyGeneration: mon={pre_mon_generation} "
+            f"mgr={pre_mgr_generation} osd={pre_osd_generation} "
+            f"mds={pre_mds_generation}"
+        )
+
+        auth_entities = rotator.discover_rook_daemon_auth_entities()
+        assert auth_entities, "No rook daemon auth entities discovered"
+        for daemon, entities in auth_entities.items():
+            if daemon == "mon" and not entities:
+                log.info(
+                    "MON auth entities not in ceph auth store; MON rotation "
+                    "will be verified via status.cephx.mon and mon pod restarts"
+                )
+                continue
+            assert entities, f"No Ceph auth entities found for {daemon}"
+            log.info(f"Pre-rotation {daemon} auth entities: {', '.join(entities)}")
+
+        all_entities = rotator.flatten_daemon_auth_entities(auth_entities)
+        pre_auth_keys = rotator.capture_auth_keys(all_entities, label="before rotation")
+        pre_auth_caps = rotator.capture_auth_caps(all_entities)
+        pre_pod_states = rotator.capture_all_daemon_pod_states()
+
+        for daemon, pods in pre_pod_states.items():
+            assert pods, f"No Running pods found for {daemon} before rotation"
+            if daemon == "osd":
+                log.info(
+                    f"Pre-rotation {daemon} pods (cephx-key-identifier not used): "
+                    f"{', '.join(pods)}"
+                )
+            else:
+                log.info(
+                    f"Pre-rotation {daemon} pods: "
+                    f"{', '.join(f'{name} (cephx-key-identifier={ann})' for name, ann in pods.items())}"
+                )
+
+        ceph_health_check(namespace=namespace)
+
+        target_generation = rotator.rotate_daemon_keys()
+        log.info(f"Triggered daemon CephX rotation to generation {target_generation}")
+
+        rotator.wait_for_rook_daemon_rotation(target_generation, timeout=1500)
+        post_pod_states = rotator.wait_for_all_daemon_pod_restarts(pre_pod_states)
+
+        log.info("Verifying post-rotation keyGeneration values")
+        rotator.assert_rook_daemon_generations(
+            target_generation, mon_rotation_supported
+        )
+
+        post_auth_keys = rotator.verify_auth_keys_changed(
+            pre_auth_keys, entities=all_entities
+        )
+        rotator.log_auth_key_snapshot("after rotation", post_auth_keys)
+        rotator.verify_auth_caps_unchanged(pre_auth_caps, entities=all_entities)
+        rotator.log_generation_status("Post-rotation")
+
+        for daemon, pods in post_pod_states.items():
+            # OSDs use cephx-status on the Deployment, not cephx-key-identifier.
+            if daemon == "osd":
+                log.info(
+                    f"Post-rotation {daemon} pods (cephx-key-identifier not used): "
+                    f"{', '.join(pods)}"
+                )
+                continue
+            for pod_name, annotation in pods.items():
+                if annotation is None and daemon == "mon" and not mon_auth_verifiable:
+                    log.warning(
+                        f"Pod {pod_name} ({daemon}) missing cephx-key-identifier; "
+                        "MON auth is not verifiable on this cluster"
+                    )
+                    continue
+                assert annotation and annotation.strip() != "", (
+                    f"Pod {pod_name} ({daemon}) missing or empty "
+                    "cephx-key-identifier annotation"
+                )
+            log.info(
+                f"Post-rotation {daemon} pods: "
+                f"{', '.join(f'{name} (cephx-key-identifier={ann})' for name, ann in pods.items())}"
+            )
+
+        # OSD restarts during rotation leave the cluster degraded until
+        # rebalance finishes; wait for full recovery before health checks.
+        rotator.wait_for_cluster_fully_recovered(timeout=1500)
+        ceph_health_check(namespace=namespace)
+
+        if mon_rotation_supported:
+            assert rotator.get_status_key_generation("mon") > pre_mon_generation, (
+                f"mon key generation did not increase: before={pre_mon_generation}, "
+                f"after={rotator.get_status_key_generation('mon')}"
+            )
+        assert rotator.get_status_key_generation("mgr") > pre_mgr_generation, (
+            f"mgr key generation did not increase: before={pre_mgr_generation}, "
+            f"after={rotator.get_status_key_generation('mgr')}"
+        )
+        assert rotator.get_status_key_generation("osd") > pre_osd_generation, (
+            f"osd key generation did not increase: before={pre_osd_generation}, "
+            f"after={rotator.get_status_key_generation('osd')}"
+        )
+        assert rotator.get_filesystem_daemon_key_generation() > pre_mds_generation, (
+            f"filesystem daemon key generation did not increase: "
+            f"before={pre_mds_generation}, "
+            f"after={rotator.get_filesystem_daemon_key_generation()}"
+        )
+
+        log.info("CephX key rotation for MON/MGR/OSD/MDS completed successfully")
+
+    @pytest.mark.polarion_id("OCS-8129")
+    @tier1
+    def test_cephx_key_rotation_consecutive_rotations(self, cephx_keyrotation_setup):
+        """
+        TC-02: Verify multiple consecutive daemon CephX key rotations.
+
+        Steps:
+            1. Record starting keyGeneration values and auth keys for all daemons.
+            2. For each of *CONSECUTIVE_ROTATION_COUNT* iterations:
+               a. Trigger daemon key rotation.
+               b. Wait for status.cephx updates and pod restarts.
+               c. Verify keyGeneration incremented and auth keys changed.
+               d. Verify no auth key value is reused across any prior generation.
+               e. Verify cluster health (HEALTH_OK) and Ready state.
+        """
+        rotator = cephx_keyrotation_setup
+        namespace = config.ENV_DATA["cluster_namespace"]
+        mon_rotation_supported = rotator.is_mon_key_rotation_supported()
+
+        auth_entities = rotator.discover_rook_daemon_auth_entities()
+        for daemon, entities in auth_entities.items():
+            if daemon == "mon" and not entities:
+                log.info(
+                    "MON auth entities not in ceph auth store; MON rotation "
+                    "will be verified via status.cephx.mon and mon pod restarts"
+                )
+                continue
+            assert entities, f"No Ceph auth entities found for {daemon}"
+            log.info(f"Auth entities for {daemon}: {', '.join(entities)}")
+
+        all_entities = rotator.flatten_daemon_auth_entities(auth_entities)
+        assert all_entities, "No Ceph auth entities found for daemon verification"
+
+        ceph_health_check(namespace=namespace)
+        rotator.log_generation_status("Initial")
+
+        current_keys = rotator.capture_auth_keys(all_entities, label="initial")
+        key_history = {entity: {key} for entity, key in current_keys.items() if key}
+
+        for rotation_index in range(1, CONSECUTIVE_ROTATION_COUNT + 1):
+            log.info(
+                f"Starting consecutive rotation {rotation_index}/"
+                f"{CONSECUTIVE_ROTATION_COUNT}"
+            )
+
+            pre_auth_keys = current_keys
+            pre_generations = rotator.record_daemon_generations()
+            pre_pod_states = rotator.capture_all_daemon_pod_states()
+
+            for daemon, pods in pre_pod_states.items():
+                assert pods, f"No Running pods found for {daemon} before rotation"
+
+            target_generation = rotator.rotate_daemon_keys()
+            log.info(
+                f"Triggered daemon CephX rotation to generation {target_generation}"
+            )
+
+            rotator.wait_for_rook_daemon_rotation(target_generation)
+            rotator.wait_for_all_daemon_pod_restarts(pre_pod_states)
+
+            rotator.assert_rook_daemon_generations(
+                target_generation, mon_rotation_supported
+            )
+            rotator.assert_generations_increased(
+                pre_generations, mon_rotation_supported
+            )
+            rotator.log_generation_status(f"After rotation {rotation_index}")
+
+            current_keys = rotator.verify_auth_keys_changed(
+                pre_auth_keys, entities=all_entities
+            )
+            rotator.log_auth_key_snapshot(
+                f"after rotation {rotation_index}", current_keys
+            )
+
+            for entity, key in current_keys.items():
+                if not key:
+                    continue
+                prior_keys = key_history.setdefault(entity, set())
+                assert key not in prior_keys, (
+                    f"CephX key for {entity} was reused during rotation "
+                    f"{rotation_index} (generation {target_generation})"
+                )
+                prior_keys.add(key)
+
+            rotator.wait_for_cluster_fully_recovered(timeout=1500)
+            ceph_health_check(namespace=namespace)
+            rotator.wait_for_cluster_ready()
+            log.info(
+                f"Consecutive rotation {rotation_index}/{CONSECUTIVE_ROTATION_COUNT} "
+                f"completed at keyGeneration {target_generation}"
+            )
+
+        log.info(
+            f"Completed {CONSECUTIVE_ROTATION_COUNT} consecutive CephX key "
+            "rotations for MON/MGR/OSD/MDS successfully"
+        )
+
+    @pytest.mark.polarion_id("OCS-8130")
+    @tier1
+    def test_cephx_key_rotation_osd_init_container(self, cephx_keyrotation_setup):
+        """
+        TC-03: Verify OSD CephX key rotation and init container key load.
+
+        Steps:
+            1. Record baseline OSD auth keys and deployment cephx-status annotations.
+            2. Trigger daemon key rotation (rotates all OSD auth entities).
+            3. Wait for OSD status.cephx and pod restarts.
+            4. Verify cephx-keyring-update init container logs and updated keys.
+            5. Verify deployment cephx-status (OSDs do not use cephx-key-identifier).
+            6. Verify PGs are active+clean and cluster health is OK.
+            7. Reconcile the same keyGeneration and verify idempotency.
+        """
+        rotator = cephx_keyrotation_setup
+        namespace = config.ENV_DATA["cluster_namespace"]
+
+        osd_entities = rotator.discover_osd_auth_entities()
+        assert len(osd_entities) >= MIN_OSD_COUNT, (
+            f"Expected at least {MIN_OSD_COUNT} OSD auth entities, "
+            f"found {len(osd_entities)}"
+        )
+        log.info(f"OSD auth entities: {', '.join(osd_entities)}")
+
+        osd_store_types = rotator.capture_osd_store_types()
+        log.info(
+            "OSD store types: "
+            + ", ".join(
+                f"{name}={store_type}"
+                for name, store_type in sorted(osd_store_types.items())
+            )
+        )
+        store_values = set(osd_store_types.values())
+        if store_values == {"pvc"}:
+            log.info("All OSDs are PVC-backed on this cluster")
+        elif store_values == {"host"}:
+            log.info("All OSDs are host-based on this cluster")
+        else:
+            log.info("Cluster has a mix of host-based and PVC-based OSDs")
+
+        pre_osd_generation = rotator.get_status_key_generation("osd")
+        log.info(f"Pre-rotation OSD keyGeneration: {pre_osd_generation}")
+
+        pre_auth_keys = rotator.capture_auth_keys(osd_entities, label="before rotation")
+        pre_cephx_status = rotator.capture_osd_deployment_cephx_status()
+        for deployment_name, status in pre_cephx_status.items():
+            log.info(
+                f"Pre-rotation {deployment_name} cephx-status: {status or '<empty>'}"
+            )
+
+        pre_pod_states = rotator.capture_daemon_pod_state(constants.OSD_APP_LABEL)
+        assert pre_pod_states, "No Running OSD pods found before rotation"
+        log.info(
+            "Pre-rotation OSD pods (cephx-key-identifier not used on OSDs): "
+            + ", ".join(pre_pod_states)
+        )
+
+        ceph_health_check(namespace=namespace)
+
+        target_generation = rotator.rotate_daemon_keys()
+        log.info(f"Triggered daemon CephX rotation to generation {target_generation}")
+
+        rotator.wait_for_osd_rotation(target_generation)
+        post_pod_states = rotator.wait_for_pod_restarts(
+            pre_pod_states, constants.OSD_APP_LABEL
+        )
+
+        assert (
+            rotator.get_status_key_generation("osd") >= target_generation
+        ), "CephCluster status.cephx.osd keyGeneration did not reach target"
+        log.info(
+            f"Post-rotation OSD keyGeneration: "
+            f"{rotator.get_status_key_generation('osd')}"
+        )
+
+        rotator.verify_osd_cephx_init_container_logs(get_osd_pods(namespace=namespace))
+
+        post_auth_keys = rotator.verify_auth_keys_changed(
+            pre_auth_keys, entities=osd_entities
+        )
+        rotator.log_auth_key_snapshot("after rotation", post_auth_keys)
+
+        rotator.assert_osd_deployment_cephx_status_updated(
+            pre_cephx_status, target_generation
+        )
+        post_cephx_status = rotator.capture_osd_deployment_cephx_status()
+        for deployment_name, status in post_cephx_status.items():
+            log.info(
+                f"Post-rotation {deployment_name} cephx-status: {status or '<empty>'}"
+            )
+
+        # OSDs track rotation via Deployment cephx-status, not cephx-key-identifier.
+        log.info(
+            "Post-rotation OSD pods (cephx-key-identifier not used on OSDs): "
+            + ", ".join(post_pod_states)
+        )
+
+        rotator.wait_for_pgs_active_clean()
+        ceph_health_check(namespace=namespace)
+        rotator.wait_for_cluster_ready()
+
+        assert rotator.get_status_key_generation("osd") > pre_osd_generation
+
+        rotator.verify_daemon_rotation_idempotent(
+            target_generation,
+            post_auth_keys,
+            post_pod_states,
+            osd_entities,
+        )
+
+        log.info("OSD CephX key rotation completed successfully")
+
+
+@skipif_external_mode
+@skipif_ocs_version(["<4.21", ">=4.23"])
+@green_squad
+class TestCephXKeyRotationIdempotency:
+    @pytest.mark.polarion_id("OCS-8131")
+    @tier1
+    def test_cephx_key_rotation_rereconcile_idempotent(self, cephx_keyrotation_setup):
+        """
+        Verify operator re-reconcile does not trigger a second daemon CephX key rotation.
+
+        Steps:
+            1. Ensure daemon CephX key rotation is enabled on the cluster.
+            2. Trigger daemon key rotation and wait for completion.
+            3. Record keyGeneration values, auth keys, pod state, and OSD cephx-status.
+            4. Restart rook-ceph-operator and wait for reconciliation.
+            5. Re-check generations, auth keys, pod state, and operator logs.
+
+        Expected:
+            - keyGeneration values remain unchanged after re-reconcile.
+            - Auth keys remain unchanged.
+            - Operator logs do not show rotation messages on re-reconcile.
+            - Daemon pods do not restart unnecessarily.
+            - OSD cephx-status annotations prevent redundant rotation.
+        """
+        rotator = cephx_keyrotation_setup
+        namespace = config.ENV_DATA["cluster_namespace"]
+
+        ceph_health_check(namespace=namespace)
+
+        target_generation = rotator.rotate_daemon_keys()
+        log.info(f"Triggered daemon CephX rotation to generation {target_generation}")
+        rotator.wait_for_rook_daemon_rotation(target_generation, timeout=1500)
+
+        baseline_generations = rotator.record_all_cephx_status_generations()
+        rotator.log_generation_status("Post-rotation baseline")
+        log.info(f"Baseline CephX status generations: {baseline_generations}")
+
+        auth_entities = rotator.flatten_daemon_auth_entities(
+            rotator.discover_rook_daemon_auth_entities()
+        )
+        if not auth_entities:
+            pytest.skip("No Ceph auth entities found for idempotency verification")
+
+        log.info(
+            "Auth entities tracked for idempotency verification: "
+            f"{', '.join(auth_entities)}"
+        )
+        post_rotation_auth_keys = rotator.capture_auth_keys(
+            auth_entities, label="after rotation before operator restart"
+        )
+        post_rotation_pod_states = rotator.capture_all_daemon_pod_states()
+        post_rotation_osd_cephx_status = rotator.capture_osd_deployment_cephx_status()
+
+        operator_log_marker = get_last_log_time_date()
+        previous_operator_pod = rotator.restart_rook_ceph_operator()
+
+        rotator.verify_key_rotation_idempotent_after_operator_restart(
+            baseline_generations,
+            post_rotation_auth_keys,
+            auth_entities,
+            post_rotation_pod_states,
+            osd_cephx_status=post_rotation_osd_cephx_status,
+            operator_log_since=operator_log_marker,
+            previous_operator_pod_name=previous_operator_pod,
+            settle_timeout=IDEMPOTENCY_SETTLE_SECONDS,
+        )
+
+        rotator.wait_for_pgs_active_clean()
+        ceph_health_check(namespace=namespace)
+        log.info(
+            "Daemon CephX key rotation idempotency after operator re-reconcile "
+            f"verified (restarted operator pod {previous_operator_pod})"
+        )
+
+
+@skipif_external_mode
+@skipif_ocs_version(["<4.21", ">=4.23"])
+@green_squad
+class TestCephXKeyRotationIOContinuity:
+    @pytest.mark.polarion_id("OCS-8132")
+    @tier1
+    def test_cephx_key_rotation_io_continuity(
+        self, cephx_keyrotation_setup, deployment_pod_factory
+    ):
+        """
+        Verify cluster health and I/O continuity during daemon CephX key rotation.
+
+        Steps:
+            1. Create RBD and CephFS PVCs mounted to pods; start continuous dd I/O.
+            2. Trigger daemon key rotation.
+            3. Monitor I/O during rotation — verify background threads stay alive.
+            4. After rotation, verify I/O files are intact and readable.
+            5. Verify no AUTH_BAD_KEY errors in workload and daemon pod logs.
+            6. Create new PVCs and pods; verify post-rotation provisioning works.
+            7. Verify PGs are active+clean and cluster health is OK.
+        """
+        rotator = cephx_keyrotation_setup
+        namespace = config.ENV_DATA["cluster_namespace"]
+
+        ceph_health_check(namespace=namespace)
+
+        log.info("Creating RBD and CephFS deployment pods for continuous I/O")
+        rbd_pod = deployment_pod_factory(
+            interface=constants.CEPHBLOCKPOOL,
+            size=WORKLOAD_PVC_SIZE,
+        )
+        cephfs_pod = deployment_pod_factory(
+            interface=constants.CEPHFILESYSTEM,
+            size=WORKLOAD_PVC_SIZE,
+        )
+
+        rbd_io_thread = rotator.start_dd_io_in_background(
+            rbd_pod, RBD_IO_FILE, bs=DD_BS, count=DD_COUNT
+        )
+        cephfs_io_thread = rotator.start_dd_io_in_background(
+            cephfs_pod, CEPHFS_IO_FILE, bs=DD_BS, count=DD_COUNT
+        )
+
+        target_generation = rotator.rotate_daemon_keys()
+        log.info(f"Triggered daemon CephX rotation to generation {target_generation}")
+
+        rotator.wait_for_rook_daemon_rotation(target_generation, timeout=1500)
+
+        if not rbd_io_thread.is_alive():
+            raise UnexpectedBehaviour(
+                f"RBD I/O stopped unexpectedly during rotation on pod {rbd_pod.name}"
+            )
+        if not cephfs_io_thread.is_alive():
+            raise UnexpectedBehaviour(
+                "CephFS I/O stopped unexpectedly during rotation on pod "
+                f"{cephfs_pod.name}"
+            )
+        log.info("Continuous I/O remained active throughout key rotation")
+
+        rotator.stop_dd_io(rbd_pod, RBD_IO_FILE)
+        rotator.stop_dd_io(cephfs_pod, CEPHFS_IO_FILE)
+
+        rotator.verify_io_file_readable(rbd_pod, RBD_IO_FILE)
+        rotator.verify_io_file_readable(cephfs_pod, CEPHFS_IO_FILE)
+
+        daemon_pods = []
+        for getter in (get_mon_pods, get_mgr_pods, get_osd_pods):
+            daemon_pods.extend(getter(namespace=namespace))
+        rotator.verify_pods_no_auth_bad_key([rbd_pod, cephfs_pod] + daemon_pods)
+
+        log.info("Creating new RBD and CephFS workloads after key rotation")
+        new_rbd_pod = deployment_pod_factory(
+            interface=constants.CEPHBLOCKPOOL,
+            size=POST_ROTATION_PVC_SIZE,
+        )
+        new_cephfs_pod = deployment_pod_factory(
+            interface=constants.CEPHFILESYSTEM,
+            size=POST_ROTATION_PVC_SIZE,
+        )
+        new_rbd_pod.exec_cmd_on_pod(
+            "dd if=/dev/urandom of=/mnt/post_rotation_test bs=4k count=100 status=none",
+            out_yaml_format=False,
+        )
+        new_cephfs_pod.exec_cmd_on_pod(
+            "dd if=/dev/urandom of=/mnt/post_rotation_test bs=4k count=100 status=none",
+            out_yaml_format=False,
+        )
+        new_rbd_pod.exec_cmd_on_pod(
+            "test -s /mnt/post_rotation_test", out_yaml_format=False
+        )
+        new_cephfs_pod.exec_cmd_on_pod(
+            "test -s /mnt/post_rotation_test", out_yaml_format=False
+        )
+        log.info("Post-rotation PVC provisioning and I/O verified successfully")
+
+        ceph_health_check(namespace=namespace)
+        log.info(
+            "Cluster health and I/O continuity verified during daemon CephX key rotation"
+        )

--- a/tests/functional/cephx_keyrotation/test_cephx_keyrotation_metrics_exporter.py
+++ b/tests/functional/cephx_keyrotation/test_cephx_keyrotation_metrics_exporter.py
@@ -1,0 +1,76 @@
+"""
+ocs-metrics-exporter CephX Key Rotation
+
+Verify ocs-metrics-exporter continues to authenticate with Ceph and export
+metrics after daemon CephX key rotation.
+"""
+
+import logging
+
+import pytest
+
+from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import (
+    green_squad,
+    skipif_external_mode,
+    skipif_ocs_version,
+    tier1,
+)
+from ocs_ci.ocs.resources.pod import get_pods_having_label
+from ocs_ci.ocs import constants
+from ocs_ci.utility.utils import ceph_health_check
+
+log = logging.getLogger(__name__)
+
+
+@skipif_external_mode
+@skipif_ocs_version(["<4.21", ">=4.23"])
+@green_squad
+class TestCephXMetricsExporterRotation:
+    @pytest.mark.polarion_id("OCS-8136")
+    @tier1
+    def test_cephx_metrics_exporter_key_rotation(self, cephx_keyrotation_setup):
+        """
+        Verify ocs-metrics-exporter survives daemon CephX key rotation.
+
+        Steps:
+            1. Verify ocs-metrics-exporter pod is Running.
+            2. Verify /metrics export from the exporter (Ceph connectivity).
+            3. Trigger daemon CephX key rotation.
+            4. Wait for exporter to pick up the rotated key (restart or reload).
+            5. Re-verify metrics export and absence of AUTH_BAD_KEY in logs.
+        """
+        rotator = cephx_keyrotation_setup
+        namespace = config.ENV_DATA["cluster_namespace"]
+
+        if not get_pods_having_label(
+            constants.OCS_METRICS_EXPORTER, namespace=namespace
+        ):
+            pytest.skip("ocs-metrics-exporter is not deployed on this cluster")
+
+        ceph_health_check(namespace=namespace)
+
+        metrics_pod = rotator.assert_metrics_exporter_running()
+        metrics_pod_name = metrics_pod["metadata"]["name"]
+        rotator.wait_for_metrics_exporter_metrics()
+        rotator.verify_metrics_exporter_no_auth_bad_key(metrics_pod)
+
+        target_generation = rotator.get_next_key_generation(rotator.COMPONENT_DAEMON)
+        log.info(
+            f"Triggering daemon CephX key rotation to generation {target_generation}"
+        )
+        rotator.rotate_daemon_keys(target_generation)
+        rotator.wait_for_rook_daemon_rotation(target_generation, timeout=1200)
+
+        rotator.wait_for_metrics_exporter_after_rotation(
+            previous_pod_name=metrics_pod_name,
+            timeout=900,
+        )
+
+        ceph_health_check(namespace=namespace)
+        rotator.wait_for_cluster_ready()
+        rotator.wait_for_pgs_active_clean()
+
+        log.info(
+            "ocs-metrics-exporter CephX key rotation verification completed successfully"
+        )

--- a/tests/functional/cephx_keyrotation/test_cephx_keyrotation_mismatch_alert.py
+++ b/tests/functional/cephx_keyrotation/test_cephx_keyrotation_mismatch_alert.py
@@ -1,0 +1,1424 @@
+"""
+CephX Key Rotation Mismatch Alert and Reconciliation Tests (PR #3910).
+
+Covers:
+  A. Alert & metric tests (TC1–TC7)
+  B. CephCluster reconciliation (TC8–TC13)
+  C. CephClient annotation tests (TC14–TC15)
+  D. Negative / edge cases (TC16–TC18; TC17 invalid keyGeneration types)
+"""
+
+import json
+import logging
+import time
+
+import pytest
+from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import (
+    green_squad,
+    ignore_leftovers,
+    skipif_external_mode,
+    skipif_ocs_version,
+    tier1,
+    tier2,
+)
+from ocs_ci.helpers.cephx_keyrotation import CephXKeyRotation
+from ocs_ci.helpers.helpers import modify_deployment_replica_count
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.exceptions import UnexpectedBehaviour
+from ocs_ci.ocs.ocp import OCP
+from ocs_ci.ocs.resources.pod import get_pod_logs, get_pods_having_label
+from ocs_ci.utility.prometheus import (
+    PrometheusAPI,
+    wait_for_alert_cleared,
+    wait_for_alert_firing,
+)
+from ocs_ci.utility.utils import TimeoutSampler, ceph_health_check, exec_cmd
+
+log = logging.getLogger(__name__)
+
+MISMATCH_METRIC = constants.OCS_CEPHX_DAEMON_KEY_ROTATION_MISMATCH_METRIC
+ALERT_NAME = constants.ALERT_CEPHX_KEY_GENERATION_FAILED
+OCS_PROMETHEUS_RULES_NAME = "ocs-prometheus-rules"
+# Historical default shipped in some builds; live clusters may differ (e.g. 5m).
+# The alert lifecycle fixture captures and restores the cluster's actual value.
+ORIGINAL_ALERT_FOR = "1h"
+TEMP_ALERT_FOR = "2m"
+DAEMON_TYPES = constants.ROOK_CEPHX_KEYROTATION_DAEMONS
+REQUIRED_METRIC_LABELS = ("daemon", "ceph_cluster", "namespace")
+MISMATCH_METRIC_TIMEOUT = 300
+# Temporary for=2m; allow prometheus reload + pending→firing transition.
+ALERT_FIRE_TIMEOUT = 300
+ALERT_PENDING_TIMEOUT = 180
+ALERT_CLEAR_TIMEOUT = 900
+ROTATION_COMPLETE_TIMEOUT = 1500
+ALERT_FOR_SETTLE_SECONDS = 15
+ALERT_FOR_ENSURE_TIMEOUT = 120
+OCS_OPERATOR_DEPLOYMENT = "ocs-operator"
+ROOK_OPERATOR_DEPLOYMENT = constants.ROOK_CEPH_OPERATOR
+EXPECTED_METRIC_EXPORTER_CEPHCLIENT = "ocs-metrics-exporter-ceph-auth"
+CSI_CEPHCLIENT_NAME_PREFIXES = (
+    "csi-rbd-provisioner",
+    "csi-rbd-node",
+    "csi-cephfs-provisioner",
+    "csi-cephfs-node",
+)
+
+
+def _get_ocs_prometheus_rules():
+    """Return the ocs-prometheus-rules PrometheusRule OCP resource."""
+    return OCP(
+        kind="PrometheusRule",
+        namespace=config.ENV_DATA["cluster_namespace"],
+        resource_name=OCS_PROMETHEUS_RULES_NAME,
+    )
+
+
+def _find_cephx_key_generation_failed_rule(rule_data):
+    """
+    Locate CephxKeyGenerationFailed in a PrometheusRule document.
+
+    Returns:
+        tuple[int, int, dict]: (group_index, rule_index, rule_dict)
+
+    Raises:
+        AssertionError: If the alert rule is not found.
+    """
+    groups = rule_data.get("spec", {}).get("groups", [])
+    for group_index, group in enumerate(groups):
+        for rule_index, rule in enumerate(group.get("rules", [])):
+            if rule.get("alert") == ALERT_NAME:
+                return group_index, rule_index, rule
+    raise AssertionError(
+        f"Alert '{ALERT_NAME}' not found in PrometheusRule "
+        f"'{OCS_PROMETHEUS_RULES_NAME}'"
+    )
+
+
+def _get_cephx_key_generation_failed_for():
+    """
+    Read the current ``for`` duration of CephxKeyGenerationFailed.
+
+    Returns:
+        tuple[str, int, int]: (for_value, group_index, rule_index)
+    """
+    rule_obj = _get_ocs_prometheus_rules()
+    rule_data = rule_obj.get()
+    group_index, rule_index, rule = _find_cephx_key_generation_failed_rule(rule_data)
+    for_value = rule.get("for")
+    log.info(
+        "PrometheusRule %s/%s alert=%s for=%s (group=%s rule=%s)",
+        config.ENV_DATA["cluster_namespace"],
+        OCS_PROMETHEUS_RULES_NAME,
+        ALERT_NAME,
+        for_value,
+        group_index,
+        rule_index,
+    )
+    return for_value, group_index, rule_index
+
+
+def _patch_cephx_key_generation_failed_for(for_value, group_index, rule_index):
+    """Patch the alert ``for`` field via JSON patch."""
+    rule_obj = _get_ocs_prometheus_rules()
+    patch = [
+        {
+            "op": "replace",
+            "path": f"/spec/groups/{group_index}/rules/{rule_index}/for",
+            "value": for_value,
+        }
+    ]
+    log.info(
+        "Patching PrometheusRule %s alert=%s for -> %s",
+        OCS_PROMETHEUS_RULES_NAME,
+        ALERT_NAME,
+        for_value,
+    )
+    patched = rule_obj.patch(params=json.dumps(patch), format_type="json")
+    assert patched, (
+        f"Failed to patch PrometheusRule '{OCS_PROMETHEUS_RULES_NAME}' "
+        f"alert '{ALERT_NAME}' for -> {for_value}"
+    )
+
+
+def _ensure_cephx_key_generation_failed_for(
+    desired_for,
+    timeout=ALERT_FOR_ENSURE_TIMEOUT,
+    settle_seconds=ALERT_FOR_SETTLE_SECONDS,
+):
+    """
+    Patch and verify the alert ``for`` value, re-applying if reconciled away.
+
+    The PrometheusRule is owned by the StorageCluster / rook-ceph operator, so
+    a manual patch may be reverted. Re-patch until the value remains stable for
+    ``settle_seconds``.
+
+    Args:
+        desired_for (str): Expected ``for`` duration (e.g. ``2m``, ``1h``).
+        timeout (int): Seconds to keep trying.
+        settle_seconds (int): Stable window required after a matching read.
+
+    Returns:
+        str: Confirmed effective ``for`` value.
+
+    Raises:
+        AssertionError: If the desired value cannot be kept applied in time.
+    """
+    deadline = time.time() + timeout
+    last_seen = None
+    while time.time() < deadline:
+        current_for, group_index, rule_index = _get_cephx_key_generation_failed_for()
+        last_seen = current_for
+        if current_for != desired_for:
+            _patch_cephx_key_generation_failed_for(desired_for, group_index, rule_index)
+            time.sleep(5)
+            continue
+
+        time.sleep(settle_seconds)
+        settled_for, _, _ = _get_cephx_key_generation_failed_for()
+        last_seen = settled_for
+        if settled_for == desired_for:
+            log.info(
+                "Confirmed PrometheusRule alert=%s for=%s is effective",
+                ALERT_NAME,
+                desired_for,
+            )
+            return settled_for
+        log.warning(
+            "PrometheusRule alert=%s for reverted from %s to %s; re-patching",
+            ALERT_NAME,
+            desired_for,
+            settled_for,
+        )
+
+    raise AssertionError(
+        f"Failed to keep PrometheusRule alert '{ALERT_NAME}' for={desired_for} "
+        f"within {timeout}s (last seen for={last_seen}). The StorageCluster "
+        "operator may be continuously reconciling the rule."
+    )
+
+
+def _query_mismatch_metrics(prometheus):
+    """Return Prometheus instant-query samples for the mismatch metric."""
+    result = prometheus.query(MISMATCH_METRIC)
+    log.info("Prometheus %s returned %d series", MISMATCH_METRIC, len(result))
+    return result
+
+
+def _metric_samples_by_daemon(result):
+    """Map daemon label -> sample dict from a Prometheus query result."""
+    by_daemon = {}
+    for sample in result:
+        daemon = sample.get("metric", {}).get("daemon")
+        if daemon:
+            by_daemon[daemon] = sample
+    return by_daemon
+
+
+def _metric_value(sample):
+    """Return integer value from a Prometheus instant-query sample."""
+    return int(float(sample["value"][1]))
+
+
+def _wait_for_mismatch_metric_values(
+    prometheus, expected_by_daemon, timeout=MISMATCH_METRIC_TIMEOUT, sleep=10
+):
+    """
+    Wait until mismatch metric values match *expected_by_daemon*.
+
+    Args:
+        prometheus (PrometheusAPI): Prometheus client.
+        expected_by_daemon (dict): daemon name -> expected int value.
+        timeout (int): Seconds to wait.
+        sleep (int): Poll interval.
+    """
+    log.info(
+        "Waiting for %s values %s (timeout=%ss)",
+        MISMATCH_METRIC,
+        expected_by_daemon,
+        timeout,
+    )
+    for result in TimeoutSampler(timeout, sleep, _query_mismatch_metrics, prometheus):
+        by_daemon = _metric_samples_by_daemon(result)
+        mismatches = {}
+        for daemon, expected in expected_by_daemon.items():
+            sample = by_daemon.get(daemon)
+            if sample is None:
+                mismatches[daemon] = "missing"
+                continue
+            actual = _metric_value(sample)
+            if actual != expected:
+                mismatches[daemon] = actual
+        if not mismatches:
+            log.info("Mismatch metric values match expected: %s", expected_by_daemon)
+            return by_daemon
+        log.info("Mismatch metric not yet ready: %s", mismatches)
+
+    raise UnexpectedBehaviour(
+        f"{MISMATCH_METRIC} did not reach {expected_by_daemon} within {timeout}s"
+    )
+
+
+def _scale_rook_operator(replicas, namespace):
+    """Scale rook-ceph-operator deployment and wait for replica status."""
+    log.info("Scaling %s to %s replicas", ROOK_OPERATOR_DEPLOYMENT, replicas)
+    assert modify_deployment_replica_count(
+        ROOK_OPERATOR_DEPLOYMENT, replicas, namespace=namespace
+    ), f"Failed to scale {ROOK_OPERATOR_DEPLOYMENT} to {replicas}"
+    deploy = OCP(
+        kind=constants.DEPLOYMENT,
+        namespace=namespace,
+        resource_name=ROOK_OPERATOR_DEPLOYMENT,
+    )
+    if replicas == 0:
+        for ready in TimeoutSampler(180, 5, lambda: deploy.get()):
+            status = ready.get("status", {}) or {}
+            if int(status.get("readyReplicas", 0) or 0) == 0:
+                log.info("rook-ceph-operator scaled to 0")
+                return
+        raise UnexpectedBehaviour("rook-ceph-operator did not scale to 0")
+    for pods in TimeoutSampler(
+        300,
+        5,
+        get_pods_having_label,
+        constants.OPERATOR_LABEL,
+        namespace=namespace,
+    ):
+        running = [
+            pod
+            for pod in pods
+            if pod.get("status", {}).get("phase") == constants.STATUS_RUNNING
+        ]
+        if len(running) >= replicas:
+            log.info("rook-ceph-operator is Running (%d pod(s))", len(running))
+            return
+    raise UnexpectedBehaviour("rook-ceph-operator did not become Running")
+
+
+def _scale_ocs_operator(replicas, namespace):
+    """
+    Scale ocs-operator and wait for replica status.
+
+    ocs-operator reconciles ``ocs-prometheus-rules`` from the StorageCluster, so
+    it must be scaled to 0 before a temporary alert ``for`` patch can stick.
+    """
+    log.info("Scaling %s to %s replicas", OCS_OPERATOR_DEPLOYMENT, replicas)
+    assert modify_deployment_replica_count(
+        OCS_OPERATOR_DEPLOYMENT, replicas, namespace=namespace
+    ), f"Failed to scale {OCS_OPERATOR_DEPLOYMENT} to {replicas}"
+    deploy = OCP(
+        kind=constants.DEPLOYMENT,
+        namespace=namespace,
+        resource_name=OCS_OPERATOR_DEPLOYMENT,
+    )
+    if replicas == 0:
+        for ready in TimeoutSampler(180, 5, lambda: deploy.get()):
+            status = ready.get("status", {}) or {}
+            if int(status.get("readyReplicas", 0) or 0) == 0:
+                log.info("ocs-operator scaled to 0")
+                return
+        raise UnexpectedBehaviour("ocs-operator did not scale to 0")
+    _wait_for_ocs_operator_running(namespace)
+    log.info("ocs-operator is Running")
+
+
+def _get_ocs_operator_env(namespace):
+    """Return env list from the ocs-operator deployment container."""
+    deploy = OCP(
+        kind=constants.DEPLOYMENT,
+        namespace=namespace,
+        resource_name=OCS_OPERATOR_DEPLOYMENT,
+    ).get()
+    containers = deploy["spec"]["template"]["spec"]["containers"]
+    return containers[0].get("env") or []
+
+
+def _wait_for_ocs_operator_running(namespace):
+    """Wait for ocs-operator deployment rollout, then a Running pod."""
+    deploy = OCP(
+        kind=constants.DEPLOYMENT,
+        namespace=namespace,
+        resource_name=OCS_OPERATOR_DEPLOYMENT,
+    )
+    deploy.exec_oc_cmd(
+        f"rollout status deployment/{OCS_OPERATOR_DEPLOYMENT} --timeout=300s",
+        out_yaml_format=False,
+    )
+    for pods in TimeoutSampler(
+        300,
+        5,
+        get_pods_having_label,
+        constants.OCS_OPERATOR_LABEL,
+        namespace=namespace,
+    ):
+        running = [
+            pod
+            for pod in pods
+            if pod.get("status", {}).get("phase") == constants.STATUS_RUNNING
+        ]
+        if running:
+            return
+    raise UnexpectedBehaviour("ocs-operator did not become Running")
+
+
+def _set_ocs_operator_env_var(namespace, name, value):
+    """
+    Set or add an env var on ocs-operator deployment and wait for rollout.
+
+    ``value`` may be a string, bool, or ``None`` (sets an empty env value to
+    exercise null-like parsing).
+
+    Returns:
+        tuple: (previous_value_or_None, existed_bool)
+    """
+    env_list = _get_ocs_operator_env(namespace)
+    previous = None
+    existed = False
+    for item in env_list:
+        if item.get("name") == name:
+            previous = item.get("value")
+            existed = True
+            break
+
+    if value is None:
+        # Keep the env key present with an empty value (null-like input).
+        env_assignment = f"{name}="
+        value_repr = "null/empty"
+    elif isinstance(value, bool):
+        env_assignment = f"{name}={str(value).lower()}"
+        value_repr = str(value).lower()
+    else:
+        env_assignment = f"{name}={value}"
+        value_repr = str(value)
+
+    exec_cmd(
+        f"oc set env deployment/{OCS_OPERATOR_DEPLOYMENT} "
+        f"{env_assignment} -n {namespace}"
+    )
+    log.info(
+        "Set %s=%s on %s (previous=%s)",
+        name,
+        value_repr,
+        OCS_OPERATOR_DEPLOYMENT,
+        previous,
+    )
+    time.sleep(5)
+    _wait_for_ocs_operator_running(namespace)
+    return previous, existed
+
+
+def _remove_ocs_operator_env_var(namespace, name):
+    """Remove an env var from ocs-operator deployment."""
+    exec_cmd(f"oc set env deployment/{OCS_OPERATOR_DEPLOYMENT} {name}- -n {namespace}")
+    log.info("Removed %s from %s env", name, OCS_OPERATOR_DEPLOYMENT)
+    time.sleep(5)
+    _wait_for_ocs_operator_running(namespace)
+
+
+def _restore_ocs_operator_env_var(namespace, name, previous_value, existed):
+    """Restore ocs-operator env var to previous state."""
+    if existed and previous_value is not None:
+        _set_ocs_operator_env_var(namespace, name, previous_value)
+    elif existed:
+        _set_ocs_operator_env_var(
+            namespace, name, str(constants.DEFAULT_DESIRED_CEPHX_KEY_GEN)
+        )
+    else:
+        _remove_ocs_operator_env_var(namespace, name)
+
+
+def _list_cephclients(namespace):
+    """Return list of CephClient resource dicts."""
+    return OCP(kind=constants.CEPHCLIENT, namespace=namespace).get().get("items") or []
+
+
+def _cephfilesystem_exists(namespace):
+    """Return True if any CephFilesystem exists in *namespace*."""
+    items = (
+        OCP(kind=constants.CEPHFILESYSTEM, namespace=namespace).get().get("items") or []
+    )
+    return bool(items)
+
+
+def _induce_daemon_key_mismatch(rotator, namespace):
+    """
+    Create a persistent daemon keyGeneration mismatch.
+
+    Scales rook-ceph-operator to 0 so status cannot catch up, then bumps
+    StorageCluster daemon keyGeneration (without waiting for rotation
+    completion — rook is intentionally down). Returns the target generation.
+    """
+    _scale_rook_operator(0, namespace)
+    target_generation = rotator.get_next_rook_daemon_key_generation()
+    log.info("Inducing CephX daemon key mismatch at generation %s", target_generation)
+
+    # Patch StorageCluster only — do not call rotate_daemon_keys(), which waits
+    # for CephCluster Progressing→Ready (impossible while rook is scaled to 0).
+    component_config = dict(
+        rotator.get_storagecluster_component_spec(rotator.COMPONENT_DAEMON)
+    )
+    component_config["keyRotationPolicy"] = (
+        CephXKeyRotation.KEY_ROTATION_POLICY_KEY_GENERATION
+    )
+    component_config["keyGeneration"] = int(target_generation)
+    rotator.patch_storagecluster_cephx_component(
+        rotator.COMPONENT_DAEMON, component_config
+    )
+
+    def _cephcluster_spec_reached():
+        daemon_spec = rotator.get_spec_cephx().get("daemon") or {}
+        return int(daemon_spec.get("keyGeneration", 0) or 0) >= target_generation
+
+    for ready in TimeoutSampler(300, 10, _cephcluster_spec_reached):
+        if ready:
+            log.info(
+                "CephCluster spec.security.cephx.daemon.keyGeneration >= %s "
+                "(rook scaled to 0; status intentionally lagging)",
+                target_generation,
+            )
+            return target_generation
+    raise UnexpectedBehaviour(
+        f"CephCluster daemon keyGeneration did not reach {target_generation}"
+    )
+
+
+@skipif_external_mode
+@skipif_ocs_version(["<4.21", ">=4.23"])
+@green_squad
+class TestCephXKeyRotationMismatchMetric:
+    """TC1–TC2: mismatch metric emission and in-sync (value 0) state."""
+
+    @pytest.mark.polarion_id("OCS-8137")
+    @tier1
+    def test_cephx_mismatch_metric_emitted_for_all_daemons(self, threading_lock):
+        """
+        TC1: Metric ocs_cephx_daemon_key_rotation_mismatch is emitted for all
+        daemon types with labels daemon, ceph_cluster, and namespace.
+        """
+        prometheus = PrometheusAPI(threading_lock=threading_lock)
+        result = _query_mismatch_metrics(prometheus)
+        assert result, f"No series returned for {MISMATCH_METRIC}"
+
+        by_daemon = _metric_samples_by_daemon(result)
+        missing = [daemon for daemon in DAEMON_TYPES if daemon not in by_daemon]
+        assert not missing, (
+            f"Missing mismatch metric series for daemon(s): {missing}; "
+            f"found={sorted(by_daemon)}"
+        )
+
+        for daemon in DAEMON_TYPES:
+            labels = by_daemon[daemon]["metric"]
+            for label in REQUIRED_METRIC_LABELS:
+                assert labels.get(
+                    label
+                ), f"Metric for daemon={daemon} missing label '{label}': {labels}"
+            assert labels["daemon"] == daemon
+            log.info(
+                "TC1 series ok: daemon=%s ceph_cluster=%s namespace=%s value=%s",
+                daemon,
+                labels.get("ceph_cluster"),
+                labels.get("namespace"),
+                _metric_value(by_daemon[daemon]),
+            )
+
+    @pytest.mark.polarion_id("OCS-8138")
+    @tier1
+    def test_cephx_mismatch_metric_zero_when_in_sync(
+        self, cephx_keyrotation_setup, threading_lock
+    ):
+        """
+        TC2: Metric value is 0 when key rotation is in sync.
+        """
+        rotator = cephx_keyrotation_setup
+        namespace = config.ENV_DATA["cluster_namespace"]
+        ceph_health_check(namespace=namespace)
+        rotator.wait_for_cluster_ready()
+
+        # Setup only enables policy at DESIRED_CEPHX_KEY_GEN; that does not
+        # advance status.keyGeneration. Wait for status catch-up only when an
+        # actual rotation above the desired baseline has been requested.
+        spec_gen = rotator.get_spec_key_generation(rotator.COMPONENT_DAEMON)
+        desired = rotator.get_desired_cephx_key_gen()
+        if spec_gen > desired:
+            rotator.wait_for_rook_daemon_rotation(spec_gen, timeout=900)
+
+        prometheus = PrometheusAPI(threading_lock=threading_lock)
+        expected = {daemon: 0 for daemon in DAEMON_TYPES}
+        _wait_for_mismatch_metric_values(prometheus, expected, timeout=180)
+        log.info("TC2: all daemon mismatch metrics are 0 (in sync)")
+
+
+@skipif_external_mode
+@skipif_ocs_version(["<4.21", ">=4.23"])
+@green_squad
+@ignore_leftovers
+class TestCephXKeyRotationMismatchAlertLifecycle:
+    """TC3–TC6, TC18: induce mismatch, fire alert, recover, check MDS + health mutes."""
+
+    @pytest.fixture(autouse=True)
+    def _temporary_cephx_alert_for_duration(self):
+        """
+        Capture/restore helpers for a temporary CephxKeyGenerationFailed ``for``.
+
+        Yields a callable that the test must invoke **after** mismatch induction:
+
+        1. Scale ocs-operator to 0 (prevents StorageCluster reconcile from
+           reverting the PrometheusRule patch).
+        2. Patch alert ``for`` to ``2m`` and verify it sticks.
+
+        ocs-operator must remain up during induction so StorageCluster
+        ``daemon.keyGeneration`` can propagate to CephCluster.
+
+        Teardown always restores the pre-test ``for`` value and ocs-operator
+        replicas. Restoration failures are raised (not swallowed).
+        """
+        namespace = config.ENV_DATA["cluster_namespace"]
+        original_for, _, _ = _get_cephx_key_generation_failed_for()
+        assert (
+            original_for
+        ), f"PrometheusRule alert={ALERT_NAME} is missing a 'for' duration"
+        assert original_for != TEMP_ALERT_FOR, (
+            f"Cannot temporarily set alert for={TEMP_ALERT_FOR!r}: cluster "
+            f"already uses that duration"
+        )
+        if original_for != ORIGINAL_ALERT_FOR:
+            log.info(
+                "CephxKeyGenerationFailed for=%s differs from historical "
+                "default %s; will restore the live value",
+                original_for,
+                ORIGINAL_ALERT_FOR,
+            )
+        state = {"applied": False}
+
+        def apply_temporary_alert_for():
+            """Scale ocs-operator down and set alert for=2m."""
+            if not state["applied"]:
+                _scale_ocs_operator(0, namespace)
+                state["applied"] = True
+            effective_for = _ensure_cephx_key_generation_failed_for(TEMP_ALERT_FOR)
+            assert effective_for == TEMP_ALERT_FOR, (
+                f"Expected alert for={TEMP_ALERT_FOR!r} after apply, got "
+                f"{effective_for!r}"
+            )
+            log.info(
+                "Applied temporary PrometheusRule alert=%s for=%s "
+                "(original=%s; ocs-operator scaled to 0)",
+                ALERT_NAME,
+                TEMP_ALERT_FOR,
+                original_for,
+            )
+            return effective_for
+
+        yield apply_temporary_alert_for
+
+        restore_errors = []
+        try:
+            current_for, _, _ = _get_cephx_key_generation_failed_for()
+            if current_for != original_for or state["applied"]:
+                # Keep ocs-operator down while restoring so reconcile cannot
+                # race with the explicit for= restore patch.
+                if not state["applied"]:
+                    _scale_ocs_operator(0, namespace)
+                    state["applied"] = True
+                log.info(
+                    "Finalizer: restoring PrometheusRule alert=%s for -> %s",
+                    ALERT_NAME,
+                    original_for,
+                )
+                restored_for = _ensure_cephx_key_generation_failed_for(original_for)
+                assert restored_for == original_for, (
+                    f"Cleanup failed: expected for={original_for!r} after "
+                    f"restore, got {restored_for!r}"
+                )
+                assert restored_for != TEMP_ALERT_FOR, (
+                    f"Cleanup failed: temporary for={TEMP_ALERT_FOR!r} is still "
+                    "present on the PrometheusRule"
+                )
+                log.info(
+                    "Finalizer: confirmed PrometheusRule alert=%s for restored to %s",
+                    ALERT_NAME,
+                    restored_for,
+                )
+        except Exception as exc:
+            restore_errors.append(f"alert for restore failed: {exc}")
+            log.error("Finalizer: %s", restore_errors[-1])
+
+        try:
+            _scale_ocs_operator(1, namespace)
+        except Exception as exc:
+            restore_errors.append(f"ocs-operator scale-up failed: {exc}")
+            log.error("Finalizer: %s", restore_errors[-1])
+
+        if restore_errors:
+            raise AssertionError(
+                "Cleanup failed for temporary CephxKeyGenerationFailed "
+                f"alert configuration: {'; '.join(restore_errors)}"
+            )
+
+    @pytest.fixture(autouse=True)
+    def _restore_rook_operator(self, request):
+        """Always restore rook-ceph-operator replicas after disruptive tests."""
+        namespace = config.ENV_DATA["cluster_namespace"]
+
+        def finalizer():
+            try:
+                _scale_rook_operator(1, namespace)
+            except Exception as exc:
+                log.warning("Teardown scale-up of rook-ceph-operator failed: %s", exc)
+            try:
+                CephXKeyRotation().ensure_daemon_key_generations_aligned()
+            except Exception as exc:
+                log.warning("Teardown: failed to align daemon keyGeneration: %s", exc)
+
+        request.addfinalizer(finalizer)
+
+    @pytest.mark.polarion_id("OCS-8139")
+    @tier1
+    def test_cephx_mismatch_metric_alert_and_recovery(
+        self,
+        cephx_keyrotation_setup,
+        threading_lock,
+        _temporary_cephx_alert_for_duration,
+    ):
+        """
+        TC3: Metric becomes 1 when keyGeneration is mismatched.
+        TC4: CephxKeyGenerationFailed transitions pending→firing (temporary for=2m).
+        TC5: Metric returns to 0 and alert resolves after successful rotation.
+        TC6: MDS mismatch is detected via CephFilesystem status.
+        TC18: Rook mutes/unmutes AUTH_INSECURE_* health warnings during rotation.
+        """
+        rotator = cephx_keyrotation_setup
+        namespace = config.ENV_DATA["cluster_namespace"]
+        prometheus = PrometheusAPI(threading_lock=threading_lock)
+        apply_temporary_alert_for = _temporary_cephx_alert_for_duration
+
+        ceph_health_check(namespace=namespace)
+        rotator.wait_for_cluster_ready()
+
+        if not _cephfilesystem_exists(namespace):
+            pytest.skip("CephFilesystem required for MDS mismatch verification (TC6)")
+
+        # --- TC3: induce mismatch while rook cannot complete rotation ---
+        # Keep ocs-operator running here so StorageCluster daemon keyGeneration
+        # propagates to CephCluster; only then freeze reconcile and shorten for.
+        target_generation = _induce_daemon_key_mismatch(rotator, namespace)
+        apply_temporary_alert_for()
+
+        expected_mismatch = {daemon: 1 for daemon in DAEMON_TYPES}
+        by_daemon = _wait_for_mismatch_metric_values(
+            prometheus, expected_mismatch, timeout=MISMATCH_METRIC_TIMEOUT
+        )
+        for daemon in DAEMON_TYPES:
+            assert (
+                _metric_value(by_daemon[daemon]) == 1
+            ), f"TC3: expected mismatch=1 for {daemon}"
+        log.info("TC3: mismatch metric is 1 for daemons %s", list(DAEMON_TYPES))
+
+        # --- TC6: MDS series specifically ---
+        mds_sample = by_daemon.get("mds")
+        assert mds_sample is not None, "TC6: missing mds mismatch metric series"
+        assert _metric_value(mds_sample) == 1, "TC6: expected mds mismatch metric = 1"
+        fs_gen = rotator.get_filesystem_daemon_key_generation()
+        log.info(
+            "TC6: mds mismatch=1 (CephFilesystem status keyGeneration=%s, "
+            "desired=%s)",
+            fs_gen,
+            target_generation,
+        )
+
+        # --- TC4: alert pending → firing (temporary for=2m) ---
+        pending_alerts = prometheus.wait_for_alert(
+            name=ALERT_NAME,
+            state="pending",
+            timeout=ALERT_PENDING_TIMEOUT,
+            sleep=5,
+            min_count=1,
+        )
+        if pending_alerts:
+            pending = pending_alerts[0]
+            log.info(
+                "TC4: alert entered pending at %s labels=%s",
+                pending.get("activeAt") or pending.get("startsAt"),
+                pending.get("labels"),
+            )
+        else:
+            log.warning(
+                "TC4: did not observe pending state for %s within %ss; "
+                "continuing to wait for firing",
+                ALERT_NAME,
+                ALERT_PENDING_TIMEOUT,
+            )
+
+        alerts = wait_for_alert_firing(
+            prometheus,
+            alert_name=ALERT_NAME,
+            timeout=ALERT_FIRE_TIMEOUT,
+            expected_severity="warning",
+            expected_message_substr="CephX key rotation failed",
+            min_count=1,
+        )
+        for alert in alerts:
+            labels = alert.get("labels") or {}
+            annotations = alert.get("annotations") or {}
+            assert (
+                labels.get("alertname") == ALERT_NAME
+            ), f"TC4: unexpected alertname {labels.get('alertname')}"
+            assert (
+                labels.get("severity") == "warning"
+            ), f"TC4: expected severity=warning label, got {labels}"
+            assert (
+                annotations.get("severity_level") == "warning"
+            ), f"TC4: expected severity_level=warning, got {annotations}"
+            description = annotations.get("description", "")
+            message = annotations.get("message", "")
+            combined = f"{description} {message}"
+            daemon = labels.get("daemon")
+            assert daemon in DAEMON_TYPES, f"TC4: unexpected daemon label {daemon}"
+            assert (
+                labels.get("namespace") == namespace
+            ), f"TC4: unexpected namespace label {labels.get('namespace')}"
+            assert labels.get(
+                "ceph_cluster"
+            ), f"TC4: missing ceph_cluster label: labels={labels}"
+            assert (
+                daemon in combined or f"{daemon}" in message or daemon in description
+            ), f"TC4: daemon name missing from alert annotations: {annotations}"
+            log.info(
+                "TC4: alert firing activeAt=%s startsAt=%s daemon=%s "
+                "severity=%s namespace=%s ceph_cluster=%s",
+                alert.get("activeAt"),
+                alert.get("startsAt"),
+                daemon,
+                labels.get("severity"),
+                labels.get("namespace"),
+                labels.get("ceph_cluster"),
+            )
+
+        # --- TC5: restore rook, complete rotation, metric=0, alert clears ---
+        log.info(
+            "TC18: will verify AUTH_INSECURE mute/unmute patterns after "
+            "rook-ceph-operator resumes rotation"
+        )
+        _scale_rook_operator(1, namespace)
+        rotator.wait_for_rook_daemon_rotation(
+            target_generation, timeout=ROTATION_COMPLETE_TIMEOUT
+        )
+
+        for entity in constants.CEPHCLUSTER_CEPHX_KEYROTATION_STATUS_ENTITIES:
+            status_gen = rotator.get_status_key_generation(entity)
+            assert status_gen >= target_generation, (
+                f"TC5: status.cephx.{entity}.keyGeneration={status_gen} "
+                f"< desired {target_generation}"
+            )
+        assert (
+            rotator.get_filesystem_daemon_key_generation() >= target_generation
+        ), "TC5: CephFilesystem daemon keyGeneration did not reach desired value"
+
+        expected_sync = {daemon: 0 for daemon in DAEMON_TYPES}
+        _wait_for_mismatch_metric_values(
+            prometheus, expected_sync, timeout=MISMATCH_METRIC_TIMEOUT
+        )
+        wait_for_alert_cleared(prometheus, ALERT_NAME, timeout=ALERT_CLEAR_TIMEOUT)
+        log.info("TC5: mismatch metrics are 0 and %s resolved", ALERT_NAME)
+
+        # --- TC18: inspect rook logs for mute/unmute behavior ---
+        operator_logs = ""
+        try:
+            pods = get_pods_having_label(constants.OPERATOR_LABEL, namespace=namespace)
+            if pods:
+                operator_logs = get_pod_logs(pods[0]["metadata"]["name"]) or ""
+        except Exception as exc:
+            log.warning("TC18: could not fetch rook-ceph-operator logs: %s", exc)
+
+        muted_markers = (
+            "AUTH_INSECURE_KEYS_ALLOWED",
+            "AUTH_INSECURE_KEYS_CREATABLE",
+        )
+        unmuted_markers = (
+            "AUTH_INSECURE_SERVICE_KEY_TYPE",
+            "AUTH_INSECURE_SERVICE_TICKETS",
+        )
+        if operator_logs:
+            found_muted = [m for m in muted_markers if m in operator_logs]
+            found_unmuted = [m for m in unmuted_markers if m in operator_logs]
+            log.info(
+                "TC18: mute-related markers in logs: muted=%s unmuted=%s",
+                found_muted,
+                found_unmuted,
+            )
+            # Soft check: do not hard-fail greenfield clusters that never emit
+            # these warnings during the rotation lifecycle.
+            if not (found_muted or found_unmuted):
+                log.warning(
+                    "TC18: no AUTH_INSECURE mute/unmute markers found in "
+                    "rook-ceph-operator logs (may be expected on greenfield)"
+                )
+        else:
+            log.warning("TC18: empty operator logs; mute/unmute check skipped")
+
+        ceph_health_check(namespace=namespace)
+        log.info(
+            "TC3/TC4/TC5/TC6/TC18 completed for target generation %s",
+            target_generation,
+        )
+
+
+@skipif_external_mode
+@skipif_ocs_version(["<4.21", ">=4.23"])
+@green_squad
+class TestCephXKeyRotationMismatchNoFilesystem:
+    """TC7: MDS mismatch metric is 0 when no CephFilesystem exists."""
+
+    @pytest.mark.polarion_id("OCS-8140")
+    @tier2
+    def test_cephx_mds_mismatch_zero_without_filesystem(self, threading_lock):
+        """
+        TC7: ocs_cephx_daemon_key_rotation_mismatch{daemon="mds"} is 0 when no
+        CephFilesystem exists.
+        """
+        namespace = config.ENV_DATA["cluster_namespace"]
+        if _cephfilesystem_exists(namespace):
+            pytest.skip(
+                "Cluster has a CephFilesystem; TC7 requires a cluster without one"
+            )
+
+        prometheus = PrometheusAPI(threading_lock=threading_lock)
+        result = _query_mismatch_metrics(prometheus)
+        by_daemon = _metric_samples_by_daemon(result)
+        mds = by_daemon.get("mds")
+        assert mds is not None, "Expected mds mismatch metric series even without FS"
+        assert _metric_value(mds) == 0, (
+            f"TC7: expected mds mismatch=0 without CephFilesystem, got "
+            f"{_metric_value(mds)}"
+        )
+
+
+@skipif_external_mode
+@skipif_ocs_version(["<4.21", ">=4.23"])
+@green_squad
+class TestCephXCephClusterReconciliation:
+    """TC8–TC13: CephCluster annotations and daemon keyGeneration reconciliation."""
+
+    @pytest.mark.polarion_id("OCS-8141")
+    @tier1
+    def test_cephx_greenfield_annotations_present(self, cephx_bootstrap_setup):
+        """
+        TC8: Greenfield CephCluster has created-with-cephx-features and
+        created-at-df-version annotations.
+        """
+        rotator = cephx_bootstrap_setup
+        cluster = rotator._get_cluster_dict()
+        annotations = cluster.get("metadata", {}).get("annotations") or {}
+        created_with = annotations.get(constants.CEPHX_CREATED_WITH_FEATURES_ANNOTATION)
+        created_at = annotations.get(constants.CEPHX_CREATED_AT_DF_VERSION_ANNOTATION)
+
+        if created_with is None:
+            pytest.skip(
+                "Cluster is brownfield (missing created-with-cephx-features); "
+                "TC8 applies to greenfield installs only"
+            )
+
+        assert (
+            created_with == ""
+        ), f"TC8: expected empty-string annotation value, got {created_with!r}"
+        assert created_at, "TC8: created-at-df-version annotation is missing"
+        log.info(
+            "TC8: greenfield annotations present created-at-df-version=%s", created_at
+        )
+
+    @pytest.mark.polarion_id("OCS-8142")
+    @tier1
+    def test_cephx_greenfield_security_spec(self, cephx_bootstrap_setup):
+        """
+        TC9: Greenfield CephCluster has correct cephx security defaults.
+        """
+        rotator = cephx_bootstrap_setup
+        cluster = rotator._get_cluster_dict()
+        annotations = cluster.get("metadata", {}).get("annotations") or {}
+        if constants.CEPHX_CREATED_WITH_FEATURES_ANNOTATION not in annotations:
+            pytest.skip(
+                "TC9 requires greenfield created-with-cephx-features annotation"
+            )
+
+        cephx = rotator.get_spec_cephx()
+        assert list(cephx.get("allowedCiphers") or []) == list(
+            constants.CEPHX_DEFAULT_ALLOWED_CIPHERS
+        ), f"TC9: unexpected allowedCiphers: {cephx.get('allowedCiphers')}"
+
+        sc_daemon = rotator.get_storagecluster_component_spec(rotator.COMPONENT_DAEMON)
+        daemon_spec = cephx.get("daemon") or {}
+        if sc_daemon.get("keyGeneration") or sc_daemon.get("keyRotationPolicy"):
+            log.info(
+                "TC9: StorageCluster sets daemon CephX config %s; CephCluster "
+                "daemon section is managed (%s) — skipping empty-daemon assertion",
+                sc_daemon,
+                daemon_spec,
+            )
+        else:
+            assert not daemon_spec.get(
+                "keyGeneration"
+            ), f"TC9: greenfield daemon.keyGeneration should be unset, got {daemon_spec}"
+            assert not daemon_spec.get("keyRotationPolicy"), (
+                f"TC9: greenfield daemon.keyRotationPolicy should be unset, got "
+                f"{daemon_spec}"
+            )
+
+        # keyType for CSI / RBD mirror peer lives on CephClients for this PR;
+        # on CephCluster the sections may be empty objects.
+        csi_spec = cephx.get("csi") or {}
+        rbd_spec = cephx.get("rbdMirrorPeer") or {}
+        if csi_spec.get("keyType"):
+            assert csi_spec["keyType"] == "aes"
+        if rbd_spec.get("keyType"):
+            assert rbd_spec["keyType"] == "aes"
+        log.info("TC9: greenfield cephx security defaults verified")
+
+    @pytest.mark.polarion_id("OCS-8143")
+    @tier2
+    def test_cephx_brownfield_no_created_with_annotation(self, cephx_bootstrap_setup):
+        """
+        TC10: Brownfield/upgraded cluster does NOT get created-with-cephx-features.
+        """
+        rotator = cephx_bootstrap_setup
+        annotations = (
+            rotator._get_cluster_dict().get("metadata", {}).get("annotations") or {}
+        )
+        if constants.CEPHX_CREATED_WITH_FEATURES_ANNOTATION in annotations:
+            pytest.skip(
+                "Cluster has greenfield created-with-cephx-features annotation; "
+                "TC10 requires a brownfield/upgraded cluster"
+            )
+        log.info("TC10: brownfield cluster correctly lacks created-with-cephx-features")
+
+    @pytest.mark.polarion_id("OCS-8144")
+    @tier2
+    def test_cephx_brownfield_daemon_key_rotation_config(self, cephx_bootstrap_setup):
+        """
+        TC11: Brownfield cluster gets daemon KeyGeneration config from env default.
+        """
+        rotator = cephx_bootstrap_setup
+        annotations = (
+            rotator._get_cluster_dict().get("metadata", {}).get("annotations") or {}
+        )
+        if constants.CEPHX_CREATED_WITH_FEATURES_ANNOTATION in annotations:
+            pytest.skip(
+                "Cluster is greenfield; TC11 requires brownfield without "
+                "created-with-cephx-features"
+            )
+
+        cephx = rotator.get_spec_cephx()
+        assert list(cephx.get("allowedCiphers") or []) == list(
+            constants.CEPHX_DEFAULT_ALLOWED_CIPHERS
+        )
+        daemon = cephx.get("daemon") or {}
+        assert daemon.get("keyRotationPolicy") == (
+            CephXKeyRotation.KEY_ROTATION_POLICY_KEY_GENERATION
+        ), f"TC11: unexpected daemon.keyRotationPolicy: {daemon}"
+        assert int(daemon.get("keyGeneration", 0) or 0) >= (
+            constants.DEFAULT_DESIRED_CEPHX_KEY_GEN
+        ), f"TC11: daemon.keyGeneration should be >= env default, got {daemon}"
+        log.info("TC11: brownfield daemon key rotation config verified: %s", daemon)
+
+    @pytest.mark.polarion_id("OCS-8146")
+    @tier2
+    def test_storagecluster_keygeneration_zero_falls_back_to_env(
+        self, cephx_bootstrap_setup
+    ):
+        """
+        TC13: Unset/0 StorageCluster keyGeneration falls back to DESIRED_CEPHX_KEY_GEN.
+
+        Runs before TC12 so a persisted StorageCluster keyGeneration override does
+        not force a skip. ``keyGeneration`` cannot be removed once set, so this
+        check only runs when the field is unset or already ``0``.
+        """
+        rotator = cephx_bootstrap_setup
+        namespace = config.ENV_DATA["cluster_namespace"]
+        env_list = _get_ocs_operator_env(namespace)
+        env_map = {item.get("name"): item.get("value") for item in env_list}
+        desired_env = env_map.get(constants.DESIRED_CEPHX_KEY_GEN_ENV)
+        assert (
+            desired_env is not None
+        ), f"TC13: {constants.DESIRED_CEPHX_KEY_GEN_ENV} must be set on ocs-operator"
+        assert int(desired_env) == constants.DEFAULT_DESIRED_CEPHX_KEY_GEN
+
+        sc_daemon = rotator.get_storagecluster_component_spec(rotator.COMPONENT_DAEMON)
+        if "keyGeneration" in sc_daemon:
+            sc_gen = int(sc_daemon.get("keyGeneration") or 0)
+            if sc_gen != 0:
+                pytest.skip(
+                    f"TC13: StorageCluster daemon.keyGeneration={sc_gen} is set; "
+                    f"{constants.CEPHX_KEY_GENERATION_REMOVE_ERROR}, so "
+                    "fallback-to-env cannot be exercised on this cluster"
+                )
+            log.info(
+                "TC13: StorageCluster daemon.keyGeneration already 0; "
+                "verifying fallback to DESIRED_CEPHX_KEY_GEN"
+            )
+
+        desired = int(desired_env)
+
+        def _fallback_applied():
+            daemon = rotator.get_spec_cephx().get("daemon") or {}
+            return int(daemon.get("keyGeneration", 0) or 0) == desired
+
+        # Wait for CephCluster to reflect env fallback before reading CC state.
+        for ready in TimeoutSampler(300, 10, _fallback_applied):
+            if ready:
+                break
+        else:
+            daemon = rotator.get_spec_cephx().get("daemon") or {}
+            cc_gen = int(daemon.get("keyGeneration", 0) or 0)
+            annotations = (
+                rotator._get_cluster_dict().get("metadata", {}).get("annotations") or {}
+            )
+            if constants.CEPHX_CREATED_WITH_FEATURES_ANNOTATION in annotations:
+                pytest.skip(
+                    "Greenfield clusters do not apply DESIRED_CEPHX_KEY_GEN to "
+                    "daemon by default (TC13 is brownfield-oriented)"
+                )
+            pytest.skip(
+                f"CephCluster daemon.keyGeneration={cc_gen} already advanced past "
+                f"env default {desired_env}; TC13 fallback check requires a "
+                "brownfield cluster that has not been rotated above the env default"
+            )
+
+        daemon = rotator.get_spec_cephx().get("daemon") or {}
+        annotations = (
+            rotator._get_cluster_dict().get("metadata", {}).get("annotations") or {}
+        )
+        if constants.CEPHX_CREATED_WITH_FEATURES_ANNOTATION in annotations:
+            pytest.skip(
+                "Greenfield clusters do not apply DESIRED_CEPHX_KEY_GEN to daemon "
+                "by default (TC13 is brownfield-oriented)"
+            )
+        cc_gen = int(daemon.get("keyGeneration", 0) or 0)
+        assert cc_gen == desired, (
+            f"TC13: expected CephCluster daemon.keyGeneration={desired_env}, "
+            f"got {daemon}"
+        )
+
+    @pytest.mark.polarion_id("OCS-8145")
+    @tier1
+    def test_storagecluster_keygeneration_overrides_env(
+        self, cephx_keyrotation_setup, request
+    ):
+        """
+        TC12: StorageCluster daemon.keyGeneration overrides DESIRED_CEPHX_KEY_GEN.
+        """
+        rotator = cephx_keyrotation_setup
+        namespace = config.ENV_DATA["cluster_namespace"]
+        original_generation = rotator.get_spec_key_generation(rotator.COMPONENT_DAEMON)
+        target_generation = max(original_generation, 5) + 1
+
+        def restore():
+            # Generations are monotonic; wait for the bumped generation to finish
+            # rotating so later tests see an in-sync cluster.
+            try:
+                rotator.wait_for_rook_daemon_rotation(
+                    target_generation, timeout=ROTATION_COMPLETE_TIMEOUT
+                )
+            except Exception as exc:
+                log.warning("TC12 teardown wait for rotation failed: %s", exc)
+            try:
+                rotator.ensure_daemon_key_generations_aligned()
+            except Exception as exc:
+                log.warning(
+                    "TC12 teardown: failed to align daemon keyGeneration: %s", exc
+                )
+
+        request.addfinalizer(restore)
+
+        env_list = _get_ocs_operator_env(namespace)
+        env_map = {item.get("name"): item.get("value") for item in env_list}
+        desired_env = env_map.get(constants.DESIRED_CEPHX_KEY_GEN_ENV)
+        log.info(
+            "TC12: DESIRED_CEPHX_KEY_GEN=%s; setting StorageCluster keyGeneration=%s",
+            desired_env,
+            target_generation,
+        )
+        assert (
+            desired_env is not None
+        ), f"{constants.DESIRED_CEPHX_KEY_GEN_ENV} missing from ocs-operator"
+        assert (
+            int(desired_env) != target_generation
+        ), "TC12: choose a StorageCluster generation different from env default"
+
+        rotator.rotate_daemon_keys(target_generation)
+
+        def _spec_matches():
+            daemon = rotator.get_spec_cephx().get("daemon") or {}
+            return int(daemon.get("keyGeneration", 0) or 0) == target_generation
+
+        for ready in TimeoutSampler(300, 10, _spec_matches):
+            if ready:
+                break
+        else:
+            raise UnexpectedBehaviour(
+                f"TC12: CephCluster daemon.keyGeneration did not become "
+                f"{target_generation}"
+            )
+
+        daemon = rotator.get_spec_cephx().get("daemon") or {}
+        assert int(daemon["keyGeneration"]) == target_generation
+        assert int(daemon["keyGeneration"]) != int(desired_env)
+        log.info(
+            "TC12: StorageCluster keyGeneration=%s won over env=%s",
+            target_generation,
+            desired_env,
+        )
+        # Allow rotation to complete so cluster stays healthy for later tests
+        rotator.wait_for_rook_daemon_rotation(target_generation, timeout=1200)
+
+
+@skipif_external_mode
+@skipif_ocs_version(["<4.21", ">=4.23"])
+@green_squad
+class TestCephXCephClientAnnotations:
+    """TC14–TC15: CephClient created-with-cephx-features and keyType."""
+
+    @pytest.mark.polarion_id("OCS-8147")
+    @tier1
+    def test_cephclients_have_cephx_annotation_and_aes_keytype(
+        self, cephx_bootstrap_setup
+    ):
+        """
+        TC14: New CephClients get created-with-cephx-features and keyType aes.
+        """
+        namespace = config.ENV_DATA["cluster_namespace"]
+        clients = _list_cephclients(namespace)
+        assert clients, "No CephClient resources found"
+
+        # Prefer metrics-exporter + CSI clients when present
+        interesting = []
+        for client in clients:
+            name = client["metadata"]["name"]
+            if name == EXPECTED_METRIC_EXPORTER_CEPHCLIENT or name.startswith(
+                CSI_CEPHCLIENT_NAME_PREFIXES
+            ):
+                interesting.append(client)
+        if not interesting:
+            interesting = clients
+
+        for client in interesting:
+            name = client["metadata"]["name"]
+            annotations = client.get("metadata", {}).get("annotations") or {}
+            if constants.CEPHX_CREATED_WITH_FEATURES_ANNOTATION not in annotations:
+                # Existing/pre-PR clients — skip individual client
+                log.info(
+                    "TC14: CephClient %s lacks greenfield annotation (likely "
+                    "pre-existing); skipping",
+                    name,
+                )
+                continue
+            assert (
+                annotations[constants.CEPHX_CREATED_WITH_FEATURES_ANNOTATION] == ""
+            ), f"TC14: unexpected annotation value on {name}"
+            key_type = (
+                (client.get("spec") or {})
+                .get("security", {})
+                .get("cephx", {})
+                .get("keyType")
+            )
+            assert (
+                key_type == "aes"
+            ), f"TC14: CephClient {name} keyType={key_type!r}, expected 'aes'"
+            log.info("TC14: CephClient %s has annotation + keyType=aes", name)
+
+    @pytest.mark.polarion_id("OCS-8148")
+    @tier2
+    def test_existing_cephclients_no_annotation_on_upgrade(self, cephx_bootstrap_setup):
+        """
+        TC15: Existing (pre-PR) CephClients do not get annotation/keyType on upgrade.
+        """
+        namespace = config.ENV_DATA["cluster_namespace"]
+        clients = _list_cephclients(namespace)
+        pre_pr = [
+            c
+            for c in clients
+            if constants.CEPHX_CREATED_WITH_FEATURES_ANNOTATION
+            not in (c.get("metadata", {}).get("annotations") or {})
+        ]
+        if not pre_pr:
+            pytest.skip(
+                "All CephClients have created-with-cephx-features; TC15 needs "
+                "pre-PR / brownfield clients"
+            )
+        for client in pre_pr:
+            name = client["metadata"]["name"]
+            key_type = (
+                (client.get("spec") or {})
+                .get("security", {})
+                .get("cephx", {})
+                .get("keyType")
+            )
+            assert not key_type, (
+                f"TC15: pre-existing CephClient {name} unexpectedly has keyType="
+                f"{key_type}"
+            )
+            log.info("TC15: pre-existing CephClient %s has no annotation/keyType", name)
+
+
+@skipif_external_mode
+@skipif_ocs_version(["<4.21", ">=4.23"])
+@green_squad
+@ignore_leftovers
+class TestCephXDesiredKeyGenNegative:
+    """TC16: DESIRED_CEPHX_KEY_GEN env; TC17: StorageCluster keyGeneration types."""
+
+    # TC17: invalid JSON types for StorageCluster daemon.keyGeneration.
+    # null is rejected with "keyGeneration cannot be removed once set" (null is
+    # treated as removing the field after it has already been set).
+    INVALID_DAEMON_KEY_GENERATION_TYPE_CASES = (
+        pytest.param("16", "string", id="value-string-16"),
+        pytest.param("abc", "string", id="value-string-abc"),
+        pytest.param(True, "boolean", id="value-boolean-true"),
+        pytest.param(None, "null", id="value-null"),
+    )
+
+    @pytest.fixture(autouse=True)
+    def _restore_desired_env(self, request):
+        namespace = config.ENV_DATA["cluster_namespace"]
+        env_list = _get_ocs_operator_env(namespace)
+        original = None
+        existed = False
+        for item in env_list:
+            if item.get("name") == constants.DESIRED_CEPHX_KEY_GEN_ENV:
+                original = item.get("value")
+                existed = True
+                break
+
+        def finalizer():
+            try:
+                _restore_ocs_operator_env_var(
+                    namespace,
+                    constants.DESIRED_CEPHX_KEY_GEN_ENV,
+                    original,
+                    existed,
+                )
+            except Exception as exc:
+                log.warning("Failed to restore DESIRED_CEPHX_KEY_GEN: %s", exc)
+            try:
+                CephXKeyRotation().ensure_daemon_key_generations_aligned()
+            except Exception as exc:
+                log.warning("Teardown: failed to align daemon keyGeneration: %s", exc)
+
+        request.addfinalizer(finalizer)
+        self._namespace = namespace
+        self._original_env = original
+        self._env_existed = existed
+
+    @pytest.mark.polarion_id("OCS-8159")
+    @tier2
+    def test_desired_cephx_key_gen_missing_errors(self, cephx_bootstrap_setup):
+        """
+        TC16: Removing DESIRED_CEPHX_KEY_GEN causes a clear operator error on
+        brownfield reconciliation.
+        """
+        rotator = cephx_bootstrap_setup
+        annotations = (
+            rotator._get_cluster_dict().get("metadata", {}).get("annotations") or {}
+        )
+        if constants.CEPHX_CREATED_WITH_FEATURES_ANNOTATION in annotations:
+            pytest.skip(
+                "TC16 targets brownfield reconciliation that consumes "
+                "DESIRED_CEPHX_KEY_GEN; this cluster is greenfield-annotated"
+            )
+
+        # When StorageCluster already carries daemon.keyGeneration, ocs-operator
+        # does not need DESIRED_CEPHX_KEY_GEN for reconcile (see TC12/TC13).
+        sc_key_gen = rotator.get_spec_key_generation(rotator.COMPONENT_DAEMON)
+        if sc_key_gen:
+            pytest.skip(
+                "TC16 requires DESIRED_CEPHX_KEY_GEN to be consumed on reconcile; "
+                f"StorageCluster daemon.keyGeneration is already {sc_key_gen}"
+            )
+
+        _remove_ocs_operator_env_var(
+            self._namespace, constants.DESIRED_CEPHX_KEY_GEN_ENV
+        )
+        # Trigger reconcile by touching StorageCluster
+        rotator.trigger_cephcluster_reconcile()
+        time.sleep(30)
+
+        pods = get_pods_having_label(
+            constants.OCS_OPERATOR_LABEL, namespace=self._namespace
+        )
+        assert pods, "ocs-operator pod not found after env removal"
+        logs = get_pod_logs(pods[0]["metadata"]["name"])
+        assert (
+            constants.DESIRED_CEPHX_KEY_GEN_ENV in logs
+        ), "TC16: expected operator logs to mention missing DESIRED_CEPHX_KEY_GEN"
+        assert any(
+            token in logs.lower()
+            for token in ("missing", "required", "panic", "error", "not set")
+        ), "TC16: expected clear error/panic about missing env var in operator logs"
+        log.info("TC16: operator reported missing DESIRED_CEPHX_KEY_GEN")
+
+    @pytest.mark.polarion_id("OCS-8158")
+    @tier2
+    @pytest.mark.parametrize(
+        "invalid_value, expected_json_type",
+        INVALID_DAEMON_KEY_GENERATION_TYPE_CASES,
+    )
+    def test_storagecluster_daemon_key_generation_invalid_type_rejected(
+        self, cephx_bootstrap_setup, invalid_value, expected_json_type
+    ):
+        """
+        TC17: StorageCluster rejects non-integer daemon keyGeneration patches.
+
+        Parametrized over JSON values that must fail validation:
+          - ``"16"`` / ``"abc"`` → must be of type integer: "string"
+          - ``true`` → must be of type integer: "boolean"
+          - ``null`` → keyGeneration cannot be removed once set
+            (null is treated as removing the field after it was set)
+
+        Patch must not succeed; StorageCluster / CephCluster state unchanged.
+        """
+        rotator = cephx_bootstrap_setup
+        namespace = config.ENV_DATA["cluster_namespace"]
+
+        ceph_health_check(namespace=namespace)
+        rotator.wait_for_cluster_ready()
+
+        # Ensure daemon.keyGeneration exists so replace exercises type checks.
+        rotator.ensure_daemon_key_rotation_enabled()
+
+        pre_generations = rotator.record_all_cephx_status_generations()
+        pre_sc_generation = rotator.get_spec_key_generation(rotator.COMPONENT_DAEMON)
+        pre_cc_phase = rotator.get_cephcluster_phase()
+        pre_sc_phase = rotator.get_storagecluster_phase()
+
+        rotator.assert_invalid_daemon_key_generation_type_rejected(
+            invalid_value, expected_json_type
+        )
+
+        time.sleep(10)
+        assert (
+            rotator.get_spec_key_generation(rotator.COMPONENT_DAEMON)
+            == pre_sc_generation
+        ), "StorageCluster daemon keyGeneration changed after rejected type patch"
+        assert pre_cc_phase == constants.STATUS_READY, (
+            "CephCluster must be Ready before invalid keyGeneration type patch; "
+            f"got {pre_cc_phase}"
+        )
+        assert pre_sc_phase == constants.STATUS_READY, (
+            "StorageCluster must be Ready before invalid keyGeneration type patch; "
+            f"got {pre_sc_phase}"
+        )
+        assert rotator.get_cephcluster_phase() == pre_cc_phase, (
+            "CephCluster phase changed unexpectedly after rejected keyGeneration "
+            f"type patch (was {pre_cc_phase})"
+        )
+        assert rotator.get_storagecluster_phase() == pre_sc_phase, (
+            "StorageCluster phase changed unexpectedly after rejected keyGeneration "
+            f"type patch (was {pre_sc_phase})"
+        )
+        rotator.assert_cephx_status_generations_unchanged(
+            pre_generations,
+            context="after rejected non-integer daemon keyGeneration patch",
+        )
+        log.info(
+            "TC17: StorageCluster rejected daemon keyGeneration type=%s value=%r",
+            expected_json_type,
+            invalid_value,
+        )

--- a/tests/functional/cephx_keyrotation/test_cephx_keyrotation_negative.py
+++ b/tests/functional/cephx_keyrotation/test_cephx_keyrotation_negative.py
@@ -1,0 +1,816 @@
+"""
+CephX Key Rotation — Negative Test Cases
+
+TC-21: Operator crash while Mon CephX key rotation is in progress.
+TC-22: Mon key rotation when Mons are not in quorum.
+TC-23: OSD key rotation blocked when PGs are not clean.
+TC-24: Single OSD rotation failure fails the entire CephCluster reconcile.
+TC-32: Brownfield OSD deployments with empty cephx-status annotations.
+TC-33: Operator restart mid OSD rotation checkpoints remaining OSDs.
+TC-34: Lockbox key preserved when lockbox rotation init container fails.
+TC-NEG-15: Disk-based encrypted OSD deployments carry encrypted=true label.
+TC-36: Bootstrap key deletion is idempotent on already-deleted keys.
+TC-37: CSI key rotation with priorKeyCount 0 and mounted volumes.
+TC-38: Decreasing StorageCluster daemon keyGeneration is rejected.
+"""
+
+import logging
+import time
+
+import pytest
+
+from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import (
+    encryption_at_rest_required,
+    green_squad,
+    ignore_leftovers,
+    skipif_external_mode,
+    skipif_ocs_version,
+    tier2,
+)
+from ocs_ci.helpers.helpers import get_last_log_time_date
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.resources.pod import get_mon_pods
+from ocs_ci.utility.utils import ceph_health_check
+
+log = logging.getLogger(__name__)
+
+MIN_MON_COUNT = 3
+MIN_OSD_COUNT = 3
+MIN_OSD_COUNT_PARTIAL_ROTATION = 5
+MIN_ROTATED_OSDS_BEFORE_OPERATOR_KILL = 3
+MON_QUORUM_BROKEN_MAX = 1
+MIN_ENCRYPTED_OSD_COUNT = 1
+MIN_DISK_ENCRYPTED_OSD_COUNT = 1
+CSI_IO_FILE = "/mnt/rbd/csi_prior_key_test"
+CSI_IO_BS = "4k"
+CSI_IO_COUNT = 10000
+CSI_WORKLOAD_PVC_SIZE = 10
+CSI_POST_ROTATION_PVC_SIZE = 5
+
+
+@skipif_external_mode
+@skipif_ocs_version(["<4.21", ">=4.23"])
+@green_squad
+@ignore_leftovers
+class TestCephXKeyRotationNegative:
+    @pytest.mark.polarion_id("OCS-8149")
+    @tier2
+    def test_cephx_operator_crash_during_mon_rotation(self, cephx_keyrotation_setup):
+        """
+        TC-21: Operator crash while Mon CephX key rotation is in progress.
+
+        Kill rook-ceph-operator while mon rotation is active; verify operator
+        recovery, healthy StorageCluster/CephCluster, and that daemon keys
+        actually rotated.
+        """
+        rotator = cephx_keyrotation_setup
+        namespace = config.ENV_DATA["cluster_namespace"]
+
+        if len(rotator.get_mon_deployment_names()) < MIN_MON_COUNT:
+            pytest.skip(f"Need at least {MIN_MON_COUNT} mon deployments for this test")
+        if not rotator.is_mon_key_rotation_supported():
+            pytest.skip("MON CephX key rotation is not supported on this cluster")
+
+        ceph_health_check(namespace=namespace)
+
+        daemon_entities = rotator.flatten_daemon_auth_entities(
+            rotator.discover_rook_daemon_auth_entities()
+        )
+        pre_auth_keys = rotator.capture_auth_keys(
+            daemon_entities,
+            label="before operator crash during mon rotation",
+        )
+
+        target_generation = rotator.kill_operator_during_mon_rotation(timeout=900)
+        rotator.recover_after_operator_crash_during_mon_rotation(timeout=1500)
+        rotator.wait_for_rook_daemon_rotation(target_generation, timeout=1500)
+        rotator.verify_auth_keys_changed(pre_auth_keys, entities=daemon_entities)
+
+        ceph_health_check(namespace=namespace)
+        log.info(
+            "Operator recovered successfully after crash during mon key rotation; "
+            "daemon keys rotated"
+        )
+
+    @pytest.mark.polarion_id("OCS-8150")
+    @tier2
+    def test_cephx_mon_rotation_without_quorum(self, cephx_keyrotation_setup):
+        """
+        TC-22: Mon key rotation is blocked when Mons are not in quorum.
+
+        Scale down two Mons, attempt rotation, verify no key changes, restore
+        quorum, and verify a subsequent rotation succeeds.
+        """
+        rotator = cephx_keyrotation_setup
+        namespace = config.ENV_DATA["cluster_namespace"]
+
+        if len(rotator.get_mon_deployment_names()) < MIN_MON_COUNT:
+            pytest.skip(f"Need at least {MIN_MON_COUNT} mon deployments for this test")
+
+        ceph_health_check(namespace=namespace)
+
+        auth_entities = rotator.flatten_daemon_auth_entities(
+            rotator.discover_rook_daemon_auth_entities()
+        )
+        if not auth_entities:
+            pytest.skip("No Ceph auth entities found for rotation verification")
+
+        pre_auth_keys = rotator.capture_auth_keys(
+            auth_entities, label="before quorum break"
+        )
+        # Ceph CLI cannot reach auth store without quorum; snapshot K8s mon secrets.
+        pre_mon_secret_keys = rotator.get_mon_keys_from_secrets()
+        if not pre_mon_secret_keys:
+            pytest.skip("No mon keys found in Kubernetes secrets for verification")
+
+        self._scaled_mon_deployments = rotator.break_mon_quorum(mons_to_stop=2)
+        rotator.wait_for_mon_quorum_count_at_most(MON_QUORUM_BROKEN_MAX, timeout=300)
+        # Snapshot after quorum break so status catch-up during auth capture
+        # does not false-fail the blocked-rotation generation check.
+        baseline_generations = rotator.record_all_cephx_status_generations()
+        operator_log_marker = get_last_log_time_date()
+
+        # Do not wait for Ready — rotation is expected to stay blocked without quorum.
+        rotator.rotate_daemon_keys(wait_for_rotation=False)
+        rotator.trigger_cephcluster_reconcile()
+        rotator.assert_reported_cephx_generations_unchanged(
+            baseline_generations,
+            context="while mon quorum is broken",
+        )
+        # Do not call ceph auth get-key here — RADOS times out without quorum.
+        rotator.assert_mon_secret_keys_unchanged(
+            pre_mon_secret_keys,
+            context="while mon quorum is broken",
+        )
+        # ODF 4.22 does not emit explicit quorum-blocked cephx rotation log lines
+        # after mon scale-down; verify rotation activity is absent instead.
+        rotator.verify_operator_no_key_rotation_logs(since_time=operator_log_marker)
+
+        rotator.restore_mon_deployments(self._scaled_mon_deployments)
+        self._scaled_mon_deployments = []
+
+        target_generation = rotator.rotate_daemon_keys()
+        rotator.wait_for_rook_daemon_rotation(target_generation, timeout=1500)
+        rotator.verify_auth_keys_changed(pre_auth_keys, entities=auth_entities)
+        rotator.verify_pods_no_auth_bad_key(get_mon_pods(namespace=namespace))
+
+        ceph_health_check(namespace=namespace)
+        log.info("Mon key rotation blocked without quorum and succeeded after restore")
+
+    @pytest.mark.polarion_id("OCS-8151")
+    @tier2
+    def test_cephx_osd_rotation_blocked_by_unhealthy_pgs(self, cephx_keyrotation_setup):
+        """
+        TC-23: OSD key rotation is deferred when PGs are not active+clean.
+
+        Mark an OSD out, verify rotation is skipped, restore the OSD, and
+        verify rotation proceeds once PGs heal.
+        """
+        rotator = cephx_keyrotation_setup
+        namespace = config.ENV_DATA["cluster_namespace"]
+
+        osd_entities = rotator.discover_osd_auth_entities()
+        if len(osd_entities) < MIN_OSD_COUNT:
+            pytest.skip(f"Need at least {MIN_OSD_COUNT} OSDs for this test")
+
+        ceph_health_check(namespace=namespace)
+        rotator.wait_for_pgs_active_clean()
+
+        pre_osd_generation = rotator.get_status_key_generation("osd")
+        pre_osd_keys = rotator.capture_auth_keys(osd_entities, label="before osd out")
+
+        osd_id = int(osd_entities[0].split(".")[-1])
+        self._osd_marked_out = osd_id
+        rotator.set_osd_out(osd_id)
+        rotator.wait_for_pgs_not_clean(timeout=300)
+        operator_log_marker = get_last_log_time_date()
+
+        # Do not wait for Ready — OSD rotation should be deferred while PGs are unclean.
+        rotator.rotate_daemon_keys(wait_for_rotation=False)
+        rotator.trigger_cephcluster_reconcile()
+        rotator.assert_auth_keys_unchanged(
+            pre_osd_keys,
+            entities=osd_entities,
+            context="while PGs are not clean",
+        )
+        assert (
+            rotator.get_status_key_generation("osd") == pre_osd_generation
+        ), "OSD keyGeneration changed while PGs were not clean"
+        # ODF 4.22 does not emit explicit PG-deferred OSD rotation log lines;
+        # only OSD rotation should be deferred — MDS/MON/admin rotations may proceed.
+        rotator.verify_operator_no_key_rotation_logs(
+            since_time=operator_log_marker,
+            rotation_patterns=constants.CEPHX_OSD_KEY_ROTATION_LOG_PATTERNS,
+        )
+
+        rotator.restore_osd_and_wait_for_recovery(osd_id, timeout=1500)
+        self._osd_marked_out = None
+
+        target_generation = rotator.rotate_daemon_keys()
+        rotator.wait_for_osd_rotation(target_generation, timeout=1500)
+        rotator.verify_auth_keys_changed(pre_osd_keys, entities=osd_entities)
+        assert rotator.get_status_key_generation("osd") > pre_osd_generation
+
+        rotator.wait_for_cluster_fully_recovered(timeout=1500)
+        ceph_health_check(namespace=namespace)
+        log.info("OSD key rotation deferred until PGs healed, then succeeded")
+
+    @pytest.mark.polarion_id("OCS-8152")
+    @tier2
+    def test_cephx_osd_rotation_failure_fails_reconcile(self, cephx_keyrotation_setup):
+        """
+        TC-24: A single OSD rotation failure fails CephCluster reconcile.
+
+        Inject an OSD auth deletion mid-rotation, verify OSD-specific reconcile
+        failure and partial rotation. Rook cannot ``auth rotate`` a missing
+        entity, so restore the deleted auth from the OSD pod keyring (admin
+        remediation), then verify rotation completes on the next reconcile.
+        """
+        rotator = cephx_keyrotation_setup
+        namespace = config.ENV_DATA["cluster_namespace"]
+
+        osd_entities = rotator.discover_osd_auth_entities()
+        if len(osd_entities) < MIN_OSD_COUNT:
+            pytest.skip(f"Need at least {MIN_OSD_COUNT} OSDs for this test")
+
+        ceph_health_check(namespace=namespace)
+        rotator.wait_for_pgs_active_clean()
+
+        pre_osd_generation = rotator.get_status_key_generation("osd")
+        pre_osd_keys = rotator.capture_auth_keys(
+            osd_entities, label="before injected osd failure"
+        )
+        pre_cephx_status = rotator.capture_osd_deployment_cephx_status()
+
+        # Trigger async so inject can race a still-pending OSD before Ready.
+        # Record a restore candidate before inject's failure-prone polling/delete.
+        self._deleted_osd_auth_entity = sorted(osd_entities)[-1]
+        target_generation = rotator.rotate_daemon_keys(wait_for_rotation=False)
+        try:
+            failed_entity, operator_log_marker = (
+                rotator.inject_osd_auth_rotation_failure(pre_osd_keys, timeout=900)
+            )
+            self._deleted_osd_auth_entity = failed_entity
+        except Exception:
+            injected = getattr(rotator, "last_deleted_osd_auth_entity", None)
+            if injected:
+                self._deleted_osd_auth_entity = injected
+            raise
+
+        rotator.wait_for_cephcluster_reconcile_failure(
+            timeout=600,
+            message_patterns=constants.CEPHX_OSD_AUTH_ROTATION_FAILURE_PATTERNS,
+            operator_log_since=operator_log_marker,
+        )
+        rotator.verify_operator_logs_contain_any_pattern(
+            constants.CEPHX_OSD_AUTH_ROTATION_FAILURE_PATTERNS,
+            since_time=operator_log_marker,
+        )
+
+        mid_rotation_keys = rotator.capture_auth_keys(osd_entities)
+        rotated_entities = [
+            entity
+            for entity in osd_entities
+            if pre_osd_keys.get(entity) != mid_rotation_keys.get(entity)
+        ]
+        unchanged_entities = [
+            entity
+            for entity in osd_entities
+            if pre_osd_keys.get(entity) == mid_rotation_keys.get(entity)
+        ]
+        assert (
+            rotated_entities
+        ), "Expected at least one OSD key to rotate before failure"
+        assert failed_entity in unchanged_entities or not mid_rotation_keys.get(
+            failed_entity
+        ), f"Failed OSD entity {failed_entity} should retain prior/missing key"
+        assert not rotator.auth_entity_exists(
+            failed_entity
+        ), f"Expected {failed_entity} to remain deleted after inject"
+
+        # Rook does not recreate a missing OSD auth entity on reconcile; restore
+        # from the on-disk keyring, then let rotation finish.
+        rotator.restore_osd_auth_entity_from_pod_keyring(failed_entity)
+        self._deleted_osd_auth_entity = None
+        rotator.trigger_cephcluster_reconcile()
+        rotator.wait_for_osd_rotation(target_generation, timeout=1500)
+        rotator.wait_for_rook_daemon_rotation(target_generation, timeout=1500)
+        post_osd_keys = rotator.verify_auth_keys_changed(
+            pre_osd_keys, entities=osd_entities
+        )
+        assert all(
+            pre_osd_keys.get(entity) != post_osd_keys.get(entity)
+            for entity in osd_entities
+            if pre_osd_keys.get(entity)
+        ), "Not all OSD auth keys reached the target generation after recovery"
+        assert rotator.get_status_key_generation("osd") > pre_osd_generation
+        rotator.assert_osd_deployment_cephx_status_updated(
+            pre_cephx_status, target_generation
+        )
+
+        ceph_health_check(namespace=namespace)
+        rotator.wait_for_cluster_ready()
+        log.info(
+            "CephCluster recovered after OSD auth restore and reconcile "
+            f"(failed_entity={failed_entity})"
+        )
+
+    @pytest.mark.polarion_id("OCS-8157")
+    @tier2
+    @skipif_ocs_version(["<4.21", ">=4.23"])
+    def test_cephx_daemon_key_generation_decrease_rejected(
+        self, cephx_keyrotation_setup
+    ):
+        """
+        TC-38: Decreasing StorageCluster daemon keyGeneration is rejected.
+
+        Steps:
+            1. Record CephCluster daemon keyGeneration / Ready phases and
+               StorageCluster daemon keyGeneration.
+            2. Patch StorageCluster daemon keyGeneration to a lower value.
+            3. Expect admission error: keyGeneration cannot be decreased.
+            4. Verify StorageCluster and CephCluster generations and phases
+               are unchanged (no reconcile / state change).
+        """
+        rotator = cephx_keyrotation_setup
+        namespace = config.ENV_DATA["cluster_namespace"]
+
+        ceph_health_check(namespace=namespace)
+        rotator.wait_for_cluster_ready()
+
+        pre_daemon_generations = rotator.record_daemon_generations()
+        pre_all_generations = rotator.record_all_cephx_status_generations()
+        pre_sc_generation = rotator.get_spec_key_generation(rotator.COMPONENT_DAEMON)
+        pre_cc_phase = rotator.get_cephcluster_phase()
+        pre_sc_phase = rotator.get_storagecluster_phase()
+        rotator.log_generation_status("Pre-decrease-reject")
+
+        if pre_sc_generation < 1:
+            pytest.skip(
+                "StorageCluster daemon keyGeneration is unset; decrease "
+                "rejection requires an existing generation"
+            )
+
+        lower_generation = pre_sc_generation - 1
+        log.info(
+            "Current StorageCluster daemon keyGeneration=%s; CephCluster "
+            "daemon generations=%s; attempting decrease to %s",
+            pre_sc_generation,
+            pre_daemon_generations,
+            lower_generation,
+        )
+
+        rotator.assert_decreasing_daemon_key_generation_rejected(lower_generation)
+
+        # Brief settle so a mistaken reconcile would be visible in phase/gens.
+        time.sleep(15)
+
+        post_sc_generation = rotator.get_spec_key_generation(rotator.COMPONENT_DAEMON)
+        post_cc_phase = rotator.get_cephcluster_phase()
+        post_sc_phase = rotator.get_storagecluster_phase()
+        assert post_sc_generation == pre_sc_generation, (
+            "StorageCluster daemon keyGeneration changed after rejected "
+            f"decrease: before={pre_sc_generation}, after={post_sc_generation}"
+        )
+        assert (
+            pre_cc_phase == constants.STATUS_READY
+        ), f"CephCluster precondition phase was not Ready: {pre_cc_phase}"
+        assert post_cc_phase == pre_cc_phase, (
+            "CephCluster phase changed after rejected keyGeneration decrease: "
+            f"before={pre_cc_phase}, after={post_cc_phase}"
+        )
+        assert (
+            pre_sc_phase == constants.STATUS_READY
+        ), f"StorageCluster precondition phase was not Ready: {pre_sc_phase}"
+        assert post_sc_phase == pre_sc_phase, (
+            "StorageCluster phase changed after rejected keyGeneration decrease: "
+            f"before={pre_sc_phase}, after={post_sc_phase}"
+        )
+        rotator.assert_cephx_status_generations_unchanged(
+            pre_all_generations,
+            context="after rejected daemon keyGeneration decrease",
+        )
+
+        ceph_health_check(namespace=namespace)
+        rotator.wait_for_cluster_ready()
+        log.info(
+            "TC-38: decreasing daemon keyGeneration to %s was rejected; "
+            "StorageCluster/CephCluster state unchanged",
+            lower_generation,
+        )
+
+    @pytest.mark.polarion_id("OCS-8162")
+    @tier2
+    @pytest.mark.skip(
+        reason="Bootstrap CephX key cleanup is not covered while only daemon "
+        "key rotation is supported"
+    )
+    def test_cephx_bootstrap_deletion_idempotent(self, cephx_bootstrap_setup):
+        """
+        TC-36: Bootstrap key deletion is idempotent on already-deleted keys.
+
+        Wait for bootstrap cleanup, restart the operator, and verify no errors
+        are logged when deletion is attempted again.
+        """
+        rotator = cephx_bootstrap_setup
+        namespace = config.ENV_DATA["cluster_namespace"]
+
+        ceph_health_check(namespace=namespace)
+        rotator.trigger_cephcluster_reconcile()
+        rotator.wait_for_post_mon_startup_bootstrap_cleanup(timeout=900)
+        rotator.verify_bootstrap_deletion_idempotent_after_operator_restart()
+
+        ceph_health_check(namespace=namespace)
+        log.info("Bootstrap key deletion idempotency verified after operator restart")
+
+
+@skipif_external_mode
+@skipif_ocs_version(["<4.21", ">=4.23"])
+@green_squad
+@ignore_leftovers
+class TestCephXKeyRotationNegativeOSD:
+    @pytest.mark.polarion_id("OCS-8153")
+    @tier2
+    def test_cephx_brownfield_osd_empty_cephx_status(
+        self, cephx_keyrotation_setup, request
+    ):
+        """
+        TC-32: Brownfield OSD deployments start with empty cephx-status.
+
+        Simulate brownfield OSDs by clearing cephx-status annotations, trigger
+        rotation, verify annotations are populated, then verify a subsequent
+        rotation behaves like a greenfield deployment.
+        """
+        rotator = cephx_keyrotation_setup
+        namespace = config.ENV_DATA["cluster_namespace"]
+
+        osd_entities = rotator.discover_osd_auth_entities()
+        if len(osd_entities) < MIN_OSD_COUNT:
+            pytest.skip(f"Need at least {MIN_OSD_COUNT} OSDs for this test")
+
+        ceph_health_check(namespace=namespace)
+        rotator.wait_for_pgs_active_clean()
+
+        pre_osd_keys = rotator.capture_auth_keys(
+            osd_entities, label="before brownfield"
+        )
+        pre_cephx_status = rotator.capture_osd_deployment_cephx_status()
+
+        def restore_cephx_status():
+            """
+            Restore the pre-test cephx-status snapshot only when annotations are
+            still empty/partial (test failed after clear).
+
+            After a successful brownfield rotation the annotations are already
+            correctly populated at a newer generation. Restoring the stale
+            pre-test snapshot patches every OSD Deployment template and rolls
+            all OSDs at once, which races health_checker teardown and can mark
+            the test ERROR despite a PASSED call phase.
+            """
+            try:
+                current = rotator.capture_osd_deployment_cephx_status()
+            except Exception as exc:
+                log.warning(
+                    "Teardown: failed to capture current OSD cephx-status: %s",
+                    exc,
+                )
+                current = {}
+
+            populated = {name: status for name, status in current.items() if status}
+            if current and len(populated) == len(current):
+                log.info(
+                    "Teardown: OSD cephx-status annotations already populated "
+                    f"({len(populated)} deployments); skipping restore of "
+                    "pre-test snapshot to avoid simultaneous OSD rollout"
+                )
+                return
+
+            log.info(
+                "Teardown: restoring OSD deployment cephx-status annotations "
+                "to pre-test state (current status incomplete/empty)"
+            )
+            try:
+                rotator.restore_osd_deployment_cephx_status_annotations(
+                    pre_cephx_status
+                )
+                # Annotation restore mutates Deployment pod templates and rolls
+                # OSDs; wait before health_checker teardown runs.
+                rotator.wait_for_rook_daemon_pods_ready()
+                rotator.wait_for_pgs_active_clean()
+            except Exception as exc:
+                log.warning(
+                    "Teardown: failed to restore OSD cephx-status annotations: %s",
+                    exc,
+                )
+
+        request.addfinalizer(restore_cephx_status)
+
+        rotator.clear_osd_deployment_cephx_status_annotations()
+        rotator.assert_osd_deployments_have_empty_cephx_status()
+
+        first_target = rotator.rotate_daemon_keys()
+        rotator.wait_for_osd_rotation(first_target, timeout=1500)
+        rotator.verify_auth_keys_changed(pre_osd_keys, entities=osd_entities)
+        rotator.assert_osd_deployment_cephx_status_updated(
+            {name: {} for name in pre_cephx_status},
+            first_target,
+        )
+        rotator.assert_all_osd_deployments_cephx_status_at_generation(first_target)
+
+        brownfield_post_keys = rotator.capture_auth_keys(
+            osd_entities, label="after brownfield rotation"
+        )
+        brownfield_post_status = rotator.capture_osd_deployment_cephx_status()
+
+        second_target = rotator.rotate_daemon_keys()
+        rotator.wait_for_osd_rotation(second_target, timeout=1500)
+        rotator.verify_auth_keys_changed(brownfield_post_keys, entities=osd_entities)
+        rotator.assert_osd_deployment_cephx_status_updated(
+            brownfield_post_status, second_target
+        )
+
+        ceph_health_check(namespace=namespace)
+        rotator.wait_for_pgs_active_clean()
+        log.info(
+            "Brownfield OSD cephx-status simulation and subsequent rotation "
+            "completed successfully"
+        )
+
+    @pytest.mark.polarion_id("OCS-8154")
+    @tier2
+    def test_cephx_operator_restart_during_partial_osd_rotation(
+        self, cephx_keyrotation_setup
+    ):
+        """
+        TC-33: Operator restart mid OSD rotation only rotates remaining OSDs.
+
+        Kill the operator after a partial OSD cephx-status checkpoint, verify
+        already-rotated OSDs are not rotated again, then verify all OSDs reach
+        the target generation.
+        """
+        rotator = cephx_keyrotation_setup
+        namespace = config.ENV_DATA["cluster_namespace"]
+
+        baseline_cephx_status = rotator.capture_osd_deployment_cephx_status()
+        osd_count = len(baseline_cephx_status)
+        if osd_count < MIN_OSD_COUNT_PARTIAL_ROTATION:
+            pytest.skip(
+                f"Need at least {MIN_OSD_COUNT_PARTIAL_ROTATION} OSD deployments; "
+                f"found {osd_count}"
+            )
+
+        osd_entities = rotator.discover_osd_auth_entities()
+        pre_osd_keys = rotator.capture_auth_keys(
+            osd_entities, label="before partial osd rotation"
+        )
+
+        ceph_health_check(namespace=namespace)
+        rotator.wait_for_pgs_active_clean()
+
+        min_rotated = min(MIN_ROTATED_OSDS_BEFORE_OPERATOR_KILL, osd_count - 1)
+        target_generation, rotated_deployments = (
+            rotator.kill_operator_during_partial_osd_rotation(
+                baseline_cephx_status,
+                min_rotated=min_rotated,
+                timeout=1500,
+            )
+        )
+        assert rotated_deployments, "Expected partial OSD rotation before operator kill"
+
+        checkpoint_entities = rotator.map_osd_deployments_to_auth_entities(
+            rotated_deployments
+        )
+        checkpoint_keys = rotator.capture_auth_keys(
+            checkpoint_entities, label="checkpoint osd keys"
+        )
+        checkpoint_status = rotator.capture_osd_deployment_cephx_status()
+
+        rotator.wait_for_rook_ceph_operator_ready()
+        rotator.assert_osd_deployment_cephx_status_unchanged_for(
+            rotated_deployments, checkpoint_status
+        )
+
+        rotator.wait_for_osd_rotation(target_generation, timeout=1500)
+        rotator.assert_all_osd_deployments_cephx_status_at_generation(target_generation)
+        rotator.assert_auth_keys_unchanged_for(
+            checkpoint_keys, entities=checkpoint_entities
+        )
+        rotator.verify_auth_keys_changed(pre_osd_keys, entities=osd_entities)
+
+        ceph_health_check(namespace=namespace)
+        rotator.wait_for_pgs_active_clean()
+        log.info(
+            "Partial OSD rotation checkpoint preserved across operator restart; "
+            f"rotated before kill: {rotated_deployments}"
+        )
+
+
+@skipif_external_mode
+@skipif_ocs_version(["<4.21", ">=4.23"])
+@green_squad
+@ignore_leftovers
+class TestCephXKeyRotationNegativeEncryptedCSI:
+    @pytest.mark.polarion_id("OCS-8155")
+    @tier2
+    @encryption_at_rest_required
+    def test_cephx_lockbox_rotation_failure_preserves_key(
+        self, cephx_keyrotation_setup
+    ):
+        """
+        TC-34: Lockbox key is preserved when lockbox rotation init fails.
+
+        Break mon quorum during lockbox rotation, verify lockbox keys are not
+        lost, restore quorum, and verify encrypted OSDs complete rotation.
+        """
+        rotator = cephx_keyrotation_setup
+        namespace = config.ENV_DATA["cluster_namespace"]
+
+        encrypted_deployments = rotator.capture_encrypted_osd_deployments()
+        if len(encrypted_deployments) < MIN_ENCRYPTED_OSD_COUNT:
+            pytest.skip(
+                f"Need at least {MIN_ENCRYPTED_OSD_COUNT} encrypted OSD "
+                f"deployment(s); found {len(encrypted_deployments)}"
+            )
+
+        lockbox_entities = rotator.discover_lockbox_auth_entities()
+        if not lockbox_entities:
+            pytest.skip("No client.osd-lockbox.* auth entities found on cluster")
+
+        if len(rotator.get_mon_deployment_names()) < MIN_MON_COUNT:
+            pytest.skip(f"Need at least {MIN_MON_COUNT} mon deployments for this test")
+
+        ceph_health_check(namespace=namespace)
+        pre_lockbox_keys = rotator.capture_auth_keys(
+            lockbox_entities, label="lockbox keys before disruption"
+        )
+
+        target_generation, self._scaled_mon_deployments = (
+            rotator.break_mon_quorum_during_lockbox_rotation(mons_to_stop=2)
+        )
+        rotator.wait_for_mon_quorum_count_at_most(MON_QUORUM_BROKEN_MAX, timeout=300)
+
+        rotator.assert_lockbox_auth_keys_present(lockbox_entities)
+        rotator.assert_auth_keys_unchanged(
+            pre_lockbox_keys,
+            entities=lockbox_entities,
+            context="during lockbox rotation disruption",
+        )
+        rotator.verify_osd_lockbox_init_container_disruption_logs()
+
+        rotator.restore_mon_deployments(self._scaled_mon_deployments)
+        self._scaled_mon_deployments = []
+        rotator.wait_for_pgs_active_clean(timeout=900)
+
+        rotator.wait_for_osd_rotation(target_generation, timeout=1500)
+        rotator.verify_auth_keys_changed(pre_lockbox_keys, entities=lockbox_entities)
+
+        encrypted_osd_pods = rotator.get_encrypted_osd_pods()
+        rotator.verify_osd_activate_lockbox_logs(encrypted_osd_pods)
+        rotator.verify_encrypted_osd_pods_running(encrypted_osd_pods)
+
+        ceph_health_check(namespace=namespace)
+        log.info("Lockbox keys preserved through rotation failure and recovered")
+
+    @pytest.mark.polarion_id("OCS-8156")
+    @tier2
+    @encryption_at_rest_required
+    def test_cephx_disk_encrypted_osd_label_and_lockbox_rotation(
+        self, cephx_keyrotation_setup
+    ):
+        """
+        TC-NEG-15: Disk-based encrypted OSD deployments are labeled encrypted=true.
+
+        Verify host/disk-based encrypted OSDs carry the encrypted label and
+        receive lockbox key rotation (not silently skipped).
+        """
+        rotator = cephx_keyrotation_setup
+        namespace = config.ENV_DATA["cluster_namespace"]
+
+        disk_encrypted = rotator.get_disk_based_encrypted_osd_deployments()
+        if len(disk_encrypted) < MIN_DISK_ENCRYPTED_OSD_COUNT:
+            pytest.skip(
+                "No disk-based encrypted OSD deployments found; "
+                "need host/disk encrypted OSDs for this test"
+            )
+
+        rotator.assert_encrypted_osd_labels(disk_encrypted)
+        log.info(
+            "Disk-based encrypted OSD deployments: "
+            + ", ".join(
+                f"{name} (osd_id={info['osd_id']})"
+                for name, info in sorted(disk_encrypted.items())
+            )
+        )
+
+        lockbox_entities = rotator.discover_lockbox_auth_entities()
+        if not lockbox_entities:
+            pytest.skip("No client.osd-lockbox.* auth entities found on cluster")
+
+        pre_lockbox_keys = rotator.capture_auth_keys(
+            lockbox_entities, label="disk encrypted lockbox keys before rotation"
+        )
+        operator_log_marker = get_last_log_time_date()
+
+        ceph_health_check(namespace=namespace)
+        target_generation = rotator.rotate_daemon_keys()
+        rotator.wait_for_osd_rotation(target_generation, timeout=1500)
+        rotator.verify_auth_keys_changed(pre_lockbox_keys, entities=lockbox_entities)
+
+        operator_logs = rotator.get_operator_logs_since(operator_log_marker)
+        disk_lockbox_logs = [
+            line for line in operator_logs if constants.OSD_LOCKBOX_OPERATOR_LOG in line
+        ]
+        assert disk_lockbox_logs, (
+            "Operator did not log lockbox rotation for encrypted OSDs; "
+            "disk-based OSDs may have been skipped"
+        )
+        log.info(
+            f"Operator logged {len(disk_lockbox_logs)} encrypted OSD lockbox "
+            "rotation line(s) for disk-based OSDs"
+        )
+
+        ceph_health_check(namespace=namespace)
+        log.info("Disk-based encrypted OSD label and lockbox rotation verified")
+
+    @pytest.mark.polarion_id("OCS-8163")
+    @tier2
+    @pytest.mark.skip(
+        reason="CSI CephX key rotation is not supported; only daemon key "
+        "rotation is currently enabled"
+    )
+    def test_cephx_csi_rotation_prior_key_count_zero_with_mounted_volume(
+        self, cephx_keyrotation_setup, deployment_pod_factory
+    ):
+        """
+        TC-37: CSI rotation with priorKeyCount 0 while a volume stays mounted.
+
+        Documents that deleting old CSI keys immediately may disrupt mounted
+        volumes; verifies new PVC provisioning still works after rotation.
+        """
+        rotator = cephx_keyrotation_setup
+        namespace = config.ENV_DATA["cluster_namespace"]
+
+        csi_entities = rotator.discover_csi_auth_entities()
+        if not csi_entities:
+            pytest.skip("No CSI Ceph auth entities found on cluster")
+
+        ceph_health_check(namespace=namespace)
+
+        workload_pod = deployment_pod_factory(
+            interface=constants.CEPHBLOCKPOOL,
+            size=CSI_WORKLOAD_PVC_SIZE,
+        )
+        io_thread = rotator.start_dd_io_in_background(
+            workload_pod, CSI_IO_FILE, bs=CSI_IO_BS, count=CSI_IO_COUNT
+        )
+
+        pre_csi_keys = rotator.capture_auth_keys(
+            csi_entities, label="csi keys before priorKeyCount=0 rotation"
+        )
+        csi_log_marker = get_last_log_time_date()
+
+        target_generation = rotator.rotate_csi_keys(keep_prior_key_count_max=0)
+        log.info(
+            f"Triggered CSI rotation to generation {target_generation} with "
+            "keepPriorKeyCountMax=0"
+        )
+
+        auth_errors = rotator.verify_csi_node_plugin_logs_for_auth_errors(
+            since_time=csi_log_marker
+        )
+        if auth_errors:
+            log.warning(
+                "AUTH_BAD_KEY observed on CSI node plugins after deleting old "
+                f"CSI keys (expected risk with priorKeyCount=0): "
+                f"{len(auth_errors)} line(s)"
+            )
+
+        if io_thread.is_alive():
+            log.info("Mounted volume I/O remained active during CSI rotation")
+            rotator.stop_dd_io(workload_pod, CSI_IO_FILE)
+            rotator.verify_io_file_readable(workload_pod, CSI_IO_FILE)
+        else:
+            log.warning(
+                "Mounted volume I/O stopped during CSI rotation with "
+                "priorKeyCount=0 (documented trade-off)"
+            )
+
+        rotator.wait_for_csi_rotation(target_generation, timeout=1500)
+        rotator.verify_auth_keys_changed(pre_csi_keys, entities=csi_entities)
+
+        new_pod = deployment_pod_factory(
+            interface=constants.CEPHBLOCKPOOL,
+            size=CSI_POST_ROTATION_PVC_SIZE,
+        )
+        new_pod.exec_cmd_on_pod(
+            "dd if=/dev/urandom of=/mnt/post_rotation_csi_test "
+            "bs=4k count=100 status=none",
+            out_yaml_format=False,
+        )
+        new_pod.exec_cmd_on_pod(
+            "test -s /mnt/post_rotation_csi_test", out_yaml_format=False
+        )
+
+        ceph_health_check(namespace=namespace)
+        log.info("CSI rotation with priorKeyCount=0 completed; new PVC mount verified")

--- a/tests/functional/cephx_keyrotation/test_cephx_keyrotation_node_cordon.py
+++ b/tests/functional/cephx_keyrotation/test_cephx_keyrotation_node_cordon.py
@@ -1,0 +1,197 @@
+"""
+CephX Key Rotation — Node Cordon Scenarios
+
+Verify daemon CephX key rotation while a node is cordoned:
+  - Cordon one OSD node, rotate daemon keys, verify rotation for all daemons.
+  - Uncordon the node, rotate daemon keys again, verify rotation succeeds.
+"""
+
+import logging
+
+import pytest
+
+from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import (
+    green_squad,
+    ignore_leftovers,
+    skipif_external_mode,
+    skipif_ocs_version,
+    tier2,
+)
+from ocs_ci.helpers.cephx_keyrotation import CephXKeyRotation
+from ocs_ci.ocs.node import (
+    get_osd_running_nodes,
+    schedule_nodes,
+    unschedule_nodes,
+)
+from ocs_ci.utility.utils import ceph_health_check
+
+log = logging.getLogger(__name__)
+
+MIN_OSD_NODES = 3
+
+
+@skipif_external_mode
+@skipif_ocs_version(["<4.21", ">=4.23"])
+@green_squad
+@ignore_leftovers
+class TestCephXKeyRotationNodeCordon:
+    @pytest.fixture(autouse=True)
+    def _restore_node_scheduling(self, request):
+        """Uncordon any node left cordoned after a test failure."""
+        self._cordoned_node = None
+
+        def finalizer():
+            if self._cordoned_node:
+                log.info(f"Teardown: uncordoning node {self._cordoned_node}")
+                schedule_nodes([self._cordoned_node])
+            try:
+                CephXKeyRotation().ensure_daemon_key_generations_aligned()
+            except Exception as exc:
+                log.warning("Teardown: failed to align daemon keyGeneration: %s", exc)
+
+        request.addfinalizer(finalizer)
+
+    @pytest.mark.polarion_id("OCS-8160")
+    @tier2
+    def test_cephx_key_rotation_with_node_cordon_and_uncordon(
+        self, cephx_keyrotation_setup
+    ):
+        """
+        Verify daemon CephX key rotation completes while one OSD node is
+        cordoned, then succeeds again after the node is uncordoned.
+
+        Steps:
+            1. Record pre-rotation auth keys and daemon pod states.
+            2. Cordon one OSD-hosting node.
+            3. Trigger daemon key rotation and wait for completion.
+            4. Verify all daemon keys rotated and cluster is healthy.
+            5. Uncordon the node.
+            6. Trigger a second daemon key rotation and wait for completion.
+            7. Verify all daemon keys rotated again and cluster is healthy.
+        """
+        rotator = cephx_keyrotation_setup
+        namespace = config.ENV_DATA["cluster_namespace"]
+        mon_rotation_supported = rotator.is_mon_key_rotation_supported()
+
+        osd_nodes = get_osd_running_nodes()
+        if len(osd_nodes) < MIN_OSD_NODES:
+            pytest.skip(
+                f"Need at least {MIN_OSD_NODES} OSD nodes; found {len(osd_nodes)}"
+            )
+
+        auth_entities = rotator.discover_rook_daemon_auth_entities()
+        for daemon, entities in auth_entities.items():
+            if daemon == "mon" and not entities:
+                log.info(
+                    "MON auth entities not in ceph auth store; MON rotation "
+                    "will be verified via status.cephx.mon and mon pod restarts"
+                )
+                continue
+            assert entities, f"No Ceph auth entities found for {daemon}"
+
+        all_entities = rotator.flatten_daemon_auth_entities(auth_entities)
+        ceph_health_check(namespace=namespace)
+
+        # --- Phase 1: Cordon one node and rotate ---
+        cordon_target = osd_nodes[0]
+        # Assign before unschedule so teardown can uncordon if readiness wait fails.
+        self._cordoned_node = cordon_target
+        log.info(f"Cordoning OSD node: {cordon_target}")
+        unschedule_nodes([cordon_target])
+
+        pre_generations_1 = rotator.record_daemon_generations()
+        pre_auth_keys_1 = rotator.capture_auth_keys(
+            all_entities, label="before rotation (node cordoned)"
+        )
+        pre_pod_states_1 = rotator.capture_all_daemon_pod_states()
+        for daemon, pods in pre_pod_states_1.items():
+            assert pods, f"No Running pods found for {daemon} before cordoned rotation"
+
+        target_gen_1 = rotator.rotate_daemon_keys()
+        log.info(
+            f"Triggered daemon CephX rotation to generation {target_gen_1} "
+            f"(node {cordon_target} cordoned)"
+        )
+
+        rotator.wait_for_rook_daemon_rotation(target_gen_1, timeout=1500)
+        rotator.wait_for_all_daemon_pod_restarts(pre_pod_states_1)
+
+        rotator.assert_rook_daemon_generations(target_gen_1, mon_rotation_supported)
+        rotator.assert_generations_increased(pre_generations_1, mon_rotation_supported)
+        rotator.log_generation_status("After rotation with node cordoned")
+
+        post_auth_keys_1 = rotator.verify_auth_keys_changed(
+            pre_auth_keys_1, entities=all_entities
+        )
+        rotator.log_auth_key_snapshot("after cordoned rotation", post_auth_keys_1)
+
+        rotator.wait_for_pgs_active_clean()
+        ceph_health_check(namespace=namespace)
+        rotator.wait_for_cluster_ready()
+        log.info(
+            "Daemon CephX rotation completed successfully with node "
+            f"{cordon_target} cordoned"
+        )
+
+        # --- Phase 2: Uncordon the node and rotate again ---
+        log.info(f"Uncordoning OSD node: {cordon_target}")
+        schedule_nodes([cordon_target])
+        self._cordoned_node = None
+
+        rotator.wait_for_rook_daemon_pods_ready()
+        rotator.wait_for_pgs_active_clean()
+        ceph_health_check(namespace=namespace)
+
+        pre_generations_2 = rotator.record_daemon_generations()
+        pre_auth_keys_2 = rotator.capture_auth_keys(
+            all_entities, label="before rotation (node uncordoned)"
+        )
+        pre_pod_states_2 = rotator.capture_all_daemon_pod_states()
+        for daemon, pods in pre_pod_states_2.items():
+            assert (
+                pods
+            ), f"No Running pods found for {daemon} before uncordoned rotation"
+
+        target_gen_2 = rotator.rotate_daemon_keys()
+        log.info(
+            f"Triggered daemon CephX rotation to generation {target_gen_2} "
+            f"(node {cordon_target} uncordoned)"
+        )
+
+        rotator.wait_for_rook_daemon_rotation(target_gen_2, timeout=1500)
+        post_pod_states_2 = rotator.wait_for_all_daemon_pod_restarts(pre_pod_states_2)
+
+        rotator.assert_rook_daemon_generations(target_gen_2, mon_rotation_supported)
+        rotator.assert_generations_increased(pre_generations_2, mon_rotation_supported)
+        rotator.log_generation_status("After rotation with node uncordoned")
+
+        post_auth_keys_2 = rotator.verify_auth_keys_changed(
+            pre_auth_keys_2, entities=all_entities
+        )
+        rotator.log_auth_key_snapshot("after uncordoned rotation", post_auth_keys_2)
+
+        for entity in all_entities:
+            key_1 = post_auth_keys_1.get(entity)
+            key_2 = post_auth_keys_2.get(entity)
+            if key_1 and key_2:
+                assert key_1 != key_2, (
+                    f"Auth key for {entity} was not rotated in the second "
+                    "rotation after uncordon"
+                )
+
+        rotator.wait_for_pgs_active_clean()
+        ceph_health_check(namespace=namespace)
+        rotator.wait_for_cluster_ready()
+
+        # AUTH_BAD_KEY check across MON/MGR/OSD/MDS using pod-name dicts from
+        # capture_all_daemon_pod_states / wait_for_all_daemon_pod_restarts.
+        all_daemon_pod_names = [
+            pod_name for pods in post_pod_states_2.values() for pod_name in pods
+        ]
+        rotator.verify_pods_no_auth_bad_key(all_daemon_pod_names)
+
+        log.info(
+            "CephX daemon key rotation with node cordon/uncordon completed "
+            "successfully across two rotation cycles"
+        )

--- a/tests/functional/cephx_keyrotation/test_cephx_keyrotation_osd_lockbox.py
+++ b/tests/functional/cephx_keyrotation/test_cephx_keyrotation_osd_lockbox.py
@@ -1,0 +1,124 @@
+"""
+OSD Lockbox CephX Key Rotation for Encrypted OSDs
+
+Verify that lockbox CephX keys (client.osd-lockbox.<UUID>) are rotated correctly
+for encrypted OSDs: encrypted labels, updated lockbox keys, activate init container
+key load, operator rotation logs, and cluster health after rotation.
+"""
+
+import logging
+
+import pytest
+
+from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import (
+    green_squad,
+    skipif_external_mode,
+    skipif_ocs_version,
+    tier1,
+)
+from ocs_ci.helpers.helpers import get_last_log_time_date
+from ocs_ci.ocs import constants
+from ocs_ci.utility.utils import ceph_health_check
+
+log = logging.getLogger(__name__)
+
+MIN_ENCRYPTED_OSD_COUNT = 1
+
+
+@skipif_external_mode
+@skipif_ocs_version(["<4.21", ">=4.23"])
+@green_squad
+class TestCephXKeyRotationOSDLockbox:
+    @pytest.mark.polarion_id("OCS-8135")
+    @tier1
+    def test_cephx_key_rotation_osd_lockbox_encrypted(self, cephx_keyrotation_setup):
+        """
+        Verify lockbox CephX key rotation for encrypted OSDs.
+
+        Steps:
+            1. Discover encrypted OSD deployments and lockbox auth entities.
+            2. Verify ``encrypted=true`` labels and record baseline lockbox keys.
+            3. Trigger daemon key rotation.
+            4. Wait for OSD pod restarts and verify lockbox keys changed.
+            5. Verify activate init container and operator lockbox rotation logs.
+            6. Verify encrypted OSD pods remain Running/Ready and PGs are clean.
+
+        Requires a cluster with encrypted OSDs (host-based and/or PVC-based).
+        """
+        rotator = cephx_keyrotation_setup
+        namespace = config.ENV_DATA["cluster_namespace"]
+
+        encrypted_deployments = rotator.capture_encrypted_osd_deployments()
+        if len(encrypted_deployments) < MIN_ENCRYPTED_OSD_COUNT:
+            pytest.skip(
+                f"Cluster has {len(encrypted_deployments)} encrypted OSD "
+                f"deployment(s); need at least {MIN_ENCRYPTED_OSD_COUNT}"
+            )
+
+        rotator.assert_encrypted_osd_labels(encrypted_deployments)
+        log.info(
+            "Encrypted OSD deployments: "
+            + ", ".join(
+                f"{name} (osd_id={info['osd_id']}, store={info['store_type']})"
+                for name, info in sorted(encrypted_deployments.items())
+            )
+        )
+        store_types = {info["store_type"] for info in encrypted_deployments.values()}
+        if store_types == {"pvc"}:
+            log.info("All encrypted OSDs are PVC-backed on this cluster")
+        elif store_types == {"host"}:
+            log.info("All encrypted OSDs are host/disk-based on this cluster")
+        else:
+            log.info("Cluster has a mix of host-based and PVC-based encrypted OSDs")
+
+        lockbox_entities = rotator.discover_lockbox_auth_entities()
+        if not lockbox_entities:
+            pytest.skip("No client.osd-lockbox.* auth entities found on cluster")
+
+        log.info(f"Lockbox auth entities: {', '.join(lockbox_entities)}")
+        pre_osd_generation = rotator.get_status_key_generation("osd")
+        pre_auth_keys = rotator.capture_auth_keys(
+            lockbox_entities, label="lockbox keys before rotation"
+        )
+        pre_pod_states = rotator.capture_daemon_pod_state(constants.OSD_APP_LABEL)
+
+        ceph_health_check(namespace=namespace)
+
+        operator_log_marker = get_last_log_time_date()
+        target_generation = rotator.rotate_daemon_keys()
+        log.info(f"Triggered daemon CephX rotation to generation {target_generation}")
+
+        rotator.wait_for_osd_rotation(target_generation, timeout=1500)
+        rotator.wait_for_pod_restarts(pre_pod_states, constants.OSD_APP_LABEL)
+
+        assert (
+            rotator.get_status_key_generation("osd") >= target_generation
+        ), "CephCluster status.cephx.osd keyGeneration did not reach target"
+
+        post_auth_keys = rotator.verify_auth_keys_changed(
+            pre_auth_keys, entities=lockbox_entities
+        )
+        rotator.log_auth_key_snapshot("lockbox keys after rotation", post_auth_keys)
+
+        encrypted_osd_pods = rotator.get_encrypted_osd_pods()
+        rotator.verify_osd_activate_lockbox_logs(encrypted_osd_pods)
+        rotator.verify_operator_lockbox_rotation_logs(
+            len(encrypted_deployments), since_time=operator_log_marker
+        )
+        rotator.verify_encrypted_osd_pods_running(encrypted_osd_pods)
+
+        # OSDs track rotation via Deployment cephx-status, not cephx-key-identifier.
+        log.info(
+            "Post-rotation encrypted OSD pods: "
+            + ", ".join(pod.name for pod in encrypted_osd_pods)
+        )
+
+        rotator.wait_for_pgs_active_clean()
+        ceph_health_check(namespace=namespace)
+        rotator.wait_for_cluster_ready()
+
+        assert (
+            rotator.get_status_key_generation("osd") > pre_osd_generation
+        ), "OSD keyGeneration should increase after lockbox CephX key rotation"
+        log.info("Encrypted OSD lockbox CephX key rotation completed successfully")

--- a/tests/functional/tlsprofile/Untitled
+++ b/tests/functional/tlsprofile/Untitled
@@ -1,0 +1,1 @@
+tests/functional/tlsprofile/test_centralized_tlsprofile_configuration.py


### PR DESCRIPTION
This is a manual cherry-pick of #15362 to release-4.21.

The automated cherry-pick (from #15966) failed due to merge conflicts in:
- `conf/ocsci/krkn_chaos_config.yaml` — formatting difference in `enabled_operations` list
- `ocs_ci/krkn_chaos/background_cluster_operations.py` — import line conflict
- `ocs_ci/ocs/constants.py` — new CephX constants block

All conflicts have been resolved while preserving the release-4.21 branch style.