### PR TITLE
Add conf/ocsci/block_only_deployment.yaml configuration file

### DIFF
--- a/conf/ocsci/block_only_deployment.yaml
+++ b/conf/ocsci/block_only_deployment.yaml
@@ -1,0 +1,12 @@
+---
+# this configuration file was tested on bm-octo-argo environment, but might be
+# working elsewhere as well
+# related to OCSQE-3874
+COMPONENTS:
+  disable_rgw: true
+  disable_cephobjectstoreusers: true
+  disable_noobaa: true
+  disable_cephfs: true
+  disable_blockpools: false
+REPORTING:
+  rp_additional_info: 'This is "Block only" deployment, which means that other components (RGW, Obejectstore, Noobaa, CephFS) are not deployed and all tests using those components should be skipped. See https://github.com/red-hat-storage/ocs-ci/pull/15478/.'


### PR DESCRIPTION
Related to: [OCSQE-3874](https://url.corp.redhat.com/a2d5da0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a block-only storage deployment configuration.
  * Enables block storage while disabling object storage, file storage, and related services.
  * Includes deployment reporting metadata and skipped component test details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->