### PR TITLE
fix: check_pool_replicas fails on ODF 4.22/5.0 due to renamed field

### DIFF
--- a/ocs_ci/ocs/ui/block_pool.py
+++ b/ocs_ci/ocs/ui/block_pool.py
@@ -1,4 +1,5 @@
 import logging
+import re
 import time
 
 from ocs_ci.ocs.ui.page_objects.page_navigator import PageNavigator
@@ -218,8 +219,15 @@ class BlockPoolUI(PageNavigator):
         self.navigate_storage_pools_page()
         self.do_click((f"a[data-test={pool_name}]", By.CSS_SELECTOR))
         block_pool_replica = self.get_element_text(self.bp_loc["block_pool_replica"])
-        logger.info(f"Pool name {pool_name} existence is {block_pool_replica}")
-        return int(block_pool_replica)
+        logger.info(
+            f"Pool name {pool_name} replicas field value is {block_pool_replica}"
+        )
+        match = re.search(r"\d+", block_pool_replica)
+        if not match:
+            raise ValueError(
+                f"Could not extract replica count from '{block_pool_replica}'"
+            )
+        return int(match.group())
 
     def check_pool_used_capacity(self, pool_name):
         """

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -2171,6 +2171,10 @@ block_pool_4_22 = {
         'span[data-test$="-replicas"]',
         By.CSS_SELECTOR,
     ),
+    "block_pool_replica": (
+        "//dt[normalize-space()='Data protection policy']/following-sibling::dd[1]",
+        By.XPATH,
+    ),
 }
 
 storageclass = {

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -2172,7 +2172,8 @@ block_pool_4_22 = {
         By.CSS_SELECTOR,
     ),
     "block_pool_replica": (
-        "//dt[normalize-space()='Data protection policy']/following-sibling::dd[1]",
+        "//dt[normalize-space()='Data protection policy']"
+        "/following-sibling::dd[@data-test='detail-item-value']",
         By.XPATH,
     ),
 }


### PR DESCRIPTION
The pool detail page in ODF 4.22+ renamed the field from 'Replicas' to 'Data protection policy' with value 'Replica 2' instead of '2'.

- Add 'block_pool_replica' locator to block_pool_4_22 targeting the new 'Data protection policy' label (overrides block_pool_4_13 for 4.22+ via dict merge order)
- Replace bare int() with re.search(r'\d+', ...) to extract the replica count from both 'Replica 2' (new) and '2' (old) formats

Fixes: #16037
Tests: test_new_sc_new_rbd_pool[2-aggressive-WaitForFirstConsumer-Pending]
       test_new_sc_new_rbd_pool[3-aggressive-Immediate-Bound]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved block pool replica count detection from the user interface.
  - Added support for locating the data protection policy on block pool details pages.
  - Improved error handling when a replica count cannot be identified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->