### PR TITLE
skip tests that are failing regression on Fusion HCI

### DIFF
--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -40,6 +40,7 @@ from ocs_ci.ocs.constants import (
     MS_CONSUMER_TYPE,
     HCI_PROVIDER,
     BAREMETAL_PLATFORMS,
+    IBM_HCI_PLATFORM,
     AZURE_KV_PROVIDER_NAME,
     ROSA_HCP_PLATFORM,
     VAULT_KMS_PROVIDER,
@@ -763,6 +764,11 @@ skipif_vsphere_platform = pytest.mark.skipif(
 skipif_azure_platform = pytest.mark.skipif(
     config.ENV_DATA["platform"].lower() == "azure",
     reason="Test will not run on Azure deployed cluster",
+)
+
+skipif_ibm_hci_platform = pytest.mark.skipif(
+    config.ENV_DATA["platform"].lower() == IBM_HCI_PLATFORM,
+    reason="Test will not run on IBM HCI platform",
 )
 
 skipif_tainted_nodes = pytest.mark.skipif(

--- a/tests/cross_functional/kcs/test_noobaa_rebuild.py
+++ b/tests/cross_functional/kcs/test_noobaa_rebuild.py
@@ -5,6 +5,7 @@ import time
 from subprocess import TimeoutExpired
 from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import magenta_squad
+from ocs_ci.framework.pytest_customization.marks import skipif_ibm_hci_platform
 from ocs_ci.framework.testlib import (
     ignore_leftovers,
     E2ETest,
@@ -33,6 +34,7 @@ logger = logging.getLogger(__name__)
 @pytest.mark.polarion_id("OCS-2653")
 @skipif_managed_service
 @skipif_external_mode
+@skipif_ibm_hci_platform
 class TestNoobaaRebuild(E2ETest):
     """
     Test to verify noobaa rebuild.

--- a/tests/functional/cephx_keyrotation/test_cephx_keyrotation_configuration.py
+++ b/tests/functional/cephx_keyrotation/test_cephx_keyrotation_configuration.py
@@ -12,6 +12,7 @@ from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import (
     green_squad,
     skipif_external_mode,
+    skipif_ibm_hci_platform,
     skipif_ocs_version,
     tier1,
 )
@@ -28,6 +29,7 @@ EXPECTED_INITIAL_GENERATION = 2
 
 @skipif_external_mode
 @skipif_ocs_version(["<4.21", ">=4.23"])
+@skipif_ibm_hci_platform
 @green_squad
 @pytest.mark.order("first")
 class TestCephXKeyRotationPolicyDisabled:
@@ -109,6 +111,7 @@ class TestCephXKeyRotationPolicyDisabled:
 
 @skipif_external_mode
 @skipif_ocs_version(["<4.21", ">=4.23"])
+@skipif_ibm_hci_platform
 @green_squad
 class TestCephXAllowedCiphers:
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
THIS PR is a result of a bug triage of https://redhat.atlassian.net/browse/DFBUGS-10194


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated platform-specific test handling to skip unsupported NooBaa rebuild and CephX key rotation tests on IBM HCI deployments.
* **Tests**
  * Added IBM HCI platform detection for more accurate test execution and reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->