### PR TITLE
Add disable_networkpolicy flag for ODF deployment and upgrade

### DIFF
--- a/conf/ocsci/disable_networkpolicy.yaml
+++ b/conf/ocsci/disable_networkpolicy.yaml
@@ -1,0 +1,6 @@
+---
+# This configuration file enables the allow-all NetworkPolicy override
+# in the storage namespace before operator installation and upgrade.
+# Use this when default deny policies block ODF operator traffic.
+DEPLOYMENT:
+  disable_networkpolicy: True

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -50,6 +50,7 @@ from ocs_ci.deployment.acm import Submariner
 from ocs_ci.deployment.ingress_node_firewall import (
     restrict_ssh_access_to_nodes,
 )
+from ocs_ci.deployment.networkpolicy import apply_allow_all_network_policy
 from ocs_ci.deployment.helpers.lso_helpers import (
     setup_local_storage,
     cleanup_nodes_for_lso_install,
@@ -1661,6 +1662,10 @@ class Deployment(object):
             else:
                 raise
 
+        if config.DEPLOYMENT.get("disable_networkpolicy"):
+            logger.test_step("Apply allow-all NetworkPolicy override")
+            apply_allow_all_network_policy()
+
         # Create Multus Networks
         if config.ENV_DATA.get("is_multus_enabled"):
             log_step("Establish Multus Network")
@@ -2085,6 +2090,10 @@ class Deployment(object):
         deployment_obj.install_ocs_ui()
         close_browser()
 
+        if config.DEPLOYMENT.get("disable_networkpolicy"):
+            logger.test_step("Apply allow-all NetworkPolicy override")
+            apply_allow_all_network_policy()
+
     def set_noobaa_core_for_rgw_ssl(self):
         """
         Set env variables for noobaa-core StatefulSet to inject SSL environment variables
@@ -2151,6 +2160,9 @@ class Deployment(object):
             if not ui_deployment:
                 logger.info("Creating namespace and operator group.")
                 run_cmd(f"oc apply -f {constants.OLM_YAML}")
+            if config.DEPLOYMENT.get("disable_networkpolicy"):
+                logger.test_step("Apply allow-all NetworkPolicy override")
+                apply_allow_all_network_policy()
             if not live_deployment:
                 create_catalog_source(image)
             self.subscribe_ocs()

--- a/ocs_ci/deployment/networkpolicy.py
+++ b/ocs_ci/deployment/networkpolicy.py
@@ -1,0 +1,54 @@
+"""
+Module for applying NetworkPolicy overrides during ODF deployment and upgrade.
+"""
+
+import logging
+import os
+import tempfile
+
+from ocs_ci.framework import config
+from ocs_ci.ocs import constants
+from ocs_ci.utility import templating
+from ocs_ci.utility.utils import exec_cmd
+
+logger = logging.getLogger(__name__)
+
+
+def apply_allow_all_network_policy():
+    """
+    Apply an allow-all NetworkPolicy to the storage namespace.
+    This overrides any default-deny policies that may block ODF operator
+    traffic during installation or upgrade.
+
+    The policy is applied only when DEPLOYMENT['disable_networkpolicy'] is True.
+    """
+    if not config.DEPLOYMENT.get("disable_networkpolicy"):
+        logger.debug(
+            "disable_networkpolicy is not set or False, skipping "
+            "allow-all NetworkPolicy override."
+        )
+        return
+
+    namespace = config.ENV_DATA.get(
+        "cluster_namespace", constants.OPENSHIFT_STORAGE_NAMESPACE
+    )
+    logger.info(f"Applying allow-all NetworkPolicy override to namespace '{namespace}'")
+
+    network_policy_data = templating.load_yaml(
+        constants.NETWORK_POLICY_ALLOW_ALL_OVERRIDE_TEMPLATE
+    )
+    network_policy_data["metadata"]["namespace"] = namespace
+
+    network_policy_file = tempfile.NamedTemporaryFile(
+        mode="w+", prefix="allow_all_network_policy_", suffix=".yaml", delete=False
+    )
+    network_policy_file.close()
+    try:
+        templating.dump_data_to_temp_yaml(network_policy_data, network_policy_file.name)
+        exec_cmd(["oc", "apply", "-f", network_policy_file.name])
+        logger.info(
+            f"Successfully applied allow-all-override NetworkPolicy "
+            f"in namespace '{namespace}'"
+        )
+    finally:
+        os.remove(network_policy_file.name)

--- a/ocs_ci/framework/conf/default_config.yaml
+++ b/ocs_ci/framework/conf/default_config.yaml
@@ -84,6 +84,10 @@ DEPLOYMENT:
   # UI deployment is not part of this framework, it will just do preparation
   # steps for openshift-console.
   ui_deployment: False
+  # Apply an allow-all NetworkPolicy to the storage namespace before operator
+  # installation and upgrade. Useful for environments where default deny
+  # policies block ODF operator traffic.
+  disable_networkpolicy: False
   # Import clusters to ACM via UI
   ui_acm_import: False
   # Following options are defaults for deployment from live content

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -114,6 +114,9 @@ UBI8_TEMPLATE = os.path.join(TEMPLATE_DIR, "app-deployments", "ubi8-simple.yaml"
 NETWORK_POLICY_PROVIDER_TO_CLIENT_TEMPLATE = os.path.join(
     TEMPLATE_DIR, "ocs-deployment", "provider-mode", "network_policy_provider_mode.yaml"
 )
+NETWORK_POLICY_ALLOW_ALL_OVERRIDE_TEMPLATE = os.path.join(
+    TEMPLATE_DIR, "ocs-deployment", "allow-all-override.yaml"
+)
 AI_NETWORK_CONFIG_TEMPLATE = os.path.join(
     "ocp-deployment", "ai-host-network-config.yaml.j2"
 )

--- a/ocs_ci/ocs/ocs_upgrade.py
+++ b/ocs_ci/ocs/ocs_upgrade.py
@@ -892,6 +892,12 @@ def run_ocs_upgrade(
         )
         exec_cmd(cmd)
 
+    if config.DEPLOYMENT.get("disable_networkpolicy"):
+        from ocs_ci.deployment.networkpolicy import apply_allow_all_network_policy
+
+        log.info("Applying allow-all NetworkPolicy override before upgrade")
+        apply_allow_all_network_policy()
+
     csv_name_pre_upgrade = upgrade_ocs.get_csv_name_pre_upgrade()
     pre_upgrade_images = upgrade_ocs.get_pre_upgrade_image(csv_name_pre_upgrade)
     upgrade_ocs.load_version_config_file(upgrade_version)

--- a/ocs_ci/templates/ocs-deployment/allow-all-override.yaml
+++ b/ocs_ci/templates/ocs-deployment/allow-all-override.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-override
+  namespace: openshift-storage
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  - {}
+  egress:
+  - {}


### PR DESCRIPTION
Add an `allow-all` NetworkPolicy override that can be applied to the storage namespace before operator installation and upgrade.

This is useful for environments where default-deny policies block ODF operator traffic.

- New `DEPLOYMENT.disable_networkpolicy` config flag (`default: False`)
- Config override file: `conf/ocsci/disable_networkpolicy.yaml`
- Applied after namespace creation in `deploy_ocs_via_operator()`
- Applied before upgrade starts in `run_ocs_upgrade()`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional setting to apply an allow-all network policy to the storage namespace.
  * The policy is applied automatically before storage operator installation and upgrades when enabled.
  * Added a default-disabled setting to preserve existing behavior.
  * The target namespace is created automatically if it does not already exist.

* **Bug Fixes**
  * Helps prevent network policy restrictions from blocking storage operator deployment or upgrade workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->