### PR TITLE
splitting the version name for better branch fit

### DIFF
--- a/ocs_ci/deployment/helpers/hypershift_base.py
+++ b/ocs_ci/deployment/helpers/hypershift_base.py
@@ -604,12 +604,14 @@ class HyperShiftBase:
                 f"Using configured hcp_version: {hcp_version} (branch release-{hcp_version})."
             )
 
+        hcp_branch_version = hcp_version.split("-")[0] if hcp_version else hcp_version
+
         logger.info("Downloading hcp binary from git")
 
         temp_dir = tempfile.mkdtemp()
 
         exec_cmd(
-            f"git clone --single-branch --branch release-{hcp_version} "
+            f"git clone --single-branch --branch release-{hcp_branch_version} "
             f"--depth 1 {constants.HCP_REPOSITORY} {temp_dir}"
         )
 


### PR DESCRIPTION
splitting the version name for better branch fit
fixes: https://github.com/red-hat-storage/ocs-ci/issues/16017

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version handling for nightly HCP releases.
  * Nightly versions now correctly use their corresponding stable release branch during installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->