### PR TITLE
deployment: fix ODF CLI validation namespace lookup in automated ACM …

### DIFF
--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -3006,12 +3006,13 @@ class Deployment(object):
                 if not wait_for_pods_by_label_count(
                     label=pod_label,
                     expected_count=1,
-                    namespace=constants.ACM_ADDONS_NAMESPACE_DISCOVERY,
+                    namespace=existing_spec["spec"]["agentInstallNamespace"],
                     timeout=400,
                     sleep=10,
                 ):
                     raise ResourceNotFoundError(
-                        f"Pod with label {pod_label} not found in the ns {constants.ACM_ADDONS_NAMESPACE_DISCOVERY}"
+                        f"Pod with label {pod_label} not found in the ns "
+                        f"{existing_spec['spec']['agentInstallNamespace']}"
                     )
 
         # Configuration for backup and restore. Add backup label to the default and new addondeploymentconfig,


### PR DESCRIPTION
…path

In the automated MCE import branch (ACM > 2.14), the pod-wait loop was reading the agentInstallNamespace from
`addon_deployment_config.data["spec"]`, where `addon_deployment_config` is an `ocp.OCP` object whose `hypershift-addon-deploy-config` resource has no `agentInstallNamespace` field. Additionally, `OCP.data` returns `dict | None`, making the subscript unsafe (Pyright reportOptionalSubscript).

Replace both occurrences with `existing_spec["spec"]["agentInstallNamespace"]`, which is the already-fetched dict from `addon_deployment_config.get()` at line 2944 — correct resource, correct type, no None risk.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved managed cluster add-on configuration by using the namespace specified in the deployment settings.
  * Updated missing-pod error messages to identify the correct namespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->