### PR TITLE
Fix multicluster orchestrator deployment with temp-gitops-wa catalog

### DIFF
--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -3861,15 +3861,27 @@ class MultiClusterDROperatorsDeploy(object):
         odf_multicluster_orchestrator_data = templating.load_yaml(
             constants.ODF_MULTICLUSTER_ORCHESTRATOR
         )
+
+        # Determine the appropriate catalog source selector
+        # to avoid non-deterministic package manifest selection when multiple
+        # catalogs provide odf-multicluster-orchestrator (e.g., redhat-operators
+        # and temp-gitops-wa)
         if use_fdf_catsrc:
-            package_manifest = packagemanifest.PackageManifest(
-                resource_name=constants.ACM_ODF_MULTICLUSTER_ORCHESTRATOR_RESOURCE,
-                selector=constants.FDF_OPERATOR_SELECTOR,
-            )
+            selector = constants.FDF_OPERATOR_SELECTOR
+        elif not live_deployment:
+            # Dev/testing deployment: use OPERATOR_INTERNAL_SELECTOR to target
+            # the custom redhat-operators catalog (with ocs-operator-internal=true)
+            # and avoid other catalogs like temp-gitops-wa
+            selector = constants.OPERATOR_INTERNAL_SELECTOR
         else:
-            package_manifest = packagemanifest.PackageManifest(
-                resource_name=constants.ACM_ODF_MULTICLUSTER_ORCHESTRATOR_RESOURCE
-            )
+            # Live/GA deployment: no selector since the real redhat-operators
+            # catalog doesn't have the ocs-operator-internal label
+            selector = None
+
+        package_manifest = packagemanifest.PackageManifest(
+            resource_name=constants.ACM_ODF_MULTICLUSTER_ORCHESTRATOR_RESOURCE,
+            selector=selector,
+        )
 
         retry(
             (


### PR DESCRIPTION
Problem:
When deploying Regional-DR on OCP 5.0, the multicluster orchestrator deployment fails with:
  ChannelNotFound: Channel: stable-5.0 not found in available channels:
  ['stable-4.21', 'stable-4.22']

Root Cause:
Commit 429d4371a introduced temp-gitops-wa catalog source as a workaround for GitOps deployment on OCP 5.0+. This creates a scenario where two catalog sources can provide odf-multicluster-orchestrator:

1. redhat-operators (custom dev catalog with ocs-operator-internal=true label)
   - Uses image: quay.io/rhceph-dev/ocs-registry:5.0.0-29.konflux
   - Provides channels: stable-5.0

2. temp-gitops-wa (GitOps workaround catalog, no special labels)
   - Uses image: quay.io/rhceph-dev/ocs-registry:latest-stable-4.22
   - Provides channels: stable-4.21, stable-4.22

Both catalogs have priority=100, making package manifest selection non-deterministic. When PackageManifest picks temp-gitops-wa, it cannot find the stable-5.0 channel that deploy_dr_multicluster_orchestrator requests, causing deployment failure.

Solution:
Use conditional catalog source selector to ensure deterministic selection:
- FDF deployment: Use FDF_OPERATOR_SELECTOR (fdf-operator-internal=true)
- Dev/testing deployment: Use OPERATOR_INTERNAL_SELECTOR to target only the custom redhat-operators catalog and exclude temp-gitops-wa
- Live/GA deployment: Use no selector (real Red Hat catalog has no label)

This ensures dev/testing deployments always use the correct catalog source with the expected ODF 5.0 channels.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved non-live deployment behavior by ensuring the correct internal operator catalog is selected.
  * Prevented development and testing deployments from unintentionally using unrelated operator catalogs.
  * Preserved existing catalog selection behavior for live and GA deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->