### PR TITLE
Add MCG performance profiles resource validation test

### DIFF
--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -1708,9 +1708,9 @@ def get_pods_having_label(
         "items"
     )
     if statuses:
-        for pod in pods:
-            if pod["status"]["phase"] not in statuses:
-                pods.remove(pod)
+        # Build a new list instead of removing from the list being iterated,
+        # which would skip consecutive non-matching pods.
+        pods = [pod for pod in pods if pod["status"]["phase"] in statuses]
     return pods
 
 

--- a/tests/functional/object/mcg/test_mcg_performance_profiles.py
+++ b/tests/functional/object/mcg/test_mcg_performance_profiles.py
@@ -1,0 +1,478 @@
+import logging
+import pytest
+
+from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import (
+    tier1,
+    red_squad,
+    mcg,
+    runs_on_provider,
+)
+from ocs_ci.ocs.ocp import OCP
+from ocs_ci.ocs.resources.pod import get_pods_having_label
+
+logger = logging.getLogger(__name__)
+
+
+def get_pod_resources(pod):
+    """
+    Get CPU and memory resources from a pod's first container.
+
+    Args:
+        pod (Pod): Pod object
+
+    Returns:
+        dict: Resources with requests and limits
+    """
+    container = pod.get()["spec"]["containers"][0]
+    return container.get("resources", {})
+
+
+def verify_resources(
+    actual,
+    expected_req_cpu,
+    expected_lim_cpu,
+    expected_req_mem,
+    expected_lim_mem,
+    component_name,
+):
+    """
+    Verify that actual resources match expected values.
+
+    Args:
+        actual (dict): Actual resource dict from pod
+        expected_req_cpu (str): Expected CPU request
+        expected_lim_cpu (str): Expected CPU limit
+        expected_req_mem (str): Expected memory request
+        expected_lim_mem (str): Expected memory limit
+        component_name (str): Name of component being verified
+
+    Returns:
+        bool: True if all values match, False otherwise
+    """
+    requests = actual.get("requests", {})
+    limits = actual.get("limits", {})
+
+    req_cpu = requests.get("cpu")
+    lim_cpu = limits.get("cpu")
+    req_mem = requests.get("memory")
+    lim_mem = limits.get("memory")
+
+    # Normalize CPU values (500m == 0.5)
+    def normalize_cpu(value):
+        if value is None:
+            return None
+        if isinstance(value, str):
+            if value.endswith("m"):
+                return float(value[:-1]) / 1000
+            return float(value)
+        return float(value)
+
+    req_cpu_norm = normalize_cpu(req_cpu)
+    lim_cpu_norm = normalize_cpu(lim_cpu)
+    exp_req_cpu_norm = normalize_cpu(expected_req_cpu)
+    exp_lim_cpu_norm = normalize_cpu(expected_lim_cpu)
+
+    errors = []
+
+    if req_cpu_norm != exp_req_cpu_norm:
+        errors.append(
+            f"{component_name} CPU request: expected {expected_req_cpu}, got {req_cpu}"
+        )
+
+    if lim_cpu_norm != exp_lim_cpu_norm:
+        errors.append(
+            f"{component_name} CPU limit: expected {expected_lim_cpu}, got {lim_cpu}"
+        )
+
+    if req_mem != expected_req_mem:
+        errors.append(
+            f"{component_name} Memory request: expected {expected_req_mem}, got {req_mem}"
+        )
+
+    if lim_mem != expected_lim_mem:
+        errors.append(
+            f"{component_name} Memory limit: expected {expected_lim_mem}, got {lim_mem}"
+        )
+
+    if errors:
+        for error in errors:
+            logger.error(error)
+        return False
+
+    logger.info(f"{component_name} resources verified successfully")
+    return True
+
+
+def get_qos_class(resources):
+    """
+    Determine QoS class from resources.
+
+    Args:
+        resources (dict): Resource dict with requests and limits
+
+    Returns:
+        str: QoS class (Guaranteed, Burstable, or BestEffort)
+    """
+    requests = resources.get("requests", {})
+    limits = resources.get("limits", {})
+
+    if not limits:
+        return "BestEffort"
+
+    # Guaranteed: requests == limits for all resources
+    if requests.get("cpu") == limits.get("cpu") and requests.get(
+        "memory"
+    ) == limits.get("memory"):
+        return "Guaranteed"
+
+    return "Burstable"
+
+
+@tier1
+@mcg
+@red_squad
+@runs_on_provider
+class TestMCGPerformanceProfiles:
+    """
+    Test MCG Performance Profiles (default, mixed-workload, small-objects).
+
+    Verifies that setting performanceProfile on StorageCluster CR correctly
+    propagates resource specifications to noobaa-core, noobaa-db, and
+    noobaa-endpoint pods.
+
+    Test cases correspond to:
+    - CLI-1: Verify "default" profile
+    - CLI-2: Verify "mixed-workload" profile
+    - CLI-3: Verify "small-objects" profile
+    """
+
+    # Profile specifications as per RHSTOR-9144 and NooBaa operator source code
+    # (https://github.com/noobaa/noobaa-operator/blob/master/pkg/system/performance_profiles.go)
+    PROFILE_SPECS = {
+        "default": {
+            "core": {
+                "req_cpu": "500m",
+                "lim_cpu": "1",
+                "req_mem": "1Gi",
+                "lim_mem": "4Gi",
+                "qos": "Burstable",
+            },
+            "db": {
+                "req_cpu": "1",
+                "lim_cpu": "1",
+                "req_mem": "2Gi",
+                "lim_mem": "2Gi",
+                "qos": "Guaranteed",
+            },
+            "endpoint": {
+                "req_cpu": "500m",
+                "lim_cpu": "2",
+                "req_mem": "1Gi",
+                "lim_mem": "3Gi",
+                "qos": "Burstable",
+            },
+            "endpoint_count": {"min": 1, "max": 2},
+            "db_instances": 2,
+            "pv_pool": {"cpu": "400m", "mem": "800Mi"},
+        },
+        "mixed-workload": {
+            "core": {
+                "req_cpu": "1",
+                "lim_cpu": "2",
+                "req_mem": "2Gi",
+                "lim_mem": "4Gi",
+                "qos": "Burstable",
+            },
+            "db": {
+                "req_cpu": "4",
+                "lim_cpu": "4",
+                "req_mem": "8Gi",
+                "lim_mem": "8Gi",
+                "qos": "Guaranteed",
+            },
+            "endpoint": {
+                "req_cpu": "2",
+                "lim_cpu": "4",
+                "req_mem": "2Gi",
+                "lim_mem": "4Gi",
+                "qos": "Burstable",
+            },
+            "endpoint_count": {"min": 2, "max": 4},
+            "db_instances": 2,
+            "pv_pool": {"cpu": "1", "mem": "2Gi"},
+        },
+        "small-objects": {
+            "core": {
+                "req_cpu": "1",
+                "lim_cpu": "2",
+                "req_mem": "2Gi",
+                "lim_mem": "6Gi",
+                "qos": "Burstable",
+            },
+            "db": {
+                "req_cpu": "6",
+                "lim_cpu": "6",
+                "req_mem": "16Gi",
+                "lim_mem": "16Gi",
+                "qos": "Guaranteed",
+            },
+            "endpoint": {
+                "req_cpu": "1",  # Note: Lower than mixed-workload due to single-process saturation
+                "lim_cpu": "4",
+                "req_mem": "2Gi",
+                "lim_mem": "4Gi",
+                "qos": "Burstable",
+            },
+            "endpoint_count": {"min": 2, "max": 4},
+            "db_instances": 2,
+            "pv_pool": {"cpu": "1", "mem": "2Gi"},
+        },
+    }
+
+    @pytest.fixture()
+    def set_profile(self, request):
+        """
+        Set MCG performance profile on StorageCluster CR and wait for propagation.
+
+        Returns:
+            str: Profile name that was set
+        """
+        profile = request.param
+        logger.info(f"Setting MCG performance profile to '{profile}'")
+
+        ocp_obj = OCP(
+            kind="StorageCluster",
+            namespace=config.ENV_DATA["cluster_namespace"],
+            resource_name="ocs-storagecluster",
+        )
+
+        # Patch StorageCluster with the profile
+        patch = {"spec": {"multiCloudGateway": {"performanceProfile": profile}}}
+        ocp_obj.patch(params=f"{patch}", format_type="merge")
+
+        # Verify it propagated to NooBaa CR
+        noobaa_ocp = OCP(
+            kind="NooBaa",
+            namespace=config.ENV_DATA["cluster_namespace"],
+            resource_name="noobaa",
+        )
+        noobaa_profile = noobaa_ocp.get()["spec"].get("performanceProfile")
+        assert noobaa_profile == profile, (
+            f"Profile '{profile}' not propagated to NooBaa CR, "
+            f"got '{noobaa_profile}' instead"
+        )
+
+        logger.info(f"Profile '{profile}' successfully set and propagated to NooBaa CR")
+
+        # Wait a bit for operator to reconcile
+        import time
+
+        time.sleep(10)
+
+        return profile
+
+    @pytest.mark.parametrize(
+        "set_profile",
+        ["default", "mixed-workload", "small-objects"],
+        indirect=True,
+    )
+    @pytest.mark.polarion_id("OCS-6000")  # TODO: Update with actual Polarion ID
+    def test_mcg_performance_profile_resources(self, set_profile):
+        """
+        Verify MCG performance profile resource specifications.
+
+        Test Steps (per profile):
+            1. Set spec.multiCloudGateway.performanceProfile on StorageCluster CR
+            2. Verify noobaa-core pod resources and QoS class
+            3. Verify noobaa-db pod resources and QoS class (per instance)
+            4. Verify noobaa-endpoint pod resources and QoS class
+            5. Verify endpoint pod count (min/max via HPA or deployment)
+            6. Verify DB instances count
+            7. Verify PV pool agent pod resources (vSphere/on-prem only)
+
+        Expected Results:
+            All resource values match the profile specification from RHSTOR-9144
+        """
+        profile = set_profile
+        spec = self.PROFILE_SPECS[profile]
+
+        logger.info(f"Testing '{profile}' profile resource specifications")
+
+        # Step 2: Verify noobaa-core pod resources
+        logger.info("Verifying noobaa-core pod resources")
+        core_pods = get_pods_having_label(
+            label="noobaa-core=noobaa",
+            namespace=config.ENV_DATA["cluster_namespace"],
+        )
+        assert core_pods, "No noobaa-core pods found"
+
+        core_pod = core_pods[0]
+        core_resources = get_pod_resources(core_pod)
+
+        assert verify_resources(
+            core_resources,
+            spec["core"]["req_cpu"],
+            spec["core"]["lim_cpu"],
+            spec["core"]["req_mem"],
+            spec["core"]["lim_mem"],
+            "noobaa-core",
+        ), f"noobaa-core resources do not match '{profile}' profile"
+
+        qos = get_qos_class(core_resources)
+        assert (
+            qos == spec["core"]["qos"]
+        ), f"noobaa-core QoS class: expected {spec['core']['qos']}, got {qos}"
+        logger.info(f"noobaa-core QoS class: {qos} ✓")
+
+        # Step 3: Verify noobaa-db pod resources (per instance)
+        logger.info("Verifying noobaa-db pod resources")
+        db_pods = get_pods_having_label(
+            label="cnpg.io/cluster=noobaa-db-pg-cluster",
+            namespace=config.ENV_DATA["cluster_namespace"],
+        )
+        assert db_pods, "No noobaa-db pods found"
+
+        for i, db_pod in enumerate(db_pods):
+            db_resources = get_pod_resources(db_pod)
+            assert verify_resources(
+                db_resources,
+                spec["db"]["req_cpu"],
+                spec["db"]["lim_cpu"],
+                spec["db"]["req_mem"],
+                spec["db"]["lim_mem"],
+                f"noobaa-db-{i+1}",
+            ), f"noobaa-db pod {i+1} resources do not match '{profile}' profile"
+
+            qos = get_qos_class(db_resources)
+            assert (
+                qos == spec["db"]["qos"]
+            ), f"noobaa-db pod {i+1} QoS class: expected {spec['db']['qos']}, got {qos}"
+        logger.info(
+            f"All {len(db_pods)} noobaa-db pods verified, QoS: {spec['db']['qos']} ✓"
+        )
+
+        # Step 4: Verify noobaa-endpoint pod resources
+        logger.info("Verifying noobaa-endpoint pod resources")
+        endpoint_pods = get_pods_having_label(
+            label="app=noobaa,noobaa-s3=noobaa",
+            namespace=config.ENV_DATA["cluster_namespace"],
+        )
+        assert endpoint_pods, "No noobaa-endpoint pods found"
+
+        endpoint_pod = endpoint_pods[0]
+        endpoint_resources = get_pod_resources(endpoint_pod)
+
+        assert verify_resources(
+            endpoint_resources,
+            spec["endpoint"]["req_cpu"],
+            spec["endpoint"]["lim_cpu"],
+            spec["endpoint"]["req_mem"],
+            spec["endpoint"]["lim_mem"],
+            "noobaa-endpoint",
+        ), f"noobaa-endpoint resources do not match '{profile}' profile"
+
+        qos = get_qos_class(endpoint_resources)
+        assert (
+            qos == spec["endpoint"]["qos"]
+        ), f"noobaa-endpoint QoS class: expected {spec['endpoint']['qos']}, got {qos}"
+        logger.info(f"noobaa-endpoint QoS class: {qos} ✓")
+
+        # Step 5: Verify endpoint pod count (min/max)
+        logger.info("Verifying endpoint pod count configuration")
+        current_count = len(endpoint_pods)
+        expected_min = spec["endpoint_count"]["min"]
+        expected_max = spec["endpoint_count"]["max"]
+
+        assert expected_min <= current_count <= expected_max, (
+            f"Endpoint pod count {current_count} not within expected range "
+            f"[{expected_min}, {expected_max}]"
+        )
+        logger.info(
+            f"Endpoint pod count: {current_count} (within range [{expected_min}, {expected_max}]) ✓"
+        )
+
+        # Check HPA if it exists
+        hpa_ocp = OCP(
+            kind="HorizontalPodAutoscaler",
+            namespace=config.ENV_DATA["cluster_namespace"],
+        )
+        hpas = hpa_ocp.get(selector="noobaa-s3=noobaa").get("items", [])
+
+        if hpas:
+            hpa = hpas[0]
+            hpa_min = hpa["spec"]["minReplicas"]
+            hpa_max = hpa["spec"]["maxReplicas"]
+
+            assert (
+                hpa_min == expected_min
+            ), f"HPA minReplicas: expected {expected_min}, got {hpa_min}"
+            assert (
+                hpa_max == expected_max
+            ), f"HPA maxReplicas: expected {expected_max}, got {hpa_max}"
+            logger.info(f"HPA configured: min={hpa_min}, max={hpa_max} ✓")
+        else:
+            logger.info("No HPA found (static replica count)")
+
+        # Step 6: Verify DB instances count
+        logger.info("Verifying DB instances count")
+        db_count = len(db_pods)
+        expected_db_instances = spec["db_instances"]
+
+        assert (
+            db_count == expected_db_instances
+        ), f"DB instance count: expected {expected_db_instances}, got {db_count}"
+        logger.info(f"DB instances: {db_count} ✓")
+
+        # Step 7: Verify PV pool agent pod resources (vSphere/on-prem only)
+        logger.info("Checking for PV pool backingstore")
+        bs_ocp = OCP(
+            kind="BackingStore", namespace=config.ENV_DATA["cluster_namespace"]
+        )
+
+        try:
+            default_bs = bs_ocp.get(resource_name="noobaa-default-backing-store")
+            bs_type = default_bs.get("spec", {}).get("type")
+
+            if bs_type == "pv-pool":
+                logger.info(
+                    "PV pool backingstore detected, verifying agent pod resources"
+                )
+
+                pv_pool_pods = get_pods_having_label(
+                    label="pool=noobaa-default-backing-store",
+                    namespace=config.ENV_DATA["cluster_namespace"],
+                )
+
+                if pv_pool_pods:
+                    pv_pod = pv_pool_pods[0]
+                    pv_resources = get_pod_resources(pv_pod)
+
+                    # PV pool pods have equal requests and limits
+                    expected_cpu = spec["pv_pool"]["cpu"]
+                    expected_mem = spec["pv_pool"]["mem"]
+
+                    assert verify_resources(
+                        pv_resources,
+                        expected_cpu,
+                        expected_cpu,  # limits == requests for PV pool
+                        expected_mem,
+                        expected_mem,  # limits == requests for PV pool
+                        "PV pool agent",
+                    ), f"PV pool agent resources do not match '{profile}' profile"
+
+                    logger.info("PV pool agent pod resources verified ✓")
+                else:
+                    logger.warning(
+                        "PV pool backingstore exists but no agent pods found"
+                    )
+            else:
+                logger.info(
+                    f"Backingstore type is '{bs_type}' (cloud storage), "
+                    "skipping PV pool verification (N/A for cloud platforms)"
+                )
+        except Exception as e:
+            logger.info(f"Default backingstore not found or error checking: {e}")
+            logger.info("Skipping PV pool verification")
+
+        logger.info(f"✅ All verifications passed for '{profile}' profile")

--- a/tests/functional/object/mcg/test_mcg_performance_profiles.py
+++ b/tests/functional/object/mcg/test_mcg_performance_profiles.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import pytest
 
@@ -8,8 +9,11 @@ from ocs_ci.framework.pytest_customization.marks import (
     mcg,
     runs_on_provider,
 )
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.exceptions import CommandFailed
 from ocs_ci.ocs.ocp import OCP
 from ocs_ci.ocs.resources.pod import get_pods_having_label
+from ocs_ci.utility.utils import TimeoutSampler
 
 logger = logging.getLogger(__name__)
 
@@ -19,13 +23,33 @@ def get_pod_resources(pod):
     Get CPU and memory resources from a pod's first container.
 
     Args:
-        pod (Pod): Pod object
+        pod (dict): Pod resource dict as returned by get_pods_having_label
 
     Returns:
         dict: Resources with requests and limits
     """
-    container = pod.get()["spec"]["containers"][0]
+    container = pod["spec"]["containers"][0]
     return container.get("resources", {})
+
+
+def normalize_cpu(value):
+    """
+    Normalize a CPU quantity so equivalent values compare equal
+    (e.g. "500m" == 0.5, "1" == "1000m").
+
+    Args:
+        value: CPU quantity as a string (e.g. "500m", "1") or number
+
+    Returns:
+        float or None: Normalized CPU value in cores, or None if value is None
+    """
+    if value is None:
+        return None
+    if isinstance(value, str):
+        if value.endswith("m"):
+            return float(value[:-1]) / 1000
+        return float(value)
+    return float(value)
 
 
 def verify_resources(
@@ -57,16 +81,6 @@ def verify_resources(
     lim_cpu = limits.get("cpu")
     req_mem = requests.get("memory")
     lim_mem = limits.get("memory")
-
-    # Normalize CPU values (500m == 0.5)
-    def normalize_cpu(value):
-        if value is None:
-            return None
-        if isinstance(value, str):
-            if value.endswith("m"):
-                return float(value[:-1]) / 1000
-            return float(value)
-        return float(value)
 
     req_cpu_norm = normalize_cpu(req_cpu)
     lim_cpu_norm = normalize_cpu(lim_cpu)
@@ -117,13 +131,19 @@ def get_qos_class(resources):
     requests = resources.get("requests", {})
     limits = resources.get("limits", {})
 
-    if not limits:
+    # BestEffort only when neither requests nor limits are set. If requests
+    # exist without limits, Kubernetes classifies the pod as Burstable.
+    if not requests and not limits:
         return "BestEffort"
 
-    # Guaranteed: requests == limits for all resources
-    if requests.get("cpu") == limits.get("cpu") and requests.get(
-        "memory"
-    ) == limits.get("memory"):
+    if not limits:
+        return "Burstable"
+
+    # Guaranteed: requests == limits for both CPU and memory. Compare CPU on
+    # normalized values so "1" and "1000m" are treated as equal.
+    if normalize_cpu(requests.get("cpu")) == normalize_cpu(
+        limits.get("cpu")
+    ) and requests.get("memory") == limits.get("memory"):
         return "Guaranteed"
 
     return "Burstable"
@@ -230,10 +250,12 @@ class TestMCGPerformanceProfiles:
         },
     }
 
-    @pytest.fixture()
+    @pytest.fixture
     def set_profile(self, request):
         """
-        Set MCG performance profile on StorageCluster CR and wait for propagation.
+        Set the MCG performance profile on the StorageCluster CR, wait for it
+        to propagate to the NooBaa CR, and restore the original profile on
+        teardown so the cluster is left as it was found.
 
         Returns:
             str: Profile name that was set
@@ -242,74 +264,76 @@ class TestMCGPerformanceProfiles:
         logger.info(f"Setting MCG performance profile to '{profile}'")
 
         ocp_obj = OCP(
-            kind="StorageCluster",
+            kind=constants.STORAGECLUSTER,
             namespace=config.ENV_DATA["cluster_namespace"],
-            resource_name="ocs-storagecluster",
+            resource_name=constants.DEFAULT_CLUSTERNAME,
         )
 
-        # Patch StorageCluster with the profile
-        patch = {"spec": {"multiCloudGateway": {"performanceProfile": profile}}}
-        ocp_obj.patch(params=f"{patch}", format_type="merge")
+        # Capture the original profile so it can be restored on teardown.
+        # A JSON-merge patch removes a key when its value is null, so if the
+        # field was unset originally we restore it to None to drop it.
+        original_profile = (
+            ocp_obj.get()
+            .get("spec", {})
+            .get("multiCloudGateway", {})
+            .get("performanceProfile")
+        )
 
-        # Verify it propagated to NooBaa CR
+        def finalizer():
+            logger.info(
+                f"Restoring MCG performance profile to its original value "
+                f"'{original_profile}'"
+            )
+            restore_patch = {
+                "spec": {"multiCloudGateway": {"performanceProfile": original_profile}}
+            }
+            ocp_obj.patch(params=json.dumps(restore_patch), format_type="merge")
+
+        request.addfinalizer(finalizer)
+
+        # Patch StorageCluster with the profile. OCP.patch returns False when
+        # the resource is not patched, so assert on it to fail fast.
+        patch = {"spec": {"multiCloudGateway": {"performanceProfile": profile}}}
+        assert ocp_obj.patch(
+            params=json.dumps(patch), format_type="merge"
+        ), f"Failed to patch StorageCluster with performance profile '{profile}'"
+
+        # The operator propagates performanceProfile to the NooBaa CR
+        # asynchronously, so poll instead of reading immediately.
         noobaa_ocp = OCP(
             kind="NooBaa",
             namespace=config.ENV_DATA["cluster_namespace"],
             resource_name="noobaa",
         )
-        noobaa_profile = noobaa_ocp.get()["spec"].get("performanceProfile")
-        assert noobaa_profile == profile, (
-            f"Profile '{profile}' not propagated to NooBaa CR, "
-            f"got '{noobaa_profile}' instead"
-        )
+        for noobaa_profile in TimeoutSampler(
+            timeout=300,
+            sleep=10,
+            func=lambda: noobaa_ocp.get()["spec"].get("performanceProfile"),
+        ):
+            if noobaa_profile == profile:
+                break
+            logger.info(
+                f"Waiting for NooBaa CR profile propagation, current: "
+                f"'{noobaa_profile}'"
+            )
 
         logger.info(f"Profile '{profile}' successfully set and propagated to NooBaa CR")
 
-        # Wait a bit for operator to reconcile
-        import time
-
-        time.sleep(10)
-
         return profile
 
-    @pytest.mark.parametrize(
-        "set_profile",
-        ["default", "mixed-workload", "small-objects"],
-        indirect=True,
-    )
-    @pytest.mark.polarion_id("OCS-6000")  # TODO: Update with actual Polarion ID
-    def test_mcg_performance_profile_resources(self, set_profile):
+    def _verify_core(self, spec, profile):
         """
-        Verify MCG performance profile resource specifications.
-
-        Test Steps (per profile):
-            1. Set spec.multiCloudGateway.performanceProfile on StorageCluster CR
-            2. Verify noobaa-core pod resources and QoS class
-            3. Verify noobaa-db pod resources and QoS class (per instance)
-            4. Verify noobaa-endpoint pod resources and QoS class
-            5. Verify endpoint pod count (min/max via HPA or deployment)
-            6. Verify DB instances count
-            7. Verify PV pool agent pod resources (vSphere/on-prem only)
-
-        Expected Results:
-            All resource values match the profile specification from RHSTOR-9144
+        Verify noobaa-core pod resources and QoS class.
         """
-        profile = set_profile
-        spec = self.PROFILE_SPECS[profile]
-
-        logger.info(f"Testing '{profile}' profile resource specifications")
-
-        # Step 2: Verify noobaa-core pod resources
         logger.info("Verifying noobaa-core pod resources")
         core_pods = get_pods_having_label(
-            label="noobaa-core=noobaa",
+            label=constants.NOOBAA_CORE_POD_LABEL,
             namespace=config.ENV_DATA["cluster_namespace"],
+            statuses=[constants.STATUS_RUNNING],
         )
-        assert core_pods, "No noobaa-core pods found"
+        assert core_pods, "No running noobaa-core pods found"
 
-        core_pod = core_pods[0]
-        core_resources = get_pod_resources(core_pod)
-
+        core_resources = get_pod_resources(core_pods[0])
         assert verify_resources(
             core_resources,
             spec["core"]["req_cpu"],
@@ -325,13 +349,18 @@ class TestMCGPerformanceProfiles:
         ), f"noobaa-core QoS class: expected {spec['core']['qos']}, got {qos}"
         logger.info(f"noobaa-core QoS class: {qos} ✓")
 
-        # Step 3: Verify noobaa-db pod resources (per instance)
+    def _verify_db(self, spec, profile):
+        """
+        Verify noobaa-db pod resources and QoS class (per instance) and the
+        expected DB instance count.
+        """
         logger.info("Verifying noobaa-db pod resources")
         db_pods = get_pods_having_label(
-            label="cnpg.io/cluster=noobaa-db-pg-cluster",
+            label=constants.NOOBAA_DB_LABEL_419_AND_ABOVE,
             namespace=config.ENV_DATA["cluster_namespace"],
+            statuses=[constants.STATUS_RUNNING],
         )
-        assert db_pods, "No noobaa-db pods found"
+        assert db_pods, "No running noobaa-db pods found"
 
         for i, db_pod in enumerate(db_pods):
             db_resources = get_pod_resources(db_pod)
@@ -352,17 +381,47 @@ class TestMCGPerformanceProfiles:
             f"All {len(db_pods)} noobaa-db pods verified, QoS: {spec['db']['qos']} ✓"
         )
 
-        # Step 4: Verify noobaa-endpoint pod resources
-        logger.info("Verifying noobaa-endpoint pod resources")
-        endpoint_pods = get_pods_having_label(
-            label="app=noobaa,noobaa-s3=noobaa",
-            namespace=config.ENV_DATA["cluster_namespace"],
+        # Verify DB instances count
+        expected_db_instances = spec["db_instances"]
+        assert len(db_pods) == expected_db_instances, (
+            f"DB instance count: expected {expected_db_instances}, "
+            f"got {len(db_pods)}"
         )
-        assert endpoint_pods, "No noobaa-endpoint pods found"
+        logger.info(f"DB instances: {len(db_pods)} ✓")
 
-        endpoint_pod = endpoint_pods[0]
-        endpoint_resources = get_pod_resources(endpoint_pod)
+    def _verify_endpoints(self, spec, profile):
+        """
+        Verify noobaa-endpoint pod resources, QoS class, and pod count
+        (min/max via HPA or deployment).
+        """
+        logger.info("Verifying noobaa-endpoint pod resources")
+        endpoint_label = (
+            f"{constants.NOOBAA_APP_LABEL},{constants.NOOBAA_ENDPOINT_POD_LABEL}"
+        )
+        expected_min = spec["endpoint_count"]["min"]
+        expected_max = spec["endpoint_count"]["max"]
 
+        # A profile change recreates/rescales the endpoint pods, so wait until
+        # the running endpoint count settles within the expected range before
+        # asserting, to avoid reading terminating or freshly created pods.
+        endpoint_pods = []
+        for endpoint_pods in TimeoutSampler(
+            timeout=300,
+            sleep=10,
+            func=get_pods_having_label,
+            label=endpoint_label,
+            namespace=config.ENV_DATA["cluster_namespace"],
+            statuses=[constants.STATUS_RUNNING],
+        ):
+            if expected_min <= len(endpoint_pods) <= expected_max:
+                break
+            logger.info(
+                f"Waiting for running endpoint pod count to reach "
+                f"[{expected_min}, {expected_max}], current: {len(endpoint_pods)}"
+            )
+        assert endpoint_pods, "No running noobaa-endpoint pods found"
+
+        endpoint_resources = get_pod_resources(endpoint_pods[0])
         assert verify_resources(
             endpoint_resources,
             spec["endpoint"]["req_cpu"],
@@ -378,18 +437,15 @@ class TestMCGPerformanceProfiles:
         ), f"noobaa-endpoint QoS class: expected {spec['endpoint']['qos']}, got {qos}"
         logger.info(f"noobaa-endpoint QoS class: {qos} ✓")
 
-        # Step 5: Verify endpoint pod count (min/max)
-        logger.info("Verifying endpoint pod count configuration")
+        # Verify endpoint pod count (min/max)
         current_count = len(endpoint_pods)
-        expected_min = spec["endpoint_count"]["min"]
-        expected_max = spec["endpoint_count"]["max"]
-
         assert expected_min <= current_count <= expected_max, (
             f"Endpoint pod count {current_count} not within expected range "
             f"[{expected_min}, {expected_max}]"
         )
         logger.info(
-            f"Endpoint pod count: {current_count} (within range [{expected_min}, {expected_max}]) ✓"
+            f"Endpoint pod count: {current_count} "
+            f"(within range [{expected_min}, {expected_max}]) ✓"
         )
 
         # Check HPA if it exists
@@ -397,13 +453,13 @@ class TestMCGPerformanceProfiles:
             kind="HorizontalPodAutoscaler",
             namespace=config.ENV_DATA["cluster_namespace"],
         )
-        hpas = hpa_ocp.get(selector="noobaa-s3=noobaa").get("items", [])
-
+        hpas = hpa_ocp.get(selector=constants.NOOBAA_ENDPOINT_POD_LABEL).get(
+            "items", []
+        )
         if hpas:
             hpa = hpas[0]
             hpa_min = hpa["spec"]["minReplicas"]
             hpa_max = hpa["spec"]["maxReplicas"]
-
             assert (
                 hpa_min == expected_min
             ), f"HPA minReplicas: expected {expected_min}, got {hpa_min}"
@@ -414,65 +470,86 @@ class TestMCGPerformanceProfiles:
         else:
             logger.info("No HPA found (static replica count)")
 
-        # Step 6: Verify DB instances count
-        logger.info("Verifying DB instances count")
-        db_count = len(db_pods)
-        expected_db_instances = spec["db_instances"]
-
-        assert (
-            db_count == expected_db_instances
-        ), f"DB instance count: expected {expected_db_instances}, got {db_count}"
-        logger.info(f"DB instances: {db_count} ✓")
-
-        # Step 7: Verify PV pool agent pod resources (vSphere/on-prem only)
+    def _verify_pv_pool(self, spec, profile):
+        """
+        Verify PV pool agent pod resources (vSphere/on-prem only). Skipped on
+        cloud platforms where the default backingstore is not a pv-pool.
+        """
         logger.info("Checking for PV pool backingstore")
         bs_ocp = OCP(
             kind="BackingStore", namespace=config.ENV_DATA["cluster_namespace"]
         )
 
+        # Limit the try to the backingstore lookup only, so a real resource
+        # mismatch below is not swallowed. A missing default backingstore is a
+        # valid skip (e.g. cloud platforms without a pv-pool).
         try:
             default_bs = bs_ocp.get(resource_name="noobaa-default-backing-store")
-            bs_type = default_bs.get("spec", {}).get("type")
-
-            if bs_type == "pv-pool":
-                logger.info(
-                    "PV pool backingstore detected, verifying agent pod resources"
-                )
-
-                pv_pool_pods = get_pods_having_label(
-                    label="pool=noobaa-default-backing-store",
-                    namespace=config.ENV_DATA["cluster_namespace"],
-                )
-
-                if pv_pool_pods:
-                    pv_pod = pv_pool_pods[0]
-                    pv_resources = get_pod_resources(pv_pod)
-
-                    # PV pool pods have equal requests and limits
-                    expected_cpu = spec["pv_pool"]["cpu"]
-                    expected_mem = spec["pv_pool"]["mem"]
-
-                    assert verify_resources(
-                        pv_resources,
-                        expected_cpu,
-                        expected_cpu,  # limits == requests for PV pool
-                        expected_mem,
-                        expected_mem,  # limits == requests for PV pool
-                        "PV pool agent",
-                    ), f"PV pool agent resources do not match '{profile}' profile"
-
-                    logger.info("PV pool agent pod resources verified ✓")
-                else:
-                    logger.warning(
-                        "PV pool backingstore exists but no agent pods found"
-                    )
-            else:
-                logger.info(
-                    f"Backingstore type is '{bs_type}' (cloud storage), "
-                    "skipping PV pool verification (N/A for cloud platforms)"
-                )
-        except Exception as e:
-            logger.info(f"Default backingstore not found or error checking: {e}")
+        except CommandFailed as e:
+            logger.info(f"Default backingstore not found: {e}")
             logger.info("Skipping PV pool verification")
+            return
+
+        bs_type = default_bs.get("spec", {}).get("type")
+        if bs_type != "pv-pool":
+            logger.info(
+                f"Backingstore type is '{bs_type}' (cloud storage), "
+                "skipping PV pool verification (N/A for cloud platforms)"
+            )
+            return
+
+        logger.info("PV pool backingstore detected, verifying agent pod resources")
+        pv_pool_pods = get_pods_having_label(
+            label=constants.NOOBAA_DEFAULT_BACKINGSTORE_LABEL,
+            namespace=config.ENV_DATA["cluster_namespace"],
+            statuses=[constants.STATUS_RUNNING],
+        )
+        assert (
+            pv_pool_pods
+        ), "PV pool backingstore exists but no running agent pods found"
+
+        pv_resources = get_pod_resources(pv_pool_pods[0])
+        # PV pool pods have equal requests and limits
+        expected_cpu = spec["pv_pool"]["cpu"]
+        expected_mem = spec["pv_pool"]["mem"]
+        assert verify_resources(
+            pv_resources,
+            expected_cpu,
+            expected_cpu,  # limits == requests for PV pool
+            expected_mem,
+            expected_mem,  # limits == requests for PV pool
+            "PV pool agent",
+        ), f"PV pool agent resources do not match '{profile}' profile"
+        logger.info("PV pool agent pod resources verified ✓")
+
+    @pytest.mark.parametrize(
+        "set_profile",
+        ["default", "mixed-workload", "small-objects"],
+        indirect=True,
+    )
+    @pytest.mark.polarion_id("OCS-6000")  # TODO: Update with actual Polarion ID
+    def test_mcg_performance_profile_resources(self, set_profile):
+        """
+        Verify MCG performance profile resource specifications.
+
+        Test Steps (per profile):
+            1. Set spec.multiCloudGateway.performanceProfile on StorageCluster CR
+            2. Verify noobaa-core pod resources and QoS class
+            3. Verify noobaa-db pod resources, QoS class, and instance count
+            4. Verify noobaa-endpoint pod resources, QoS class, and count
+            5. Verify PV pool agent pod resources (vSphere/on-prem only)
+
+        Expected Results:
+            All resource values match the profile specification from RHSTOR-9144
+        """
+        profile = set_profile
+        spec = self.PROFILE_SPECS[profile]
+
+        logger.info(f"Testing '{profile}' profile resource specifications")
+
+        self._verify_core(spec, profile)
+        self._verify_db(spec, profile)
+        self._verify_endpoints(spec, profile)
+        self._verify_pv_pool(spec, profile)
 
         logger.info(f"✅ All verifications passed for '{profile}' profile")

--- a/tests/functional/object/mcg/test_mcg_performance_profiles.py
+++ b/tests/functional/object/mcg/test_mcg_performance_profiles.py
@@ -118,6 +118,33 @@ def verify_resources(
     return True
 
 
+def resources_match(actual, req_cpu, lim_cpu, req_mem, lim_mem):
+    """
+    Return whether a pod's resource dict matches the expected requests/limits.
+
+    A quiet, non-logging counterpart to verify_resources, intended for polling
+    while the operator recreates pods after a profile change.
+
+    Args:
+        actual (dict): Actual resource dict from a pod
+        req_cpu (str): Expected CPU request
+        lim_cpu (str): Expected CPU limit
+        req_mem (str): Expected memory request
+        lim_mem (str): Expected memory limit
+
+    Returns:
+        bool: True if requests and limits match (CPU compared normalized)
+    """
+    requests = actual.get("requests", {})
+    limits = actual.get("limits", {})
+    return (
+        normalize_cpu(requests.get("cpu")) == normalize_cpu(req_cpu)
+        and normalize_cpu(limits.get("cpu")) == normalize_cpu(lim_cpu)
+        and requests.get("memory") == req_mem
+        and limits.get("memory") == lim_mem
+    )
+
+
 def get_qos_class(resources):
     """
     Determine QoS class from resources.
@@ -268,6 +295,11 @@ class TestMCGPerformanceProfiles:
             namespace=config.ENV_DATA["cluster_namespace"],
             resource_name=constants.DEFAULT_CLUSTERNAME,
         )
+        noobaa_ocp = OCP(
+            kind="NooBaa",
+            namespace=config.ENV_DATA["cluster_namespace"],
+            resource_name="noobaa",
+        )
 
         # Capture the original profile so it can be restored on teardown.
         # A JSON-merge patch removes a key when its value is null, so if the
@@ -288,6 +320,10 @@ class TestMCGPerformanceProfiles:
                 "spec": {"multiCloudGateway": {"performanceProfile": original_profile}}
             }
             ocp_obj.patch(params=json.dumps(restore_patch), format_type="merge")
+            # Wait for the restore to fully reconcile so the cluster is left
+            # healthy and the next test's NooBaa health check does not run
+            # while NooBaa is still recreating pods.
+            self._wait_for_profile_settled(noobaa_ocp, original_profile)
 
         request.addfinalizer(finalizer)
 
@@ -298,28 +334,57 @@ class TestMCGPerformanceProfiles:
             params=json.dumps(patch), format_type="merge"
         ), f"Failed to patch StorageCluster with performance profile '{profile}'"
 
-        # The operator propagates performanceProfile to the NooBaa CR
-        # asynchronously, so poll instead of reading immediately.
-        noobaa_ocp = OCP(
-            kind="NooBaa",
-            namespace=config.ENV_DATA["cluster_namespace"],
-            resource_name="noobaa",
-        )
-        for noobaa_profile in TimeoutSampler(
-            timeout=300,
-            sleep=10,
-            func=lambda: noobaa_ocp.get()["spec"].get("performanceProfile"),
-        ):
-            if noobaa_profile == profile:
-                break
-            logger.info(
-                f"Waiting for NooBaa CR profile propagation, current: "
-                f"'{noobaa_profile}'"
-            )
-
-        logger.info(f"Profile '{profile}' successfully set and propagated to NooBaa CR")
+        # The operator recreates the NooBaa pods asynchronously after the
+        # profile changes, so wait until NooBaa is back to Ready and the core
+        # pods have actually been recreated with the new resources before the
+        # test reads pod state.
+        self._wait_for_profile_settled(noobaa_ocp, profile)
+        logger.info(f"Profile '{profile}' successfully applied and reconciled")
 
         return profile
+
+    def _wait_for_profile_settled(self, noobaa_ocp, profile):
+        """
+        Wait until a performance-profile change has fully reconciled: NooBaa is
+        back to the Ready phase and the running noobaa-core pod has been
+        recreated with the target profile's resources.
+
+        The operator recreates the NooBaa pods asynchronously, so both reading
+        pod resources and starting the next test must wait for this; otherwise
+        the previous profile's pods (or a NooBaa still in the Creating phase)
+        are observed. TimeoutSampler swallows transient errors raised while
+        pods churn and retries until the timeout.
+
+        Args:
+            noobaa_ocp (OCP): OCP handle for the NooBaa CR
+            profile (str or None): target profile; None means the default spec
+        """
+        core_spec = self.PROFILE_SPECS[profile or "default"]["core"]
+
+        def _settled():
+            phase = noobaa_ocp.get().get("status", {}).get("phase")
+            if phase != constants.STATUS_READY:
+                return False
+            core_pods = get_pods_having_label(
+                label=constants.NOOBAA_CORE_POD_LABEL,
+                namespace=config.ENV_DATA["cluster_namespace"],
+                statuses=[constants.STATUS_RUNNING],
+            )
+            return bool(core_pods) and resources_match(
+                get_pod_resources(core_pods[0]),
+                core_spec["req_cpu"],
+                core_spec["lim_cpu"],
+                core_spec["req_mem"],
+                core_spec["lim_mem"],
+            )
+
+        for settled in TimeoutSampler(timeout=900, sleep=20, func=_settled):
+            if settled:
+                break
+            logger.info(
+                f"Waiting for NooBaa to settle on profile '{profile}' "
+                "(Ready phase and core pods recreated with new resources)"
+            )
 
     def _verify_core(self, spec, profile):
         """

--- a/tests/functional/object/mcg/test_mcg_performance_profiles.py
+++ b/tests/functional/object/mcg/test_mcg_performance_profiles.py
@@ -145,37 +145,6 @@ def resources_match(actual, req_cpu, lim_cpu, req_mem, lim_mem):
     )
 
 
-def get_qos_class(resources):
-    """
-    Determine QoS class from resources.
-
-    Args:
-        resources (dict): Resource dict with requests and limits
-
-    Returns:
-        str: QoS class (Guaranteed, Burstable, or BestEffort)
-    """
-    requests = resources.get("requests", {})
-    limits = resources.get("limits", {})
-
-    # BestEffort only when neither requests nor limits are set. If requests
-    # exist without limits, Kubernetes classifies the pod as Burstable.
-    if not requests and not limits:
-        return "BestEffort"
-
-    if not limits:
-        return "Burstable"
-
-    # Guaranteed: requests == limits for both CPU and memory. Compare CPU on
-    # normalized values so "1" and "1000m" are treated as equal.
-    if normalize_cpu(requests.get("cpu")) == normalize_cpu(
-        limits.get("cpu")
-    ) and requests.get("memory") == limits.get("memory"):
-        return "Guaranteed"
-
-    return "Burstable"
-
-
 @tier1
 @mcg
 @red_squad
@@ -319,7 +288,17 @@ class TestMCGPerformanceProfiles:
             restore_patch = {
                 "spec": {"multiCloudGateway": {"performanceProfile": original_profile}}
             }
-            ocp_obj.patch(params=json.dumps(restore_patch), format_type="merge")
+            patched = ocp_obj.patch(
+                params=json.dumps(restore_patch), format_type="merge"
+            )
+            # patch() returns False when nothing changed, which is expected when
+            # the profile was already at its original value (e.g. restoring a
+            # None/unset field), so only warn rather than fail the teardown.
+            if not patched:
+                logger.warning(
+                    "Restore patch reported no change while restoring profile to "
+                    f"'{original_profile}'"
+                )
             # Wait for the restore to fully reconcile so the cluster is left
             # healthy and the next test's NooBaa health check does not run
             # while NooBaa is still recreating pods.
@@ -408,7 +387,10 @@ class TestMCGPerformanceProfiles:
             "noobaa-core",
         ), f"noobaa-core resources do not match '{profile}' profile"
 
-        qos = get_qos_class(core_resources)
+        # Use the pod-reported QoS class, which Kubernetes computes across all
+        # (app and init) containers, rather than deriving it from a single
+        # container's resources.
+        qos = core_pods[0]["status"]["qosClass"]
         assert (
             qos == spec["core"]["qos"]
         ), f"noobaa-core QoS class: expected {spec['core']['qos']}, got {qos}"
@@ -438,7 +420,7 @@ class TestMCGPerformanceProfiles:
                 f"noobaa-db-{i+1}",
             ), f"noobaa-db pod {i+1} resources do not match '{profile}' profile"
 
-            qos = get_qos_class(db_resources)
+            qos = db_pod["status"]["qosClass"]
             assert (
                 qos == spec["db"]["qos"]
             ), f"noobaa-db pod {i+1} QoS class: expected {spec['db']['qos']}, got {qos}"
@@ -486,21 +468,28 @@ class TestMCGPerformanceProfiles:
             )
         assert endpoint_pods, "No running noobaa-endpoint pods found"
 
-        endpoint_resources = get_pod_resources(endpoint_pods[0])
-        assert verify_resources(
-            endpoint_resources,
-            spec["endpoint"]["req_cpu"],
-            spec["endpoint"]["lim_cpu"],
-            spec["endpoint"]["req_mem"],
-            spec["endpoint"]["lim_mem"],
-            "noobaa-endpoint",
-        ), f"noobaa-endpoint resources do not match '{profile}' profile"
+        # Verify every endpoint pod, not just the first one, so a pod with
+        # stale or incorrect resources cannot slip through.
+        for i, endpoint_pod in enumerate(endpoint_pods):
+            endpoint_resources = get_pod_resources(endpoint_pod)
+            assert verify_resources(
+                endpoint_resources,
+                spec["endpoint"]["req_cpu"],
+                spec["endpoint"]["lim_cpu"],
+                spec["endpoint"]["req_mem"],
+                spec["endpoint"]["lim_mem"],
+                f"noobaa-endpoint-{i+1}",
+            ), f"noobaa-endpoint pod {i+1} resources do not match '{profile}' profile"
 
-        qos = get_qos_class(endpoint_resources)
-        assert (
-            qos == spec["endpoint"]["qos"]
-        ), f"noobaa-endpoint QoS class: expected {spec['endpoint']['qos']}, got {qos}"
-        logger.info(f"noobaa-endpoint QoS class: {qos} ✓")
+            qos = endpoint_pod["status"]["qosClass"]
+            assert qos == spec["endpoint"]["qos"], (
+                f"noobaa-endpoint pod {i+1} QoS class: "
+                f"expected {spec['endpoint']['qos']}, got {qos}"
+            )
+        logger.info(
+            f"All {len(endpoint_pods)} noobaa-endpoint pods verified, "
+            f"QoS: {spec['endpoint']['qos']} ✓"
+        )
 
         # Verify endpoint pod count (min/max)
         current_count = len(endpoint_pods)
@@ -551,9 +540,14 @@ class TestMCGPerformanceProfiles:
         try:
             default_bs = bs_ocp.get(resource_name="noobaa-default-backing-store")
         except CommandFailed as e:
-            logger.info(f"Default backingstore not found: {e}")
-            logger.info("Skipping PV pool verification")
-            return
+            # Only a genuine "not found" is a valid skip (e.g. cloud platforms
+            # without a pv-pool). Authorization, connectivity, or other API
+            # errors must fail the test rather than be silently skipped.
+            if "not found" in str(e).lower() or "notfound" in str(e).lower():
+                logger.info(f"Default backingstore not found: {e}")
+                logger.info("Skipping PV pool verification")
+                return
+            raise
 
         bs_type = default_bs.get("spec", {}).get("type")
         if bs_type != "pv-pool":

--- a/tests/functional/object/mcg/test_mcg_performance_profiles.py
+++ b/tests/functional/object/mcg/test_mcg_performance_profiles.py
@@ -449,8 +449,10 @@ class TestMCGPerformanceProfiles:
         expected_max = spec["endpoint_count"]["max"]
 
         # A profile change recreates/rescales the endpoint pods, so wait until
-        # the running endpoint count settles within the expected range before
-        # asserting, to avoid reading terminating or freshly created pods.
+        # the running endpoint count settles within the expected range AND every
+        # running endpoint already carries the target profile's resources. The
+        # count alone can be valid mid-transition while a terminating pod (still
+        # phase Running) still has the previous profile's resources.
         endpoint_pods = []
         for endpoint_pods in TimeoutSampler(
             timeout=300,
@@ -460,11 +462,22 @@ class TestMCGPerformanceProfiles:
             namespace=config.ENV_DATA["cluster_namespace"],
             statuses=[constants.STATUS_RUNNING],
         ):
-            if expected_min <= len(endpoint_pods) <= expected_max:
+            count_ok = expected_min <= len(endpoint_pods) <= expected_max
+            resources_ok = bool(endpoint_pods) and all(
+                resources_match(
+                    get_pod_resources(pod),
+                    spec["endpoint"]["req_cpu"],
+                    spec["endpoint"]["lim_cpu"],
+                    spec["endpoint"]["req_mem"],
+                    spec["endpoint"]["lim_mem"],
+                )
+                for pod in endpoint_pods
+            )
+            if count_ok and resources_ok:
                 break
             logger.info(
-                f"Waiting for running endpoint pod count to reach "
-                f"[{expected_min}, {expected_max}], current: {len(endpoint_pods)}"
+                f"Waiting for {expected_min}-{expected_max} running endpoint pods "
+                f"with '{profile}' resources, current running: {len(endpoint_pods)}"
             )
         assert endpoint_pods, "No running noobaa-endpoint pods found"
 


### PR DESCRIPTION
This PR adds automated coverage for https://redhat.atlassian.net/browse/RHSTOR-8629  :  

It adds an automated test that validates the MCG (NooBaa) performance profiles feature. It sets spec.multiCloudGateway.performanceProfile on the StorageCluster CR and verifies that the operator propagates the correct resource specifications to the NooBaa components.

Coverage

New test TestMCGPerformanceProfiles::test_mcg_performance_profile_resources, parametrized over the three profiles:

- default
- mixed-workload
- small-objects

For each profile the test verifies:

- noobaa-core pod CPU/memory requests and limits, plus QoS class
- noobaa-db pod CPU/memory requests and limits, plus QoS class (per instance) and the expected DB instance count
- noobaa-endpoint pod CPU/memory requests and limits, plus QoS class and pod count (min/max, cross-checked against the HPA when present)
- PV pool agent pod resources on vSphere/on-prem (skipped on cloud platforms where the default backingstore is not a pv-pool)

Expected resource values follow the profile specifications in [RHSTOR-9144](https://redhat.atlassian.net/browse/RHSTOR-9144) and the NooBaa operator source.

Design notes

- The set_profile fixture patches the StorageCluster and waits for the profile to propagate to the NooBaa CR (polled, not a fixed sleep).
- Pod queries are filtered to Running pods, and the endpoint count is polled until it settles within the expected range, so the test does not read terminating or freshly created pods right after a profile switch.
- The profile patch is serialized as JSON and the patch result is asserted, so a rejected patch fails fast.

Cleanup

A teardown finalizer captures the profile that was set before the test ran and restores it after each parametrized case (removing the field entirely if it was unset originally), so the cluster is always returned to its original state, even if the test or the propagation check fails.

Markers

tier1, mcg, red_squad, runs_on_provider

How to validate

Run the parametrized test path:

tests/functional/object/mcg/test_mcg_performance_profiles.py::TestMCGPerformanceProfiles::test_mcg_performance_profile_resources

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added functional coverage for Multi-Cloud Gateway performance profiles.
  * Validates resource requests and limits, QoS classes, endpoint scaling, and database instance counts across supported profiles.
  * Confirms profile changes propagate correctly after resources settle.
  * Restores the original performance profile after testing.

* **Bug Fixes**
  * Fixed pod filtering so consecutive pods with non-matching statuses are handled correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->