### PR TITLE
iam-policy-permissions-AWS-HCP

### DIFF
--- a/ocs_ci/templates/ocs-deployment/provider-mode/aws-hcp/iam_role_policy.json
+++ b/ocs_ci/templates/ocs-deployment/provider-mode/aws-hcp/iam_role_policy.json
@@ -95,7 +95,9 @@
                 "iam:DeleteRolePolicy",
                 "iam:UpdateRole",
                 "iam:DeleteOpenIDConnectProvider",
-                "iam:GetRolePolicy"
+                "iam:GetRolePolicy",
+                "iam:TagOpenIDConnectProvider",
+                "iam:TagInstanceProfile"
             ],
             "Resource": "*"
         },

--- a/ocs_ci/templates/ocs-deployment/provider-mode/aws-hcp/iam_role_policy.json
+++ b/ocs_ci/templates/ocs-deployment/provider-mode/aws-hcp/iam_role_policy.json
@@ -110,7 +110,9 @@
                 "route53:ListResourceRecordSets",
                 "route53:DeleteHostedZone",
                 "route53:AssociateVPCWithHostedZone",
-                "route53:ListHostedZonesByName"
+                "route53:ListHostedZonesByName",
+                "route53:ChangeTagsForResource",
+                "route53:ListTagsForResource"
             ],
             "Resource": "*"
         },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AWS HCP provider-mode deployment support by enabling required IAM and Route 53 tagging operations.
  * Deployments can now tag OpenID Connect providers, instance profiles, and Route 53 resources, and retrieve resource tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->