### PR TITLE
Remove multicloudgateway key from noobaa commands

### DIFF
--- a/tests/cross_functional/kcs/test_disable_mcg_external_service.py
+++ b/tests/cross_functional/kcs/test_disable_mcg_external_service.py
@@ -44,7 +44,7 @@ class TestDisableMCGExternalService:
         logger.test_step("Scale up NooBaa endpoints (min=2, max=4)")
         noobaa_ocp_obj.patch(
             resource_name="noobaa",
-            params='{"spec": {"multiCloudGateway": {"endpoints": {"minCount": 2,"maxCount": 4}}}}',
+            params='{"spec": {"endpoints": {"minCount": 2,"maxCount": 4}}}',
             format_type="merge",
         )
         wait_for_noobaa_db_ready()
@@ -61,7 +61,7 @@ class TestDisableMCGExternalService:
             logger.test_step("Restore NooBaa endpoints to defaults (min=1, max=2)")
             noobaa_ocp_obj.patch(
                 resource_name="noobaa",
-                params='{"spec": {"multiCloudGateway": {"endpoints": {"minCount": 1,"maxCount": 2}}}}',
+                params='{"spec": {"endpoints": {"minCount": 1,"maxCount": 2}}}',
                 format_type="merge",
             )
             wait_for_noobaa_db_ready()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated NooBaa endpoint configuration handling in the related test workflow.
  * Ensured endpoint scaling and default restoration use the correct configuration path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->