### PR TITLE
Update Submariner to 0.24.0 for OCP 4.23 and 5.0

### DIFF
--- a/ocs_ci/framework/conf/ocp_version/ocp-4.23-config.yaml
+++ b/ocs_ci/framework/conf/ocp_version/ocp-4.23-config.yaml
@@ -20,7 +20,6 @@ ENV_DATA:
   acm_hub_channel: "release-2.17"
   acm_version: "2.17"
   mce_version: "2.17"
-  submariner_version: "0.23.1"
-  submariner_image: "quay.io/redhat-user-workloads/submariner-tenant/submariner-fbc-4-21@sha256:1585a2a6c372f8a66b7644e742d95356b577072dfc83492c14759f6b2372b609"
-  # Below values needs to be changed when acm and submariner are GAed
+  submariner_version: "0.24.0"
+  submariner_image: "quay.io/redhat-user-workloads/submariner-tenant/submariner-fbc-4-22@sha256:1a666c3c2c99b1148f184f54efcee293f45cfff32cf9ca7a239097fe574ff700"
   oadp_version: "1.6"

--- a/ocs_ci/framework/conf/ocp_version/ocp-5.0-config.yaml
+++ b/ocs_ci/framework/conf/ocp_version/ocp-5.0-config.yaml
@@ -19,6 +19,6 @@ ENV_DATA:
   acm_hub_channel: "release-2.17"
   acm_version: "2.17"
   mce_version: "2.17"
-  submariner_version: "0.23.1"
-  submariner_image: "quay.io/redhat-user-workloads/submariner-tenant/submariner-fbc-4-21@sha256:1585a2a6c372f8a66b7644e742d95356b577072dfc83492c14759f6b2372b609"
+  submariner_version: "0.24.0"
+  submariner_image: "quay.io/redhat-user-workloads/submariner-tenant/submariner-fbc-4-22@sha256:1a666c3c2c99b1148f184f54efcee293f45cfff32cf9ca7a239097fe574ff700"
   oadp_version: "1.6"


### PR DESCRIPTION
## Summary
Follow-up to #15452. The new OCP 4.23 and 5.0 configs were added with Submariner 0.23.1 and the old 4.21 FBC image.

- Bump `submariner_version` to 0.24.0 in `ocp-4.23-config.yaml` and `ocp-5.0-config.yaml`
- Pin the 0.24 `submariner_image` in those files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated Submariner to version 0.24.0 for supported OpenShift configurations.
  * Updated the associated container image references to the Submariner FBC 4.22 images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->