### PR TITLE
Fix RHCOS version defaults for OCP 4.23 and 5.0

### DIFF
--- a/conf/README.md
+++ b/conf/README.md
@@ -266,7 +266,7 @@ higher priority).
 * `vm_template` - VMWare template to use for RHCOS images (legacy single template, used as fallback)
 * `vm_template_overwrite` - VM template to overwirthe for early testing deployment e.g. rhcos-47.84.202103151537-0-vmware.x86_64
 * `vm_templates` - Dictionary of available RHCOS templates by major version for VMWare deployments (e.g., `{"9": "rhcos-9.6...", "10": "rhcos-10.2..."}`)
-* `rhcos_version` - Select which RHCOS major version to use from vm_templates dictionary (e.g., "9" or "10"). Defaults to "9" if not specified. When set to "10", automatically configures `featureSet: "TechPreviewNoUpgrade"` and `osImageStream: "rhel-10"` in install-config.yaml.
+* `rhcos_version` - Select which RHCOS major version to use from vm_templates dictionary (e.g., "9" or "10"). Defaults to "9" for OCP 4.x and "10" for OCP 5.0+. When set to "10" on OCP < 5.0, automatically configures `featureSet: "TechPreviewNoUpgrade"` and `osImageStream: "rhel-10"` in install-config.yaml. On OCP 5.0+, RHEL 10 is the default and no TechPreviewNoUpgrade or osImageStream is needed.
 * `fio_storageutilization_min_mbps` - Minimal write speed of FIO used in workload_fio_storageutilization
 * `TF_LOG_LEVEL` - Terraform log level
 * `TF_LOG_FILE` - Terraform log file

--- a/conf/ocsci/rhcos10_testing.yaml
+++ b/conf/ocsci/rhcos10_testing.yaml
@@ -5,7 +5,7 @@
 #
 # This automatically configures:
 # - VM template from vm_templates["10"] in OCP version config
-# - featureSet: "TechPreviewNoUpgrade" in install-config.yaml
-# - osImageStream: "rhel-10" in install-config.yaml
+# - On OCP < 5.0: featureSet: "TechPreviewNoUpgrade" and osImageStream: "rhel-10"
+# - On OCP 5.0+: no install-config changes needed (RHEL 10 is the default)
 ENV_DATA:
   rhcos_version: "10"

--- a/ocs_ci/deployment/baremetal.py
+++ b/ocs_ci/deployment/baremetal.py
@@ -716,12 +716,19 @@ class BAREMETALUPI(BAREMETALBASE):
             # Configure RHCOS 10 specific settings
             rhcos_version = config.ENV_DATA.get("rhcos_version")
             if rhcos_version and str(rhcos_version) == "10":
-                install_config_obj["featureSet"] = "TechPreviewNoUpgrade"
-                install_config_obj["osImageStream"] = "rhel-10"
-                logger.info(
-                    "Configured install-config for RHEL 10 deployment with "
-                    "TechPreviewNoUpgrade feature set"
-                )
+                ocp_version = version.get_semantic_ocp_version_from_config()
+                if ocp_version < version.VERSION_5_0:
+                    install_config_obj["featureSet"] = "TechPreviewNoUpgrade"
+                    install_config_obj["osImageStream"] = "rhel-10"
+                    logger.info(
+                        "Configured install-config for RHEL 10 deployment with "
+                        "TechPreviewNoUpgrade feature set"
+                    )
+                else:
+                    logger.info(
+                        "OCP 5.0+ detected - RHEL 10 is the default, skipping "
+                        "TechPreviewNoUpgrade and osImageStream configuration"
+                    )
 
             install_config_str = yaml.safe_dump(install_config_obj)
             install_config = os.path.join(self.cluster_path, "install-config.yaml")

--- a/ocs_ci/deployment/ocp.py
+++ b/ocs_ci/deployment/ocp.py
@@ -205,12 +205,19 @@ class OCPDeployment:
         # Configure RHCOS 10 specific settings
         rhcos_version = config.ENV_DATA.get("rhcos_version")
         if rhcos_version and str(rhcos_version) == "10":
-            install_config_obj["featureSet"] = "TechPreviewNoUpgrade"
-            install_config_obj["osImageStream"] = "rhel-10"
-            logger.info(
-                "Configured install-config for RHEL 10 deployment with "
-                "TechPreviewNoUpgrade feature set"
-            )
+            ocp_version = version.get_semantic_ocp_version_from_config()
+            if ocp_version < version.VERSION_5_0:
+                install_config_obj["featureSet"] = "TechPreviewNoUpgrade"
+                install_config_obj["osImageStream"] = "rhel-10"
+                logger.info(
+                    "Configured install-config for RHEL 10 deployment with "
+                    "TechPreviewNoUpgrade feature set"
+                )
+            else:
+                logger.info(
+                    "OCP 5.0+ detected - RHEL 10 is the default, skipping "
+                    "TechPreviewNoUpgrade and osImageStream configuration"
+                )
 
         install_config_str = yaml.safe_dump(install_config_obj)
         install_config = os.path.join(self.cluster_path, "install-config.yaml")

--- a/ocs_ci/deployment/vmware.py
+++ b/ocs_ci/deployment/vmware.py
@@ -1054,12 +1054,19 @@ class VSPHEREUPI(VSPHEREBASE):
             # Configure RHCOS 10 specific settings
             rhcos_version = config.ENV_DATA.get("rhcos_version")
             if rhcos_version and str(rhcos_version) == "10":
-                install_config_obj["featureSet"] = "TechPreviewNoUpgrade"
-                install_config_obj["osImageStream"] = "rhel-10"
-                logger.info(
-                    "Configured install-config for RHEL 10 deployment with "
-                    "TechPreviewNoUpgrade feature set"
-                )
+                ocp_version = version.get_semantic_ocp_version_from_config()
+                if ocp_version < version.VERSION_5_0:
+                    install_config_obj["featureSet"] = "TechPreviewNoUpgrade"
+                    install_config_obj["osImageStream"] = "rhel-10"
+                    logger.info(
+                        "Configured install-config for RHEL 10 deployment with "
+                        "TechPreviewNoUpgrade feature set"
+                    )
+                else:
+                    logger.info(
+                        "OCP 5.0+ detected - RHEL 10 is the default, skipping "
+                        "TechPreviewNoUpgrade and osImageStream configuration"
+                    )
 
             # prepare configuration for disconnected deployment (including deployment behind proxy)
             if config.DEPLOYMENT.get("disconnected") or config.DEPLOYMENT.get("proxy"):
@@ -1770,12 +1777,19 @@ class VSPHEREIPI(VSPHEREBASE):
             # Configure RHCOS 10 specific settings
             rhcos_version = config.ENV_DATA.get("rhcos_version")
             if rhcos_version and str(rhcos_version) == "10":
-                install_config_obj["featureSet"] = "TechPreviewNoUpgrade"
-                install_config_obj["osImageStream"] = "rhel-10"
-                logger.info(
-                    "Configured install-config for RHEL 10 deployment with "
-                    "TechPreviewNoUpgrade feature set"
-                )
+                ocp_version = version.get_semantic_ocp_version_from_config()
+                if ocp_version < version.VERSION_5_0:
+                    install_config_obj["featureSet"] = "TechPreviewNoUpgrade"
+                    install_config_obj["osImageStream"] = "rhel-10"
+                    logger.info(
+                        "Configured install-config for RHEL 10 deployment with "
+                        "TechPreviewNoUpgrade feature set"
+                    )
+                else:
+                    logger.info(
+                        "OCP 5.0+ detected - RHEL 10 is the default, skipping "
+                        "TechPreviewNoUpgrade and osImageStream configuration"
+                    )
 
             install_config_obj["platform"]["vsphere"]["apiVIP"] = config.ENV_DATA[
                 "vips"

--- a/ocs_ci/framework/conf/ocp_version/ocp-4.23-config.yaml
+++ b/ocs_ci/framework/conf/ocp_version/ocp-4.23-config.yaml
@@ -10,13 +10,13 @@ DEPLOYMENT:
   ignition_version: "3.2.0" # TODO: We might want to update to 3.5 or later: https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/release_notes/ocp-4-19-release-notes
 ENV_DATA:
   # Dictionary of available RHCOS templates by major version
-  # To use RHCOS 10, set rhcos_version: "10" in your custom config
+  # RHEL 9 is the default for 4.23. To use RHCOS 10, set rhcos_version: "10"
+  # in your custom config (requires TechPreviewNoUpgrade feature set).
   vm_templates:
     "9": "rhcos-9.8.20260428-0-vmware.x86_64"
     "10": "rhcos-10.2.20260423-0-vmware.x86_64"
   # Legacy single template (fallback if vm_templates not defined)
-  vm_template: "rhcos-10.2.20260423-0-vmware.x86_64"
-  rhcos_version: "10"
+  vm_template: "rhcos-9.8.20260428-0-vmware.x86_64"
   acm_hub_channel: "release-2.17"
   acm_version: "2.17"
   mce_version: "2.17"

--- a/ocs_ci/framework/conf/ocp_version/ocp-5.0-config.yaml
+++ b/ocs_ci/framework/conf/ocp_version/ocp-5.0-config.yaml
@@ -10,12 +10,14 @@ DEPLOYMENT:
   ignition_version: "3.2.0" # TODO: We might want to update to 3.5 or later: https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/release_notes/ocp-4-19-release-notes
 ENV_DATA:
   # Dictionary of available RHCOS templates by major version
-  # To use RHCOS 10, set rhcos_version: "10" in your custom config
+  # RHEL 10 is the default for new OCP 5.0 installs (no TechPreviewNoUpgrade needed).
+  # To use RHCOS 9, set rhcos_version: "9" in your custom config.
   vm_templates:
     "9": "rhcos-9.8.20260428-0-vmware.x86_64"
     "10": "rhcos-10.2.20260423-0-vmware.x86_64"
   # Legacy single template (fallback if vm_templates not defined)
   vm_template: "rhcos-10.2.20260423-0-vmware.x86_64"
+  rhcos_version: "10"
   acm_hub_channel: "release-2.17"
   acm_version: "2.17"
   mce_version: "2.17"


### PR DESCRIPTION
OCP 4.23: RHEL 9 is the default OS (RHEL 10 is still Tech Preview). The config incorrectly defaulted to rhcos_version: "10", which would set TechPreviewNoUpgrade and osImageStream in install-config.yaml. Removed that default so 4.23 uses RHEL 9 by default. Users can still opt-in to RHEL 10 via rhcos10_testing.yaml overlay.

OCP 5.0: RHEL 10 is GA and the default for new installs, so TechPreviewNoUpgrade must NOT be set. Added OCP version gating in all 4 deployment files (ocp.py, vmware.py UPI/IPI, baremetal.py) to skip TechPreviewNoUpgrade and osImageStream when OCP >= 5.0. Also set rhcos_version: "10" as the default in the 5.0 config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated RHCOS version guidance for OCP 4.x and OCP 5.0+.
  * Clarified default RHCOS versions and available opt-in configurations.

* **Bug Fixes**
  * Adjusted RHEL 10 installation settings for compatibility with OCP versions below 5.0.
  * OCP 5.0 and later now use default RHEL 10 behavior without legacy configuration overrides.
  * Corrected the OCP 4.23 fallback to use the RHCOS 9 template.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->