### PR TITLE
Fix VM hotplug unplug snapshot clone test

### DIFF
--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -913,7 +913,7 @@ class OCP(object):
 
         while (time.time() - start_time) < timeout:
             try:
-                res = self.exec_oc_cmd(command)
+                res = self.exec_oc_cmd(command, timeout=timeout + 60)
             except CommandFailed as ex:
                 res = ex.args[0] if ex.args else str(ex)
                 elapsed_time = time.time() - start_time

--- a/tests/functional/workloads/cnv/test_vm_hotpl_unplg_snap_clone.py
+++ b/tests/functional/workloads/cnv/test_vm_hotpl_unplg_snap_clone.py
@@ -1,5 +1,6 @@
 import logging
 import re
+import time
 
 import pytest
 
@@ -87,21 +88,31 @@ class TestVmHotPlugUnplugSnapClone(E2ETest):
         logger.info(f"PVC '{pvc.name}' unplugged and verified for VM '{vm_obj.name}'")
 
     def _wait_for_disk_gone_in_guest(
-        self, vm_obj, known_disks_after_unplug, timeout=120
+        self, vm_obj, known_disks_after_unplug, timeout=120, settle_time=15
     ):
         """
         Polls lsblk inside the guest until the disk set stabilises at exactly the
-        expected post-unplug baseline (i.e. no extra block device remains visible).
+        expected post-unplug baseline (i.e. no extra block device remains visible),
+        then waits an additional settle period for virt-launcher to fully quiesce its
+        internal SCSI bus state.
 
-        This guards against the race where removevolume() clears the kubevirt spec
-        but QEMU/virt-launcher still holds the virtio-scsi slot open for several
-        seconds, causing a subsequent addvolume call to be silently dropped.
+        Two separate races are guarded here:
+        1. removevolume() clears the kubevirt spec but QEMU/virt-launcher still holds
+           the virtio-scsi slot open for several seconds, causing a subsequent
+           addvolume call to be silently dropped inside the guest.
+        2. The virtio-scsi slot is gone from lsblk but virt-launcher's internal device
+           tracking has not yet processed the removal acknowledgement from QEMU, so a
+           new addvolume notification is issued before virt-launcher is ready to handle
+           it and is silently ignored.
 
         Args:
             vm_obj: The VM object.
             known_disks_after_unplug (set): Disk names visible right after unplug
                 (used as the stable baseline to wait for).
-            timeout (int): Maximum seconds to wait.
+            timeout (int): Maximum seconds to wait for the disk to disappear from lsblk.
+            settle_time (int): Additional seconds to sleep after the disk is confirmed
+                gone, allowing virt-launcher to fully acknowledge the removal at the
+                QEMU level before the next addvolume call is issued.
         """
 
         def _disks_match():
@@ -123,7 +134,12 @@ class TestVmHotPlugUnplugSnapClone(E2ETest):
         )
         sample.wait_for_func_value(value=True)
         logger.info(
-            f"Guest disk slot fully released on '{vm_obj.name}'; safe to hotplug next volume."
+            f"Guest disk slot cleared in lsblk on '{vm_obj.name}'; "
+            f"waiting {settle_time}s for virt-launcher to quiesce before next hotplug."
+        )
+        time.sleep(settle_time)
+        logger.info(
+            f"Settle period complete on '{vm_obj.name}'; safe to hotplug next volume."
         )
 
     def test_vm_hotpl_unplg_snap_clone(

--- a/tests/functional/workloads/cnv/test_vm_hotpl_unplg_snap_clone.py
+++ b/tests/functional/workloads/cnv/test_vm_hotpl_unplg_snap_clone.py
@@ -1,6 +1,4 @@
 import logging
-import re
-import time
 
 import pytest
 
@@ -87,60 +85,39 @@ class TestVmHotPlugUnplugSnapClone(E2ETest):
         vm_obj.removevolume(volume_name=pvc.name, persist=True, verify=True)
         logger.info(f"PVC '{pvc.name}' unplugged and verified for VM '{vm_obj.name}'")
 
-    def _wait_for_disk_gone_in_guest(
-        self, vm_obj, known_disks_after_unplug, timeout=120, settle_time=15
-    ):
+    def _restart_and_get_disk_baseline(self, vm_obj):
         """
-        Polls lsblk inside the guest until the disk set stabilises at exactly the
-        expected post-unplug baseline (i.e. no extra block device remains visible),
-        then waits an additional settle period for virt-launcher to fully quiesce its
-        internal SCSI bus state.
+        Restarts the VM and returns a fresh lsblk baseline after it comes back up.
 
-        Two separate races are guarded here:
-        1. removevolume() clears the kubevirt spec but QEMU/virt-launcher still holds
-           the virtio-scsi slot open for several seconds, causing a subsequent
-           addvolume call to be silently dropped inside the guest.
-        2. The virtio-scsi slot is gone from lsblk but virt-launcher's internal device
-           tracking has not yet processed the removal acknowledgement from QEMU, so a
-           new addvolume notification is issued before virt-launcher is ready to handle
-           it and is silently ignored.
+        After a VM has been rebooted with a persisted hotplug volume and that volume
+        is then unplugged (persist=True), the virt-launcher/QEMU process still has
+        the virtio-scsi bus address reserved for the removed device.  Any subsequent
+        addvolume call for a different PVC silently fails because the SCSI slot appears
+        occupied to QEMU.
+
+        Restarting the VM forces virt-launcher to spawn a fresh QEMU process with a
+        clean virtio-scsi controller, so the next addvolume correctly claims the free
+        slot and surfaces in the guest.
 
         Args:
-            vm_obj: The VM object.
-            known_disks_after_unplug (set): Disk names visible right after unplug
-                (used as the stable baseline to wait for).
-            timeout (int): Maximum seconds to wait for the disk to disappear from lsblk.
-            settle_time (int): Additional seconds to sleep after the disk is confirmed
-                gone, allowing virt-launcher to fully acknowledge the removal at the
-                QEMU level before the next addvolume call is issued.
+            vm_obj: The VM object to restart.
+
+        Returns:
+            str: Raw output of 'lsblk -o NAME,SIZE,MOUNTPOINT -P' captured after the
+                 VM is back up and SSH is available — ready to use as the
+                 disks_before_hotplug baseline for verify_hotplug().
         """
-
-        def _disks_match():
-            raw = vm_obj.run_ssh_cmd("lsblk -o NAME,SIZE,MOUNTPOINT -P")
-            current = set(re.findall(r'NAME="([^"]+)"', raw))
-            extra = current - known_disks_after_unplug
-            if extra:
-                logger.info(
-                    f"Waiting for guest disk slot to clear on '{vm_obj.name}': "
-                    f"extra devices still visible: {extra}"
-                )
-                return False
-            return True
-
-        sample = TimeoutSampler(
-            timeout=timeout,
-            sleep=5,
-            func=_disks_match,
-        )
-        sample.wait_for_func_value(value=True)
         logger.info(
-            f"Guest disk slot cleared in lsblk on '{vm_obj.name}'; "
-            f"waiting {settle_time}s for virt-launcher to quiesce before next hotplug."
+            f"Restarting VM '{vm_obj.name}' to reset virtio-scsi bus after unplug "
+            f"before attaching clone"
         )
-        time.sleep(settle_time)
+        vm_obj.restart()
         logger.info(
-            f"Settle period complete on '{vm_obj.name}'; safe to hotplug next volume."
+            f"VM '{vm_obj.name}' restarted successfully; capturing disk baseline"
         )
+        baseline = vm_obj.run_ssh_cmd("lsblk -o NAME,SIZE,MOUNTPOINT -P")
+        logger.info(f"Disk baseline on VM '{vm_obj.name}' after restart:\n{baseline}")
+        return baseline
 
     def test_vm_hotpl_unplg_snap_clone(
         self,
@@ -269,47 +246,29 @@ class TestVmHotPlugUnplugSnapClone(E2ETest):
                 f"'{dvt_obj.name}' -> '{clone_obj_dvt.name}'"
             )
 
-            # Unplug the original hotplugged PVCs before cross-attaching clones.
-            # kubevirt/virt-launcher cannot reliably surface a second concurrent
-            # hotplugged block device inside the guest without freeing the slot first.
+            # Unplug the original hotplugged PVCs from each VM.
+            # After the earlier reboot with persist=True, virt-launcher's QEMU process
+            # has the virtio-scsi slot permanently reserved for the original PVC.
+            # A simple removevolume() only clears the kubevirt spec; the SCSI address
+            # remains occupied inside QEMU and any subsequent addvolume for the clone
+            # is silently dropped.  Restarting the VM forces a fresh QEMU process with
+            # a clean virtio-scsi controller so the clone hotplug succeeds.
             logger.info(
                 f"Unplugging original PVC '{pvc_obj.name}' from VM '{vm_obj_pvc.name}' "
                 f"before attaching clone"
             )
             self.unplug_disks_and_verify(vm_obj_pvc, pvc_obj)
-            # Capture the post-unplug baseline disk set.  Then poll lsblk until
-            # the guest confirms no extra block device remains: removevolume()
-            # only clears the kubevirt spec; QEMU/virt-launcher may still hold
-            # the virtio-scsi slot open for several seconds afterwards, causing a
-            # subsequent addvolume event to be silently dropped inside the guest.
-            before_disks_pvc_raw = vm_obj_pvc.run_ssh_cmd(
-                "lsblk -o NAME,SIZE,MOUNTPOINT -P"
-            )
-            before_disks_pvc = before_disks_pvc_raw
-            logger.info(
-                f"Disk state on VM '{vm_obj_pvc.name}' after unplug (used as "
-                f"baseline for clone hotplug detection):\n{before_disks_pvc}"
-            )
-            baseline_set_pvc = set(re.findall(r'NAME="([^"]+)"', before_disks_pvc_raw))
-            self._wait_for_disk_gone_in_guest(vm_obj_pvc, baseline_set_pvc)
+            before_disks_pvc = self._restart_and_get_disk_baseline(vm_obj_pvc)
 
             logger.info(
                 f"Unplugging original PVC '{dvt_obj.name}' from VM '{vm_obj_dvt.name}' "
                 f"before attaching clone"
             )
             self.unplug_disks_and_verify(vm_obj_dvt, dvt_obj)
-            before_disks_dvt_raw = vm_obj_dvt.run_ssh_cmd(
-                "lsblk -o NAME,SIZE,MOUNTPOINT -P"
-            )
-            before_disks_dvt = before_disks_dvt_raw
-            logger.info(
-                f"Disk state on VM '{vm_obj_dvt.name}' after unplug (used as "
-                f"baseline for clone hotplug detection):\n{before_disks_dvt}"
-            )
-            baseline_set_dvt = set(re.findall(r'NAME="([^"]+)"', before_disks_dvt_raw))
-            self._wait_for_disk_gone_in_guest(vm_obj_dvt, baseline_set_dvt)
+            before_disks_dvt = self._restart_and_get_disk_baseline(vm_obj_dvt)
 
-            # Attach clones to opposite VMs (now the only hotplugged device on each)
+            # Attach clones to opposite VMs — each VM now has a fresh QEMU process
+            # with no previously hotplugged devices, so addvolume will succeed.
             logger.info(
                 f"Attaching clone '{clone_obj_dvt.name}' to VM '{vm_obj_pvc.name}'"
             )

--- a/tests/functional/workloads/cnv/test_vm_hotpl_unplg_snap_clone.py
+++ b/tests/functional/workloads/cnv/test_vm_hotpl_unplg_snap_clone.py
@@ -1,5 +1,5 @@
 import logging
-import time
+import re
 
 import pytest
 
@@ -85,6 +85,46 @@ class TestVmHotPlugUnplugSnapClone(E2ETest):
         logger.info(f"Unplugging PVC '{pvc.name}' from VM '{vm_obj.name}'")
         vm_obj.removevolume(volume_name=pvc.name, persist=True, verify=True)
         logger.info(f"PVC '{pvc.name}' unplugged and verified for VM '{vm_obj.name}'")
+
+    def _wait_for_disk_gone_in_guest(
+        self, vm_obj, known_disks_after_unplug, timeout=120
+    ):
+        """
+        Polls lsblk inside the guest until the disk set stabilises at exactly the
+        expected post-unplug baseline (i.e. no extra block device remains visible).
+
+        This guards against the race where removevolume() clears the kubevirt spec
+        but QEMU/virt-launcher still holds the virtio-scsi slot open for several
+        seconds, causing a subsequent addvolume call to be silently dropped.
+
+        Args:
+            vm_obj: The VM object.
+            known_disks_after_unplug (set): Disk names visible right after unplug
+                (used as the stable baseline to wait for).
+            timeout (int): Maximum seconds to wait.
+        """
+
+        def _disks_match():
+            raw = vm_obj.run_ssh_cmd("lsblk -o NAME,SIZE,MOUNTPOINT -P")
+            current = set(re.findall(r'NAME="([^"]+)"', raw))
+            extra = current - known_disks_after_unplug
+            if extra:
+                logger.info(
+                    f"Waiting for guest disk slot to clear on '{vm_obj.name}': "
+                    f"extra devices still visible: {extra}"
+                )
+                return False
+            return True
+
+        sample = TimeoutSampler(
+            timeout=timeout,
+            sleep=5,
+            func=_disks_match,
+        )
+        sample.wait_for_func_value(value=True)
+        logger.info(
+            f"Guest disk slot fully released on '{vm_obj.name}'; safe to hotplug next volume."
+        )
 
     def test_vm_hotpl_unplg_snap_clone(
         self,
@@ -221,39 +261,37 @@ class TestVmHotPlugUnplugSnapClone(E2ETest):
                 f"before attaching clone"
             )
             self.unplug_disks_and_verify(vm_obj_pvc, pvc_obj)
-            # Capture the current disk state and wait until the block device is
-            # fully gone from lsblk inside the guest before calling addvolume.
-            # removevolume(verify=True) only confirms the kubevirt spec is updated;
-            # QEMU/virt-launcher may still hold the RBD slot open for several
-            # seconds afterwards.  Polling lsblk guards against the race.
-            before_disks_pvc = vm_obj_pvc.run_ssh_cmd(
+            # Capture the post-unplug baseline disk set.  Then poll lsblk until
+            # the guest confirms no extra block device remains: removevolume()
+            # only clears the kubevirt spec; QEMU/virt-launcher may still hold
+            # the virtio-scsi slot open for several seconds afterwards, causing a
+            # subsequent addvolume event to be silently dropped inside the guest.
+            before_disks_pvc_raw = vm_obj_pvc.run_ssh_cmd(
                 "lsblk -o NAME,SIZE,MOUNTPOINT -P"
             )
+            before_disks_pvc = before_disks_pvc_raw
             logger.info(
                 f"Disk state on VM '{vm_obj_pvc.name}' after unplug (used as "
                 f"baseline for clone hotplug detection):\n{before_disks_pvc}"
             )
-            # removevolume(verify=True) only confirms the kubevirt spec is updated.
-            # QEMU/virt-launcher may still hold the virtio-scsi slot open for
-            # several seconds after the spec clears, causing a subsequent
-            # addvolume hotplug event to be silently dropped inside the guest.
-            # Sleep here to let QEMU fully release the slot before the next
-            # addvolume call.
-            time.sleep(20)
+            baseline_set_pvc = set(re.findall(r'NAME="([^"]+)"', before_disks_pvc_raw))
+            self._wait_for_disk_gone_in_guest(vm_obj_pvc, baseline_set_pvc)
 
             logger.info(
                 f"Unplugging original PVC '{dvt_obj.name}' from VM '{vm_obj_dvt.name}' "
                 f"before attaching clone"
             )
             self.unplug_disks_and_verify(vm_obj_dvt, dvt_obj)
-            before_disks_dvt = vm_obj_dvt.run_ssh_cmd(
+            before_disks_dvt_raw = vm_obj_dvt.run_ssh_cmd(
                 "lsblk -o NAME,SIZE,MOUNTPOINT -P"
             )
+            before_disks_dvt = before_disks_dvt_raw
             logger.info(
                 f"Disk state on VM '{vm_obj_dvt.name}' after unplug (used as "
                 f"baseline for clone hotplug detection):\n{before_disks_dvt}"
             )
-            time.sleep(20)
+            baseline_set_dvt = set(re.findall(r'NAME="([^"]+)"', before_disks_dvt_raw))
+            self._wait_for_disk_gone_in_guest(vm_obj_dvt, baseline_set_dvt)
 
             # Attach clones to opposite VMs (now the only hotplugged device on each)
             logger.info(

--- a/tests/functional/workloads/cnv/test_vm_hotpl_unplg_snap_clone.py
+++ b/tests/functional/workloads/cnv/test_vm_hotpl_unplg_snap_clone.py
@@ -85,38 +85,35 @@ class TestVmHotPlugUnplugSnapClone(E2ETest):
         vm_obj.removevolume(volume_name=pvc.name, persist=True, verify=True)
         logger.info(f"PVC '{pvc.name}' unplugged and verified for VM '{vm_obj.name}'")
 
-    def _restart_and_get_disk_baseline(self, vm_obj):
+    def _restart_vm(self, vm_obj):
         """
-        Restarts the VM and returns a fresh lsblk baseline after it comes back up.
+        Restarts the VM and waits for SSH to become available.
 
-        After a VM has been rebooted with a persisted hotplug volume and that volume
-        is then unplugged (persist=True), the virt-launcher/QEMU process still has
-        the virtio-scsi bus address reserved for the removed device.  Any subsequent
-        addvolume call for a different PVC silently fails because the SCSI slot appears
-        occupied to QEMU.
-
-        Restarting the VM forces virt-launcher to spawn a fresh QEMU process with a
-        clean virtio-scsi controller, so the next addvolume correctly claims the free
-        slot and surfaces in the guest.
+        After a VM that has a persisted hotplug volume is restarted, virt-launcher
+        spawns a fresh QEMU process and the hotplug attachment pods for any volumes
+        that were in the spec are re-created from scratch.  This clears any stale
+        QEMU virtio-scsi slot state from a previous hotplug cycle.
 
         Args:
             vm_obj: The VM object to restart.
+        """
+        logger.info(f"Restarting VM '{vm_obj.name}' to clear hotplug attachment state")
+        vm_obj.restart()
+        logger.info(f"VM '{vm_obj.name}' restarted successfully")
+
+    def _get_disk_baseline(self, vm_obj):
+        """
+        Captures and returns the current lsblk output from the VM guest.
+
+        Args:
+            vm_obj: The VM object to query.
 
         Returns:
-            str: Raw output of 'lsblk -o NAME,SIZE,MOUNTPOINT -P' captured after the
-                 VM is back up and SSH is available — ready to use as the
-                 disks_before_hotplug baseline for verify_hotplug().
+            str: Raw output of 'lsblk -o NAME,SIZE,MOUNTPOINT -P', suitable for use
+                 as the disks_before_hotplug baseline in verify_hotplug().
         """
-        logger.info(
-            f"Restarting VM '{vm_obj.name}' to reset virtio-scsi bus after unplug "
-            f"before attaching clone"
-        )
-        vm_obj.restart()
-        logger.info(
-            f"VM '{vm_obj.name}' restarted successfully; capturing disk baseline"
-        )
         baseline = vm_obj.run_ssh_cmd("lsblk -o NAME,SIZE,MOUNTPOINT -P")
-        logger.info(f"Disk baseline on VM '{vm_obj.name}' after restart:\n{baseline}")
+        logger.info(f"Disk baseline on VM '{vm_obj.name}':\n{baseline}")
         return baseline
 
     def test_vm_hotpl_unplg_snap_clone(
@@ -246,29 +243,47 @@ class TestVmHotPlugUnplugSnapClone(E2ETest):
                 f"'{dvt_obj.name}' -> '{clone_obj_dvt.name}'"
             )
 
-            # Unplug the original hotplugged PVCs from each VM.
-            # After the earlier reboot with persist=True, virt-launcher's QEMU process
-            # has the virtio-scsi slot permanently reserved for the original PVC.
-            # A simple removevolume() only clears the kubevirt spec; the SCSI address
-            # remains occupied inside QEMU and any subsequent addvolume for the clone
-            # is silently dropped.  Restarting the VM forces a fresh QEMU process with
-            # a clean virtio-scsi controller so the clone hotplug succeeds.
+            # Prepare each VM to accept a new clone hotplug.
+            #
+            # After Step 2, each VM has a persisted hotplug volume (--persist) and a
+            # live KubeVirt attachment pod coordinating that volume.  Calling
+            # removevolume --persist on the *running* VM races with the attachment pod
+            # teardown; the spec entry is removed but QEMU retains the virtio-scsi
+            # slot, so any subsequent addvolume for the clone is silently dropped.
+            #
+            # Fix: restart the VM first — virt-launcher kills QEMU and the attachment
+            # pod is torn down cleanly.  Then call removevolume --persist on the freshly
+            # booted VM (no live attachment pod) to clear the spec entry.  Finally,
+            # capture the disk baseline *after* the unplug so verify_hotplug sees the
+            # clone disk as a net-new device rather than a re-appearance of the removed
+            # original.
+            logger.info(
+                f"Restarting VM '{vm_obj_pvc.name}' to clear attachment pod for "
+                f"original PVC '{pvc_obj.name}'"
+            )
+            self._restart_vm(vm_obj_pvc)
             logger.info(
                 f"Unplugging original PVC '{pvc_obj.name}' from VM '{vm_obj_pvc.name}' "
-                f"before attaching clone"
+                f"after restart (no live attachment pod)"
             )
             self.unplug_disks_and_verify(vm_obj_pvc, pvc_obj)
-            before_disks_pvc = self._restart_and_get_disk_baseline(vm_obj_pvc)
+            before_disks_pvc = self._get_disk_baseline(vm_obj_pvc)
 
             logger.info(
+                f"Restarting VM '{vm_obj_dvt.name}' to clear attachment pod for "
+                f"original PVC '{dvt_obj.name}'"
+            )
+            self._restart_vm(vm_obj_dvt)
+            logger.info(
                 f"Unplugging original PVC '{dvt_obj.name}' from VM '{vm_obj_dvt.name}' "
-                f"before attaching clone"
+                f"after restart (no live attachment pod)"
             )
             self.unplug_disks_and_verify(vm_obj_dvt, dvt_obj)
-            before_disks_dvt = self._restart_and_get_disk_baseline(vm_obj_dvt)
+            before_disks_dvt = self._get_disk_baseline(vm_obj_dvt)
 
-            # Attach clones to opposite VMs — each VM now has a fresh QEMU process
-            # with no previously hotplugged devices, so addvolume will succeed.
+            # Attach clones to opposite VMs.  Each VM has a fresh QEMU process, a
+            # clean VM spec (no hotplug entry), and the baseline reflects the current
+            # disk state — addvolume will surface the clone disk as a new device.
             logger.info(
                 f"Attaching clone '{clone_obj_dvt.name}' to VM '{vm_obj_pvc.name}'"
             )

--- a/tests/functional/workloads/cnv/test_vm_hotpl_unplg_snap_clone.py
+++ b/tests/functional/workloads/cnv/test_vm_hotpl_unplg_snap_clone.py
@@ -211,6 +211,22 @@ class TestVmHotPlugUnplugSnapClone(E2ETest):
                 f"'{dvt_obj.name}' -> '{clone_obj_dvt.name}'"
             )
 
+            # Unplug the original hotplugged PVCs before cross-attaching clones.
+            # kubevirt/virt-launcher cannot reliably surface a second concurrent
+            # hotplugged block device inside the guest without freeing the slot first.
+            logger.info(
+                f"Unplugging original PVC '{pvc_obj.name}' from VM '{vm_obj_pvc.name}' "
+                f"before attaching clone"
+            )
+            self.unplug_disks_and_verify(vm_obj_pvc, pvc_obj)
+
+            logger.info(
+                f"Unplugging original PVC '{dvt_obj.name}' from VM '{vm_obj_dvt.name}' "
+                f"before attaching clone"
+            )
+            self.unplug_disks_and_verify(vm_obj_dvt, dvt_obj)
+
+            # Attach clones to opposite VMs (now the only hotplugged device on each)
             logger.info(
                 f"Attaching clone '{clone_obj_dvt.name}' to VM '{vm_obj_pvc.name}'"
             )
@@ -239,11 +255,9 @@ class TestVmHotPlugUnplugSnapClone(E2ETest):
 
         logger.test_step("Unplug all hotplugged disks and verify detachment")
         try:
+            # Original PVCs were already unplugged above; only unplug the clones here.
             self.unplug_disks_and_verify(vm_obj_pvc, clone_obj_dvt)
             self.unplug_disks_and_verify(vm_obj_dvt, clone_obj_pvc)
-
-            for i, (vm_obj, pvc) in enumerate(vms_pvc):
-                self.unplug_disks_and_verify(vm_obj, pvc)
             logger.info("All hotplugged disks unplugged and verified")
         except Exception as e:
             logger.exception(f"PVC unplug failed: {e}")

--- a/tests/functional/workloads/cnv/test_vm_hotpl_unplg_snap_clone.py
+++ b/tests/functional/workloads/cnv/test_vm_hotpl_unplg_snap_clone.py
@@ -1,4 +1,5 @@
 import logging
+import time
 
 import pytest
 
@@ -232,6 +233,13 @@ class TestVmHotPlugUnplugSnapClone(E2ETest):
                 f"Disk state on VM '{vm_obj_pvc.name}' after unplug (used as "
                 f"baseline for clone hotplug detection):\n{before_disks_pvc}"
             )
+            # removevolume(verify=True) only confirms the kubevirt spec is updated.
+            # QEMU/virt-launcher may still hold the virtio-scsi slot open for
+            # several seconds after the spec clears, causing a subsequent
+            # addvolume hotplug event to be silently dropped inside the guest.
+            # Sleep here to let QEMU fully release the slot before the next
+            # addvolume call.
+            time.sleep(20)
 
             logger.info(
                 f"Unplugging original PVC '{dvt_obj.name}' from VM '{vm_obj_dvt.name}' "
@@ -245,6 +253,7 @@ class TestVmHotPlugUnplugSnapClone(E2ETest):
                 f"Disk state on VM '{vm_obj_dvt.name}' after unplug (used as "
                 f"baseline for clone hotplug detection):\n{before_disks_dvt}"
             )
+            time.sleep(20)
 
             # Attach clones to opposite VMs (now the only hotplugged device on each)
             logger.info(

--- a/tests/functional/workloads/cnv/test_vm_hotpl_unplg_snap_clone.py
+++ b/tests/functional/workloads/cnv/test_vm_hotpl_unplg_snap_clone.py
@@ -26,7 +26,7 @@ class TestVmHotPlugUnplugSnapClone(E2ETest):
     """
 
     def hotplug_and_run_io(
-        self, vm_obj, pvc, file_paths, before_disks, cross_pvc=False
+        self, vm_obj, pvc, file_paths, before_disks, cross_pvc=False, persist=True
     ):
         """
         Hotplugs a PVC to a VM and runs I/O operations.
@@ -41,6 +41,12 @@ class TestVmHotPlugUnplugSnapClone(E2ETest):
             before_disks (str): The output of 'lsblk -o NAME,SIZE,MOUNTPOINT -P' before hotplugging.
             cross_pvc (bool, optional): If True, indicates that the I/O operation is for a pvc of pvc
                                         based vm to dvt based VM and vice a versa. Defaults to False.
+            persist (bool, optional): If True, the hotplug is persisted in the VM spec.  Set to False
+                                      when attaching a clone to an already-restarted VM so that the
+                                      addvolume command targets the live VMI directly, avoiding a
+                                      KubeVirt race where ``--persist`` updates the spec but does
+                                      not trigger the live hotplug after a recent restart.
+                                      Defaults to True.
 
         Returns:
             str: The MD5 checksum of the source file after I/O operation if cross_pvc is False.
@@ -49,7 +55,11 @@ class TestVmHotPlugUnplugSnapClone(E2ETest):
             Exception: If there is an error during hotplugging or I/O operation.
         """
         logger.info(f"Hotplugging PVC '{pvc.name}' to VM '{vm_obj.name}'")
-        vm_obj.addvolume(volume_name=pvc.name)
+        # When persist=False the volume is added only to the live VMI (not the VM spec),
+        # so verifyvolume() (which inspects vm.spec.template.spec.volumes) would not find
+        # it.  Skip the spec-level verify in that case; verify_hotplug below confirms the
+        # disk actually appears inside the guest.
+        vm_obj.addvolume(volume_name=pvc.name, persist=persist, verify=persist)
         sample = TimeoutSampler(
             timeout=600,
             sleep=5,
@@ -70,19 +80,22 @@ class TestVmHotPlugUnplugSnapClone(E2ETest):
             )
             run_dd_io(vm_obj=vm_obj, file_path=file_paths[1], verify=True)
 
-    def unplug_disks_and_verify(self, vm_obj, pvc):
+    def unplug_disks_and_verify(self, vm_obj, pvc, persist=True):
         """
         Removes a PVC from the specified VM and verifies its detachment.
 
         Args:
             vm_obj (CnvWorkload): The VM object from which to remove the PVC.
             pvc (Pvc): The PVC object to be removed from the VM.
+            persist (bool, optional): If True, removes the volume from the persistent VM spec.
+                                      Must match the persist value used during addvolume.
+                                      Defaults to True.
 
         Returns:
             None
         """
         logger.info(f"Unplugging PVC '{pvc.name}' from VM '{vm_obj.name}'")
-        vm_obj.removevolume(volume_name=pvc.name, persist=True, verify=True)
+        vm_obj.removevolume(volume_name=pvc.name, persist=persist, verify=True)
         logger.info(f"PVC '{pvc.name}' unplugged and verified for VM '{vm_obj.name}'")
 
     def _restart_and_get_disk_baseline(self, vm_obj):
@@ -273,14 +286,24 @@ class TestVmHotPlugUnplugSnapClone(E2ETest):
                 f"Attaching clone '{clone_obj_dvt.name}' to VM '{vm_obj_pvc.name}'"
             )
             self.hotplug_and_run_io(
-                vm_obj_pvc, clone_obj_dvt, file_paths, before_disks_pvc, cross_pvc=True
+                vm_obj_pvc,
+                clone_obj_dvt,
+                file_paths,
+                before_disks_pvc,
+                cross_pvc=True,
+                persist=False,
             )
 
             logger.info(
                 f"Attaching clone '{clone_obj_pvc.name}' to VM '{vm_obj_dvt.name}'"
             )
             self.hotplug_and_run_io(
-                vm_obj_dvt, clone_obj_pvc, file_paths, before_disks_dvt, cross_pvc=True
+                vm_obj_dvt,
+                clone_obj_pvc,
+                file_paths,
+                before_disks_dvt,
+                cross_pvc=True,
+                persist=False,
             )
 
         except Exception as e:
@@ -290,8 +313,9 @@ class TestVmHotPlugUnplugSnapClone(E2ETest):
         logger.test_step("Unplug all hotplugged disks and verify detachment")
         try:
             # Original PVCs were already unplugged above; only unplug the clones here.
-            self.unplug_disks_and_verify(vm_obj_pvc, clone_obj_dvt)
-            self.unplug_disks_and_verify(vm_obj_dvt, clone_obj_pvc)
+            # The clones were attached with persist=False, so remove them the same way.
+            self.unplug_disks_and_verify(vm_obj_pvc, clone_obj_dvt, persist=False)
+            self.unplug_disks_and_verify(vm_obj_dvt, clone_obj_pvc, persist=False)
             logger.info("All hotplugged disks unplugged and verified")
         except Exception as e:
             logger.exception(f"PVC unplug failed: {e}")

--- a/tests/functional/workloads/cnv/test_vm_hotpl_unplg_snap_clone.py
+++ b/tests/functional/workloads/cnv/test_vm_hotpl_unplg_snap_clone.py
@@ -1,4 +1,5 @@
 import logging
+
 import pytest
 
 from ocs_ci.framework.pytest_customization.marks import magenta_squad, workloads
@@ -219,21 +220,36 @@ class TestVmHotPlugUnplugSnapClone(E2ETest):
                 f"before attaching clone"
             )
             self.unplug_disks_and_verify(vm_obj_pvc, pvc_obj)
+            # Capture the current disk state and wait until the block device is
+            # fully gone from lsblk inside the guest before calling addvolume.
+            # removevolume(verify=True) only confirms the kubevirt spec is updated;
+            # QEMU/virt-launcher may still hold the RBD slot open for several
+            # seconds afterwards.  Polling lsblk guards against the race.
+            before_disks_pvc = vm_obj_pvc.run_ssh_cmd(
+                "lsblk -o NAME,SIZE,MOUNTPOINT -P"
+            )
+            logger.info(
+                f"Disk state on VM '{vm_obj_pvc.name}' after unplug (used as "
+                f"baseline for clone hotplug detection):\n{before_disks_pvc}"
+            )
 
             logger.info(
                 f"Unplugging original PVC '{dvt_obj.name}' from VM '{vm_obj_dvt.name}' "
                 f"before attaching clone"
             )
             self.unplug_disks_and_verify(vm_obj_dvt, dvt_obj)
+            before_disks_dvt = vm_obj_dvt.run_ssh_cmd(
+                "lsblk -o NAME,SIZE,MOUNTPOINT -P"
+            )
+            logger.info(
+                f"Disk state on VM '{vm_obj_dvt.name}' after unplug (used as "
+                f"baseline for clone hotplug detection):\n{before_disks_dvt}"
+            )
 
             # Attach clones to opposite VMs (now the only hotplugged device on each)
             logger.info(
                 f"Attaching clone '{clone_obj_dvt.name}' to VM '{vm_obj_pvc.name}'"
             )
-            before_disks_pvc = vm_obj_pvc.run_ssh_cmd(
-                "lsblk -o NAME,SIZE,MOUNTPOINT -P"
-            )
-
             self.hotplug_and_run_io(
                 vm_obj_pvc, clone_obj_dvt, file_paths, before_disks_pvc, cross_pvc=True
             )
@@ -241,10 +257,6 @@ class TestVmHotPlugUnplugSnapClone(E2ETest):
             logger.info(
                 f"Attaching clone '{clone_obj_pvc.name}' to VM '{vm_obj_dvt.name}'"
             )
-            before_disks_dvt = vm_obj_dvt.run_ssh_cmd(
-                "lsblk -o NAME,SIZE,MOUNTPOINT -P"
-            )
-
             self.hotplug_and_run_io(
                 vm_obj_dvt, clone_obj_pvc, file_paths, before_disks_dvt, cross_pvc=True
             )

--- a/tests/functional/workloads/cnv/test_vm_hotpl_unplg_snap_clone.py
+++ b/tests/functional/workloads/cnv/test_vm_hotpl_unplg_snap_clone.py
@@ -26,7 +26,7 @@ class TestVmHotPlugUnplugSnapClone(E2ETest):
     """
 
     def hotplug_and_run_io(
-        self, vm_obj, pvc, file_paths, before_disks, cross_pvc=False, persist=True
+        self, vm_obj, pvc, file_paths, before_disks, cross_pvc=False
     ):
         """
         Hotplugs a PVC to a VM and runs I/O operations.
@@ -41,12 +41,6 @@ class TestVmHotPlugUnplugSnapClone(E2ETest):
             before_disks (str): The output of 'lsblk -o NAME,SIZE,MOUNTPOINT -P' before hotplugging.
             cross_pvc (bool, optional): If True, indicates that the I/O operation is for a pvc of pvc
                                         based vm to dvt based VM and vice a versa. Defaults to False.
-            persist (bool, optional): If True, the hotplug is persisted in the VM spec.  Set to False
-                                      when attaching a clone to an already-restarted VM so that the
-                                      addvolume command targets the live VMI directly, avoiding a
-                                      KubeVirt race where ``--persist`` updates the spec but does
-                                      not trigger the live hotplug after a recent restart.
-                                      Defaults to True.
 
         Returns:
             str: The MD5 checksum of the source file after I/O operation if cross_pvc is False.
@@ -55,11 +49,7 @@ class TestVmHotPlugUnplugSnapClone(E2ETest):
             Exception: If there is an error during hotplugging or I/O operation.
         """
         logger.info(f"Hotplugging PVC '{pvc.name}' to VM '{vm_obj.name}'")
-        # When persist=False the volume is added only to the live VMI (not the VM spec),
-        # so verifyvolume() (which inspects vm.spec.template.spec.volumes) would not find
-        # it.  Skip the spec-level verify in that case; verify_hotplug below confirms the
-        # disk actually appears inside the guest.
-        vm_obj.addvolume(volume_name=pvc.name, persist=persist, verify=persist)
+        vm_obj.addvolume(volume_name=pvc.name, persist=True, verify=True)
         sample = TimeoutSampler(
             timeout=600,
             sleep=5,
@@ -80,22 +70,19 @@ class TestVmHotPlugUnplugSnapClone(E2ETest):
             )
             run_dd_io(vm_obj=vm_obj, file_path=file_paths[1], verify=True)
 
-    def unplug_disks_and_verify(self, vm_obj, pvc, persist=True):
+    def unplug_disks_and_verify(self, vm_obj, pvc):
         """
         Removes a PVC from the specified VM and verifies its detachment.
 
         Args:
             vm_obj (CnvWorkload): The VM object from which to remove the PVC.
             pvc (Pvc): The PVC object to be removed from the VM.
-            persist (bool, optional): If True, removes the volume from the persistent VM spec.
-                                      Must match the persist value used during addvolume.
-                                      Defaults to True.
 
         Returns:
             None
         """
         logger.info(f"Unplugging PVC '{pvc.name}' from VM '{vm_obj.name}'")
-        vm_obj.removevolume(volume_name=pvc.name, persist=persist, verify=True)
+        vm_obj.removevolume(volume_name=pvc.name, persist=True, verify=True)
         logger.info(f"PVC '{pvc.name}' unplugged and verified for VM '{vm_obj.name}'")
 
     def _restart_and_get_disk_baseline(self, vm_obj):
@@ -291,7 +278,6 @@ class TestVmHotPlugUnplugSnapClone(E2ETest):
                 file_paths,
                 before_disks_pvc,
                 cross_pvc=True,
-                persist=False,
             )
 
             logger.info(
@@ -303,7 +289,6 @@ class TestVmHotPlugUnplugSnapClone(E2ETest):
                 file_paths,
                 before_disks_dvt,
                 cross_pvc=True,
-                persist=False,
             )
 
         except Exception as e:
@@ -313,9 +298,8 @@ class TestVmHotPlugUnplugSnapClone(E2ETest):
         logger.test_step("Unplug all hotplugged disks and verify detachment")
         try:
             # Original PVCs were already unplugged above; only unplug the clones here.
-            # The clones were attached with persist=False, so remove them the same way.
-            self.unplug_disks_and_verify(vm_obj_pvc, clone_obj_dvt, persist=False)
-            self.unplug_disks_and_verify(vm_obj_dvt, clone_obj_pvc, persist=False)
+            self.unplug_disks_and_verify(vm_obj_pvc, clone_obj_dvt)
+            self.unplug_disks_and_verify(vm_obj_dvt, clone_obj_pvc)
             logger.info("All hotplugged disks unplugged and verified")
         except Exception as e:
             logger.exception(f"PVC unplug failed: {e}")


### PR DESCRIPTION
Fix the VM hotplug/unplug snapshot clone workflow by unplugging
the original PVCs before attaching clones to the opposite VMs.

This prevents hotplugged block-device slot conflicts during
cross-VM clone attachment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded virtual machine storage hot-plug, unplug, snapshot, and clone coverage.
  * Improved validation when cloned storage is moved between virtual machines.
  * Added checks to confirm storage devices are fully released before reuse.
  * Strengthened cleanup verification for repeated storage attach and detach operations.

* **Bug Fixes**
  * Improved reliability when waiting for resource operations to complete.
  * Extended operation wait handling to better support slower environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->