### PR TITLE
enable eus to eus odf upgrade

### DIFF
--- a/conf/upgrade/eus_upgrade.yaml
+++ b/conf/upgrade/eus_upgrade.yaml
@@ -1,0 +1,6 @@
+UPGRADE:
+  eus_upgrade: true
+  eus_max_ocp_version_override: "4.22"
+  eus_csvs_to_patch:
+    - "odf-operator"
+    - "odf-dependencies"

--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -335,6 +335,12 @@ UPGRADE:
   # Values to be set after upgrade started - used for resiliancy testing
   csi_rbd_plugin_update_strategy_max_unavailable_upgrade_middle: null
   csi_cephfs_plugin_update_strategy_max_unavailable_upgrade_middle: null
+  # EUS-to-EUS ODF upgrade settings
+  eus_upgrade: false
+  eus_max_ocp_version_override: null
+  eus_csvs_to_patch:
+    - "odf-operator"
+    - "odf-dependencies"
 
 # This section stores secret and uploaded from home dir or s3
 # for entry into this section, please email ecosystem team

--- a/ocs_ci/ocs/ocs_upgrade.py
+++ b/ocs_ci/ocs/ocs_upgrade.py
@@ -428,6 +428,12 @@ def verify_noobaa_pods_upgraded(old_images, upgrade_version):
         + config.ENV_DATA.get("infra_replicas", 0)
     )
     timeout = 600 if num_nodes < 6 else 900
+    # Workaround: In EUS-to-EUS upgrades to ODF 4.22+ the noobaa-core pod takes
+    # considerably longer to roll to the new image (the NooBaa DB is migrated to
+    # a CNPG-managed PostgreSQL cluster and noobaa-core only rolls once that
+    # migration completes). Extend the timeout for this scenario.
+    if config.UPGRADE.get("eus_upgrade") and upgrade_version >= parse_version("4.22"):
+        timeout = max(timeout, 1800)
 
     verify_pods_upgraded(
         old_images,

--- a/ocs_ci/ocs/ocs_upgrade.py
+++ b/ocs_ci/ocs/ocs_upgrade.py
@@ -198,6 +198,12 @@ def _patch_max_openshift_version_in_annotation(annotation_value, target_version)
                     changed = True
     elif isinstance(data, dict):
         props = data.get("properties", [])
+        if not isinstance(props, list):
+            log.warning(
+                "Unexpected type for 'properties' in annotation: %s",
+                type(props).__name__,
+            )
+            return None
         for entry in props:
             if (
                 isinstance(entry, dict)

--- a/ocs_ci/ocs/ocs_upgrade.py
+++ b/ocs_ci/ocs/ocs_upgrade.py
@@ -1,3 +1,4 @@
+import json
 import os
 import logging
 from datetime import datetime
@@ -164,6 +165,133 @@ def prune_old_df_repo_idms(keep_latest: int = 1, force_delete_pods: bool = False
     )
 
     return to_delete
+
+
+def _patch_max_openshift_version_in_annotation(annotation_value, target_version):
+    """
+    Parse a JSON annotation string containing olm.maxOpenShiftVersion
+    and replace its value with target_version.
+
+    Args:
+        annotation_value (str): JSON string from CSV annotation
+        target_version (str): New maxOpenShiftVersion value
+
+    Returns:
+        str: Updated JSON string, or None if no change was needed
+
+    """
+    try:
+        data = json.loads(annotation_value)
+    except (json.JSONDecodeError, TypeError):
+        log.warning("Failed to parse annotation value as JSON: %s", annotation_value)
+        return None
+
+    changed = False
+    if isinstance(data, list):
+        for entry in data:
+            if (
+                isinstance(entry, dict)
+                and entry.get("type") == "olm.maxOpenShiftVersion"
+            ):
+                if entry.get("value") != target_version:
+                    entry["value"] = target_version
+                    changed = True
+    elif isinstance(data, dict):
+        props = data.get("properties", [])
+        for entry in props:
+            if (
+                isinstance(entry, dict)
+                and entry.get("type") == "olm.maxOpenShiftVersion"
+            ):
+                if entry.get("value") != target_version:
+                    entry["value"] = target_version
+                    changed = True
+
+    return json.dumps(data) if changed else None
+
+
+def patch_csv_max_openshift_version(target_version, csv_prefixes=None, namespace=None):
+    """
+    Patch maxOpenShiftVersion in olm.properties and
+    operatorframework.io/properties annotations on ODF CSVs.
+
+    During EUS-to-EUS upgrades, ODF CSVs restrict OCP upgrades via the
+    maxOpenShiftVersion annotation. This patches the restriction so that
+    OCP can advance to the target version.
+
+    Args:
+        target_version (str): The maxOpenShiftVersion value to set
+            (e.g., "4.22")
+        csv_prefixes (list): CSV name prefixes to patch. Defaults to
+            config UPGRADE.eus_csvs_to_patch or
+            ["odf-operator", "odf-dependencies"].
+        namespace (str): Namespace where CSVs live. Defaults to
+            config ENV_DATA.cluster_namespace.
+
+    """
+    if csv_prefixes is None:
+        csv_prefixes = config.UPGRADE.get(
+            "eus_csvs_to_patch", ["odf-operator", "odf-dependencies"]
+        )
+    if namespace is None:
+        namespace = config.ENV_DATA["cluster_namespace"]
+
+    log.info(
+        "EUS upgrade: patching maxOpenShiftVersion to %s on CSVs "
+        "matching prefixes %s in namespace %s",
+        target_version,
+        csv_prefixes,
+        namespace,
+    )
+
+    annotation_keys = ["olm.properties", "operatorframework.io/properties"]
+    csv_ocp = OCP(kind="csv", namespace=namespace)
+
+    for prefix in csv_prefixes:
+        matching_csvs = get_csvs_start_with_prefix(prefix, namespace)
+        if not matching_csvs:
+            log.warning("No CSVs found matching prefix %s", prefix)
+            continue
+
+        for csv_data in matching_csvs:
+            csv_name = csv_data["metadata"]["name"]
+            annotations = csv_data.get("metadata", {}).get("annotations", {})
+
+            for ann_key in annotation_keys:
+                ann_value = annotations.get(ann_key)
+                if not ann_value:
+                    continue
+
+                updated = _patch_max_openshift_version_in_annotation(
+                    ann_value, target_version
+                )
+                if updated is None:
+                    log.info(
+                        "No maxOpenShiftVersion change needed in %s "
+                        "annotation on CSV %s",
+                        ann_key,
+                        csv_name,
+                    )
+                    continue
+
+                escaped = json.dumps(updated)
+                patch_str = (
+                    f'{{"metadata":{{"annotations":' f'{{"{ann_key}":{escaped}}}}}}}'
+                )
+                log.info(
+                    "Patching annotation %s on CSV %s to allow "
+                    "maxOpenShiftVersion %s",
+                    ann_key,
+                    csv_name,
+                    target_version,
+                )
+                csv_ocp.patch(
+                    resource_name=csv_name,
+                    params=patch_str,
+                    format_type="merge",
+                )
+
+    log.info("EUS upgrade: maxOpenShiftVersion patch complete")
 
 
 def get_upgrade_image_info(old_csv_images, new_csv_images):
@@ -850,6 +978,16 @@ def run_ocs_upgrade(
         f"is not higher or equal to the version you currently running: "
         f"{upgrade_ocs.version_before_upgrade}"
     )
+
+    if config.UPGRADE.get("eus_upgrade"):
+        eus_target = config.UPGRADE.get("eus_max_ocp_version_override")
+        if eus_target:
+            patch_csv_max_openshift_version(eus_target, namespace=namespace)
+        else:
+            log.warning(
+                "EUS upgrade enabled but eus_max_ocp_version_override is not set, "
+                "skipping maxOpenShiftVersion patch"
+            )
 
     # Update values CSI_RBD_PLUGIN_UPDATE_STRATEGY_MAX_UNAVAILABLE and CSI_CEPHFS_PLUGIN_UPDATE_STRATEGY_MAX_UNAVAILABLE
     # in rook-ceph-operator-config configmap


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for EUS-to-EUS ODF upgrades.
  * Added configuration for maximum OpenShift version overrides and targeted ODF components.
  * Automatically updates supported component metadata during configured upgrades.
  * Supports selecting specific ODF components for metadata updates.

* **Bug Fixes**
  * Improved handling of malformed or unchanged upgrade metadata.
  * Added warnings when a required version override is not configured.
  * Extended upgrade verification time for ODF 4.22 and later.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->