### PR TITLE
conftest: use env_data.logwriter_image when set

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9636,9 +9636,11 @@ def setup_logwriter_workload(request, teardown_factory):
         dc_data = templating.load_yaml(logwriter_path)
         dc_data["metadata"]["namespace"] = pvc.namespace
         dc_data["spec"]["replicas"] = 4
-        dc_data["spec"]["template"]["spec"]["containers"][0][
-            "image"
-        ] = "quay.io/ocsci/logwriter:latest"
+        dc_data["spec"]["template"]["spec"]["containers"][0]["image"] = (
+            ocsci_config.ENV_DATA.get(
+                "logwriter_image", "quay.io/ocsci/logwriter:latest"
+            )
+        )
         dc_data["spec"]["template"]["spec"]["volumes"][0]["persistentVolumeClaim"][
             "claimName"
         ] = pvc.name
@@ -9700,9 +9702,11 @@ def setup_logreader_workload(request, teardown_factory):
         job_data["spec"]["template"]["spec"]["volumes"][0]["persistentVolumeClaim"][
             "claimName"
         ] = pvc.name
-        job_data["spec"]["template"]["spec"]["containers"][0][
-            "image"
-        ] = "quay.io/ocsci/logwriter:latest"
+        job_data["spec"]["template"]["spec"]["containers"][0]["image"] = (
+            ocsci_config.ENV_DATA.get(
+                "logwriter_image", "quay.io/ocsci/logwriter:latest"
+            )
+        )
         job_data["spec"]["template"]["spec"]["containers"][0]["command"][
             2
         ] = f"/opt/logreader.py -t {duration} *.log -d"


### PR DESCRIPTION
Override the hardcoded "quay.io/ocsci/logwriter:latest" image in setup_logwriter_workload and the logreader job with the value from ENV_DATA["logwriter_image"] if provided, falling back to the default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Logwriter and logreader workloads can now use a configured container image.
  * A default image is used automatically when no custom image is specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->