### PR TITLE
Add STS and standard backingstore coexistence test

### DIFF
--- a/ocs_ci/ocs/bucket_utils.py
+++ b/ocs_ci/ocs/bucket_utils.py
@@ -763,6 +763,7 @@ def cli_create_aws_backingstore(mcg_obj, cld_mgr, backingstore_name, uls_name, r
         region (str): which region to create backingstore (should be the same as uls)
 
     """
+    region = region or "us-east-1"
     mcg_obj.exec_mcg_cmd(
         f"backingstore create aws-s3 {backingstore_name} "
         f"--secret-name {cld_mgr.aws_client.secret.name} "
@@ -785,6 +786,7 @@ def cli_create_aws_sts_backingstore(
         region (str): which region to create backingstore (should be the same as uls)
 
     """
+    region = region or "us-east-1"
     mcg_obj.exec_mcg_cmd(
         f"backingstore create aws-sts-s3 {backingstore_name} "
         f"--aws-sts-arn {cld_mgr.aws_sts_client.role_arn} "

--- a/ocs_ci/ocs/resources/cloud_manager.py
+++ b/ocs_ci/ocs/resources/cloud_manager.py
@@ -838,6 +838,18 @@ class AwsSTSClient(S3Client):
             **kwargs,
         )
 
+        self.region = "us-east-1"
+        self.endpoint = None
+        self.client = boto3.resource(
+            "s3",
+            verify=verify,
+            endpoint_url=self.endpoint,
+            aws_access_key_id=self.access_key,
+            aws_secret_access_key=self.secret_key,
+            region_name=self.region,
+            config=Config(s3={"addressing_style": "virtual"}),
+        )
+
 
 class AzureSTSClient(AzureClient):
     """

--- a/tests/functional/object/mcg/test_sts_bucket.py
+++ b/tests/functional/object/mcg/test_sts_bucket.py
@@ -268,3 +268,132 @@ class TestSTSBucket:
                 remaining.get("KeyCount", 0) == 0
             ), f"Bucket {bucketname} still has objects after deletion"
             logger.info(f"IO round-trip verified for bucket {bucketname}")
+
+    @pytest.mark.parametrize(
+        argnames=["sts_platform", "std_platform", "region", "interface"],
+        argvalues=[
+            pytest.param(
+                "aws-sts",
+                "aws",
+                "eu-central-1",
+                "CLI",
+                marks=[tier2, aws_platform_required, polarion_id("OCS-8213")],
+            ),
+            pytest.param(
+                "azure-sts",
+                "azure",
+                None,
+                "CLI",
+                marks=[
+                    tier2,
+                    azure_platform_required,
+                    polarion_id("OCS-8214"),
+                ],
+            ),
+            pytest.param(
+                "gcp-sts",
+                "gcp",
+                None,
+                "OC",
+                marks=[tier2, gcp_platform_required, polarion_id("OCS-8215")],
+            ),
+        ],
+        ids=["AWS", "AZURE", "GCP"],
+    )
+    def test_multiple_sts_and_standard_backingstores(
+        self,
+        backingstore_factory,
+        bucket_factory,
+        awscli_pod_session,
+        test_directory_setup,
+        mcg_obj_session,
+        sts_platform,
+        std_platform,
+        region,
+        interface,
+    ):
+        """
+        Test that multiple STS backingstores and a mixed combination
+        of standard + STS backingstores can coexist on the same cluster.
+
+        1. Create 3 STS backingstores
+        2. Create 1 standard (non-STS) backingstore
+        3. Create a bucketclass and OBC for each backingstore
+        4. Upload, download, and verify data integrity on each bucket
+        """
+
+        # 1. Create 3 STS backingstores
+        logger.test_step(f"Create 3 {sts_platform} backingstores via {interface}")
+        sts_backingstores = backingstore_factory(
+            interface, {sts_platform: [(3, region)]}
+        )
+
+        # 2. Create 1 standard (non-STS) backingstore
+        logger.test_step(
+            f"Create 1 standard {std_platform} backingstore via {interface}"
+        )
+        std_backingstores = backingstore_factory(
+            interface, {std_platform: [(1, region)]}
+        )
+
+        all_backingstores = sts_backingstores + std_backingstores
+
+        # 3. Create a bucketclass and OBC for each backingstore
+        logger.test_step("Create a bucketclass and OBC for each backingstore")
+        bucketclass_dicts = [
+            {"interface": interface, "backingstores": [bs]} for bs in all_backingstores
+        ]
+        bucketnames = [
+            bucket_factory(bucketclass=bc)[0].name for bc in bucketclass_dicts
+        ]
+        logger.info(f"Created buckets: {bucketnames}")
+
+        # 4. Upload, download, and verify data integrity on each bucket
+        logger.test_step("Upload, download, and verify data integrity on each bucket")
+        for bucketname in bucketnames:
+            awscli_pod_session.exec_cmd_on_pod(
+                f"rm -rf '{test_directory_setup.origin_dir}'"
+                f" '{test_directory_setup.result_dir}'"
+            )
+
+            obj_list = write_random_test_objects_to_bucket(
+                io_pod=awscli_pod_session,
+                bucket_to_write=bucketname,
+                file_dir=test_directory_setup.origin_dir,
+                amount=5,
+                pattern="Random-Obj",
+                mcg_obj=mcg_obj_session,
+            )
+
+            sync_object_directory(
+                podobj=awscli_pod_session,
+                src=f"s3://{bucketname}",
+                target=test_directory_setup.result_dir,
+                s3_obj=mcg_obj_session,
+            )
+
+            assert compare_directory(
+                awscli_pod=awscli_pod_session,
+                original_dir=test_directory_setup.origin_dir,
+                result_dir=test_directory_setup.result_dir,
+                amount=5,
+                pattern="Random-Obj",
+            ), f"Data integrity check failed for bucket {bucketname}"
+
+            s3_delete_objects(
+                mcg_obj_session,
+                bucketname=bucketname,
+                object_keys=[{"Key": f"{obj}"} for obj in obj_list],
+            )
+
+            remaining = s3_list_objects_v2(
+                s3_obj=mcg_obj_session, bucketname=bucketname
+            )
+            logger.assertion(
+                f"Bucket emptied after delete: bucket='{bucketname}', "
+                f"remaining_objects={remaining.get('KeyCount', 0)}"
+            )
+            assert (
+                remaining.get("KeyCount", 0) == 0
+            ), f"Bucket {bucketname} still has objects after deletion"
+            logger.info(f"IO round-trip verified for bucket {bucketname}")

--- a/tests/functional/object/mcg/test_sts_bucket.py
+++ b/tests/functional/object/mcg/test_sts_bucket.py
@@ -275,7 +275,7 @@ class TestSTSBucket:
             pytest.param(
                 "aws-sts",
                 "aws",
-                "eu-central-1",
+                None,
                 "CLI",
                 marks=[tier2, aws_platform_required, polarion_id("OCS-8213")],
             ),


### PR DESCRIPTION
## Summary
- Add tier2 parametrized test verifying that multiple STS backingstores and a mixed combination of STS + standard backingstores can coexist on the same cluster
- Covers AWS, Azure, and GCP STS platforms

## Changes
- `tests/functional/object/mcg/test_sts_bucket.py` - new `test_multiple_sts_and_standard_backingstores` test (Polarion: OCS-8213, OCS-8214, OCS-8215)
- `ocs_ci/ocs/resources/cloud_manager.py` - fix `AwsSTSClient` to use the same cross-region-safe boto3 client configuration that `AwsClient` uses (`us-east-1` signing region, dynamic endpoint, virtual addressing style). Without this fix, `AwsSTSClient` inherits `S3Client`'s hardcoded endpoint and cluster region, which breaks `head_bucket` for buckets created in a different region (e.g. `eu-central-1` on a `us-east-2` cluster). This was discovered during verification of the coexistence test on an AWS STS cluster.
- `tests/functional/object/mcg/test_sts_bucket.py` - change AWS STS parametrize region from `eu-central-1` to `None` (cluster region). AWS STS regional endpoints must be explicitly activated per account, and `eu-central-1` was not activated for the test account (861790564636), causing backingstore reconciliation to fail with `STS is not activated in this region`. Using `None` lets the test use the cluster's own region, which is guaranteed to have STS activated on an STS-enabled cluster.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved AWS STS-backed storage handling by consistently applying the configured region, credentials, endpoint, and addressing settings.
  - Increased compatibility with AWS S3 configurations.

- **Reliability**
  - Added validation for environments using multiple STS-backed storage buckets alongside standard storage across AWS, Azure, and GCP.
  - Confirmed reliable object upload, download, deletion, and bucket cleanup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->