### PR TITLE
Add TLSProfile tests for ocs-metrics-exporter

### DIFF
--- a/ocs_ci/helpers/tlsprofile_helper.py
+++ b/ocs_ci/helpers/tlsprofile_helper.py
@@ -4,7 +4,8 @@ scanning via :func:`scan_cluster`. The scan logic lives in
 ``scripts/bash/tls_scan_endpoints.sh`` (loaded at runtime).
 
 References (DF 4.22+): ``TLSProfile`` centralizes TLS version, ciphers, and groups
-for NooBaa and RGW; CR name ``ocs-tls-profile`` in the operator namespace;
+for NooBaa, RGW, ocs-metrics-exporter, csi-snapshot-metadata, and
+ocs-client-operator; CR name ``ocs-tls-profile`` in the operator namespace;
 ``ocs-tls-profiles`` is an OLM dependency (include in disconnected mirroring).
 Cipher/group sets follow the product-supported lists (Mozilla Intermediate/Modern
 plus PQC groups). On FIPS-enabled clusters, PQ hybrids and ChaCha are not
@@ -12,12 +13,15 @@ FIPS 140-2 approved; use the ``skipif_fips_enabled`` pytest mark on tests that
 rely on those algorithms.
 """
 
+import copy
 import csv
 import io
 import json
 import logging
 import os
 import re
+import subprocess
+import time
 import uuid
 
 from ocs_ci.framework import config
@@ -45,6 +49,16 @@ TLS_PROFILE_V13_GROUPS = [
     "SecP256r1MLKEM768",
     "SecP384r1MLKEM1024",
 ]
+# csi-snapshot-metadata sidecar (DF 5.0) accepts only CurveP256/P384/P521, X25519,
+# and X25519MLKEM768. Passing SecP256r1MLKEM768 / SecP384r1MLKEM1024 makes it
+# crashloop: unsupported curve "... must be one of: CurveP256, ... X25519MLKEM768".
+CSI_SNAPSHOT_METADATA_V13_GROUPS = [
+    "secp256r1",
+    "secp384r1",
+    "secp521r1",
+    "X25519",
+    "X25519MLKEM768",
+]
 TLS_PROFILE_V12_CIPHERS = [
     "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
     "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
@@ -63,8 +77,73 @@ TLS_PROFILE_V12_GROUPS = [
 # Selector strings for rook Object Gateway TLS (domain form domain or domain/server).
 # DF docs list ``noobaa.io``, ``rook.io``, and ``*``; RGW reconciliation uses the
 # ceph object store gateway domain ``ceph.rook.io`` in practice.
+# ocs-metrics-exporter is selected with ``ocs.openshift.io/metrics-exporter``.
+# csi-snapshot-metadata (Changed Block Tracking gRPC) uses ``cbt.storage.k8s.io``.
+# ocs-client-operator uses ``ocs.openshift.io/webhook`` and ``ocs.openshift.io/metrics``.
 TLS_PROFILE_SELECTOR_NOOBAA_DOMAIN = "noobaa.io"
 TLS_PROFILE_SELECTOR_RGW_DOMAIN = "ceph.rook.io"
+TLS_PROFILE_SELECTOR_METRICS_EXPORTER = "ocs.openshift.io/metrics-exporter"
+TLS_PROFILE_SELECTOR_CSI_SNAPSHOT_METADATA = "cbt.storage.k8s.io"
+TLS_PROFILE_SELECTOR_CLIENT_OPERATOR_WEBHOOK = "ocs.openshift.io/webhook"
+TLS_PROFILE_SELECTOR_CLIENT_OPERATOR_METRICS = "ocs.openshift.io/metrics"
+# ocs-metrics-exporter HTTPS listeners: https-main (metrics scrape) and
+# https-self (exporter process metrics). TLSProfile applies to both.
+METRICS_EXPORTER_HTTPS_PORTS = (
+    constants.OCS_METRICS_EXPORTER_PORT,
+    constants.OCS_METRICS_EXPORTER_LEGACY_PORT,
+)
+CSI_SNAPSHOT_METADATA_HTTPS_PORTS = (constants.CSI_SNAPSHOT_METADATA_PORT,)
+# ocs-client-operator HTTPS listeners: metrics (:8443) and webhook (:7443).
+CLIENT_OPERATOR_HTTPS_PORTS = (
+    constants.OCS_CLIENT_OPERATOR_METRICS_PORT,
+    constants.OCS_CLIENT_OPERATOR_WEBHOOK_PORT,
+)
+CLIENT_OPERATOR_HTTPS_PORT_ROLES = {
+    constants.OCS_CLIENT_OPERATOR_METRICS_PORT: "metrics",
+    constants.OCS_CLIENT_OPERATOR_WEBHOOK_PORT: "webhook",
+}
+CSI_ADDONS_GRPC_PORTS = (
+    constants.CSI_ADDONS_GRPC_PORT,
+    constants.CSI_ADDONS_NODEPLUGIN_GRPC_PORT,
+    constants.CSI_ADDONS_CEPHFS_CTRLPLUGIN_GRPC_PORT,
+)
+METRICS_EXPORTER_TLS_PROFILE_GENERATION_ENV = "TLS_PROFILE_GENERATION"
+# TLSProfile IANA groups -> Go crypto/tls --tls-curve-preferences names.
+TLS_PROFILE_GROUP_TO_GO_CURVE = {
+    "secp256r1": "CurveP256",
+    "secp384r1": "CurveP384",
+    "secp521r1": "CurveP521",
+    "X25519": "X25519",
+    "X25519MLKEM768": "X25519MLKEM768",
+    "SecP256r1MLKEM768": "SecP256r1MLKEM768",
+    "SecP384r1MLKEM1024": "SecP384r1MLKEM1024",
+}
+TLS_PROFILE_VERSION_TO_GO_MIN = {
+    "TLSv1.2": "VersionTLS12",
+    "TLSv1.3": "VersionTLS13",
+}
+
+# IANA names from TLSProfile spec -> OpenSSL names produced by scantls.
+TLS_PROFILE_IANA_TO_OPENSSL_CIPHER = {
+    "TLS_AES_128_GCM_SHA256": "TLS_AES_128_GCM_SHA256",
+    "TLS_AES_256_GCM_SHA384": "TLS_AES_256_GCM_SHA384",
+    "TLS_CHACHA20_POLY1305_SHA256": "TLS_CHACHA20_POLY1305_SHA256",
+    "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256": "ECDHE-ECDSA-AES128-GCM-SHA256",
+    "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384": "ECDHE-ECDSA-AES256-GCM-SHA384",
+    "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256": "ECDHE-ECDSA-CHACHA20-POLY1305",
+    "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256": "ECDHE-RSA-AES128-GCM-SHA256",
+    "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384": "ECDHE-RSA-AES256-GCM-SHA384",
+    "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256": "ECDHE-RSA-CHACHA20-POLY1305",
+}
+TLS_PROFILE_IANA_TO_OPENSSL_GROUP = {
+    "secp256r1": "prime256v1",
+    "secp384r1": "secp384r1",
+    "secp521r1": "secp521r1",
+    "X25519": "X25519",
+    "X25519MLKEM768": "X25519MLKEM768",
+    "SecP256r1MLKEM768": "SecP256r1MLKEM768",
+    "SecP384r1MLKEM1024": "SecP384r1MLKEM1024",
+}
 
 # Heuristic: log lines that likely indicate TLS/handshake/cert/TLSProfile handling failures.
 # Use re.IGNORECASE: inline (?i) after "|" is invalid in Python 3.11+.
@@ -79,10 +158,14 @@ _TLS_LOG_ERROR_RE = re.compile(
 )
 
 # Transient / non-TLS errors that sometimes mention "tls" or "handshake" in unrelated contexts.
+# scantls probes each cipher and version one at a time, so Go HTTP servers log
+# expected handshake rejections for the suites/versions the profile does not offer.
 _TLS_LOG_EXCLUDE_RE = re.compile(
     r"(?i)connection refused|dial tcp|websocket dial|handshake request|"
     r"RPC:\s*Reconnect|reconnect\s*-\s*got error|context deadline exceeded|"
-    r"i/o timeout|no route to host|broken pipe|\bEOF\b|temporary failure",
+    r"i/o timeout|no route to host|broken pipe|\bEOF\b|temporary failure|"
+    r"no cipher suite supported by both client and server|"
+    r"client offered only unsupported versions",
 )
 
 
@@ -90,8 +173,9 @@ def gather_tls_relevant_pod_names(namespace, component):
     """
     Pod names to scan for TLS-related log errors based on test parametrization.
 
-    Always includes ocs-operator and rook-ceph-operator; adds NooBaa / RGW pods when
-    those paths are under test.
+    Always includes ocs-operator and rook-ceph-operator; adds NooBaa / RGW /
+    ocs-metrics-exporter / csi-snapshot-metadata / ocs-client-operator /
+    csi-addons pods when those paths are under test.
     """
     from ocs_ci.ocs.resources.pod import get_pods_having_label
 
@@ -108,11 +192,28 @@ def gather_tls_relevant_pod_names(namespace, component):
         )
     if component in ("rgw", "all"):
         selectors.append(constants.RGW_APP_LABEL)
+    if component == "metrics-exporter":
+        selectors.append(constants.OCS_METRICS_EXPORTER)
+    if component == "ocs-client-operator":
+        selectors.append(constants.OCS_CLIENT_OPERATOR_LABEL)
+    if component == "csi-addons":
+        selectors.extend(
+            [
+                constants.CSI_ADDONS_CONTROLLER_MANAGER_LABEL,
+                constants.CSI_RBD_ADDON_NODEPLUGIN_LABEL_420,
+                constants.CSI_CEPHFS_ADDON_NODEPLUGIN_LABEL_420,
+            ]
+        )
 
     names = set()
     for label in selectors:
         items = get_pods_having_label(label, namespace) or []
         for item in items:
+            name = item.get("metadata", {}).get("name")
+            if name:
+                names.add(name)
+    if component == "csi-snapshot-metadata":
+        for item in _list_csi_snapshot_metadata_pod_items(namespace):
             name = item.get("metadata", {}).get("name")
             if name:
                 names.add(name)
@@ -174,7 +275,9 @@ def assert_no_tls_errors_in_relevant_pod_logs(
 
     Args:
         namespace (str): Storage namespace (e.g. openshift-storage).
-        component (str): Test parametrization key: ``all``, ``noobaa``, or ``rgw``.
+        component (str): Test parametrization key: ``all``, ``noobaa``,
+            ``rgw``, ``metrics-exporter``, ``csi-snapshot-metadata``,
+            ``ocs-client-operator``, or ``csi-addons``.
         since (str): Passed to ``oc logs --since`` (recent window for this run).
         tail (str|int): Max tail lines per pod.
         max_lines_per_pod (int): Cap lines included in failure output.
@@ -237,6 +340,10 @@ SCAN_CLUSTER_DEFAULT_TLS13_GROUPS = (
 
 TLS_SCANNER_IMAGE = "ghcr.io/leelavg/scantls@sha256:5e80dd5576812f3c8248fad7cbf19a74b74384aafd14614ccd53ef6b4e1f40d1"
 TLS_SCANNER_NAMESPACE = "scantls-system"
+# Extra NetworkPolicy name prefix (not StorageCluster-owned) so the scanner can
+# reach ocs-metrics-exporter HTTPS. The operator reverts patches to the owned NP.
+# Each scan appends a unique suffix so overlapping scans do not share a policy.
+TLS_SCAN_METRICS_EXPORTER_SCANNER_NP = "ocs-metrics-exporter-scantls"
 # Seconds between ``oc get pod … jsonpath={.status.phase}`` samples (scanner pod startup).
 TLS_SCAN_POD_PHASE_POLL_SLEEP = 2
 
@@ -251,6 +358,25 @@ TLS_SCAN_COMPONENT_SELECTORS = {
     },
     "ceph": {"label": "rook_cluster=openshift-storage"},
     "csi": {"name_filter": "csi"},
+    "metrics-exporter": {"label": constants.OCS_METRICS_EXPORTER},
+    "csi-snapshot-metadata": {
+        "name_filter": constants.CSI_SNAPSHOT_METADATA_NAME_SUBSTRING,
+        "container_name_filter": constants.CSI_SNAPSHOT_METADATA_NAME_SUBSTRING,
+    },
+    "ocs-client-operator": {
+        "label": constants.OCS_CLIENT_OPERATOR_LABEL,
+        "name_filter": constants.OCS_CLIENT_OPERATOR_CONTROLLER_MANAGER_PREFIX,
+        "extra_ports": CLIENT_OPERATOR_HTTPS_PORTS,
+    },
+    "csi-addons": {
+        "labels": [
+            constants.CSI_RBD_ADDON_NODEPLUGIN_LABEL_420,
+            constants.CSI_CEPHFS_ADDON_NODEPLUGIN_LABEL_420,
+            constants.RBD_CTRLPLUGIN_LABEL,
+            constants.CEPHFS_CTRLPLUGIN_LABEL,
+        ],
+        "container_name_filter": "csi-addons",
+    },
     "all": {},
 }
 
@@ -301,6 +427,32 @@ def _tls_scan_run_oc(args, kubeconfig=None, timeout=60):
         cmd.extend(["--kubeconfig", kubeconfig])
     completed = exec_cmd(cmd, timeout=timeout)
     return completed.stdout.decode()
+
+
+def _tls_scan_include_container(
+    pod_name, container_name, containers, name_filter, container_name_filter
+):
+    """
+    Return True if this container should be scanned for ``component`` filters.
+
+    Pod matches if ``name_filter`` is in the pod name or ``container_name_filter``
+    is in any container name. When a matching sidecar exists, only that sidecar
+    is scanned; if only the pod name matches, all of its containers are scanned.
+    """
+    if not name_filter and not container_name_filter:
+        return True
+    name_ok = bool(name_filter and name_filter in pod_name)
+    this_container_ok = bool(
+        container_name_filter and container_name_filter in container_name
+    )
+    if this_container_ok:
+        return True
+    if name_ok and not any(
+        container_name_filter and container_name_filter in (c.get("name") or "")
+        for c in containers
+    ):
+        return True
+    return False
 
 
 def _find_fallback_ports(selector, component, pod):
@@ -356,40 +508,119 @@ def _tls_scan_discover_endpoints(kubeconfig, namespaces, component="all"):
     selector = TLS_SCAN_COMPONENT_SELECTORS.get(component, {})
     label = selector.get("label")
     name_filter = selector.get("name_filter")
+    container_name_filter = selector.get("container_name_filter")
+    extra_ports = tuple(int(p) for p in (selector.get("extra_ports") or ()))
+    labels = selector.get("labels")
+    if labels:
+        label_list = list(labels)
+    elif label:
+        label_list = [label]
+    else:
+        label_list = [None]
 
     endpoints = []
+    seen = set()
     for ns in namespaces:
         log.info("TLS scan: discovering %s pods in namespace %s", component, ns)
-        cmd = [
-            "get",
-            "pods",
-            "-n",
-            ns,
-            "-o",
-            "json",
-            "--field-selector=status.phase=Running",
-        ]
-        if label:
-            cmd.extend(["-l", label])
+        for lbl in label_list:
+            cmd = [
+                "get",
+                "pods",
+                "-n",
+                ns,
+                "-o",
+                "json",
+                "--field-selector=status.phase=Running",
+            ]
+            if lbl:
+                cmd.extend(["-l", lbl])
 
-        out = _tls_scan_run_oc(cmd, kubeconfig=kubeconfig, timeout=30)
-        data = json.loads(out)
+            out = _tls_scan_run_oc(cmd, kubeconfig=kubeconfig, timeout=30)
+            data = json.loads(out)
 
-        for pod in data.get("items", []):
-            pod_name = pod["metadata"]["name"]
-            pod_ns = pod["metadata"]["namespace"]
-            pod_ip = pod["status"].get("podIP", "")
-            if not pod_ip:
-                continue
-            if name_filter and name_filter not in pod_name:
-                continue
-            fallback_ports = _find_fallback_ports(selector, component, pod)
-            for container in pod["spec"]["containers"]:
-                endpoints.extend(
-                    _build_container_endpoints(
+            for pod in data.get("items", []):
+                pod_name = pod["metadata"]["name"]
+                pod_ns = pod["metadata"]["namespace"]
+                pod_ip = pod["status"].get("podIP", "")
+                if not pod_ip:
+                    continue
+                containers = pod["spec"]["containers"]
+                fallback_ports = _find_fallback_ports(selector, component, pod)
+                declared_ports = set()
+                extra_template = None
+                snapshot_fallback_added = False
+                for container in containers:
+                    c_name = container["name"]
+                    if not _tls_scan_include_container(
+                        pod_name,
+                        c_name,
+                        containers,
+                        name_filter,
+                        container_name_filter,
+                    ):
+                        continue
+                    new_eps = _build_container_endpoints(
                         container, pod_name, pod_ns, pod_ip, fallback_ports
                     )
-                )
+                    cmd_parts = container.get("command", []) + container.get("args", [])
+                    process = ""
+                    if cmd_parts:
+                        process = cmd_parts[0].rsplit("/", 1)[-1][:15]
+                    if not process:
+                        process = (
+                            container.get("image", "").split("/")[-1].split(":")[0][:15]
+                        )
+                    # Prefer the manager container so extra-port probes are not
+                    # labeled with a later sidecar.
+                    if extra_template is None or c_name == "manager":
+                        extra_template = {
+                            "pod_namespace": pod_ns,
+                            "pod_name": pod_name,
+                            "pod_ip": pod_ip,
+                            "container_name": c_name,
+                            "process": process,
+                        }
+                    for ep in new_eps:
+                        declared_ports.add(int(ep["port"]))
+                        key = (ep["pod_namespace"], ep["pod_name"], int(ep["port"]))
+                        if key not in seen:
+                            seen.add(key)
+                            endpoints.append(ep)
+                    if (
+                        not new_eps
+                        and component == "csi-snapshot-metadata"
+                        and not snapshot_fallback_added
+                    ):
+                        snapshot_port = int(constants.CSI_SNAPSHOT_METADATA_PORT)
+                        if snapshot_port not in declared_ports:
+                            snapshot_fallback_added = True
+                            declared_ports.add(snapshot_port)
+                            key = (pod_ns, pod_name, snapshot_port)
+                            if key not in seen:
+                                seen.add(key)
+                                endpoints.append(
+                                    {
+                                        "pod_namespace": pod_ns,
+                                        "pod_name": pod_name,
+                                        "pod_ip": pod_ip,
+                                        "container_name": c_name,
+                                        "process": process,
+                                        "port": str(snapshot_port),
+                                    }
+                                )
+                if extra_template:
+                    for extra in extra_ports:
+                        if extra not in declared_ports:
+                            key = (pod_ns, pod_name, int(extra))
+                            if key in seen:
+                                continue
+                            seen.add(key)
+                            endpoints.append(
+                                {
+                                    **extra_template,
+                                    "port": str(extra),
+                                }
+                            )
 
     log.info(
         "TLS scan: discovered %d endpoints for component %r in %d namespace(s)",
@@ -425,6 +656,24 @@ def _tls_scan_setup_namespace(kubeconfig):
             kubeconfig=kubeconfig,
             timeout=10,
         )
+        # Ensure namespaceSelector matchLabels used by NetworkPolicy resolve.
+        try:
+            _tls_scan_run_oc(
+                [
+                    "label",
+                    "namespace",
+                    TLS_SCANNER_NAMESPACE,
+                    f"kubernetes.io/metadata.name={TLS_SCANNER_NAMESPACE}",
+                    "--overwrite",
+                ],
+                kubeconfig=kubeconfig,
+                timeout=10,
+            )
+        except CommandFailed:
+            log.warning(
+                "TLS scan: could not label namespace %s for NetworkPolicy selection",
+                TLS_SCANNER_NAMESPACE,
+            )
 
 
 def _tls_scan_wait_for_pod_ready(
@@ -599,6 +848,180 @@ def _tls_scan_delete_scanner_namespace(kubeconfig):
         log.warning("TLS scan: namespace cleanup failed: %s", e)
 
 
+def _tls_scan_metrics_exporter_scanner_ingress():
+    """Ingress rule allowing ``scantls-system`` to HTTPS ports 8443 and 9443."""
+    return {
+        "from": [
+            {
+                "namespaceSelector": {
+                    "matchLabels": {
+                        "kubernetes.io/metadata.name": TLS_SCANNER_NAMESPACE,
+                    }
+                }
+            }
+        ],
+        "ports": [
+            {"port": int(constants.OCS_METRICS_EXPORTER_PORT), "protocol": "TCP"},
+            {
+                "port": int(constants.OCS_METRICS_EXPORTER_LEGACY_PORT),
+                "protocol": "TCP",
+            },
+        ],
+    }
+
+
+def _tls_scan_np_rule_selects_scanner(rule):
+    """Return True if an ingress rule selects the ``scantls-system`` namespace."""
+    for src in rule.get("from") or []:
+        labels = (src.get("namespaceSelector") or {}).get("matchLabels") or {}
+        if labels.get("kubernetes.io/metadata.name") == TLS_SCANNER_NAMESPACE:
+            return True
+    return False
+
+
+def _tls_scan_np_rule_allows_metrics_exporter_https_ports(rule):
+    """
+    Return True if ``rule`` has no port restriction or allows TCP 8443 and 9443.
+    """
+    ports = rule.get("ports")
+    if ports is None:
+        return True
+    required = {
+        int(constants.OCS_METRICS_EXPORTER_PORT),
+        int(constants.OCS_METRICS_EXPORTER_LEGACY_PORT),
+    }
+    allowed = set()
+    for entry in ports:
+        proto = (entry.get("protocol") or "TCP").upper()
+        if proto != "TCP":
+            continue
+        port = entry.get("port")
+        if port is None:
+            continue
+        try:
+            allowed.add(int(port))
+        except (TypeError, ValueError):
+            continue
+    return required.issubset(allowed)
+
+
+def _tls_scan_np_ingress_allows_scanner(ingress):
+    """
+    Return True if any ingress rule selects ``scantls-system`` and permits both
+    metrics-exporter HTTPS ports (8443 and 9443), or has no port restriction.
+    """
+    for rule in ingress or []:
+        if _tls_scan_np_rule_selects_scanner(
+            rule
+        ) and _tls_scan_np_rule_allows_metrics_exporter_https_ports(rule):
+            return True
+    return False
+
+
+def _tls_scan_metrics_exporter_np_allow_scanner(kubeconfig, namespace, policy_name):
+    """
+    Temporarily allow scantls-system to reach ocs-metrics-exporter HTTPS ports.
+
+    StorageCluster owns NetworkPolicy ``ocs-metrics-exporter`` (ingress only
+    from openshift-monitoring). ocs-operator reverts patches to that object, so
+    this creates a separate additive policy instead of mutating the owned one.
+
+    Args:
+        kubeconfig: Path to kubeconfig for ``oc``.
+        namespace (str): Namespace of ocs-metrics-exporter.
+        policy_name (str): Unique NetworkPolicy name for this scan.
+
+    Returns:
+        callable | None: Restore function, or None if there is nothing to restore.
+    """
+    try:
+        raw = _tls_scan_run_oc(
+            [
+                "get",
+                "networkpolicy",
+                "ocs-metrics-exporter",
+                "-n",
+                namespace,
+                "-o",
+                "json",
+            ],
+            kubeconfig=kubeconfig,
+            timeout=30,
+        )
+    except CommandFailed:
+        log.info(
+            "TLS scan: no NetworkPolicy ocs-metrics-exporter in %s; "
+            "not adding scanner ingress",
+            namespace,
+        )
+        return None
+    data = json.loads(raw)
+    spec = data.get("spec") or {}
+    original_ingress = spec.get("ingress") or []
+    if _tls_scan_np_ingress_allows_scanner(original_ingress):
+        log.info(
+            "TLS scan: ocs-metrics-exporter NetworkPolicy already allows %s",
+            TLS_SCANNER_NAMESPACE,
+        )
+        return None
+    pod_selector = copy.deepcopy(spec.get("podSelector") or {})
+    if not pod_selector:
+        pod_selector = {
+            "matchLabels": {"app.kubernetes.io/name": "ocs-metrics-exporter"}
+        }
+    np_manifest = {
+        "apiVersion": "networking.k8s.io/v1",
+        "kind": "NetworkPolicy",
+        "metadata": {
+            "name": policy_name,
+            "namespace": namespace,
+            "labels": {"app": "tls-scanner"},
+        },
+        "spec": {
+            "podSelector": pod_selector,
+            "policyTypes": ["Ingress"],
+            "ingress": [_tls_scan_metrics_exporter_scanner_ingress()],
+        },
+    }
+    apply_cmd = ["oc", "apply", "-f", "-"]
+    if kubeconfig:
+        apply_cmd.extend(["--kubeconfig", kubeconfig])
+    exec_cmd(apply_cmd, timeout=30, input=json.dumps(np_manifest).encode())
+    log.info(
+        "TLS scan: created NetworkPolicy %s so %s can scrape "
+        "ocs-metrics-exporter HTTPS in %s",
+        policy_name,
+        TLS_SCANNER_NAMESPACE,
+        namespace,
+    )
+
+    def _restore():
+        try:
+            _tls_scan_run_oc(
+                [
+                    "delete",
+                    "networkpolicy",
+                    policy_name,
+                    "-n",
+                    namespace,
+                    "--ignore-not-found",
+                ],
+                kubeconfig=kubeconfig,
+                timeout=30,
+            )
+            log.info(
+                "TLS scan: deleted NetworkPolicy %s",
+                policy_name,
+            )
+        except CommandFailed:
+            log.exception(
+                "TLS scan: failed to delete NetworkPolicy %s",
+                policy_name,
+            )
+
+    return _restore
+
+
 def scan_cluster(
     component="all",
     kubeconfig=None,
@@ -618,8 +1041,16 @@ def scan_cluster(
     Discover pod container ports in the storage namespace(s), run a short-lived
     scanner pod in ``scantls-system``, and return per-endpoint TLS probe results.
 
+    For ``metrics-exporter`` (and ``all``), a temporary NetworkPolicy named
+    ``ocs-metrics-exporter-scantls-<scan-id>`` is applied so ``scantls-system``
+    may reach ports 8443/9443 (the StorageCluster-owned policy is left
+    unchanged). The scan-id matches the scanner pod suffix so overlapping
+    scans do not delete each other's policy.
+
     Args:
-        component: ``noobaa``, ``rgw``, ``ceph``, ``csi``, or ``all``.
+        component: ``noobaa``, ``rgw``, ``ceph``, ``csi``, ``metrics-exporter``,
+            ``csi-snapshot-metadata``, ``ocs-client-operator``, ``csi-addons``,
+            or ``all``.
         kubeconfig: Path to kubeconfig; defaults from RUN / ENV_DATA (see
             :func:`_resolve_tls_scan_kubeconfig`).
         namespaces: Namespaces to scan; default
@@ -681,7 +1112,9 @@ def scan_cluster(
 
     endpoints_data = _tls_scan_build_endpoints_file(endpoints)
 
-    pod_name = f"tls-scanner-{uuid.uuid4().hex[:8]}"
+    scan_id = uuid.uuid4().hex[:8]
+    pod_name = f"tls-scanner-{scan_id}"
+    np_name = f"{TLS_SCAN_METRICS_EXPORTER_SCANNER_NP}-{scan_id}"
     pod_manifest = {
         "apiVersion": "v1",
         "kind": "Pod",
@@ -720,8 +1153,16 @@ def scan_cluster(
     if kubeconfig:
         apply_cmd.extend(["--kubeconfig", kubeconfig])
 
+    restore_np = []
     try:
         _tls_scan_setup_namespace(kubeconfig)
+        if component in ("metrics-exporter", "all"):
+            for ns in namespaces:
+                restore_fn = _tls_scan_metrics_exporter_np_allow_scanner(
+                    kubeconfig, ns, np_name
+                )
+                if restore_fn:
+                    restore_np.append(restore_fn)
         exec_cmd(apply_cmd, timeout=30, input=manifest_json.encode())
         _tls_scan_wait_for_pod_ready(kubeconfig, pod_name)
         csv_output = _tls_scan_run_in_pod(
@@ -737,6 +1178,8 @@ def scan_cluster(
         )
         return results
     finally:
+        for restore_fn in restore_np:
+            restore_fn()
         if cleanup:
             _tls_scan_cleanup_pod(kubeconfig, pod_name)
             _tls_scan_delete_scanner_namespace(kubeconfig)
@@ -1028,6 +1471,138 @@ class TLSProfile:
                 self.name,
             )
 
+    def apply_rules(self, rules, do_reload=True, metadata=None, spec=None):
+        """
+        Replace spec.rules, creating the TLSProfile if it is absent.
+
+        When recreating a missing CR, ``metadata`` and ``spec`` restore
+        user-managed fields (labels, annotations, and non-rules spec) from a
+        prior snapshot. ``rules`` always wins over ``spec["rules"]``.
+
+        Args:
+            rules (list): spec.rules value to apply.
+            do_reload (bool): Reload OCS object after create when the CR is missing.
+            metadata (dict): Optional user-managed metadata to restore on create
+                or merge-patch (labels, annotations, and other non-system keys).
+            spec (dict): Optional full spec to restore; ``rules`` overwrites
+                ``spec["rules"]``.
+        """
+        rules = copy.deepcopy(list(rules))
+        spec_body = copy.deepcopy(spec) if spec is not None else {}
+        spec_body["rules"] = rules
+        meta = {"name": self.name, "namespace": self.namespace}
+        if metadata:
+            extra_meta = copy.deepcopy(metadata)
+            extra_meta.pop("name", None)
+            extra_meta.pop("namespace", None)
+            meta.update(extra_meta)
+            meta["name"] = self.name
+            meta["namespace"] = self.namespace
+        if not self.is_tls_profile_available(silent=True):
+            tls_resource = {
+                "apiVersion": self.API_VERSION,
+                "kind": self.KIND,
+                "metadata": meta,
+                "spec": spec_body,
+            }
+            log.info(
+                "Recreating %s %s in namespace %s to restore configuration",
+                self.KIND,
+                self.name,
+                self.namespace,
+            )
+            OCS(**tls_resource).create(do_reload=do_reload)
+            return
+        patch = {"spec": spec_body}
+        if metadata:
+            patch_meta = copy.deepcopy(metadata)
+            patch_meta.pop("name", None)
+            patch_meta.pop("namespace", None)
+            if patch_meta:
+                patch["metadata"] = patch_meta
+        patched = self._ocp.patch(
+            resource_name=self.name,
+            params=json.dumps(patch),
+            format_type="merge",
+        )
+        if not patched:
+            log.warning(
+                "oc patch for %s did not report success; validating via get",
+                self.name,
+            )
+
+
+_TLS_PROFILE_SYSTEM_METADATA_KEYS = (
+    "uid",
+    "resourceVersion",
+    "generation",
+    "creationTimestamp",
+    "deletionTimestamp",
+    "deletionGracePeriodSeconds",
+    "managedFields",
+    "selfLink",
+    "ownerReferences",
+)
+
+
+def _tlsprofile_user_managed_fields(data):
+    """
+    Return user-managed metadata and spec from a TLSProfile object.
+
+    Drops controller/system metadata so a later create/patch can restore labels,
+    annotations, and the full spec without resourceVersion/uid conflicts.
+    """
+    metadata = copy.deepcopy(data.get("metadata") or {})
+    for key in _TLS_PROFILE_SYSTEM_METADATA_KEYS:
+        metadata.pop(key, None)
+    return {
+        "metadata": metadata,
+        "spec": copy.deepcopy(data.get("spec") or {}),
+    }
+
+
+def snapshot_tlsprofile_state(tls):
+    """
+    Capture whether ``ocs-tls-profile`` exists and its user-managed fields.
+
+    Returns:
+        tuple: ``(existed_before, original_state)``. ``original_state`` is a
+        dict with ``metadata`` and ``spec`` when the profile is present, else
+        None.
+    """
+    existed_before = tls.is_tls_profile_available(silent=True)
+    if not existed_before:
+        return False, None
+    data = tls.get_tls_profile()
+    return True, _tlsprofile_user_managed_fields(data)
+
+
+def teardown_tlsprofile(tls, existed_before, original_state):
+    """
+    Restore a pre-existing TLSProfile or delete one this test created.
+
+    No-op when the profile is still absent after a skip, or when pre-existing
+    user-managed metadata and spec are unchanged.
+    """
+    present = tls.is_tls_profile_available(silent=True)
+    if not existed_before:
+        if present:
+            log.info("Teardown: deleting ocs-tls-profile created by this test")
+            tls.delete_tls_profile(wait=True, force=True)
+        return
+    if original_state is None:
+        return
+    if present:
+        data = tls.get_tls_profile()
+        if _tlsprofile_user_managed_fields(data) == original_state:
+            return
+    log.info("Teardown: restoring pre-existing ocs-tls-profile configuration")
+    tls.apply_rules(
+        original_state.get("spec", {}).get("rules") or [],
+        metadata=original_state.get("metadata"),
+        spec=original_state.get("spec"),
+    )
+
 
 def tlsprofile_crd_exists():
     """Return True if tlsprofiles.ocs.openshift.io CRD is installed."""
@@ -1074,15 +1649,35 @@ def wait_for_noobaa_tls_min_version_substring(
     Wait until NooBaa apiServerSecurity.tlsMinVersion contains expected_substring
     (e.g. '1.2' or '1.3').
     """
+    from ocs_ci.ocs.resources.storage_cluster import get_noobaa_phase
+
+    last = {"phase": None, "sec": None, "ver": None}
 
     def _match():
-        sec = get_noobaa_api_server_security(namespace)
-        if sec is None:
+        last["phase"] = get_noobaa_phase(namespace)
+        last["sec"] = get_noobaa_api_server_security(namespace)
+        last["ver"] = None if last["sec"] is None else last["sec"].get("tlsMinVersion")
+        log.info(
+            "Waiting for NooBaa tlsMinVersion to contain %r "
+            "(phase=%s apiServerSecurity=%s tlsMinVersion=%s)",
+            expected_substring,
+            last["phase"],
+            last["sec"],
+            last["ver"],
+        )
+        if last["sec"] is None:
             return False
-        ver = sec.get("tlsMinVersion")
-        return ver is not None and expected_substring in str(ver).lower()
+        return (
+            last["ver"] is not None and expected_substring in str(last["ver"]).lower()
+        )
 
-    TimeoutSampler(timeout, sleep, _match).wait_for_func_value(True)
+    try:
+        TimeoutSampler(timeout, sleep, _match).wait_for_func_value(True)
+    except TimeoutExpiredError:
+        raise TimeoutExpiredError(
+            f"NooBaa tlsMinVersion never contained {expected_substring!r} "
+            f"(phase={last['phase']}, apiServerSecurity={last['sec']})"
+        )
 
 
 def get_first_cephobjectstore_name(namespace):
@@ -1145,3 +1740,1428 @@ def wait_for_cephobjectstore_security_cleared(
         return len(ciphers) == 0 and len(groups) == 0
 
     TimeoutSampler(timeout, sleep, _cleared).wait_for_func_value(True)
+
+
+def _tls_container_fingerprints(pods, container_name_substr=None):
+    """
+    Return a frozenset identifying ready/running containers for rollout waits.
+
+    Each item is ``(pod_uid, pod_name, container_name, startedAt, restartCount)``.
+    """
+    fingerprints = []
+    for pod in pods or []:
+        uid = pod.get("metadata", {}).get("uid") or ""
+        pname = pod.get("metadata", {}).get("name") or ""
+        for cs in pod.get("status", {}).get("containerStatuses") or []:
+            cname = cs.get("name") or ""
+            if container_name_substr and container_name_substr not in cname:
+                continue
+            started = ((cs.get("state") or {}).get("running") or {}).get(
+                "startedAt"
+            ) or ""
+            restarts = int(cs.get("restartCount") or 0)
+            fingerprints.append((uid, pname, cname, started, restarts))
+    return frozenset(fingerprints)
+
+
+def _tls_workload_containers_ready(pods, container_name_substr=None):
+    """Return True if matching containers exist and all of them are ready."""
+    running = [
+        p
+        for p in (pods or [])
+        if p.get("status", {}).get("phase") == constants.STATUS_RUNNING
+    ]
+    if not running:
+        return False
+    saw_match = False
+    for pod in running:
+        statuses = pod.get("status", {}).get("containerStatuses") or []
+        if not statuses:
+            return False
+        for cs in statuses:
+            cname = cs.get("name") or ""
+            if container_name_substr and container_name_substr not in cname:
+                continue
+            saw_match = True
+            if not cs.get("ready"):
+                return False
+        if not container_name_substr and not all(cs.get("ready") for cs in statuses):
+            return False
+    if container_name_substr:
+        return saw_match
+    return True
+
+
+def _wait_for_tls_workload_ready(
+    list_pods_fn,
+    previous_fingerprints,
+    container_name_substr=None,
+    timeout=600,
+    sleep=15,
+    workload_name="workload",
+):
+    """
+    Wait until the workload is ready. When ``previous_fingerprints`` is set,
+    also wait until none of those fingerprints remain (new pod UID, restart,
+    or container start time).
+    """
+    log.info(
+        "Waiting for %s to be ready after TLSProfile change "
+        "(previous fingerprints=%d)",
+        workload_name,
+        len(previous_fingerprints or ()),
+    )
+
+    def _done():
+        pods = list_pods_fn() or []
+        if not _tls_workload_containers_ready(pods, container_name_substr):
+            return False
+        if previous_fingerprints is None:
+            return True
+        current = _tls_container_fingerprints(pods, container_name_substr)
+        if not current:
+            return False
+        return previous_fingerprints.isdisjoint(current)
+
+    TimeoutSampler(timeout, sleep, _done).wait_for_func_value(True)
+
+
+def snapshot_metrics_exporter_roll_state(namespace):
+    """Capture ocs-metrics-exporter container fingerprints before a TLSProfile apply."""
+    from ocs_ci.ocs.resources.pod import get_pods_having_label
+
+    pods = (
+        get_pods_having_label(constants.OCS_METRICS_EXPORTER, namespace=namespace) or []
+    )
+    return _tls_container_fingerprints(pods)
+
+
+def get_metrics_exporter_tls_profile_generations(namespace):
+    """Return [(pod_name, TLS_PROFILE_GENERATION), ...] for exporter pods."""
+    from ocs_ci.ocs.resources.pod import get_pods_having_label
+
+    rows = []
+    for pod in (
+        get_pods_having_label(constants.OCS_METRICS_EXPORTER, namespace=namespace) or []
+    ):
+        name = pod.get("metadata", {}).get("name")
+        if not name:
+            continue
+        gen = get_container_env_value(
+            pod, "ocs-metrics-exporter", METRICS_EXPORTER_TLS_PROFILE_GENERATION_ENV
+        )
+        rows.append((name, gen))
+    return rows
+
+
+def assert_metrics_exporter_tls_profile_generation(namespace):
+    """Fail unless every exporter pod has a non-zero TLS_PROFILE_GENERATION."""
+    rows = get_metrics_exporter_tls_profile_generations(namespace)
+    log.info(
+        "ocs-metrics-exporter %s: expected>=1 pods with non-zero generation, "
+        "actual=%s",
+        METRICS_EXPORTER_TLS_PROFILE_GENERATION_ENV,
+        rows,
+    )
+    if not rows:
+        raise AssertionError("ocs-metrics-exporter pods were not found")
+    problems = [
+        f"{name}: {METRICS_EXPORTER_TLS_PROFILE_GENERATION_ENV}={gen!r}"
+        for name, gen in rows
+        if gen in (None, "", "0")
+    ]
+    if problems:
+        raise AssertionError(
+            "ocs-metrics-exporter did not record a TLSProfile generation:\n"
+            + "\n".join(f"  - {p}" for p in problems)
+        )
+
+
+def snapshot_csi_snapshot_metadata_roll_state(namespace):
+    """Capture csi-snapshot-metadata sidecar fingerprints before a TLSProfile apply."""
+    return _tls_container_fingerprints(
+        _list_csi_snapshot_metadata_pod_items(namespace),
+        constants.CSI_SNAPSHOT_METADATA_NAME_SUBSTRING,
+    )
+
+
+def snapshot_ocs_client_operator_roll_state(namespace):
+    """Capture ocs-client-operator manager fingerprints before a TLSProfile apply."""
+    from ocs_ci.ocs.resources.pod import get_pods_having_label
+
+    pods = (
+        get_pods_having_label(constants.OCS_CLIENT_OPERATOR_LABEL, namespace=namespace)
+        or []
+    )
+    return _tls_container_fingerprints(pods, "manager")
+
+
+def metrics_exporter_is_deployed(namespace):
+    """Return True if at least one ocs-metrics-exporter pod exists in namespace."""
+    from ocs_ci.ocs.resources.pod import get_pods_having_label
+
+    return bool(
+        get_pods_having_label(constants.OCS_METRICS_EXPORTER, namespace=namespace)
+    )
+
+
+def wait_for_metrics_exporter_ready(
+    namespace, timeout=600, sleep=15, previous_fingerprints=None
+):
+    """
+    Wait until ocs-metrics-exporter is Running and ready.
+
+    When ``previous_fingerprints`` is set (from
+    :func:`snapshot_metrics_exporter_roll_state` taken before applying a
+    TLSProfile), also wait until every remaining fingerprint is new so the
+    scan does not hit a pre-rollout pod.
+    """
+    from ocs_ci.ocs.resources.pod import get_pods_having_label
+
+    def _list_pods():
+        return (
+            get_pods_having_label(
+                constants.OCS_METRICS_EXPORTER,
+                namespace=namespace,
+                statuses=[constants.STATUS_RUNNING],
+            )
+            or []
+        )
+
+    _wait_for_tls_workload_ready(
+        _list_pods,
+        previous_fingerprints,
+        workload_name="ocs-metrics-exporter",
+        timeout=timeout,
+        sleep=sleep,
+    )
+
+
+def _format_tls_scan_row(row):
+    """Short one-line summary of a :func:`scan_cluster` row for assertions."""
+    return (
+        f"{row.get('pod_namespace')}/{row.get('pod_name')}:"
+        f"{row.get('port')} status={row.get('status')!r} "
+        f"tls_versions={row.get('tls_versions')!r} "
+        f"tls12_ciphers={row.get('tls12_ciphers')!r} "
+        f"tls13_ciphers={row.get('tls13_ciphers')!r} "
+        f"reason={row.get('reason')!r}"
+    )
+
+
+def filter_tls_scan_results_by_ports(results, ports):
+    """Return scan rows whose ``port`` is in ``ports`` (int-compared)."""
+    port_set = {int(p) for p in ports}
+    return [r for r in results if int(r.get("port") or 0) in port_set]
+
+
+def _tls_port_label(port, port_roles=None):
+    """Return ``(label, role)`` for assertion messages. ``role`` is None unless mapped."""
+    if port_roles:
+        role = port_roles.get(int(port), "unknown")
+        return f"port {port} ({role})", role
+    return f"port {port}", None
+
+
+def _assert_https_tls_applied(
+    results,
+    api_tls_version,
+    ports,
+    component_label,
+    error_header,
+    context="",
+    expected_ciphers=None,
+    expected_groups=None,
+    port_roles=None,
+    verify_ciphers_groups=False,
+    success_log_includes_role=False,
+    exact_version=True,
+):
+    """
+    Fail unless each required port is serving HTTPS with the TLSProfile version.
+
+    Every OK scan row for a port must negotiate ``api_tls_version``. When
+    ``exact_version`` is True, the row must not also offer the other of
+    tls1.2 / tls1.3. When False (min-version semantics), a higher version such
+    as tls1.3 may still be offered for a TLSv1.2 profile. When
+    ``verify_ciphers_groups`` is True, scantls cipher/group names for the
+    requested version must stay within the TLSProfile set.
+    """
+    token = tls_profile_api_version_to_scan_token(api_tls_version)
+    other_token = "tls1.2" if token == "tls1.3" else "tls1.3"
+    suffix = f" ({context})" if context else ""
+    problems = []
+
+    if verify_ciphers_groups:
+        if expected_ciphers is None:
+            expected_ciphers = (
+                TLS_PROFILE_V13_CIPHERS
+                if token == "tls1.3"
+                else TLS_PROFILE_V12_CIPHERS
+            )
+        if expected_groups is None:
+            expected_groups = (
+                TLS_PROFILE_V13_GROUPS if token == "tls1.3" else TLS_PROFILE_V12_GROUPS
+            )
+        allowed_ciphers = set(openssl_ciphers_for_tls_profile(expected_ciphers))
+        allowed_groups = set(openssl_groups_for_tls_profile(expected_groups))
+        cipher_field = "tls13_ciphers" if token == "tls1.3" else "tls12_ciphers"
+        group_field = "tls13_groups" if token == "tls1.3" else "tls12_groups"
+        other_cipher_field = "tls12_ciphers" if token == "tls1.3" else "tls13_ciphers"
+
+    for port in ports:
+        port_label, role = _tls_port_label(port, port_roles)
+        rows = filter_tls_scan_results_by_ports(results, (port,))
+        if not rows:
+            problems.append(
+                f"{port_label}: no scan row (HTTPS listener not discovered on "
+                f"{component_label})"
+            )
+            continue
+
+        ok_rows = [r for r in rows if r.get("status") == "OK"]
+        if not ok_rows:
+            problems.append(
+                f"{port_label}: not serving HTTPS/TLS "
+                f"(rows: {'; '.join(_format_tls_scan_row(r) for r in rows)})"
+            )
+            continue
+
+        missing_token = [
+            r for r in ok_rows if token not in (r.get("tls_versions") or [])
+        ]
+        if missing_token:
+            problems.append(
+                f"{port_label}: HTTPS is up but {api_tls_version} ({token!r}) "
+                f"was not negotiated "
+                f"(rows: {'; '.join(_format_tls_scan_row(r) for r in missing_token)})"
+            )
+            continue
+
+        leaked = [r for r in ok_rows if other_token in (r.get("tls_versions") or [])]
+        if exact_version and leaked:
+            problems.append(
+                f"{port_label}: TLSProfile {api_tls_version} should be exact, "
+                f"but {other_token!r} was still offered "
+                f"(rows: {'; '.join(_format_tls_scan_row(r) for r in leaked)})"
+            )
+            continue
+
+        if verify_ciphers_groups:
+            for r in ok_rows:
+                scanned_ciphers = r.get(cipher_field) or []
+                other_ciphers = r.get(other_cipher_field) or []
+                scanned_groups = r.get(group_field) or []
+                if not scanned_ciphers:
+                    problems.append(
+                        f"{port_label}: {api_tls_version} negotiated but scantls "
+                        f"reported no {cipher_field} "
+                        f"({_format_tls_scan_row(r)})"
+                    )
+                    continue
+                unexpected_ciphers = [
+                    c for c in scanned_ciphers if c not in allowed_ciphers
+                ]
+                if unexpected_ciphers:
+                    problems.append(
+                        f"{port_label}: scantls reported ciphers not in TLSProfile "
+                        f"{api_tls_version}: {unexpected_ciphers}; "
+                        f"allowed={sorted(allowed_ciphers)} "
+                        f"({_format_tls_scan_row(r)})"
+                    )
+                if exact_version and other_ciphers:
+                    problems.append(
+                        f"{port_label}: TLSProfile {api_tls_version} should not offer "
+                        f"{other_cipher_field}={other_ciphers} "
+                        f"({_format_tls_scan_row(r)})"
+                    )
+                unexpected_groups = [
+                    g for g in scanned_groups if g not in allowed_groups
+                ]
+                if unexpected_groups:
+                    problems.append(
+                        f"{port_label}: scantls reported groups not in TLSProfile "
+                        f"{api_tls_version}: {unexpected_groups}; "
+                        f"allowed={sorted(allowed_groups)} "
+                        f"({_format_tls_scan_row(r)})"
+                    )
+
+        if success_log_includes_role:
+            log.info(
+                "%s HTTPS TLSProfile applied: port=%s role=%s version=%s%s",
+                component_label,
+                port,
+                role,
+                api_tls_version,
+                suffix,
+            )
+        else:
+            log.info(
+                "%s HTTPS TLSProfile applied: port=%s version=%s%s",
+                component_label,
+                port,
+                api_tls_version,
+                suffix,
+            )
+        for r in ok_rows:
+            log.info(
+                "HTTPS %s:%s pod=%s container=%s tls_versions=%s "
+                "tls12_ciphers=%s tls13_ciphers=%s tls12_groups=%s tls13_groups=%s",
+                r.get("pod_ip"),
+                r.get("port"),
+                r.get("pod_name"),
+                r.get("container_name"),
+                r.get("tls_versions"),
+                r.get("tls12_ciphers"),
+                r.get("tls13_ciphers"),
+                r.get("tls12_groups"),
+                r.get("tls13_groups"),
+            )
+
+    if problems:
+        raise AssertionError(
+            f"{error_header} {api_tls_version}{suffix}:\n"
+            + "\n".join(f"  - {p}" for p in problems)
+        )
+
+
+def assert_metrics_exporter_https_tls_applied(
+    results,
+    api_tls_version,
+    ports=None,
+    context="",
+    expected_ciphers=None,
+    expected_groups=None,
+    exact_version=True,
+    verify_ciphers_groups=True,
+):
+    """
+    Fail unless ocs-metrics-exporter HTTPS ports (default 8443 and 9443) are
+    serving TLS and the TLSProfile version is in effect on each port.
+
+    TLSProfile version is exact (min == max), so a matching port must negotiate
+    the expected version and must not still offer the other of tls1.2 / tls1.3.
+    Cipher/group names from the TLSProfile spec are mapped to OpenSSL names.
+    TLS 1.3 cipher subsets are not enforced: ocs-metrics-exporter is Go and
+    always offers the Go TLS 1.3 suite (AES-GCM and ChaCha). TLS 1.2 cipher
+    lists and TLS 1.3 groups are still checked.
+
+    Args:
+        results: Return value of :func:`scan_cluster` for component
+            ``metrics-exporter``.
+        api_tls_version: ``TLSv1.2`` or ``TLSv1.3``.
+        ports: HTTPS ports to require (default ``METRICS_EXPORTER_HTTPS_PORTS``).
+        context: Short string appended to failure messages.
+        expected_ciphers: TLSProfile IANA cipher list (defaults from version).
+        expected_groups: TLSProfile IANA group list (defaults from version).
+        exact_version: When False, TLSv1.2 is treated as a minimum.
+        verify_ciphers_groups: When False, skip cipher/group membership checks
+            (cluster TLSSecurityProfile Modern uses a different suite).
+    """
+    ports = tuple(ports) if ports is not None else METRICS_EXPORTER_HTTPS_PORTS
+    ciphers = expected_ciphers
+    if (
+        verify_ciphers_groups
+        and api_tls_version == "TLSv1.3"
+        and expected_ciphers is not None
+    ):
+        # Go crypto/tls does not honor TLS 1.3 cipher configuration (CRD:
+        # OpenSSL only). The exporter still offers the full Go TLS 1.3 suite.
+        log.info(
+            "ocs-metrics-exporter TLS 1.3 cipher subset %s is not enforced "
+            "on Go servers; allowing %s",
+            expected_ciphers,
+            TLS_PROFILE_V13_CIPHERS,
+        )
+        ciphers = list(TLS_PROFILE_V13_CIPHERS)
+    _assert_https_tls_applied(
+        results,
+        api_tls_version,
+        ports,
+        component_label="ocs-metrics-exporter",
+        error_header="ocs-metrics-exporter HTTPS ports 8443/9443 did not apply",
+        context=context,
+        expected_ciphers=ciphers,
+        expected_groups=expected_groups,
+        verify_ciphers_groups=verify_ciphers_groups,
+        exact_version=exact_version,
+    )
+
+
+def openssl_ciphers_for_tls_profile(iana_ciphers):
+    """Map TLSProfile IANA cipher names to OpenSSL names used by scantls."""
+    mapped = []
+    for name in iana_ciphers:
+        openssl_name = TLS_PROFILE_IANA_TO_OPENSSL_CIPHER.get(name, name)
+        mapped.append(openssl_name)
+    return mapped
+
+
+def openssl_groups_for_tls_profile(iana_groups):
+    """Map TLSProfile IANA group names to OpenSSL names used by scantls."""
+    mapped = []
+    for name in iana_groups:
+        openssl_name = TLS_PROFILE_IANA_TO_OPENSSL_GROUP.get(name, name)
+        mapped.append(openssl_name)
+    return mapped
+
+
+def _list_csi_snapshot_metadata_pod_items(namespace):
+    """
+    Return pod dicts for csi-snapshot-metadata (dedicated Deployment or CSI
+    sidecar). Matches label ``app=csi-snapshot-metadata``, pod name, or
+    container name containing ``snapshot-metadata``.
+    """
+    from ocs_ci.ocs.resources.pod import get_pods_having_label
+
+    needle = constants.CSI_SNAPSHOT_METADATA_NAME_SUBSTRING
+    seen = set()
+    matched = []
+
+    def _add(pod):
+        name = pod.get("metadata", {}).get("name")
+        if name and name not in seen:
+            seen.add(name)
+            matched.append(pod)
+
+    for pod in get_pods_having_label(constants.CSI_SNAPSHOT_METADATA, namespace) or []:
+        _add(pod)
+
+    ocp_pods = OCP(kind=constants.POD, namespace=namespace)
+    for pod in ocp_pods.get().get("items") or []:
+        name = pod.get("metadata", {}).get("name", "")
+        if needle in name:
+            _add(pod)
+            continue
+        for container in pod.get("spec", {}).get("containers", []):
+            if needle in (container.get("name") or ""):
+                _add(pod)
+                break
+    return matched
+
+
+def csi_snapshot_metadata_is_deployed(namespace):
+    """Return True if a csi-snapshot-metadata pod or sidecar exists."""
+    return bool(_list_csi_snapshot_metadata_pod_items(namespace))
+
+
+def wait_for_csi_snapshot_metadata_ready(
+    namespace, timeout=600, sleep=15, previous_fingerprints=None
+):
+    """
+    Wait until csi-snapshot-metadata sidecars are Running and ready.
+
+    When ``previous_fingerprints`` is set, wait until those sidecars have
+    rolled (new UID/start/restart) so scantls does not hit pre-TLSProfile
+    listeners that still offer both TLS 1.2 and 1.3.
+    """
+
+    def _list_pods():
+        return _list_csi_snapshot_metadata_pod_items(namespace)
+
+    _wait_for_tls_workload_ready(
+        _list_pods,
+        previous_fingerprints,
+        container_name_substr=constants.CSI_SNAPSHOT_METADATA_NAME_SUBSTRING,
+        workload_name="csi-snapshot-metadata",
+        timeout=timeout,
+        sleep=sleep,
+    )
+
+
+def assert_csi_snapshot_metadata_https_tls_applied(
+    results,
+    api_tls_version,
+    ports=None,
+    context="",
+    expected_ciphers=None,
+    expected_groups=None,
+):
+    """
+    Fail unless csi-snapshot-metadata port 50051 is serving HTTPS with the
+    TLSProfile version, and scantls reports only the configured ciphers/groups.
+
+    Cipher/group names from the TLSProfile spec are mapped to OpenSSL names
+    used by scantls.
+
+    ``TLSv1.3`` is exact (no tls1.2). ``TLSv1.2`` is a minimum: the sidecar
+    sets ``--tls-min-version=VersionTLS12`` with no max, so tls1.3 may still
+    be offered.
+
+    Args:
+        results: Return value of :func:`scan_cluster` for component
+            ``csi-snapshot-metadata``.
+        api_tls_version: ``TLSv1.2`` or ``TLSv1.3``.
+        ports: HTTPS/gRPC ports to require (default port 50051).
+        context: Short string appended to failure messages.
+        expected_ciphers: TLSProfile IANA cipher list (defaults from version).
+        expected_groups: TLSProfile IANA group list (defaults from version).
+    """
+    ports = tuple(ports) if ports is not None else CSI_SNAPSHOT_METADATA_HTTPS_PORTS
+    _assert_https_tls_applied(
+        results,
+        api_tls_version,
+        ports,
+        component_label="csi-snapshot-metadata",
+        error_header="csi-snapshot-metadata HTTPS port 50051 did not apply",
+        context=context,
+        expected_ciphers=expected_ciphers,
+        expected_groups=expected_groups,
+        verify_ciphers_groups=True,
+        exact_version=api_tls_version != "TLSv1.2",
+    )
+
+
+def assert_ocs_client_operator_https_tls_applied(
+    results,
+    api_tls_version,
+    ports=None,
+    context="",
+    expected_ciphers=None,
+    expected_groups=None,
+):
+    """
+    Fail unless ocs-client-operator webhook and metrics HTTPS ports are
+    serving TLS with the TLSProfile version, and scantls reports only the
+    configured ciphers/groups.
+
+    TLSProfile version is exact (min == max). Cipher/group names from the
+    TLSProfile spec are mapped to OpenSSL names used by scantls.
+
+    Args:
+        results: Return value of :func:`scan_cluster` for component
+            ``ocs-client-operator``.
+        api_tls_version: ``TLSv1.2`` or ``TLSv1.3``.
+        ports: HTTPS ports to require (default metrics 8443 and webhook 7443).
+        context: Short string appended to failure messages.
+        expected_ciphers: TLSProfile IANA cipher list (defaults from version).
+        expected_groups: TLSProfile IANA group list (defaults from version).
+    """
+    ports = tuple(ports) if ports is not None else CLIENT_OPERATOR_HTTPS_PORTS
+    _assert_https_tls_applied(
+        results,
+        api_tls_version,
+        ports,
+        component_label="ocs-client-operator",
+        error_header=("ocs-client-operator webhook/metrics HTTPS ports did not apply"),
+        context=context,
+        expected_ciphers=expected_ciphers,
+        expected_groups=expected_groups,
+        port_roles=CLIENT_OPERATOR_HTTPS_PORT_ROLES,
+        verify_ciphers_groups=True,
+        success_log_includes_role=True,
+    )
+
+
+def wait_for_ocs_client_operator_https_tls(
+    namespace,
+    api_tls_version,
+    expected_ciphers=None,
+    expected_groups=None,
+    context="",
+    timeout=600,
+    sleep=20,
+):
+    """
+    Wait until ocs-client-operator webhook/metrics HTTPS matches the
+    TLSProfile version.
+
+    Polls scantls instead of requiring a manager restart. TLS 1.3 usually
+    rolls the pod; TLS 1.2 may apply in-process with the same fingerprints.
+    """
+    from ocs_ci.ocs.resources.pod import wait_for_ocs_client_operator_ready
+
+    wait_for_ocs_client_operator_ready(namespace)
+    last_error = {"msg": None}
+
+    def _done():
+        results = scan_cluster(component="ocs-client-operator", namespaces=[namespace])
+        try:
+            assert_ocs_client_operator_https_tls_applied(
+                results,
+                api_tls_version,
+                expected_ciphers=expected_ciphers,
+                expected_groups=expected_groups,
+                context=context,
+            )
+            return True
+        except AssertionError as err:
+            last_error["msg"] = str(err)
+            log.info(
+                "ocs-client-operator HTTPS not yet at %s: %s",
+                api_tls_version,
+                err,
+            )
+            return False
+
+    try:
+        TimeoutSampler(timeout, sleep, _done).wait_for_func_value(True)
+    except TimeoutExpiredError:
+        detail = last_error["msg"] or "scantls assertion did not succeed"
+        raise TimeoutExpiredError(
+            f"Timed out after {timeout}s waiting for ocs-client-operator "
+            f"HTTPS to apply {api_tls_version}: {detail}"
+        )
+
+
+def parse_tls_cli_flags(command_and_args):
+    """
+    Parse --tls-min-version, --tls-max-version, --tls-cipher-suites, and
+    --tls-curve-preferences from a container command/args list.
+    """
+    flags = {
+        "min_version": None,
+        "max_version": None,
+        "cipher_suites": [],
+        "curve_preferences": [],
+    }
+    items = list(command_and_args or [])
+    i = 0
+    while i < len(items):
+        item = items[i]
+        if not isinstance(item, str):
+            i += 1
+            continue
+        if item.startswith("--tls-min-version="):
+            flags["min_version"] = item.split("=", 1)[1]
+        elif item == "--tls-min-version" and i + 1 < len(items):
+            i += 1
+            flags["min_version"] = items[i]
+        elif item.startswith("--tls-max-version="):
+            flags["max_version"] = item.split("=", 1)[1]
+        elif item == "--tls-max-version" and i + 1 < len(items):
+            i += 1
+            flags["max_version"] = items[i]
+        elif item.startswith("--tls-cipher-suites="):
+            flags["cipher_suites"] = [p for p in item.split("=", 1)[1].split(",") if p]
+        elif item == "--tls-cipher-suites" and i + 1 < len(items):
+            i += 1
+            flags["cipher_suites"] = [p for p in str(items[i]).split(",") if p]
+        elif item.startswith("--tls-curve-preferences="):
+            flags["curve_preferences"] = [
+                p for p in item.split("=", 1)[1].split(",") if p
+            ]
+        elif item == "--tls-curve-preferences" and i + 1 < len(items):
+            i += 1
+            flags["curve_preferences"] = [p for p in str(items[i]).split(",") if p]
+        i += 1
+    return flags
+
+
+def go_curves_for_tls_profile_groups(iana_groups):
+    """Map TLSProfile IANA groups to Go --tls-curve-preferences names."""
+    return [TLS_PROFILE_GROUP_TO_GO_CURVE.get(g, g) for g in iana_groups]
+
+
+def get_container_command_args(pod_item, container_name_substr):
+    """Return command+args for the first container whose name contains substr."""
+    for container in pod_item.get("spec", {}).get("containers") or []:
+        if container_name_substr in (container.get("name") or ""):
+            return list(container.get("command") or []) + list(
+                container.get("args") or []
+            )
+    return []
+
+
+def get_container_env_value(pod_item, container_name_substr, env_name):
+    """Return an env value from the first container whose name contains substr."""
+    for container in pod_item.get("spec", {}).get("containers") or []:
+        if container_name_substr not in (container.get("name") or ""):
+            continue
+        for env in container.get("env") or []:
+            if env.get("name") == env_name:
+                return env.get("value")
+    return None
+
+
+def list_labeled_container_cli(namespace, labels, container_name_substr):
+    """
+    Return list of (pod_name, command_and_args) for matching containers.
+
+    Args:
+        labels: One label selector string or an iterable of them.
+    """
+    from ocs_ci.ocs.resources.pod import get_pods_having_label
+
+    if isinstance(labels, str):
+        labels = [labels]
+    seen = set()
+    results = []
+    for label in labels:
+        for pod_item in get_pods_having_label(label, namespace=namespace) or []:
+            name = pod_item.get("metadata", {}).get("name")
+            if not name or name in seen:
+                continue
+            args = get_container_command_args(pod_item, container_name_substr)
+            if not args:
+                continue
+            seen.add(name)
+            results.append((name, args))
+    return results
+
+
+def assert_tls_cli_flags(
+    flags,
+    min_version=None,
+    max_version=None,
+    cipher_suites=None,
+    curve_preferences=None,
+    require_max_version=False,
+    context="",
+):
+    """Fail unless parsed CLI flags include the expected TLS settings."""
+    suffix = f" ({context})" if context else ""
+    problems = []
+    if min_version and flags.get("min_version") != min_version:
+        problems.append(
+            f"tls-min-version: expected={min_version!r}, "
+            f"actual={flags.get('min_version')!r}{suffix}"
+        )
+    if require_max_version and not flags.get("max_version"):
+        problems.append(f"tls-max-version is not set{suffix}")
+    if max_version and flags.get("max_version") != max_version:
+        problems.append(
+            f"tls-max-version: expected={max_version!r}, "
+            f"actual={flags.get('max_version')!r}{suffix}"
+        )
+    if cipher_suites:
+        actual = set(flags.get("cipher_suites") or [])
+        missing = [c for c in cipher_suites if c not in actual]
+        if missing:
+            problems.append(
+                f"tls-cipher-suites missing {missing}; actual={sorted(actual)}{suffix}"
+            )
+    if curve_preferences:
+        actual = set(flags.get("curve_preferences") or [])
+        missing = [c for c in curve_preferences if c not in actual]
+        if missing:
+            problems.append(
+                f"tls-curve-preferences missing {missing}; "
+                f"actual={sorted(actual)}{suffix}"
+            )
+    if problems:
+        raise AssertionError(
+            "TLS CLI flags did not match expected configuration:\n"
+            + "\n".join(f"  - {p}" for p in problems)
+        )
+
+
+def maybe_assert_tls_cli_flags(
+    cli_rows,
+    min_version=None,
+    max_version=None,
+    cipher_suites=None,
+    curve_preferences=None,
+    require_max_version=False,
+):
+    """
+    Assert TLS CLI flags on containers that set any ``--tls-*`` flag.
+
+    ocs-metrics-exporter (DF 5.0) applies TLSProfile through process config
+    and ``TLS_PROFILE_GENERATION`` rather than CLI flags. When flags are
+    absent this logs and returns False instead of failing.
+    """
+    saw_flags = False
+    for pod_name, args in cli_rows:
+        flags = parse_tls_cli_flags(args)
+        log.info("TLS CLI flags for %s: %s", pod_name, flags)
+        if not (
+            flags.get("min_version")
+            or flags.get("max_version")
+            or flags.get("cipher_suites")
+            or flags.get("curve_preferences")
+        ):
+            continue
+        saw_flags = True
+        assert_tls_cli_flags(
+            flags,
+            min_version=min_version if flags.get("min_version") else None,
+            max_version=max_version if flags.get("max_version") else None,
+            cipher_suites=cipher_suites if flags.get("cipher_suites") else None,
+            curve_preferences=(
+                curve_preferences if flags.get("curve_preferences") else None
+            ),
+            require_max_version=require_max_version,
+            context=pod_name,
+        )
+    if not saw_flags:
+        log.info(
+            "No --tls-* CLI flags on matching containers; listener scan is "
+            "the source of truth"
+        )
+    return saw_flags
+
+
+def wait_for_tls_cli_min_version(
+    namespace,
+    labels,
+    container_name_substr,
+    expected_min_version,
+    timeout=600,
+    sleep=15,
+):
+    """Wait until at least one matching container has --tls-min-version set."""
+
+    def _done():
+        for _name, args in list_labeled_container_cli(
+            namespace, labels, container_name_substr
+        ):
+            flags = parse_tls_cli_flags(args)
+            if flags.get("min_version") == expected_min_version:
+                return True
+        return False
+
+    TimeoutSampler(timeout, sleep, _done).wait_for_func_value(True)
+
+
+def snapshot_apiserver_tls_security_profile():
+    """Return a copy of APIServer/cluster spec.tlsSecurityProfile (may be None)."""
+    raw = _tls_scan_run_oc(["get", "apiserver", "cluster", "-o", "json"], timeout=60)
+    data = json.loads(raw)
+    return copy.deepcopy((data.get("spec") or {}).get("tlsSecurityProfile"))
+
+
+def set_apiserver_tls_security_profile(profile_type):
+    """
+    Merge-patch APIServer/cluster spec.tlsSecurityProfile.type.
+
+    ``profile_type`` is ``Modern`` or ``Intermediate`` (OpenShift named profiles).
+    """
+    key = profile_type.lower()
+    patch = {"spec": {"tlsSecurityProfile": {"type": profile_type, key: {}}}}
+    _tls_scan_run_oc(
+        [
+            "patch",
+            "apiserver",
+            "cluster",
+            "--type",
+            "merge",
+            "-p",
+            json.dumps(patch),
+        ],
+        timeout=60,
+    )
+    log.info("Patched APIServer/cluster tlsSecurityProfile.type=%s", profile_type)
+
+
+def restore_apiserver_tls_security_profile(original):
+    """Restore APIServer/cluster tlsSecurityProfile (remove if original is None)."""
+    if original:
+        patch = [
+            {
+                "op": "replace",
+                "path": "/spec/tlsSecurityProfile",
+                "value": original,
+            }
+        ]
+        try:
+            _tls_scan_run_oc(
+                [
+                    "patch",
+                    "apiserver",
+                    "cluster",
+                    "--type",
+                    "json",
+                    "-p",
+                    json.dumps(patch),
+                ],
+                timeout=60,
+            )
+            log.info("Restored APIServer/cluster tlsSecurityProfile to prior value")
+            return
+        except CommandFailed:
+            log.warning(
+                "JSON replace of tlsSecurityProfile failed; falling back to merge"
+            )
+            _tls_scan_run_oc(
+                [
+                    "patch",
+                    "apiserver",
+                    "cluster",
+                    "--type",
+                    "merge",
+                    "-p",
+                    json.dumps({"spec": {"tlsSecurityProfile": original}}),
+                ],
+                timeout=60,
+            )
+            return
+    try:
+        _tls_scan_run_oc(
+            [
+                "patch",
+                "apiserver",
+                "cluster",
+                "--type",
+                "json",
+                "-p",
+                json.dumps([{"op": "remove", "path": "/spec/tlsSecurityProfile"}]),
+            ],
+            timeout=60,
+        )
+        log.info("Removed APIServer/cluster spec.tlsSecurityProfile")
+    except CommandFailed:
+        set_apiserver_tls_security_profile("Intermediate")
+        log.info("Restored APIServer/cluster tlsSecurityProfile to Intermediate")
+
+
+_KUBE_APISERVER_STATUS_EXCEPTIONS = (
+    CommandFailed,
+    TimeoutExpiredError,
+    subprocess.TimeoutExpired,
+)
+
+
+def _cluster_operator_conditions(name, timeout=60):
+    """Return {type: status} for a ClusterOperator without dumping full JSON."""
+    raw = _tls_scan_run_oc(
+        [
+            "get",
+            "clusteroperator",
+            name,
+            "-o",
+            "jsonpath={range .status.conditions[*]}{.type}={.status};{end}",
+        ],
+        timeout=timeout,
+    )
+    conditions = {}
+    for part in (raw or "").split(";"):
+        part = part.strip()
+        if "=" in part:
+            key, value = part.split("=", 1)
+            conditions[key] = value
+    return conditions
+
+
+def _apiserver_tls_profile_type():
+    """Return APIServer/cluster spec.tlsSecurityProfile.type, or None."""
+    raw = _tls_scan_run_oc(
+        [
+            "get",
+            "apiserver",
+            "cluster",
+            "-o",
+            "jsonpath={.spec.tlsSecurityProfile.type}",
+        ],
+        timeout=60,
+    )
+    return (raw or "").strip() or None
+
+
+def _kube_apiserver_rollout_snapshot():
+    """
+    Return ClusterOperator plus per-node installer revision state.
+
+    kube-apiserver TLS profile changes roll static pods one master at a time.
+    ClusterOperator Progressing can stay True across installer retries; the
+    kubeapiserver operator CR is the source for per-node currentRevision.
+    """
+    cond = _cluster_operator_conditions(constants.OPENSHIFT_API_CLUSTER_OPERATOR)
+    raw = _tls_scan_run_oc(
+        ["get", "kubeapiserver.operator.openshift.io", "cluster", "-o", "json"],
+        timeout=60,
+    )
+    data = json.loads(raw) if raw else {}
+    status = data.get("status") or {}
+    nodes = []
+    for node_status in status.get("nodeStatuses") or []:
+        nodes.append(
+            {
+                "node": node_status.get("nodeName"),
+                "current": node_status.get("currentRevision"),
+                "target": node_status.get("targetRevision") or 0,
+                "last_failed_revision": node_status.get("lastFailedRevision"),
+                "last_failed_reason": node_status.get("lastFailedReason"),
+                "last_failed_time": node_status.get("lastFailedTime"),
+            }
+        )
+    latest = status.get("latestAvailableRevision")
+    all_at_latest = (
+        bool(nodes)
+        and latest is not None
+        and all(node["current"] == latest and not node["target"] for node in nodes)
+    )
+    return {
+        "available": cond.get("Available") == "True",
+        "progressing": cond.get("Progressing") == "True",
+        "degraded": cond.get("Degraded") == "True",
+        "latest_revision": latest,
+        "nodes": nodes,
+        "all_nodes_at_latest": all_at_latest,
+    }
+
+
+def _kube_apiserver_rollout_signature(snapshot):
+    """Comparable tuple that changes when installer revision progress happens."""
+    nodes = tuple(
+        (
+            node.get("node"),
+            node.get("current"),
+            node.get("target"),
+            node.get("last_failed_revision"),
+            node.get("last_failed_time"),
+        )
+        for node in snapshot.get("nodes") or []
+    )
+    return (
+        snapshot.get("latest_revision"),
+        snapshot.get("progressing"),
+        snapshot.get("available"),
+        snapshot.get("degraded"),
+        nodes,
+    )
+
+
+def _kube_apiserver_rollout_is_complete(snapshot):
+    """True when HA kube-apiserver is serving the latest revision on every master."""
+    return (
+        snapshot.get("available")
+        and not snapshot.get("degraded")
+        and not snapshot.get("progressing")
+        and snapshot.get("all_nodes_at_latest")
+    )
+
+
+def _kube_apiserver_node_progress(snapshot):
+    """Installer fields that change while a static-pod revision is rolling."""
+    return [
+        (
+            node.get("node"),
+            node.get("current"),
+            node.get("target"),
+            node.get("last_failed_revision"),
+            node.get("last_failed_time"),
+        )
+        for node in snapshot.get("nodes") or []
+    ]
+
+
+def _kube_apiserver_rollout_has_started(initial, snapshot):
+    """True when Progressing, a new revision, or installer node state changed."""
+    if snapshot.get("progressing"):
+        return True
+    if initial is None:
+        return False
+    if snapshot.get("latest_revision") != initial.get("latest_revision"):
+        return True
+    return _kube_apiserver_node_progress(snapshot) != _kube_apiserver_node_progress(
+        initial
+    )
+
+
+def _format_kube_apiserver_rollout(snapshot):
+    """Short one-line kube-apiserver rollout status for logs."""
+    node_bits = []
+    for node in snapshot.get("nodes") or []:
+        bit = f"{node.get('node')}={node.get('current')}"
+        if node.get("target"):
+            bit += f"->{node['target']}"
+        if node.get("last_failed_reason"):
+            bit += (
+                f"(failed:{node.get('last_failed_revision')}/"
+                f"{node['last_failed_reason']})"
+            )
+        node_bits.append(bit)
+    return (
+        f"Available={snapshot.get('available')} "
+        f"Progressing={snapshot.get('progressing')} "
+        f"Degraded={snapshot.get('degraded')} "
+        f"latest={snapshot.get('latest_revision')} "
+        f"nodes=[{', '.join(node_bits)}]"
+    )
+
+
+def wait_for_kube_apiserver_stable(timeout=1800, sleep=15):
+    """
+    Wait until kube-apiserver is Available, not Degraded, and every master is
+    on latestAvailableRevision.
+
+    The stall clock resets when installer revision state changes (including
+    InstallerFailed retries). A fixed clock from Progressing=True expires
+    mid-roll on 3-master clouds when one installer pod hits API timeouts.
+    """
+    last_progress = time.time()
+    last_sig = None
+    last_status_log = 0
+    while True:
+        now = time.time()
+        try:
+            snapshot = _kube_apiserver_rollout_snapshot()
+        except _KUBE_APISERVER_STATUS_EXCEPTIONS as ex:
+            log.info(
+                "kube-apiserver status query failed (%s); retrying",
+                type(ex).__name__,
+            )
+            if now - last_progress > timeout:
+                raise TimeoutExpiredError(
+                    f"Timed out after {timeout}s querying kube-apiserver status "
+                    f"({type(ex).__name__}: {ex})"
+                ) from ex
+            time.sleep(sleep)
+            continue
+        sig = _kube_apiserver_rollout_signature(snapshot)
+        if sig != last_sig:
+            log.info(
+                "kube-apiserver rollout: %s",
+                _format_kube_apiserver_rollout(snapshot),
+            )
+            last_sig = sig
+            last_progress = now
+            last_status_log = now
+        elif now - last_status_log >= 60:
+            log.info(
+                "Still waiting for kube-apiserver stable: %s (stall %ss/%ss)",
+                _format_kube_apiserver_rollout(snapshot),
+                int(now - last_progress),
+                timeout,
+            )
+            last_status_log = now
+        if _kube_apiserver_rollout_is_complete(snapshot):
+            log.info("kube-apiserver ClusterOperator is Available and not Progressing")
+            return
+        if now - last_progress > timeout:
+            raise TimeoutExpiredError(
+                f"Timed out after {timeout}s with no kube-apiserver revision "
+                f"progress ({_format_kube_apiserver_rollout(snapshot)})"
+            )
+        time.sleep(sleep)
+
+
+def wait_for_kube_apiserver_tls_profile_rollout(
+    expected_type, timeout=1800, progressing_timeout=600, sleep=15
+):
+    """
+    Wait for an APIServer tlsSecurityProfile change to finish rolling kube-apiserver.
+
+    OpenShift does not set Progressing in the same second as the patch.
+    Sampling Available once races the rollout and leaves operands on the
+    previous (usually Intermediate) listener.
+
+    After Progressing (or a revision bump) is observed, wait for every master
+    to reach latestAvailableRevision. Installer retries count as progress so
+    a serial 3-master roll with one failed installer does not hit a fixed
+    1800s clock started at Progressing=True. If the operator never starts a
+    roll and remains complete, treat the change as a no-op.
+    """
+    expected = (expected_type or "").strip() or None
+
+    def _spec_matches():
+        try:
+            actual = _apiserver_tls_profile_type()
+        except _KUBE_APISERVER_STATUS_EXCEPTIONS:
+            return False
+        if expected is None:
+            return actual in (None, "", "Intermediate")
+        return actual == expected
+
+    TimeoutSampler(timeout, sleep, _spec_matches).wait_for_func_value(True)
+    log.info("APIServer/cluster tlsSecurityProfile.type=%s", expected or "(unset)")
+
+    try:
+        initial = _kube_apiserver_rollout_snapshot()
+    except _KUBE_APISERVER_STATUS_EXCEPTIONS:
+        initial = None
+    if initial:
+        log.info(
+            "kube-apiserver snapshot after TLS spec change: %s",
+            _format_kube_apiserver_rollout(initial),
+        )
+
+    rollout_started = False
+    phase1_deadline = time.time() + progressing_timeout
+    log.info(
+        "Waiting up to %ss for kube-apiserver Progressing or a revision bump "
+        "after TLS profile change",
+        progressing_timeout,
+    )
+    while time.time() < phase1_deadline:
+        try:
+            snapshot = _kube_apiserver_rollout_snapshot()
+        except _KUBE_APISERVER_STATUS_EXCEPTIONS as ex:
+            log.info(
+                "kube-apiserver status query failed (%s); retrying",
+                type(ex).__name__,
+            )
+            time.sleep(sleep)
+            continue
+        if _kube_apiserver_rollout_has_started(initial, snapshot):
+            rollout_started = True
+            log.info(
+                "kube-apiserver TLS profile rollout started: %s",
+                _format_kube_apiserver_rollout(snapshot),
+            )
+            break
+        time.sleep(sleep)
+
+    if not rollout_started:
+        try:
+            snapshot = _kube_apiserver_rollout_snapshot()
+        except _KUBE_APISERVER_STATUS_EXCEPTIONS as ex:
+            raise TimeoutExpiredError(
+                "kube-apiserver did not start a TLS profile rollout and status "
+                f"could not be read ({type(ex).__name__}: {ex})"
+            ) from ex
+        if _kube_apiserver_rollout_is_complete(snapshot):
+            log.info(
+                "kube-apiserver did not Progress after TLS profile change; "
+                "already complete (%s)",
+                _format_kube_apiserver_rollout(snapshot),
+            )
+            return
+        raise TimeoutExpiredError(
+            "kube-apiserver did not start Progressing within "
+            f"{progressing_timeout}s ({_format_kube_apiserver_rollout(snapshot)})"
+        )
+
+    wait_for_kube_apiserver_stable(timeout=timeout, sleep=sleep)
+
+
+def csi_addons_sidecar_is_deployed(namespace):
+    """Return True if a csi-addons sidecar container is present."""
+    return bool(
+        list_labeled_container_cli(
+            namespace,
+            [
+                constants.CSI_RBD_ADDON_NODEPLUGIN_LABEL_420,
+                constants.CSI_CEPHFS_ADDON_NODEPLUGIN_LABEL_420,
+                constants.RBD_CTRLPLUGIN_LABEL,
+                constants.CEPHFS_CTRLPLUGIN_LABEL,
+            ],
+            "csi-addons",
+        )
+    )
+
+
+def _args_enable_auth(command_and_args):
+    """Return True if CLI args enable CSI-Addons gRPC TLS (--enable-auth)."""
+    items = list(command_and_args or [])
+    for i, item in enumerate(items):
+        if not isinstance(item, str):
+            continue
+        if item.startswith("--enable-auth="):
+            return item.split("=", 1)[1].lower() in ("true", "1", "yes")
+        if item == "--enable-auth":
+            if i + 1 < len(items) and str(items[i + 1]).lower() in (
+                "false",
+                "0",
+                "no",
+            ):
+                return False
+            return True
+    return False
+
+
+def csi_addons_grpc_tls_is_enabled(namespace):
+    """Return True if any csi-addons sidecar is started with --enable-auth."""
+    for _name, args in list_labeled_container_cli(
+        namespace,
+        [
+            constants.CSI_RBD_ADDON_NODEPLUGIN_LABEL_420,
+            constants.CSI_CEPHFS_ADDON_NODEPLUGIN_LABEL_420,
+            constants.RBD_CTRLPLUGIN_LABEL,
+            constants.CEPHFS_CTRLPLUGIN_LABEL,
+        ],
+        "csi-addons",
+    ):
+        if _args_enable_auth(args):
+            return True
+    return False
+
+
+def snapshot_csi_addons_sidecar_roll_state(namespace):
+    """Capture csi-addons sidecar fingerprints before a TLS change."""
+    from ocs_ci.ocs.resources.pod import get_pods_having_label
+
+    pods = []
+    seen = set()
+    for label in (
+        constants.CSI_RBD_ADDON_NODEPLUGIN_LABEL_420,
+        constants.CSI_CEPHFS_ADDON_NODEPLUGIN_LABEL_420,
+        constants.RBD_CTRLPLUGIN_LABEL,
+        constants.CEPHFS_CTRLPLUGIN_LABEL,
+    ):
+        for pod_item in get_pods_having_label(label, namespace=namespace) or []:
+            name = pod_item.get("metadata", {}).get("name")
+            if name and name not in seen:
+                seen.add(name)
+                pods.append(pod_item)
+    return _tls_container_fingerprints(pods, "csi-addons")
+
+
+def wait_for_csi_addons_sidecar_ready(
+    namespace, timeout=600, sleep=15, previous_fingerprints=None
+):
+    """Wait until csi-addons sidecar containers are ready (and rolled if asked)."""
+    from ocs_ci.ocs.resources.pod import get_pods_having_label
+
+    def _list_pods():
+        pods = []
+        seen = set()
+        for label in (
+            constants.CSI_RBD_ADDON_NODEPLUGIN_LABEL_420,
+            constants.CSI_CEPHFS_ADDON_NODEPLUGIN_LABEL_420,
+            constants.RBD_CTRLPLUGIN_LABEL,
+            constants.CEPHFS_CTRLPLUGIN_LABEL,
+        ):
+            for pod_item in (
+                get_pods_having_label(
+                    label, namespace=namespace, statuses=[constants.STATUS_RUNNING]
+                )
+                or []
+            ):
+                name = pod_item.get("metadata", {}).get("name")
+                if name and name not in seen:
+                    seen.add(name)
+                    pods.append(pod_item)
+        return pods
+
+    _wait_for_tls_workload_ready(
+        _list_pods,
+        previous_fingerprints,
+        container_name_substr="csi-addons",
+        workload_name="csi-addons sidecar",
+        timeout=timeout,
+        sleep=sleep,
+    )
+
+
+def assert_csi_addons_grpc_tls_applied(
+    results,
+    api_tls_version,
+    ports=None,
+    context="",
+    expected_ciphers=None,
+    expected_groups=None,
+    exact_version=True,
+    verify_ciphers_groups=True,
+):
+    """
+    Fail unless discovered CSI-Addons sidecar gRPC ports serve the expected TLS.
+
+    Default ports are 9070 (RBD ctrlplugin), 9071 (nodeplugin), and 9080
+    (CephFS ctrlplugin). Only ports that appear in ``results`` are required,
+    so a cluster without CephFS does not fail on 9080.
+    """
+    requested = tuple(ports) if ports is not None else CSI_ADDONS_GRPC_PORTS
+    discovered = []
+    for port in requested:
+        if filter_tls_scan_results_by_ports(results, (port,)):
+            discovered.append(port)
+    if not discovered:
+        raise AssertionError(
+            "csi-addons gRPC ports were not discovered "
+            f"(looked for {list(requested)})"
+            f"{(' (' + context + ')') if context else ''}"
+        )
+    _assert_https_tls_applied(
+        results,
+        api_tls_version,
+        tuple(discovered),
+        component_label="csi-addons",
+        error_header="csi-addons gRPC TLS did not apply",
+        context=context,
+        expected_ciphers=expected_ciphers,
+        expected_groups=expected_groups,
+        verify_ciphers_groups=verify_ciphers_groups,
+        exact_version=exact_version,
+    )

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -949,6 +949,12 @@ CEPH_OBJECT_CONTROLLER_DETECT_VERSION_LABEL = (
     "app=ceph-object-controller-detect-version"
 )
 CSI_ADDONS_CONTROLLER_MANAGER_LABEL = "app.kubernetes.io/name=csi-addons"
+# CSI-Addons sidecar gRPC. TLS only when the sidecar is started with
+# --enable-auth. Ports differ by plugin: RBD ctrlplugin 9070, RBD/CephFS
+# nodeplugin 9071, CephFS ctrlplugin 9080.
+CSI_ADDONS_GRPC_PORT = 9070
+CSI_ADDONS_NODEPLUGIN_GRPC_PORT = 9071
+CSI_ADDONS_CEPHFS_CTRLPLUGIN_GRPC_PORT = 9080
 CEPH_CSI_CONTROLLER_MANAGER_LABEL = "control-plane=ceph-csi-op-controller-manager"
 OCS_CLIENT_OPERATOR_LABEL = "app=ocs-client-operator"
 DEFAULT_DEVICESET_PVC_NAME = "ocs-deviceset"
@@ -960,6 +966,14 @@ ROOK_CEPH_MON_PVC_LABEL = "pvc_name"
 PGSQL_APP_LABEL = "app=postgres"
 HOSTNAME_LABEL = "kubernetes.io/hostname"
 OCS_METRICS_EXPORTER = "app.kubernetes.io/name=ocs-metrics-exporter"
+CSI_SNAPSHOT_METADATA = "app=csi-snapshot-metadata"
+CSI_SNAPSHOT_METADATA_NAME_SUBSTRING = "snapshot-metadata"
+CSI_SNAPSHOT_METADATA_PORT = 50051
+# ocs-client-operator HTTPS listeners (controller-runtime). Metrics is bound
+# with --metrics-bind-address=:8443; webhook default flag is --webhook-port=7443.
+# Do not confuse these with ocs-metrics-exporter 8443/9443.
+OCS_CLIENT_OPERATOR_METRICS_PORT = 8443
+OCS_CLIENT_OPERATOR_WEBHOOK_PORT = 7443
 MANAGED_PROMETHEUS_LABEL = "prometheus=managed-ocs-prometheus"
 MANAGED_ALERTMANAGER_LABEL = "alertmanager=managed-ocs-alertmanager"
 MANAGED_CONTROLLER_LABEL = "control-plane=controller-manager"

--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -4779,6 +4779,48 @@ def get_ocs_client_operator_controller_manager(
     return [Pod(**pod) for pod in ocs_client_operator_controller_manager]
 
 
+def wait_for_ocs_client_operator_ready(
+    namespace=None, timeout=600, sleep=15, previous_fingerprints=None
+):
+    """
+    Wait until ocs-client-operator manager is Running and ready.
+
+    A TLS 1.3 apply typically restarts the manager in place (same pod UID,
+    new startedAt). A later TLS 1.2 patch may reload in-process with no
+    fingerprint change. When ``previous_fingerprints`` is set, wait until
+    those fingerprints are gone; omit it when a roll is not required.
+
+    Args:
+        namespace (str): Namespace of the operator pod.
+        timeout (int): Seconds to wait.
+        sleep (int): Seconds between polls.
+        previous_fingerprints: Optional fingerprints from before a TLSProfile
+            apply; when set, wait until none remain.
+    """
+    from ocs_ci.helpers.tlsprofile_helper import _wait_for_tls_workload_ready
+
+    namespace = namespace or config.ENV_DATA["cluster_namespace"]
+
+    def _list_pods():
+        return (
+            get_pods_having_label(
+                constants.OCS_CLIENT_OPERATOR_LABEL,
+                namespace=namespace,
+                statuses=[constants.STATUS_RUNNING],
+            )
+            or []
+        )
+
+    _wait_for_tls_workload_ready(
+        _list_pods,
+        previous_fingerprints,
+        container_name_substr="manager",
+        workload_name="ocs-client-operator",
+        timeout=timeout,
+        sleep=sleep,
+    )
+
+
 def get_csi_addons_controller_manager_pod():
     """
     Get  csi_addons_controller_manager_pod pod

--- a/tests/functional/tlsprofile/test_centralized_tlsprofile_configuration.py
+++ b/tests/functional/tlsprofile/test_centralized_tlsprofile_configuration.py
@@ -5,8 +5,9 @@ import pytest
 
 from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import (
-    brown_squad,
+    green_squad,
     ignore_leftover_label,
+    mcg,
     skipif_disconnected_cluster,
     skipif_external_mode,
     skipif_fips_enabled,
@@ -16,6 +17,8 @@ from ocs_ci.framework.pytest_customization.marks import (
 )
 from ocs_ci.framework.testlib import ManageTest
 from ocs_ci.ocs import constants
+from ocs_ci.ocs.exceptions import CommandFailed, TimeoutExpiredError
+from ocs_ci.ocs.resources.storage_cluster import get_noobaa_phase
 from ocs_ci.helpers.tlsprofile_helper import (
     TLS_PROFILE_SELECTOR_NOOBAA_DOMAIN,
     TLS_PROFILE_SELECTOR_RGW_DOMAIN,
@@ -47,14 +50,20 @@ def require_tlsprofile_crd():
         )
 
 
-@brown_squad
+@green_squad
 @tier3
 @skipif_ocs_version("<4.22")
 @skipif_disconnected_cluster
 @skipif_fips_enabled
 @skipif_external_mode
 @skipif_managed_service
-@ignore_leftover_label(constants.NOOBAA_ENDPOINT_POD_LABEL)
+@ignore_leftover_label(
+    constants.NOOBAA_ENDPOINT_POD_LABEL,
+    constants.OCS_METRICS_EXPORTER,
+    constants.OCS_CLIENT_OPERATOR_LABEL,
+    constants.RBD_CTRLPLUGIN_LABEL,
+    constants.CEPHFS_CTRLPLUGIN_LABEL,
+)
 class TestCentralizedTLSProfileConfiguration(ManageTest):
     """
     Lifecycle tests for centralized ``TLSProfile`` (DF 4.22+): TLS 1.3 / 1.2 rules,
@@ -75,7 +84,7 @@ class TestCentralizedTLSProfileConfiguration(ManageTest):
                 if tls.is_tls_profile_available(silent=True):
                     log.info("Teardown: deleting leftover ocs-tls-profile")
                     tls.delete_tls_profile(wait=True, force=True)
-            except Exception:
+            except (CommandFailed, TimeoutExpiredError):
                 log.exception("Teardown: failed to delete TLSProfile")
                 raise
 
@@ -93,7 +102,7 @@ class TestCentralizedTLSProfileConfiguration(ManageTest):
             pytest.param(
                 "noobaa",
                 [TLS_PROFILE_SELECTOR_NOOBAA_DOMAIN],
-                marks=pytest.mark.polarion_id("OCS-7936"),
+                marks=[mcg, pytest.mark.polarion_id("OCS-7936")],
                 id="Centralized TLSProfile: noobaa.io selector",
             ),
             pytest.param(
@@ -146,6 +155,22 @@ class TestCentralizedTLSProfileConfiguration(ManageTest):
                 namespace,
             )
             verify_rgw = False
+
+        if verify_nb:
+            nb_phase = get_noobaa_phase(namespace)
+            if nb_phase != constants.STATUS_READY:
+                if component == "noobaa" or not verify_rgw:
+                    pytest.skip(
+                        f"NooBaa is not Ready (phase={nb_phase}); TLSProfile "
+                        "NooBaa checks require a Ready MCG (apiServerSecurity "
+                        "is not applied while NooBaa is Creating/Error)"
+                    )
+                log.warning(
+                    "NooBaa is not Ready (phase=%s); skipping NooBaa-side "
+                    "assertions for selector-all",
+                    nb_phase,
+                )
+                verify_nb = False
 
         tls = TLSProfile()
         assert (

--- a/tests/functional/tlsprofile/test_cluster_tls_security_profile.py
+++ b/tests/functional/tlsprofile/test_cluster_tls_security_profile.py
@@ -1,0 +1,250 @@
+import logging
+import subprocess
+from datetime import datetime, timezone
+
+import pytest
+
+from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import (
+    green_squad,
+    ignore_leftover_label,
+    skipif_external_mode,
+    skipif_fips_enabled,
+    skipif_managed_service,
+    skipif_ocs_version,
+    tier3,
+)
+from ocs_ci.framework.testlib import ManageTest
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.exceptions import CommandFailed, TimeoutExpiredError
+from ocs_ci.helpers.tlsprofile_helper import (
+    CSI_ADDONS_GRPC_PORTS,
+    METRICS_EXPORTER_HTTPS_PORTS,
+    TLS_PROFILE_VERSION_TO_GO_MIN,
+    TLSProfile,
+    assert_csi_addons_grpc_tls_applied,
+    assert_no_tls_errors_in_relevant_pod_logs,
+    csi_addons_grpc_tls_is_enabled,
+    csi_addons_sidecar_is_deployed,
+    filter_tls_scan_results_by_ports,
+    get_metrics_exporter_tls_profile_generations,
+    list_labeled_container_cli,
+    maybe_assert_tls_cli_flags,
+    metrics_exporter_is_deployed,
+    restore_apiserver_tls_security_profile,
+    scan_cluster,
+    set_apiserver_tls_security_profile,
+    snapshot_apiserver_tls_security_profile,
+    wait_for_csi_addons_sidecar_ready,
+    wait_for_kube_apiserver_tls_profile_rollout,
+    wait_for_metrics_exporter_ready,
+)
+
+log = logging.getLogger(__name__)
+
+_CSI_ADDONS_SIDECAR_LABELS = [
+    constants.CSI_RBD_ADDON_NODEPLUGIN_LABEL_420,
+    constants.CSI_CEPHFS_ADDON_NODEPLUGIN_LABEL_420,
+    constants.RBD_CTRLPLUGIN_LABEL,
+    constants.CEPHFS_CTRLPLUGIN_LABEL,
+]
+
+
+@pytest.fixture(scope="class")
+def cluster_modern_tls_profile(request):
+    """Set APIServer tlsSecurityProfile to Modern; restore after the class."""
+    namespace = config.ENV_DATA["cluster_namespace"]
+    tls = TLSProfile()
+    original = snapshot_apiserver_tls_security_profile()
+    original_type = (original or {}).get("type")
+
+    def _restore():
+        try:
+            restore_apiserver_tls_security_profile(original)
+            wait_for_kube_apiserver_tls_profile_rollout(original_type)
+        except (CommandFailed, TimeoutExpiredError, subprocess.TimeoutExpired):
+            log.exception("Failed to restore APIServer tlsSecurityProfile")
+            raise
+
+    request.addfinalizer(_restore)
+
+    if tls.is_tls_profile_available(silent=True):
+        log.info(
+            "Deleting ocs-tls-profile so the cluster APIServer profile is "
+            "not overridden by a CR"
+        )
+        tls.delete_tls_profile(wait=True, force=True)
+
+    log.info("Setting APIServer/cluster tlsSecurityProfile to Modern")
+    set_apiserver_tls_security_profile("Modern")
+    wait_for_kube_apiserver_tls_profile_rollout("Modern")
+    if metrics_exporter_is_deployed(namespace):
+        wait_for_metrics_exporter_ready(namespace, timeout=900)
+    if csi_addons_sidecar_is_deployed(namespace):
+        wait_for_csi_addons_sidecar_ready(namespace, timeout=900)
+    return original
+
+
+@green_squad
+@tier3
+@skipif_ocs_version("<4.22")
+@skipif_fips_enabled
+@skipif_external_mode
+@skipif_managed_service
+@ignore_leftover_label(
+    constants.OCS_METRICS_EXPORTER,
+    constants.OCS_CLIENT_OPERATOR_LABEL,
+    constants.RBD_CTRLPLUGIN_LABEL,
+    constants.CEPHFS_CTRLPLUGIN_LABEL,
+    constants.CSI_ADDONS_CONTROLLER_MANAGER_LABEL,
+    constants.CSI_RBD_ADDON_NODEPLUGIN_LABEL_420,
+    constants.CSI_CEPHFS_ADDON_NODEPLUGIN_LABEL_420,
+    # kube-apiserver TLS profile rolls recreate these node-local rook pods
+    constants.CRASHCOLLECTOR_APP_LABEL,
+    constants.EXPORTER_APP_LABEL,
+)
+class TestClusterTLSSecurityProfile(ManageTest):
+    """
+    Cluster APIServer tlsSecurityProfile Modern with no ocs-tls-profile CR.
+
+    ocs-metrics-exporter applies TLS only from ``ocs-tls-profile``
+    (``TLS_PROFILE_GENERATION``). Cluster Modern does not restrict the
+    exporter listener. CSI-Addons sidecar gRPC is checked only when the
+    sidecar is started with ``--enable-auth`` (otherwise the ports are
+    plaintext).
+    """
+
+    @pytest.mark.polarion_id("OCS-8250")
+    def test_metrics_exporter_cluster_modern_tls_profile(
+        self, cluster_modern_tls_profile
+    ):
+        """
+        Without ocs-tls-profile, cluster Modern does not make
+        ocs-metrics-exporter TLS 1.3-only. HTTPS stays on the operand
+        default (tls1.2 and tls1.3) and TLS_PROFILE_GENERATION stays 0.
+        """
+        test_start_time = datetime.now(timezone.utc)
+        namespace = config.ENV_DATA["cluster_namespace"]
+        if not metrics_exporter_is_deployed(namespace):
+            pytest.skip(
+                f"ocs-metrics-exporter is not deployed in {namespace}; "
+                "cluster Modern TLS profile check requires it"
+            )
+
+        log.test_step(
+            "Confirm exporter has no ocs-tls-profile generation bump and "
+            "no TLS 1.3-only CLI flags"
+        )
+        generations = get_metrics_exporter_tls_profile_generations(namespace)
+        log.assertion(
+            f"TLS_PROFILE_GENERATION: expected all '0' (no ocs-tls-profile), "
+            f"actual={generations}"
+        )
+        assert generations, "ocs-metrics-exporter pods were not found"
+        nonzero = [
+            (name, gen)
+            for name, gen in generations
+            if str(gen if gen is not None else "0") != "0"
+        ]
+        assert not nonzero, (
+            "ocs-metrics-exporter TLS_PROFILE_GENERATION is non-zero without "
+            f"ocs-tls-profile; cluster Modern is not the TLSProfile CR path: "
+            f"{nonzero}"
+        )
+        cli_rows = list_labeled_container_cli(
+            namespace, constants.OCS_METRICS_EXPORTER, "ocs-metrics-exporter"
+        )
+        # Flags are optional; if present they must not claim TLS 1.3-only.
+        maybe_assert_tls_cli_flags(cli_rows)
+
+        log.test_step(
+            f"scantls metrics-exporter ports {list(METRICS_EXPORTER_HTTPS_PORTS)}: "
+            "expect tls1.2 and tls1.3 (cluster Modern is not inherited)"
+        )
+        results = scan_cluster(component="metrics-exporter", namespaces=[namespace])
+        for port in METRICS_EXPORTER_HTTPS_PORTS:
+            rows = filter_tls_scan_results_by_ports(results, (port,))
+            ok_rows = [row for row in rows if row.get("status") == "OK"]
+            log.assertion(
+                f"exporter port {port}: expected HTTPS OK, actual_ok={len(ok_rows)}"
+            )
+            assert ok_rows, (
+                f"ocs-metrics-exporter port {port} is not serving HTTPS after "
+                f"cluster Modern (rows={rows})"
+            )
+            versions = set()
+            for row in ok_rows:
+                versions.update(row.get("tls_versions") or [])
+            log.assertion(
+                f"exporter port {port} tls_versions: expected tls1.2 and "
+                f"tls1.3, actual={sorted(versions)}"
+            )
+            assert "tls1.2" in versions and "tls1.3" in versions, (
+                "without ocs-tls-profile, cluster Modern must not restrict "
+                f"ocs-metrics-exporter port {port}; got {sorted(versions)}"
+            )
+
+        elapsed_s = max(
+            120,
+            int((datetime.now(timezone.utc) - test_start_time).total_seconds()) + 30,
+        )
+        log.test_step("Scan exporter logs for TLS-related errors")
+        assert_no_tls_errors_in_relevant_pod_logs(
+            namespace, "metrics-exporter", since=f"{elapsed_s}s"
+        )
+
+    @pytest.mark.polarion_id("OCS-8251")
+    def test_csi_addons_cluster_modern_tls_profile(self, cluster_modern_tls_profile):
+        """
+        CSI-Addons sidecar gRPC follows the cluster Modern TLS profile when
+        --enable-auth is set: TLS 1.2 rejected, TLS 1.3 accepted.
+
+        Sidecars without --enable-auth speak plaintext on 9070/9071/9080.
+        """
+        test_start_time = datetime.now(timezone.utc)
+        namespace = config.ENV_DATA["cluster_namespace"]
+        if not csi_addons_sidecar_is_deployed(namespace):
+            pytest.skip(
+                f"csi-addons sidecar is not deployed in {namespace}; "
+                "cluster Modern TLS profile check requires it"
+            )
+        if not csi_addons_grpc_tls_is_enabled(namespace):
+            pytest.skip(
+                "csi-addons sidecar gRPC is plaintext (--enable-auth is not set); "
+                "cluster Modern TLS profile does not apply until auth is enabled"
+            )
+
+        log.test_step("Check CSI-Addons sidecar TLS CLI after Modern profile")
+        cli_rows = list_labeled_container_cli(
+            namespace, _CSI_ADDONS_SIDECAR_LABELS, "csi-addons"
+        )
+        log.assertion(
+            f"csi-addons sidecar containers: expected>=1, actual={len(cli_rows)}"
+        )
+        assert cli_rows, "csi-addons sidecar container args were not found"
+        maybe_assert_tls_cli_flags(
+            cli_rows,
+            min_version=TLS_PROFILE_VERSION_TO_GO_MIN["TLSv1.3"],
+        )
+
+        log.test_step(
+            f"scantls csi-addons gRPC {list(CSI_ADDONS_GRPC_PORTS)}: "
+            "expect tls1.3 only (TLS 1.2 rejected)"
+        )
+        results = scan_cluster(component="csi-addons", namespaces=[namespace])
+        assert_csi_addons_grpc_tls_applied(
+            results,
+            "TLSv1.3",
+            context="cluster tlsSecurityProfile=Modern",
+            exact_version=True,
+            verify_ciphers_groups=False,
+        )
+
+        elapsed_s = max(
+            120,
+            int((datetime.now(timezone.utc) - test_start_time).total_seconds()) + 30,
+        )
+        log.test_step("Scan CSI-Addons logs for TLS-related errors")
+        assert_no_tls_errors_in_relevant_pod_logs(
+            namespace, "csi-addons", since=f"{elapsed_s}s"
+        )

--- a/tests/functional/tlsprofile/test_csi_snapshot_metadata_tlsprofile.py
+++ b/tests/functional/tlsprofile/test_csi_snapshot_metadata_tlsprofile.py
@@ -1,0 +1,237 @@
+import logging
+from datetime import datetime, timezone
+
+import pytest
+
+from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import (
+    green_squad,
+    ignore_leftover_label,
+    skipif_external_mode,
+    skipif_fips_enabled,
+    skipif_managed_service,
+    skipif_ocs_version,
+    tier3,
+)
+from ocs_ci.framework.testlib import ManageTest
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.exceptions import CommandFailed, TimeoutExpiredError
+from ocs_ci.helpers.tlsprofile_helper import (
+    CSI_SNAPSHOT_METADATA_HTTPS_PORTS,
+    CSI_SNAPSHOT_METADATA_V13_GROUPS,
+    TLS_PROFILE_SELECTOR_CSI_SNAPSHOT_METADATA,
+    TLS_PROFILE_V12_CIPHERS,
+    TLS_PROFILE_V12_GROUPS,
+    TLS_PROFILE_V13_CIPHERS,
+    TLSProfile,
+    assert_csi_snapshot_metadata_https_tls_applied,
+    assert_no_tls_errors_in_relevant_pod_logs,
+    csi_snapshot_metadata_is_deployed,
+    scan_cluster,
+    snapshot_csi_snapshot_metadata_roll_state,
+    snapshot_tlsprofile_state,
+    teardown_tlsprofile,
+    tlsprofile_crd_exists,
+    wait_for_csi_snapshot_metadata_ready,
+    wait_for_tlsprofile_config_version,
+)
+
+log = logging.getLogger(__name__)
+
+_CSI_SNAPSHOT_METADATA_COMPONENT = "csi-snapshot-metadata"
+_CSI_SNAPSHOT_METADATA_SELECTORS = [TLS_PROFILE_SELECTOR_CSI_SNAPSHOT_METADATA]
+
+
+@pytest.fixture(scope="module", autouse=True)
+def require_tlsprofile_crd():
+    if not tlsprofile_crd_exists():
+        pytest.skip(
+            "TLSProfile CRD tlsprofiles.ocs.openshift.io not found on this cluster"
+        )
+
+
+@green_squad
+@tier3
+@skipif_ocs_version("<4.22")
+@skipif_fips_enabled
+@skipif_external_mode
+@skipif_managed_service
+@ignore_leftover_label(
+    constants.CSI_SNAPSHOT_METADATA,
+    constants.RBD_CTRLPLUGIN_LABEL,
+    constants.CEPHFS_CTRLPLUGIN_LABEL,
+    constants.OCS_METRICS_EXPORTER,
+    constants.OCS_CLIENT_OPERATOR_LABEL,
+)
+class TestCSISnapshotMetadataTLSProfile(ManageTest):
+    """
+    Lifecycle tests for centralized ``TLSProfile`` on csi-snapshot-metadata
+    (DF 4.22+): selector ``cbt.storage.k8s.io``, TLS 1.3 then TLS 1.2, in-cluster
+    scantls of gRPC HTTPS port 50051, then delete ``ocs-tls-profile``.
+
+    The CSI Snapshot Metadata sidecar rejects SecP256r1MLKEM768 and
+    SecP384r1MLKEM1024 (crashloop). TLS 1.3 rules use
+    ``CSI_SNAPSHOT_METADATA_V13_GROUPS`` instead of the full product list.
+    TLS 1.2 is a minimum (``--tls-min-version=VersionTLS12``); TLS 1.3 may
+    still be offered. Deletes the CR at the end—only run where that is safe. An autouse fixture
+    also deletes a leftover ``ocs-tls-profile`` if the test aborts early. CSI
+    provisioner / snapshot-metadata pods may roll when TLS settings change.
+    """
+
+    @pytest.fixture(autouse=True)
+    def cleanup_tlsprofile(self, request):
+        tls = TLSProfile()
+        existed_before, original_state = snapshot_tlsprofile_state(tls)
+
+        def _cleanup():
+            try:
+                teardown_tlsprofile(tls, existed_before, original_state)
+            except (CommandFailed, TimeoutExpiredError):
+                log.exception("Teardown: failed to restore or delete TLSProfile")
+                raise
+
+        request.addfinalizer(_cleanup)
+
+    @pytest.mark.polarion_id("OCS-8247")
+    def test_csi_snapshot_metadata_tls_profile_version_lifecycle(self):
+        """
+        csi-snapshot-metadata TLSProfile: TLS 1.3 then TLS 1.2 on port 50051.
+
+        Steps:
+        1. Skip if csi-snapshot-metadata is not deployed.
+        2. Apply centralized TLS configuration with selector ``cbt.storage.k8s.io``
+           using TLS 1.3 and the required cipher suites and TLS groups.
+        3. Wait for reconciliation.
+        4. Run scantls against port 50051 and verify TLS 1.3 (and only the
+           configured ciphers/groups) is used.
+        5. Repeat with a TLS 1.2 profile (minimum version; TLS 1.3 may still
+           be offered). The service must update without manual intervention.
+        6. Delete the TLSProfile and scan operator / snapshot-metadata logs
+           for TLS-related errors.
+        """
+        test_start_time = datetime.now(timezone.utc)
+        namespace = config.ENV_DATA["cluster_namespace"]
+
+        if not csi_snapshot_metadata_is_deployed(namespace):
+            pytest.skip(
+                f"csi-snapshot-metadata is not deployed in {namespace}; "
+                "TLSProfile selector cbt.storage.k8s.io requires it"
+            )
+
+        tls = TLSProfile()
+        log.assertion(
+            f"TLSProfile metadata.name: expected='ocs-tls-profile', actual='{tls.name}'"
+        )
+        assert (
+            tls.name == "ocs-tls-profile"
+        ), "TLSProfile metadata.name must be ocs-tls-profile"
+
+        log.test_step(
+            "Apply TLSProfile selector cbt.storage.k8s.io with TLSv1.3, "
+            "required cipher suites, and TLS groups supported by "
+            "csi-snapshot-metadata"
+        )
+        prev_roll = snapshot_csi_snapshot_metadata_roll_state(namespace)
+        if not tls.is_tls_profile_available():
+            log.info(
+                "TLSProfile absent; creating with TLSv1.3 for csi-snapshot-metadata"
+            )
+            tls.create_tls_profile(
+                selectors=_CSI_SNAPSHOT_METADATA_SELECTORS,
+                tls_version="TLSv1.3",
+                ciphers=TLS_PROFILE_V13_CIPHERS,
+                groups=CSI_SNAPSHOT_METADATA_V13_GROUPS,
+            )
+        else:
+            log.info(
+                "TLSProfile exists; replacing rules with TLSv1.3 for "
+                "csi-snapshot-metadata"
+            )
+            tls.replace_rules(
+                _CSI_SNAPSHOT_METADATA_SELECTORS,
+                "TLSv1.3",
+                TLS_PROFILE_V13_CIPHERS,
+                CSI_SNAPSHOT_METADATA_V13_GROUPS,
+            )
+
+        log.test_step("Wait for TLSProfile reconciliation (TLSv1.3)")
+        wait_for_tlsprofile_config_version(tls, "TLSv1.3")
+        actual_version = tls.get_config_version()
+        log.assertion(
+            f"TLSProfile version: expected='TLSv1.3', actual='{actual_version}'"
+        )
+        assert actual_version == "TLSv1.3"
+        wait_for_csi_snapshot_metadata_ready(namespace, previous_fingerprints=prev_roll)
+
+        log.test_step(
+            "scantls csi-snapshot-metadata HTTPS port "
+            f"{list(CSI_SNAPSHOT_METADATA_HTTPS_PORTS)}: expect tls1.3 only, "
+            "configured ciphers/groups"
+        )
+        scan_after_v13 = scan_cluster(
+            component=_CSI_SNAPSHOT_METADATA_COMPONENT, namespaces=[namespace]
+        )
+        assert_csi_snapshot_metadata_https_tls_applied(
+            scan_after_v13,
+            "TLSv1.3",
+            expected_ciphers=TLS_PROFILE_V13_CIPHERS,
+            expected_groups=CSI_SNAPSHOT_METADATA_V13_GROUPS,
+            context="TLSProfile TLSv1.3, component=csi-snapshot-metadata",
+        )
+
+        log.test_step(
+            "Patch TLSProfile to TLSv1.2; service must update without "
+            "manual intervention"
+        )
+        prev_roll = snapshot_csi_snapshot_metadata_roll_state(namespace)
+        tls.replace_rules(
+            _CSI_SNAPSHOT_METADATA_SELECTORS,
+            "TLSv1.2",
+            TLS_PROFILE_V12_CIPHERS,
+            TLS_PROFILE_V12_GROUPS,
+        )
+        log.test_step("Wait for TLSProfile reconciliation (TLSv1.2)")
+        wait_for_tlsprofile_config_version(tls, "TLSv1.2")
+        actual_version = tls.get_config_version()
+        log.assertion(
+            f"TLSProfile version: expected='TLSv1.2', actual='{actual_version}'"
+        )
+        assert actual_version == "TLSv1.2"
+        wait_for_csi_snapshot_metadata_ready(namespace, previous_fingerprints=prev_roll)
+
+        log.test_step(
+            "scantls csi-snapshot-metadata HTTPS port "
+            f"{list(CSI_SNAPSHOT_METADATA_HTTPS_PORTS)}: expect tls1.2 "
+            "(min version; tls1.3 may still be offered), configured ciphers/groups"
+        )
+        scan_after_v12 = scan_cluster(
+            component=_CSI_SNAPSHOT_METADATA_COMPONENT, namespaces=[namespace]
+        )
+        assert_csi_snapshot_metadata_https_tls_applied(
+            scan_after_v12,
+            "TLSv1.2",
+            expected_ciphers=TLS_PROFILE_V12_CIPHERS,
+            expected_groups=TLS_PROFILE_V12_GROUPS,
+            context="TLSProfile TLSv1.2, component=csi-snapshot-metadata",
+        )
+
+        prev_roll = snapshot_csi_snapshot_metadata_roll_state(namespace)
+        tls.delete_tls_profile(wait=True, force=False)
+        still_present = tls.is_tls_profile_available()
+        log.assertion(
+            f"TLSProfile after delete: expected=absent, actual_present={still_present}"
+        )
+        assert not still_present, "TLSProfile should be absent after delete"
+        wait_for_csi_snapshot_metadata_ready(namespace, previous_fingerprints=prev_roll)
+
+        elapsed_s = max(
+            120,
+            int((datetime.now(timezone.utc) - test_start_time).total_seconds()) + 30,
+        )
+        log.test_step(
+            f"Scan operator/csi-snapshot-metadata pod logs for TLS-related errors "
+            f"(since last {elapsed_s}s, from test start)"
+        )
+        assert_no_tls_errors_in_relevant_pod_logs(
+            namespace, _CSI_SNAPSHOT_METADATA_COMPONENT, since=f"{elapsed_s}s"
+        )

--- a/tests/functional/tlsprofile/test_metrics_exporter_tlsprofile.py
+++ b/tests/functional/tlsprofile/test_metrics_exporter_tlsprofile.py
@@ -1,0 +1,369 @@
+import logging
+from datetime import datetime, timezone
+
+import pytest
+
+from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import (
+    green_squad,
+    ignore_leftover_label,
+    skipif_external_mode,
+    skipif_fips_enabled,
+    skipif_managed_service,
+    skipif_ocs_version,
+    tier3,
+)
+from ocs_ci.framework.testlib import ManageTest
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.exceptions import CommandFailed, TimeoutExpiredError
+from ocs_ci.helpers.tlsprofile_helper import (
+    METRICS_EXPORTER_HTTPS_PORTS,
+    TLS_PROFILE_SELECTOR_METRICS_EXPORTER,
+    TLS_PROFILE_V12_CIPHERS,
+    TLS_PROFILE_V12_GROUPS,
+    TLS_PROFILE_V13_CIPHERS,
+    TLS_PROFILE_V13_GROUPS,
+    TLS_PROFILE_VERSION_TO_GO_MIN,
+    TLSProfile,
+    assert_metrics_exporter_https_tls_applied,
+    assert_metrics_exporter_tls_profile_generation,
+    assert_no_tls_errors_in_relevant_pod_logs,
+    go_curves_for_tls_profile_groups,
+    list_labeled_container_cli,
+    maybe_assert_tls_cli_flags,
+    metrics_exporter_is_deployed,
+    scan_cluster,
+    snapshot_metrics_exporter_roll_state,
+    snapshot_tlsprofile_state,
+    teardown_tlsprofile,
+    tlsprofile_crd_exists,
+    wait_for_metrics_exporter_ready,
+    wait_for_tlsprofile_config_version,
+)
+
+log = logging.getLogger(__name__)
+
+_METRICS_EXPORTER_COMPONENT = "metrics-exporter"
+_METRICS_EXPORTER_SELECTORS = [TLS_PROFILE_SELECTOR_METRICS_EXPORTER]
+
+
+@pytest.fixture(scope="module", autouse=True)
+def require_tlsprofile_crd():
+    if not tlsprofile_crd_exists():
+        pytest.skip(
+            "TLSProfile CRD tlsprofiles.ocs.openshift.io not found on this cluster"
+        )
+
+
+@green_squad
+@tier3
+@skipif_ocs_version("<4.22")
+@skipif_fips_enabled
+@skipif_external_mode
+@skipif_managed_service
+@ignore_leftover_label(
+    constants.OCS_METRICS_EXPORTER,
+    constants.OCS_CLIENT_OPERATOR_LABEL,
+    constants.RBD_CTRLPLUGIN_LABEL,
+    constants.CEPHFS_CTRLPLUGIN_LABEL,
+)
+class TestMetricsExporterTLSProfile(ManageTest):
+    """
+    Lifecycle tests for centralized ``TLSProfile`` on ocs-metrics-exporter
+    (DF 4.22+): selector ``ocs.openshift.io/metrics-exporter``, TLS 1.3 / 1.2
+    rules, in-cluster TLS scan of exporter HTTPS ports 8443 (https-main)
+    and 9443 (https-self), then delete ``ocs-tls-profile``.
+
+    Skips on FIPS (PQ / ChaCha in our cipher lists). Deletes the CR at the
+    end—only run where that is safe. An autouse fixture also deletes a leftover
+    ``ocs-tls-profile`` if the test aborts before the in-test delete. Exporter
+    pods may roll when TLS settings change.
+    """
+
+    @pytest.fixture(autouse=True)
+    def cleanup_tlsprofile(self, request):
+        tls = TLSProfile()
+        existed_before, original_state = snapshot_tlsprofile_state(tls)
+
+        def _cleanup():
+            try:
+                teardown_tlsprofile(tls, existed_before, original_state)
+            except (CommandFailed, TimeoutExpiredError):
+                log.exception("Teardown: failed to restore or delete TLSProfile")
+                raise
+
+        request.addfinalizer(_cleanup)
+
+    @pytest.mark.polarion_id("OCS-8248")
+    def test_metrics_exporter_tls_profile_version_lifecycle(self):
+        """
+        ocs-metrics-exporter TLSProfile: version toggle (1.3 / 1.2 / 1.3), scan,
+        delete, log check.
+
+        Steps:
+        1. Skip if ocs-metrics-exporter is not deployed.
+        2. Detect whether ``ocs-tls-profile`` exists (required metadata name).
+        3. If missing, create it with selector ``ocs.openshift.io/metrics-exporter``
+           and TLS 1.3; otherwise normalize the rule to TLS 1.3.
+        4. Wait until the exporter is ready; scan HTTPS ports 8443 and 9443
+           and assert both speak TLS with ``tls1.3`` only.
+        5. Patch to TLS 1.2, wait for the exporter, scan 8443/9443 and assert
+           both speak ``tls1.2`` only.
+        6. Restore TLS 1.3; scan 8443/9443 and assert both speak ``tls1.3`` only.
+        7. Delete the TLSProfile and confirm it is gone.
+        8. Confirm the exporter remains ready after delete.
+        9. Scan operator / exporter pod logs for TLS-related error lines.
+        """
+        test_start_time = datetime.now(timezone.utc)
+        namespace = config.ENV_DATA["cluster_namespace"]
+
+        if not metrics_exporter_is_deployed(namespace):
+            pytest.skip(
+                f"ocs-metrics-exporter is not deployed in {namespace}; "
+                "TLSProfile selector ocs.openshift.io/metrics-exporter requires it"
+            )
+
+        tls = TLSProfile()
+        log.assertion(
+            f"TLSProfile metadata.name: expected='ocs-tls-profile', actual='{tls.name}'"
+        )
+        assert (
+            tls.name == "ocs-tls-profile"
+        ), "TLSProfile metadata.name must be ocs-tls-profile"
+
+        log.test_step(
+            "Create or normalize TLSProfile with ocs.openshift.io/metrics-exporter "
+            "selector and TLSv1.3"
+        )
+        prev_roll = snapshot_metrics_exporter_roll_state(namespace)
+        if not tls.is_tls_profile_available():
+            log.info("TLSProfile absent; creating with TLSv1.3 for metrics-exporter")
+            tls.create_tls_profile(
+                selectors=_METRICS_EXPORTER_SELECTORS,
+                tls_version="TLSv1.3",
+                ciphers=TLS_PROFILE_V13_CIPHERS,
+                groups=TLS_PROFILE_V13_GROUPS,
+            )
+        else:
+            log.info(
+                "TLSProfile exists; normalizing rule to TLSv1.3 for metrics-exporter"
+            )
+            tls.replace_rules(
+                _METRICS_EXPORTER_SELECTORS,
+                "TLSv1.3",
+                TLS_PROFILE_V13_CIPHERS,
+                TLS_PROFILE_V13_GROUPS,
+            )
+
+        wait_for_tlsprofile_config_version(tls, "TLSv1.3")
+        actual_version = tls.get_config_version()
+        log.assertion(
+            f"TLSProfile version: expected='TLSv1.3', actual='{actual_version}'"
+        )
+        assert actual_version == "TLSv1.3"
+        wait_for_metrics_exporter_ready(namespace, previous_fingerprints=prev_roll)
+
+        log.test_step(
+            "Scan ocs-metrics-exporter HTTPS ports "
+            f"{list(METRICS_EXPORTER_HTTPS_PORTS)}: expect tls1.3"
+        )
+        scan_after_v13 = scan_cluster(
+            component=_METRICS_EXPORTER_COMPONENT, namespaces=[namespace]
+        )
+        assert_metrics_exporter_https_tls_applied(
+            scan_after_v13,
+            "TLSv1.3",
+            expected_ciphers=TLS_PROFILE_V13_CIPHERS,
+            expected_groups=TLS_PROFILE_V13_GROUPS,
+            context="TLSProfile TLSv1.3, component=metrics-exporter",
+        )
+
+        log.test_step("Patch TLSProfile to TLSv1.2 and validate metrics-exporter")
+        prev_roll = snapshot_metrics_exporter_roll_state(namespace)
+        tls.replace_rules(
+            _METRICS_EXPORTER_SELECTORS,
+            "TLSv1.2",
+            TLS_PROFILE_V12_CIPHERS,
+            TLS_PROFILE_V12_GROUPS,
+        )
+        wait_for_tlsprofile_config_version(tls, "TLSv1.2")
+        actual_version = tls.get_config_version()
+        log.assertion(
+            f"TLSProfile version: expected='TLSv1.2', actual='{actual_version}'"
+        )
+        assert actual_version == "TLSv1.2"
+        wait_for_metrics_exporter_ready(namespace, previous_fingerprints=prev_roll)
+
+        log.test_step(
+            "Scan ocs-metrics-exporter HTTPS ports "
+            f"{list(METRICS_EXPORTER_HTTPS_PORTS)}: expect tls1.2"
+        )
+        scan_after_v12 = scan_cluster(
+            component=_METRICS_EXPORTER_COMPONENT, namespaces=[namespace]
+        )
+        assert_metrics_exporter_https_tls_applied(
+            scan_after_v12,
+            "TLSv1.2",
+            expected_ciphers=TLS_PROFILE_V12_CIPHERS,
+            expected_groups=TLS_PROFILE_V12_GROUPS,
+            context="TLSProfile TLSv1.2, component=metrics-exporter",
+        )
+
+        log.test_step("Restore TLSv1.3 on TLSProfile, then delete the resource")
+        prev_roll = snapshot_metrics_exporter_roll_state(namespace)
+        tls.replace_rules(
+            _METRICS_EXPORTER_SELECTORS,
+            "TLSv1.3",
+            TLS_PROFILE_V13_CIPHERS,
+            TLS_PROFILE_V13_GROUPS,
+        )
+        wait_for_tlsprofile_config_version(tls, "TLSv1.3")
+        wait_for_metrics_exporter_ready(namespace, previous_fingerprints=prev_roll)
+
+        log.test_step(
+            "Scan ocs-metrics-exporter HTTPS ports "
+            f"{list(METRICS_EXPORTER_HTTPS_PORTS)} after restore: expect tls1.3"
+        )
+        scan_after_restore = scan_cluster(
+            component=_METRICS_EXPORTER_COMPONENT, namespaces=[namespace]
+        )
+        assert_metrics_exporter_https_tls_applied(
+            scan_after_restore,
+            "TLSv1.3",
+            expected_ciphers=TLS_PROFILE_V13_CIPHERS,
+            expected_groups=TLS_PROFILE_V13_GROUPS,
+            context="TLSProfile restored to TLSv1.3, component=metrics-exporter",
+        )
+
+        prev_roll = snapshot_metrics_exporter_roll_state(namespace)
+        tls.delete_tls_profile(wait=True, force=False)
+        still_present = tls.is_tls_profile_available()
+        log.assertion(
+            f"TLSProfile after delete: expected=absent, actual_present={still_present}"
+        )
+        assert not still_present, "TLSProfile should be absent after delete"
+        wait_for_metrics_exporter_ready(namespace, previous_fingerprints=prev_roll)
+
+        elapsed_s = max(
+            120,
+            int((datetime.now(timezone.utc) - test_start_time).total_seconds()) + 30,
+        )
+        log.test_step(
+            f"Scan operator/exporter pod logs for TLS-related errors "
+            f"(since last {elapsed_s}s, from test start)"
+        )
+        assert_no_tls_errors_in_relevant_pod_logs(
+            namespace, _METRICS_EXPORTER_COMPONENT, since=f"{elapsed_s}s"
+        )
+
+    @pytest.mark.polarion_id("OCS-8249")
+    def test_metrics_exporter_tls_cli_flags(self):
+        """
+        ocs-metrics-exporter applies TLSProfile on 8443/9443 as an exclusive
+        version (TLS 1.2 rejects 1.3 and the reverse). DF 5.0 records the
+        apply with ``TLS_PROFILE_GENERATION``; ``--tls-*`` CLI flags are
+        asserted only when the exporter sets them. TLS 1.3 cipher subsets in
+        the CR are not enforced (Go crypto/tls).
+
+        Steps:
+        1. Apply TLS 1.2 with a single RSA GCM cipher and X25519/P-256/P-384.
+        2. Assert TLS_PROFILE_GENERATION, optional CLI flags, scan 8443/9443.
+        3. Switch to TLS 1.3 with AES-GCM in the CR (Go still offers ChaCha)
+           and PQ/classic groups.
+        4. Assert generation and scan tls1.3 only (cipher subset not enforced).
+        """
+        namespace = config.ENV_DATA["cluster_namespace"]
+        if not metrics_exporter_is_deployed(namespace):
+            pytest.skip(
+                f"ocs-metrics-exporter is not deployed in {namespace}; "
+                "TLSProfile listener checks require it"
+            )
+
+        tls = TLSProfile()
+        v12_ciphers = ["TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"]
+        v12_groups = ["X25519", "secp256r1", "secp384r1"]
+        v13_ciphers = [
+            "TLS_AES_128_GCM_SHA256",
+            "TLS_AES_256_GCM_SHA384",
+        ]
+        v13_groups = ["X25519MLKEM768", "X25519", "secp256r1"]
+
+        log.test_step(
+            "Apply TLSProfile TLSv1.2 with one TLS 1.2 cipher suite and "
+            "X25519/CurveP256/CurveP384"
+        )
+        prev_roll = snapshot_metrics_exporter_roll_state(namespace)
+        if not tls.is_tls_profile_available():
+            tls.create_tls_profile(
+                selectors=_METRICS_EXPORTER_SELECTORS,
+                tls_version="TLSv1.2",
+                ciphers=v12_ciphers,
+                groups=v12_groups,
+            )
+        else:
+            tls.replace_rules(
+                _METRICS_EXPORTER_SELECTORS, "TLSv1.2", v12_ciphers, v12_groups
+            )
+        wait_for_tlsprofile_config_version(tls, "TLSv1.2")
+        wait_for_metrics_exporter_ready(namespace, previous_fingerprints=prev_roll)
+        assert_metrics_exporter_tls_profile_generation(namespace)
+
+        cli_rows = list_labeled_container_cli(
+            namespace, constants.OCS_METRICS_EXPORTER, "ocs-metrics-exporter"
+        )
+        log.assertion(
+            f"ocs-metrics-exporter containers with CLI args: expected>=1, "
+            f"actual={len(cli_rows)}"
+        )
+        assert cli_rows, "ocs-metrics-exporter container args were not found"
+        maybe_assert_tls_cli_flags(
+            cli_rows,
+            min_version=TLS_PROFILE_VERSION_TO_GO_MIN["TLSv1.2"],
+            cipher_suites=v12_ciphers,
+            curve_preferences=go_curves_for_tls_profile_groups(v12_groups),
+        )
+
+        log.test_step(
+            "scantls metrics-exporter 8443/9443 after TLS 1.2: expect tls1.2 only"
+        )
+        scan_v12 = scan_cluster(
+            component=_METRICS_EXPORTER_COMPONENT, namespaces=[namespace]
+        )
+        assert_metrics_exporter_https_tls_applied(
+            scan_v12,
+            "TLSv1.2",
+            expected_ciphers=v12_ciphers,
+            expected_groups=v12_groups,
+            context="TLSProfile TLSv1.2 on metrics-exporter",
+        )
+
+        log.test_step("Patch TLSProfile to TLSv1.3 (exclusive) with AES-GCM ciphers")
+        prev_roll = snapshot_metrics_exporter_roll_state(namespace)
+        tls.replace_rules(
+            _METRICS_EXPORTER_SELECTORS, "TLSv1.3", v13_ciphers, v13_groups
+        )
+        wait_for_tlsprofile_config_version(tls, "TLSv1.3")
+        wait_for_metrics_exporter_ready(namespace, previous_fingerprints=prev_roll)
+        assert_metrics_exporter_tls_profile_generation(namespace)
+
+        cli_rows = list_labeled_container_cli(
+            namespace, constants.OCS_METRICS_EXPORTER, "ocs-metrics-exporter"
+        )
+        assert cli_rows, "ocs-metrics-exporter container args were not found"
+        maybe_assert_tls_cli_flags(
+            cli_rows,
+            min_version=TLS_PROFILE_VERSION_TO_GO_MIN["TLSv1.3"],
+            curve_preferences=go_curves_for_tls_profile_groups(v13_groups),
+        )
+
+        log.test_step("scantls metrics-exporter 8443/9443: expect tls1.3 only")
+        scan_v13 = scan_cluster(
+            component=_METRICS_EXPORTER_COMPONENT, namespaces=[namespace]
+        )
+        assert_metrics_exporter_https_tls_applied(
+            scan_v13,
+            "TLSv1.3",
+            expected_ciphers=v13_ciphers,
+            expected_groups=v13_groups,
+            context="TLSProfile TLSv1.3 on metrics-exporter",
+        )

--- a/tests/functional/tlsprofile/test_ocs_client_operator_tlsprofile.py
+++ b/tests/functional/tlsprofile/test_ocs_client_operator_tlsprofile.py
@@ -1,0 +1,226 @@
+import logging
+from datetime import datetime, timezone
+
+import pytest
+
+from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import (
+    green_squad,
+    ignore_leftover_label,
+    skipif_external_mode,
+    skipif_fips_enabled,
+    skipif_managed_service,
+    skipif_ocs_version,
+    tier3,
+)
+from ocs_ci.framework.testlib import ManageTest
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.exceptions import CommandFailed, TimeoutExpiredError
+from ocs_ci.ocs.resources.pod import (
+    get_ocs_client_operator_controller_manager,
+    wait_for_ocs_client_operator_ready,
+)
+from ocs_ci.helpers.tlsprofile_helper import (
+    CLIENT_OPERATOR_HTTPS_PORTS,
+    TLS_PROFILE_SELECTOR_CLIENT_OPERATOR_METRICS,
+    TLS_PROFILE_SELECTOR_CLIENT_OPERATOR_WEBHOOK,
+    TLS_PROFILE_V12_CIPHERS,
+    TLS_PROFILE_V12_GROUPS,
+    TLS_PROFILE_V13_CIPHERS,
+    TLS_PROFILE_V13_GROUPS,
+    TLSProfile,
+    assert_no_tls_errors_in_relevant_pod_logs,
+    snapshot_tlsprofile_state,
+    teardown_tlsprofile,
+    tlsprofile_crd_exists,
+    wait_for_ocs_client_operator_https_tls,
+    wait_for_tlsprofile_config_version,
+)
+
+log = logging.getLogger(__name__)
+
+_CLIENT_OPERATOR_COMPONENT = "ocs-client-operator"
+_CLIENT_OPERATOR_SELECTORS = [
+    TLS_PROFILE_SELECTOR_CLIENT_OPERATOR_WEBHOOK,
+    TLS_PROFILE_SELECTOR_CLIENT_OPERATOR_METRICS,
+]
+
+
+@pytest.fixture(scope="module", autouse=True)
+def require_tlsprofile_crd():
+    if not tlsprofile_crd_exists():
+        pytest.skip(
+            "TLSProfile CRD tlsprofiles.ocs.openshift.io not found on this cluster"
+        )
+
+
+@green_squad
+@tier3
+@skipif_ocs_version("<4.22")
+@skipif_fips_enabled
+@skipif_external_mode
+@skipif_managed_service
+@ignore_leftover_label(
+    constants.OCS_CLIENT_OPERATOR_LABEL,
+    constants.OCS_METRICS_EXPORTER,
+    constants.RBD_CTRLPLUGIN_LABEL,
+    constants.CEPHFS_CTRLPLUGIN_LABEL,
+)
+class TestOCSClientOperatorTLSProfile(ManageTest):
+    """
+    Lifecycle tests for centralized ``TLSProfile`` on ocs-client-operator
+    (DF 4.22+): selectors ``ocs.openshift.io/webhook`` and
+    ``ocs.openshift.io/metrics`` in one rule, TLS 1.3 then TLS 1.2, in-cluster
+    scantls of webhook (7443) and metrics (8443) HTTPS endpoints, then delete
+    ``ocs-tls-profile``.
+
+    Both servers must pick up the ODF TLS API without manual restarts. Skips
+    on FIPS (PQ / ChaCha in our cipher lists). Deletes the CR at the end—only
+    run where that is safe. An autouse fixture also deletes a leftover
+    ``ocs-tls-profile`` if the test aborts early. TLS 1.3 typically restarts
+    the manager; TLS 1.2 may reload in-process.
+    """
+
+    @pytest.fixture(autouse=True)
+    def cleanup_tlsprofile(self, request):
+        tls = TLSProfile()
+        existed_before, original_state = snapshot_tlsprofile_state(tls)
+
+        def _cleanup():
+            try:
+                teardown_tlsprofile(tls, existed_before, original_state)
+            except (CommandFailed, TimeoutExpiredError):
+                log.exception("Teardown: failed to restore or delete TLSProfile")
+                raise
+
+        request.addfinalizer(_cleanup)
+
+    @pytest.mark.polarion_id("OCS-8246")
+    def test_ocs_client_operator_tls_profile_version_lifecycle(self):
+        """
+        ocs-client-operator TLSProfile: TLS 1.3 then TLS 1.2 on webhook and
+        metrics endpoints.
+
+        Steps:
+        1. Skip if ocs-client-operator is not deployed.
+        2. Apply centralized TLS configuration with selectors
+           ``ocs.openshift.io/webhook`` and ``ocs.openshift.io/metrics`` using
+           TLS 1.3 and the required cipher suites and TLS groups.
+        3. Wait for reconciliation.
+        4. Run scantls against the webhook and metrics endpoints and verify
+           TLS 1.3 (and only the configured ciphers/groups) is used.
+        5. Repeat with a TLS 1.2 profile; both servers must update without
+           manual intervention.
+        6. Delete the TLSProfile and scan operator logs for TLS-related errors.
+        """
+        test_start_time = datetime.now(timezone.utc)
+        namespace = config.ENV_DATA["cluster_namespace"]
+
+        if not get_ocs_client_operator_controller_manager(namespace=namespace):
+            pytest.skip(
+                f"ocs-client-operator is not deployed in {namespace}; "
+                "TLSProfile selectors ocs.openshift.io/webhook and "
+                "ocs.openshift.io/metrics require it"
+            )
+
+        tls = TLSProfile()
+        log.assertion(
+            f"TLSProfile metadata.name: expected='ocs-tls-profile', actual='{tls.name}'"
+        )
+        assert (
+            tls.name == "ocs-tls-profile"
+        ), "TLSProfile metadata.name must be ocs-tls-profile"
+
+        log.test_step(
+            "Apply TLSProfile selectors ocs.openshift.io/webhook and "
+            "ocs.openshift.io/metrics with TLSv1.3, required cipher suites, "
+            "and TLS groups"
+        )
+        if not tls.is_tls_profile_available():
+            log.info("TLSProfile absent; creating with TLSv1.3 for ocs-client-operator")
+            tls.create_tls_profile(
+                selectors=_CLIENT_OPERATOR_SELECTORS,
+                tls_version="TLSv1.3",
+                ciphers=TLS_PROFILE_V13_CIPHERS,
+                groups=TLS_PROFILE_V13_GROUPS,
+            )
+        else:
+            log.info(
+                "TLSProfile exists; replacing rules with TLSv1.3 for "
+                "ocs-client-operator"
+            )
+            tls.replace_rules(
+                _CLIENT_OPERATOR_SELECTORS,
+                "TLSv1.3",
+                TLS_PROFILE_V13_CIPHERS,
+                TLS_PROFILE_V13_GROUPS,
+            )
+
+        log.test_step("Wait for TLSProfile reconciliation (TLSv1.3)")
+        wait_for_tlsprofile_config_version(tls, "TLSv1.3")
+        actual_version = tls.get_config_version()
+        log.assertion(
+            f"TLSProfile version: expected='TLSv1.3', actual='{actual_version}'"
+        )
+        assert actual_version == "TLSv1.3"
+        log.test_step(
+            "Wait until ocs-client-operator HTTPS is TLSv1.3 "
+            f"(ports {list(CLIENT_OPERATOR_HTTPS_PORTS)}: metrics 8443, webhook 7443)"
+        )
+        wait_for_ocs_client_operator_https_tls(
+            namespace,
+            "TLSv1.3",
+            expected_ciphers=TLS_PROFILE_V13_CIPHERS,
+            expected_groups=TLS_PROFILE_V13_GROUPS,
+            context="TLSProfile TLSv1.3, component=ocs-client-operator",
+        )
+
+        log.test_step(
+            "Patch TLSProfile to TLSv1.2; webhook and metrics must update "
+            "without manual intervention"
+        )
+        tls.replace_rules(
+            _CLIENT_OPERATOR_SELECTORS,
+            "TLSv1.2",
+            TLS_PROFILE_V12_CIPHERS,
+            TLS_PROFILE_V12_GROUPS,
+        )
+        log.test_step("Wait for TLSProfile reconciliation (TLSv1.2)")
+        wait_for_tlsprofile_config_version(tls, "TLSv1.2")
+        actual_version = tls.get_config_version()
+        log.assertion(
+            f"TLSProfile version: expected='TLSv1.2', actual='{actual_version}'"
+        )
+        assert actual_version == "TLSv1.2"
+        log.test_step(
+            "Wait until ocs-client-operator HTTPS is TLSv1.2 "
+            f"(ports {list(CLIENT_OPERATOR_HTTPS_PORTS)}: metrics 8443, webhook 7443); "
+            "TLS 1.2 may apply without a manager restart"
+        )
+        wait_for_ocs_client_operator_https_tls(
+            namespace,
+            "TLSv1.2",
+            expected_ciphers=TLS_PROFILE_V12_CIPHERS,
+            expected_groups=TLS_PROFILE_V12_GROUPS,
+            context="TLSProfile TLSv1.2, component=ocs-client-operator",
+        )
+
+        tls.delete_tls_profile(wait=True, force=False)
+        still_present = tls.is_tls_profile_available()
+        log.assertion(
+            f"TLSProfile after delete: expected=absent, actual_present={still_present}"
+        )
+        assert not still_present, "TLSProfile should be absent after delete"
+        wait_for_ocs_client_operator_ready(namespace)
+
+        elapsed_s = max(
+            120,
+            int((datetime.now(timezone.utc) - test_start_time).total_seconds()) + 30,
+        )
+        log.test_step(
+            f"Scan operator/ocs-client-operator pod logs for TLS-related errors "
+            f"(since last {elapsed_s}s, from test start)"
+        )
+        assert_no_tls_errors_in_relevant_pod_logs(
+            namespace, _CLIENT_OPERATOR_COMPONENT, since=f"{elapsed_s}s"
+        )


### PR DESCRIPTION
## Summary
- Adds a dedicated TLSProfile lifecycle test for `ocs-metrics-exporter` using selector `ocs.openshift.io/metrics-exporter`.
- Extends `tlsprofile_helper` to scan the exporter and assert HTTPS on ports 8443 (`https-main`) and 9443 (`https-self`).
- Verifies TLS 1.3 → 1.2 → 1.3, then deletes `ocs-tls-profile` and checks exporter logs for TLS errors.

## Test plan
- [x] Run `tests/functional/tlsprofile/test_metrics_exporter_tlsprofile.py` on ODF 4.22+ (non-FIPS, non-external)
- [x] Confirm skip when the TLSProfile CRD or ocs-metrics-exporter is absent
- [x] After TLSv1.3, ports 8443 and 9443 negotiate `tls1.3` only
- [x] After TLSv1.2, both ports negotiate `tls1.2` only
- [x] After restore + delete, exporter stays ready and logs have no TLS errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended TLS profile support to the metrics exporter, CSI snapshot metadata, and client operator.
  * Added HTTPS validation for metrics, webhook, and metadata services.
  * Added verification of configured TLS versions, ciphers, and security groups.

* **Bug Fixes**
  * Improved endpoint discovery, rollout handling, readiness checks, and TLS error detection.

* **Tests**
  * Added lifecycle coverage for creating, updating, restoring, and deleting TLS profiles across supported components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->