### PR TITLE
Nvmeof deployment and happy path

### DIFF
--- a/conf/ocsci/nvmeof_enabled.yaml
+++ b/conf/ocsci/nvmeof_enabled.yaml
@@ -2,6 +2,10 @@
 # Use this config to enable NVMe-oF (NVMe over Fabrics) on the StorageCluster.
 # When nvmeof_enable is true, the StorageCluster spec.nvmeof section is populated
 # during OCS deployment with the enable flag and the number of gateway instances.
+#
+# Availability: NVMe-oF is currently supported only with FDF (Fusion Data
+# Foundation) deployments. Enabling it with other deployment types is not
+# supported at the moment.
 DEPLOYMENT:
   nvmeof_enable: true
   nvmeof_gateway_instances: 2

--- a/conf/ocsci/nvmeof_enabled.yaml
+++ b/conf/ocsci/nvmeof_enabled.yaml
@@ -1,0 +1,7 @@
+---
+# Use this config to enable NVMe-oF (NVMe over Fabrics) on the StorageCluster.
+# When nvmeof_enable is true, the StorageCluster spec.nvmeof section is populated
+# during OCS deployment with the enable flag and the number of gateway instances.
+DEPLOYMENT:
+  nvmeof_enable: true
+  nvmeof_gateway_instances: 2

--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -826,6 +826,9 @@ skipif_lvm_not_installed = pytest.mark.skipif_lvm_not_installed
 # encryption with KMS properly
 skipif_no_kms = pytest.mark.skipif_no_kms
 
+# Marker for skipping tests if NVMe-oF is not enabled/configured on the cluster
+skipif_no_nvmeof = pytest.mark.skipif_no_nvmeof
+
 skipif_ibm_flash = pytest.mark.skipif(
     config.ENV_DATA.get("ibm_flash"),
     reason="This test doesn't work correctly on IBM Flash system",

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -205,6 +205,7 @@ CEPHBLOCKPOOL = "CephBlockPool"
 CEPHBLOCKPOOLRADOSNS = "cephblockpoolradosnamespaces"
 CEPHBLOCKPOOL_THICK = "CephBlockPoolThick"
 CEPHBLOCKPOOL_SC = "ocs-storagecluster-ceph-rbd"
+CEPH_NVMEOF_SC = "ocs-storagecluster-ceph-nvmeof"
 CEPHFILESYSTEM_SC = "ocs-storagecluster-cephfs"
 CEPHFILESYSTEM_SC_SELINUX = "ocs-storagecluster-cephfs-selinux-relabel"
 CEPHOBJECTSTORE = "CephObjectStore"
@@ -783,6 +784,7 @@ MGR_APP_LABEL = "app=rook-ceph-mgr"
 OSD_APP_LABEL = "app=rook-ceph-osd"
 OSD_PREPARE_APP_LABEL = "app=rook-ceph-osd-prepare"
 RGW_APP_LABEL = "app=rook-ceph-rgw"
+NVMEOF_APP_LABEL = "app=rook-ceph-nvmeof"
 # Map performance profile component name to pod label selector for Ceph daemons
 CEPH_DAEMON_LABEL_BY_COMPONENT = {
     "mgr": MGR_APP_LABEL,

--- a/ocs_ci/utility/storage_cluster_setup.py
+++ b/ocs_ci/utility/storage_cluster_setup.py
@@ -462,6 +462,18 @@ class StorageClusterSetup(object):
         # Enable data replication separation
         cluster_data = add_data_replication_separation_to_cluster_data(cluster_data)
 
+        # Enable NVMe-oF (NVMe over Fabrics) gateway
+        if config.DEPLOYMENT.get("nvmeof_enable"):
+            gateway_instances = config.DEPLOYMENT.get("nvmeof_gateway_instances")
+            logger.info(
+                "Enabling NVMe-oF on StorageCluster with %s gateway instances",
+                gateway_instances,
+            )
+            cluster_data["spec"]["nvmeof"] = {
+                "enable": config.DEPLOYMENT.get("nvmeof_enable"),
+                "gatewayInstances": gateway_instances,
+            }
+
         # Erasure Coding: configure EC as default pool type
         if config.DEPLOYMENT.get("ec_default_pools"):
             k = config.DEPLOYMENT.get("ec_data_chunks", 2)

--- a/pytest.ini
+++ b/pytest.ini
@@ -53,6 +53,7 @@ markers =
     skipif_ocs_version: to skip tests based on ocs version applicable
     skipif_upgraded_from: to skip tests if OCS cluster is upgraded from a particular version
     skipif_no_kms: to skip tests if OCS cluster has not configured KMS integration
+    skipif_no_nvmeof: to skip tests if OCS cluster has not configured NVMe-oF
     last: for tests to be executed with priority, from pytest-ordering plugin. test case executes at last
     second_to_last: for tests to be executed with priority, from pytest-ordering plugin. test case executes at second to last
     post_ocp_upgrade: marker for post ocp upgrade tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -484,6 +484,7 @@ def pytest_collection_modifyitems(session, config, items):
                 "skipif_upgraded_from"
             )
             skipif_no_kms_marker = item.get_closest_marker("skipif_no_kms")
+            skipif_no_nvmeof_marker = item.get_closest_marker("skipif_no_nvmeof")
             skipif_ui_not_support_marker = item.get_closest_marker(
                 "skipif_ui_not_support"
             )
@@ -537,6 +538,14 @@ def pytest_collection_modifyitems(session, config, items):
                     log.warning(
                         "Cluster is not yet installed. Skipping skipif_no_kms check."
                     )
+            if skipif_no_nvmeof_marker:
+                if not ocsci_config.DEPLOYMENT.get("nvmeof_enable"):
+                    log.debug(
+                        f"Test: {item} will be skipped because NVMe-oF is not"
+                        " enabled/configured on the OCS cluster"
+                    )
+                    items.remove(item)
+                    continue
             if skipif_ui_not_support_marker:
                 skip_condition = skipif_ui_not_support_marker
                 if skipif_ui_not_support(skip_condition.args[0]):

--- a/tests/functional/pv/pv_services/test_nvmeof_pvc.py
+++ b/tests/functional/pv/pv_services/test_nvmeof_pvc.py
@@ -44,7 +44,7 @@ class TestNvmeofPvc(ManageTest):
             f"NVMe-oF StorageClass {constants.CEPH_NVMEOF_SC} does not exist. "
             "Ensure the StorageCluster was deployed with nvmeof enabled."
         )
-        logger.info("NVMe-oF StorageClass %s exists", constants.CEPH_NVMEOF_SC)
+        logger.assertion("NVMe-oF StorageClass %s exists", constants.CEPH_NVMEOF_SC)
 
         # NVMe-oF Gateway pods must be deployed and healthy
         gateway_pods = pod.get_pods_having_label(
@@ -59,7 +59,7 @@ class TestNvmeofPvc(ManageTest):
         assert pod.wait_for_pods_to_be_running(
             namespace=namespace, pod_names=gateway_pod_names, timeout=300
         ), "NVMe-oF Gateway pods are not in Running state"
-        logger.info("All NVMe-oF Gateway pods are healthy (Running)")
+        logger.assertion("All NVMe-oF Gateway pods are healthy (Running)")
 
     @pytest.fixture()
     def nvmeof_storageclass(self):
@@ -95,8 +95,8 @@ class TestNvmeofPvc(ManageTest):
 
         """
         # Step 1: Create a RWO PVC using the NVMe-oF StorageClass
-        logger.info(
-            "Creating a RWO PVC using StorageClass %s", constants.CEPH_NVMEOF_SC
+        logger.test_step(
+            "Create a RWO PVC using StorageClass %s", constants.CEPH_NVMEOF_SC
         )
         pvc_obj = pvc_factory(
             interface=constants.CEPHBLOCKPOOL,
@@ -105,7 +105,7 @@ class TestNvmeofPvc(ManageTest):
             access_mode=constants.ACCESS_MODE_RWO,
             status=constants.STATUS_BOUND,
         )
-        logger.info("PVC %s reached Bound state", pvc_obj.name)
+        logger.assertion("PVC %s reached Bound state", pvc_obj.name)
 
         # Capture PV details and reclaim policy before deletion
         pv_obj = pvc_obj.backed_pv_obj
@@ -119,6 +119,10 @@ class TestNvmeofPvc(ManageTest):
         )
 
         # Step 2: Create a pod mounting the PVC, run IO and verify data integrity
+        logger.test_step(
+            "Create a pod mounting PVC %s, run IO and verify data integrity",
+            pvc_obj.name,
+        )
         pod_obj = pod_factory(
             interface=constants.CEPHBLOCKPOOL,
             pvc=pvc_obj,
@@ -144,14 +148,13 @@ class TestNvmeofPvc(ManageTest):
 
         # Calculate md5sum of the written file and verify data integrity on re-read
         original_md5sum = pod.cal_md5sum(pod_obj, file_name)
-        logger.info("Verifying data integrity on pod %s", pod_obj.name)
         assert pod.verify_data_integrity(
             pod_obj, file_name, original_md5sum
         ), f"Data integrity check failed for file {file_name} on pod {pod_obj.name}"
-        logger.info("Data integrity verified on pod %s", pod_obj.name)
+        logger.assertion("Data integrity verified on pod %s", pod_obj.name)
 
         # Step 3: Delete the pod, then the PVC
-        logger.info("Deleting pod %s", pod_obj.name)
+        logger.test_step("Delete pod %s and PVC %s", pod_obj.name, pvc_obj.name)
         pod_obj.delete()
         pod_obj.ocp.wait_for_delete(resource_name=pod_obj.name)
 
@@ -160,18 +163,19 @@ class TestNvmeofPvc(ManageTest):
         pvc_obj.ocp.wait_for_delete(resource_name=pvc_obj.name)
 
         # Step 4: Verify the PV is reclaimed according to its reclaim policy
+        logger.test_step(
+            "Verify PV %s is reclaimed according to its %s reclaim policy",
+            pv_name,
+            reclaim_policy,
+        )
         if reclaim_policy == constants.RECLAIM_POLICY_DELETE:
-            logger.info("Reclaim policy is Delete, verifying PV %s is deleted", pv_name)
             pv_obj.ocp.wait_for_delete(resource_name=pv_name, timeout=180)
-            logger.info("PV %s deleted as per Delete reclaim policy", pv_name)
+            logger.assertion("PV %s deleted as per Delete reclaim policy", pv_name)
         elif reclaim_policy == constants.RECLAIM_POLICY_RETAIN:
-            logger.info(
-                "Reclaim policy is Retain, verifying PV %s is Released", pv_name
-            )
             helpers.wait_for_resource_state(
                 pv_obj, constants.STATUS_RELEASED, timeout=180
             )
-            logger.info("PV %s is Released as per Retain reclaim policy", pv_name)
+            logger.assertion("PV %s is Released as per Retain reclaim policy", pv_name)
             # Cleanup the retained PV so no leftovers remain. Switch the reclaim
             # policy to Delete so the controller removes the backing volume too,
             # then wait for controller-driven deletion (pvc_factory_fixture pattern).

--- a/tests/functional/pv/pv_services/test_nvmeof_pvc.py
+++ b/tests/functional/pv/pv_services/test_nvmeof_pvc.py
@@ -2,8 +2,13 @@ import logging
 
 import pytest
 
-from ocs_ci.framework.pytest_customization.marks import green_squad, skipif_no_nvmeof
-from ocs_ci.framework.testlib import ManageTest, tier1, polarion_id
+from ocs_ci.framework.pytest_customization.marks import (
+    green_squad,
+    skipif_no_nvmeof,
+    tier1,
+    polarion_id,
+)
+from ocs_ci.framework.testlib import ManageTest
 from ocs_ci.framework import config
 from ocs_ci.helpers import helpers
 from ocs_ci.ocs import constants

--- a/tests/functional/pv/pv_services/test_nvmeof_pvc.py
+++ b/tests/functional/pv/pv_services/test_nvmeof_pvc.py
@@ -167,8 +167,11 @@ class TestNvmeofPvc(ManageTest):
                 pv_obj, constants.STATUS_RELEASED, timeout=180
             )
             logger.info("PV %s is Released as per Retain reclaim policy", pv_name)
-            # Cleanup the retained PV so no leftovers remain
-            pv_obj.delete()
+            # Cleanup the retained PV so no leftovers remain. Switch the reclaim
+            # policy to Delete so the controller removes the backing volume too,
+            # then wait for controller-driven deletion (pvc_factory_fixture pattern).
+            patch_param = '{"spec":{"persistentVolumeReclaimPolicy":"Delete"}}'
+            pv_obj.ocp.patch(resource_name=pv_name, params=patch_param)
             pv_obj.ocp.wait_for_delete(resource_name=pv_name, timeout=180)
         else:
             pytest.fail(f"Unexpected reclaim policy {reclaim_policy} for PV {pv_name}")

--- a/tests/functional/pv/pv_services/test_nvmeof_pvc.py
+++ b/tests/functional/pv/pv_services/test_nvmeof_pvc.py
@@ -73,7 +73,7 @@ class TestNvmeofPvc(ManageTest):
         )
         return OCS(**sc_ocp_obj.get())
 
-    @polarion_id("OCS-6666")
+    @polarion_id("OCS-8237")
     def test_nvmeof_pvc_data_integrity_and_reclaim(
         self, nvmeof_storageclass, pvc_factory, pod_factory
     ):

--- a/tests/functional/pv/pv_services/test_nvmeof_pvc.py
+++ b/tests/functional/pv/pv_services/test_nvmeof_pvc.py
@@ -1,0 +1,174 @@
+import logging
+
+import pytest
+
+from ocs_ci.framework.pytest_customization.marks import green_squad, skipif_no_nvmeof
+from ocs_ci.framework.testlib import ManageTest, tier1, polarion_id
+from ocs_ci.framework import config
+from ocs_ci.helpers import helpers
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.ocp import OCP
+from ocs_ci.ocs.resources import pod
+from ocs_ci.ocs.resources.ocs import OCS
+
+logger = logging.getLogger(__name__)
+
+
+@green_squad
+@tier1
+@skipif_no_nvmeof
+class TestNvmeofPvc(ManageTest):
+    """
+    Tests for basic PVC lifecycle and data integrity using the NVMe-oF
+    (NVMe over Fabrics) StorageClass.
+    """
+
+    @pytest.fixture(autouse=True)
+    def nvmeof_prerequisites(self):
+        """
+        Verify NVMe-oF prerequisites before running the test:
+            - NVMe-oF Gateway pods are deployed and healthy (Running).
+            - NVMe-oF StorageClass exists.
+
+        """
+        namespace = config.ENV_DATA["cluster_namespace"]
+
+        # NVMe-oF StorageClass must exist
+        sc_ocp_obj = OCP(kind=constants.STORAGECLASS, namespace=namespace)
+        assert sc_ocp_obj.is_exist(resource_name=constants.CEPH_NVMEOF_SC), (
+            f"NVMe-oF StorageClass {constants.CEPH_NVMEOF_SC} does not exist. "
+            "Ensure the StorageCluster was deployed with nvmeof enabled."
+        )
+        logger.info("NVMe-oF StorageClass %s exists", constants.CEPH_NVMEOF_SC)
+
+        # NVMe-oF Gateway pods must be deployed and healthy
+        gateway_pods = pod.get_pods_having_label(
+            label=constants.NVMEOF_APP_LABEL, namespace=namespace
+        )
+        assert gateway_pods, (
+            "No NVMe-oF Gateway pods found with label "
+            f"{constants.NVMEOF_APP_LABEL} in namespace {namespace}"
+        )
+        gateway_pod_names = [pod_data["metadata"]["name"] for pod_data in gateway_pods]
+        logger.info("Found NVMe-oF Gateway pods: %s", gateway_pod_names)
+        assert pod.wait_for_pods_to_be_running(
+            namespace=namespace, pod_names=gateway_pod_names, timeout=300
+        ), "NVMe-oF Gateway pods are not in Running state"
+        logger.info("All NVMe-oF Gateway pods are healthy (Running)")
+
+    @pytest.fixture()
+    def nvmeof_storageclass(self):
+        """
+        Return the existing NVMe-oF StorageClass as an OCS object so that it can
+        be consumed by the pvc_factory fixture.
+
+        Returns:
+            OCS: OCS instance of the NVMe-oF StorageClass
+
+        """
+        sc_ocp_obj = OCP(
+            kind=constants.STORAGECLASS,
+            namespace=config.ENV_DATA["cluster_namespace"],
+            resource_name=constants.CEPH_NVMEOF_SC,
+        )
+        return OCS(**sc_ocp_obj.get())
+
+    @polarion_id("OCS-6666")
+    def test_nvmeof_pvc_data_integrity_and_reclaim(
+        self, nvmeof_storageclass, pvc_factory, pod_factory
+    ):
+        """
+        Verify PVC lifecycle and data integrity on the NVMe-oF StorageClass.
+
+        Steps:
+            1. Create a RWO PVC using the NVMe-oF StorageClass and verify it
+               reaches the Bound state.
+            2. Create a pod that mounts the PVC, write data with fio and verify
+               data integrity by comparing md5sum after re-reading.
+            3. Delete the pod and the PVC.
+            4. Verify the PV is reclaimed according to its reclaim policy.
+
+        """
+        # Step 1: Create a RWO PVC using the NVMe-oF StorageClass
+        logger.info(
+            "Creating a RWO PVC using StorageClass %s", constants.CEPH_NVMEOF_SC
+        )
+        pvc_obj = pvc_factory(
+            interface=constants.CEPHBLOCKPOOL,
+            storageclass=nvmeof_storageclass,
+            size=5,
+            access_mode=constants.ACCESS_MODE_RWO,
+            status=constants.STATUS_BOUND,
+        )
+        logger.info("PVC %s reached Bound state", pvc_obj.name)
+
+        # Capture PV details and reclaim policy before deletion
+        pv_obj = pvc_obj.backed_pv_obj
+        pv_name = pv_obj.name
+        reclaim_policy = pvc_obj.reclaim_policy
+        logger.info(
+            "PVC %s is backed by PV %s with reclaim policy %s",
+            pvc_obj.name,
+            pv_name,
+            reclaim_policy,
+        )
+
+        # Step 2: Create a pod mounting the PVC, run IO and verify data integrity
+        pod_obj = pod_factory(
+            interface=constants.CEPHBLOCKPOOL,
+            pvc=pvc_obj,
+            status=constants.STATUS_RUNNING,
+        )
+        logger.info("Pod %s is running and mounts PVC %s", pod_obj.name, pvc_obj.name)
+
+        file_name = pod_obj.name
+        logger.info("Running fio on pod %s to write file %s", pod_obj.name, file_name)
+        pod_obj.run_io(
+            storage_type="fs",
+            size="1G",
+            io_direction="write",
+            fio_filename=file_name,
+            end_fsync=1,
+        )
+        fio_result = pod_obj.get_fio_results()
+        err_count = fio_result.get("jobs")[0].get("error")
+        assert (
+            err_count == 0
+        ), f"IO error on pod {pod_obj.name}. FIO result: {fio_result}"
+        logger.info("fio completed successfully on pod %s", pod_obj.name)
+
+        # Calculate md5sum of the written file and verify data integrity on re-read
+        original_md5sum = pod.cal_md5sum(pod_obj, file_name)
+        logger.info("Verifying data integrity on pod %s", pod_obj.name)
+        assert pod.verify_data_integrity(
+            pod_obj, file_name, original_md5sum
+        ), f"Data integrity check failed for file {file_name} on pod {pod_obj.name}"
+        logger.info("Data integrity verified on pod %s", pod_obj.name)
+
+        # Step 3: Delete the pod, then the PVC
+        logger.info("Deleting pod %s", pod_obj.name)
+        pod_obj.delete()
+        pod_obj.ocp.wait_for_delete(resource_name=pod_obj.name)
+
+        logger.info("Deleting PVC %s", pvc_obj.name)
+        pvc_obj.delete()
+        pvc_obj.ocp.wait_for_delete(resource_name=pvc_obj.name)
+
+        # Step 4: Verify the PV is reclaimed according to its reclaim policy
+        if reclaim_policy == constants.RECLAIM_POLICY_DELETE:
+            logger.info("Reclaim policy is Delete, verifying PV %s is deleted", pv_name)
+            pv_obj.ocp.wait_for_delete(resource_name=pv_name, timeout=180)
+            logger.info("PV %s deleted as per Delete reclaim policy", pv_name)
+        elif reclaim_policy == constants.RECLAIM_POLICY_RETAIN:
+            logger.info(
+                "Reclaim policy is Retain, verifying PV %s is Released", pv_name
+            )
+            helpers.wait_for_resource_state(
+                pv_obj, constants.STATUS_RELEASED, timeout=180
+            )
+            logger.info("PV %s is Released as per Retain reclaim policy", pv_name)
+            # Cleanup the retained PV so no leftovers remain
+            pv_obj.delete()
+            pv_obj.ocp.wait_for_delete(resource_name=pv_name, timeout=180)
+        else:
+            pytest.fail(f"Unexpected reclaim policy {reclaim_policy} for PV {pv_name}")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional NVMe-oF enablement for StorageCluster deployments.
  - Configured support for two NVMe-oF gateway instances in supported FDF deployments.
  - Added automatic handling for environments where NVMe-oF is unavailable.

- **Validation**
  - Added functional coverage for NVMe-oF-backed PVC creation, workload I/O, data integrity, and volume reclamation.
  - Verified both Delete and Retain persistent-volume policies, including retained-volume cleanup.
  - Tests requiring NVMe-oF are automatically skipped when the feature is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->