### PR TITLE
Fix: Use dynamic agentInstallNamespace instead of hardcoded constant

### DIFF
--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -2629,6 +2629,12 @@ class Deployment(object):
             run_cmd(cmd=cmd)
             logger.info("Sleeping for 60 Sec for Background Activity")
             time.sleep(60)
+            addon_deployment_config = OCP(
+                kind=constants.ADDONDEPLOYMENTCONFIG,
+                namespace=constants.MCE_NAMESPACE,
+                resource_name=constants.ADDONDEPLOYMENTCONFIG_HYPERSHIFT_ADDON_DEPLOY_CONFIG,
+            )
+            existing_spec = addon_deployment_config.get()
             for pod_label in [
                 "open-cluster-management.io/addon=cluster-proxy",
                 "component=work-manager",
@@ -2638,12 +2644,13 @@ class Deployment(object):
                 if not wait_for_pods_by_label_count(
                     label=pod_label,
                     expected_count=1,
-                    namespace=constants.ACM_ADDONS_NAMESPACE_DISCOVERY,
+                    namespace=existing_spec["spec"]["agentInstallNamespace"],
                     timeout=400,
                     sleep=10,
                 ):
                     raise ResourceNotFoundError(
-                        f"Pod with label {pod_label} not found in the ns {constants.ACM_ADDONS_NAMESPACE_DISCOVERY}"
+                        f"Pod with label {pod_label} not found in the ns "
+                        f"{existing_spec['spec']['agentInstallNamespace']}"
                     )
 
         # Configuration for backup and restore. Add backup label to the default and new addondeploymentconfig,


### PR DESCRIPTION
In configure_acm_to_import_mce_clusters(), the pod-label wait loop in the automated way (ACM > 2.14) was using the hardcoded constant ACM_ADDONS_NAMESPACE_DISCOVERY as the namespace. This fails when the actual agentInstallNamespace configured in the hypershift-addon-deploy-config AddonDeploymentConfig differs from the default.

Fix by fetching the live AddonDeploymentConfig resource after the patch and reading agentInstallNamespace from its spec dynamically.