### PR TITLE
skip validate application for mdr

### DIFF
--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -4553,6 +4553,13 @@ def validate_application_odf_cli(
             )
             return None
 
+    if config.MULTICLUSTER.get("multicluster_mode") == constants.MDR_MODE:
+        logger.info(
+            f"Skipping ODF CLI DR {action} for DRPC '{drpc_name}': "
+            f"MDR environment does not require application validation"
+        )
+        return None
+
     dir_label = dr_action or f"{action}-app"
     output_dir = os.path.join(
         os.path.expanduser(config.RUN["log_dir"]),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Application validation is now skipped in MDR environments, avoiding unnecessary ODF CLI commands.
  * Existing hosted-cluster validation behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->