### PR TITLE
Fix clone_repo timeout on large repos by fetching only the needed branch

### DIFF
--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -4029,6 +4029,7 @@ def clone_repo(
     force_checkout=False,
     clone_token=None,
     sparse_checkout_dirs=None,
+    timeout=3600,
 ):
     """
     Clone a repository or checkout latest changes if it already exists at
@@ -4049,6 +4050,8 @@ def clone_repo(
         sparse_checkout_dirs (list): list of directories to include in sparse
             checkout. When provided, only the specified directories will be
             checked out, significantly reducing disk usage for large repos.
+        timeout (int): Timeout in seconds for git clone/fetch commands.
+            Defaults to 3600 (60 minutes).
 
     Raises:
         UnknownCloneTypeException: In case of incorrect clone_type is used
@@ -4094,7 +4097,11 @@ def clone_repo(
         if clone_token:
             url = url.replace("https://", f"https://{clone_token}@")
             clone_token = [clone_token]
-        exec_cmd(cmd=f"git clone {git_params} {url} {location}", secrets=clone_token)
+        exec_cmd(
+            cmd=f"git clone {git_params} {url} {location}",
+            secrets=clone_token,
+            timeout=timeout,
+        )
         if sparse_checkout_dirs:
             sparse_paths = " ".join(sparse_checkout_dirs)
             log.info("Setting sparse checkout for directories: %s", sparse_paths)
@@ -4102,7 +4109,7 @@ def clone_repo(
     else:
         log.info("Repository already cloned at %s, skipping clone", location)
         log.info("Fetching latest changes from repository")
-        exec_cmd("git fetch --all", cwd=location)
+        exec_cmd("git fetch --all", cwd=location, timeout=timeout)
     log.info("Checking out repository to specific branch: %s", branch)
     if force_checkout:
         exec_cmd(f"git checkout --force {branch}", cwd=location)


### PR DESCRIPTION
Initially I tried to replace the 'git fetch --all' with 'git fetch origin <branch>' to avoid downloading all refs from all remotes (e.g. openshift/installer at 3.7GB) and use shallow/filtered fetch parameters matching the clone_type (`--depth=1`, `--filter=blob:none`, etc.), but it didn't work correctly and will require more debugging and fixes to actually work correctly and didn't break anything. So for now, I'm just extending the timeout for the affected git commands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Improved repository cloning reliability with configurable operation timeouts, defaulting to 30 minutes.
- Standardized clone, fetch, checkout, and reset operations for more consistent execution.
- Improved branch checkout behavior, including optional forced checkout.
- Added support for checking out a specific commit or tag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->