### PR TITLE
Dynamically discover all noobaa-core-* pods

### DIFF
--- a/ocs_ci/ocs/ocs_upgrade.py
+++ b/ocs_ci/ocs/ocs_upgrade.py
@@ -227,7 +227,6 @@ def get_expected_noobaa_pod_count(upgrade_version):
 
     """
     expected_noobaa_pods = [
-        "noobaa-core-0",
         "noobaa-operator",
         "noobaa-db-pg-cluster-1",
         "noobaa-db-pg-cluster-2",
@@ -238,6 +237,8 @@ def get_expected_noobaa_pod_count(upgrade_version):
     noobaa_pod_names = [pod.name for pod in noobaa_pod_obj]
     logger.info(f"Current noobaa pods under validation: {noobaa_pod_names}")
     for pod in noobaa_pod_obj:
+        if pod.name.startswith("noobaa-core-"):
+            expected_noobaa_pods.append(pod.name)
         if "pv-backingstore" in pod.name:
             expected_noobaa_pods.append(pod.name)
         if upgrade_version >= parse_version("4.19"):


### PR DESCRIPTION
Fixed an issue where the expected noobaa pod list doesn't match the actual pods in ODF 5.0 upgrades due to there being more than one noobaa-core pod

Ex: https://url.corp.redhat.com/5a3410e
```
E           ValueError: Expected noobaa pods: ['noobaa-core-0', 'noobaa-operator', 'noobaa-db-pg-cluster-1', 'noobaa-db-pg-cluster-2', 'cnpg-controller-manager-588bd9bc85-zw6xx', 'noobaa-endpoint-674b7bb7d7-z8cmh'] do not match actual noobaa pods: ['cnpg-controller-manager-588bd9bc85-zw6xx', 'noobaa-core-0', 'noobaa-core-1', 'noobaa-db-pg-cluster-1', 'noobaa-db-pg-cluster-2', 'noobaa-endpoint-674b7bb7d7-z8cmh', 'noobaa-operator-86998cf9c6-vxh4z']
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of NooBaa core pods by recognizing dynamically named core pods.
  * Prevented validation issues caused by relying on a single fixed pod name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->