### PR TITLE
remove rbd/cephfs_dr_scenario flags; reorder RDR deploy steps

### DIFF
--- a/docs/usecases/ocs-ci-rdr-deployment.md
+++ b/docs/usecases/ocs-ci-rdr-deployment.md
@@ -624,12 +624,6 @@ UPGRADE_TEST_ORDER = {
 ### Configuration Parameters
 
 ```python
-# DR configuration dictionary
-dr_conf = {
-    "rbd_dr_scenario": True/False,      # Enable RBD DR
-    "cephfs_dr_scenario": True/False,   # Enable CephFS DR
-}
-
 # Environment variables
 ENV_DATA = {
     "skip_dr_deployment": False,

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -5250,10 +5250,6 @@ class RDRMultiClusterDROperatorsDeploy(MultiClusterDROperatorsDeploy):
         )
         exec_cmd(f"oc create -f {thanos_data_yaml.name}")
 
-        logger.info("Thanos secret created, checking observability status")
-        self.check_observability_status()
-        logger.info("Observability status check passed, thanos_secret() completed")
-
     def enable_acm_observability(self):
         """
         Function to enable ACM observability for enabling DR monitoring dashboard for Regional DR on the RHACM console.
@@ -5300,6 +5296,10 @@ class RDRMultiClusterDROperatorsDeploy(MultiClusterDROperatorsDeploy):
         )
 
         exec_cmd(f"oc create -f {multiclusterobservability_data_yaml.name}")
+
+        logger.info("Thanos secret created, checking observability status")
+        self.check_observability_status()
+        logger.info("Observability status check passed, thanos_secret() completed")
 
         # Ensure we're in ACM context after thanos_secret() completes
         # (in case context was switched during ODF bucket creation)

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -5269,6 +5269,14 @@ class RDRMultiClusterDROperatorsDeploy(MultiClusterDROperatorsDeploy):
             )
             return
 
+        logger.info(f"Creating namespace {constants.ACM_OBSERVABILITY_NAMESPACE}")
+        observability_namespace = OCP(
+            kind=constants.NAMESPACE,
+            resource_name=constants.ACM_OBSERVABILITY_NAMESPACE,
+        )
+        if not observability_namespace.is_exist():
+            exec_cmd(f"oc create namespace {constants.ACM_OBSERVABILITY_NAMESPACE}")
+
         logger.info("Create thanos secret yaml")
         self.thanos_secret()
 

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -1086,7 +1086,7 @@ class Deployment(object):
 
         """
         dr_conf = dict()
-        dr_conf["dr_metadata_store"] = config.ENV_DATA.get("dr_metadata_store", "awss3")
+        dr_conf["rbd_dr_scenario"] = config.ENV_DATA.get("rbd_dr_scenario", False)
         return dr_conf
 
     def deploy_ocp(self, log_cli_level="DEBUG"):
@@ -3821,13 +3821,7 @@ class MultiClusterDROperatorsDeploy(object):
     """
 
     def __init__(self, dr_conf):
-        self.meta_map = {
-            "awss3": self.s3_meta_obj_store,
-            "mcg": self.mcg_meta_obj_store,
-        }
-        # Default to s3 for metadata store
-        self.meta_obj_store = dr_conf.get("dr_metadata_store", "awss3")
-        self.meta_obj = self.meta_map[self.meta_obj_store]()
+        self.meta_obj = self.s3_meta_obj_store()
         self.channel = config.DEPLOYMENT.get("ocs_csv_channel")
 
     def deploy(self):
@@ -4955,6 +4949,10 @@ class RDRMultiClusterDROperatorsDeploy(MultiClusterDROperatorsDeploy):
 
     def __init__(self, dr_conf):
         super().__init__(dr_conf)
+        # DR use case could be RBD or CephFS or Both
+        self.rbd = dr_conf.get("rbd_dr_scenario", False)
+        # CephFS For future usecase
+        self.cephfs = dr_conf.get("cephfs_dr_scenario", False)
 
     def deploy(self):
         """
@@ -5056,24 +5054,20 @@ class RDRMultiClusterDROperatorsDeploy(MultiClusterDROperatorsDeploy):
             # create service exporter
             create_service_exporter()
 
-        # RBD DR deployment
-        rbddops = RBDDRDeployOps()
-        self.configure_mirror_peer()
-        rbddops.deploy()
+        # RBD specific dr deployment
+        if self.rbd:
+            rbddops = RBDDRDeployOps()
+            self.configure_mirror_peer()
+            rbddops.deploy()
 
         self.apply_custom_ramen_image()
-
-        logger.info("Creating Drpolicy")
-        self.deploy_dr_policy()
-
-        # Adding Ca Cert
-        self.add_cacert_ramen_configmap()
 
         multicluster_observability = ocp.OCP(kind="MultiClusterObservability")
         if not multicluster_observability.get()["items"]:
             # TODO: Check whether this need to be enabled for each pair of RDR clusters
             self.enable_acm_observability()
 
+        self.deploy_dr_policy()
         if odf_running_version >= version.VERSION_4_19:
             # validate storage cluster peer state
             validate_storage_cluster_peer_state()
@@ -5152,7 +5146,8 @@ class RDRMultiClusterDROperatorsDeploy(MultiClusterDROperatorsDeploy):
         config.switch_acm_ctx()
         if config.ENV_DATA["platform"] == constants.IBMCLOUD_PLATFORM:
             apply_oadp_workaround(namespace=constants.ACM_HUB_BACKUP_NAMESPACE)
-
+        # Adding Ca Cert
+        self.add_cacert_ramen_configmap()
         # Only on the active hub enable managedserviceaccount-preview
         managed_clusters = get_non_acm_cluster_config()
         for cluster in managed_clusters:

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -1085,9 +1085,7 @@ class Deployment(object):
             dict: of Regional DR config parameters
 
         """
-        dr_conf = dict()
-        dr_conf["rbd_dr_scenario"] = config.ENV_DATA.get("rbd_dr_scenario", False)
-        return dr_conf
+        return dict()
 
     def deploy_ocp(self, log_cli_level="DEBUG"):
         """
@@ -4949,10 +4947,6 @@ class RDRMultiClusterDROperatorsDeploy(MultiClusterDROperatorsDeploy):
 
     def __init__(self, dr_conf):
         super().__init__(dr_conf)
-        # DR use case could be RBD or CephFS or Both
-        self.rbd = dr_conf.get("rbd_dr_scenario", False)
-        # CephFS For future usecase
-        self.cephfs = dr_conf.get("cephfs_dr_scenario", False)
 
     def deploy(self):
         """
@@ -5054,11 +5048,10 @@ class RDRMultiClusterDROperatorsDeploy(MultiClusterDROperatorsDeploy):
             # create service exporter
             create_service_exporter()
 
-        # RBD specific dr deployment
-        if self.rbd:
-            rbddops = RBDDRDeployOps()
-            self.configure_mirror_peer()
-            rbddops.deploy()
+        # RBD dr deployment
+        rbddops = RBDDRDeployOps()
+        self.configure_mirror_peer()
+        rbddops.deploy()
 
         self.apply_custom_ramen_image()
 

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -846,8 +846,7 @@ class Deployment(object):
         if config.ENV_DATA.get("skip_dr_deployment", False):
             return
         if config.multicluster:
-            dr_conf = self.get_rdr_conf()
-            deploy_dr = get_multicluster_dr_deployment()(dr_conf)
+            deploy_dr = get_multicluster_dr_deployment()()
             deploy_dr.deploy()
 
     def do_deploy_lvmo(self):
@@ -1076,16 +1075,6 @@ class Deployment(object):
         self.do_deploy_fusion_access()
         self.do_deploy_hosted_spoke_clusters()
         self.do_deploy_external_spoke_clusters()
-
-    def get_rdr_conf(self):
-        """
-        Aggregate important Regional DR parameters in the dictionary
-
-        Returns:
-            dict: of Regional DR config parameters
-
-        """
-        return dict()
 
     def deploy_ocp(self, log_cli_level="DEBUG"):
         """
@@ -3818,7 +3807,7 @@ class MultiClusterDROperatorsDeploy(object):
 
     """
 
-    def __init__(self, dr_conf):
+    def __init__(self):
         self.meta_obj = self.s3_meta_obj_store()
         self.channel = config.DEPLOYMENT.get("ocs_csv_channel")
 
@@ -4945,8 +4934,8 @@ class RDRMultiClusterDROperatorsDeploy(MultiClusterDROperatorsDeploy):
     A class for Regional-DR deployments
     """
 
-    def __init__(self, dr_conf):
-        super().__init__(dr_conf)
+    def __init__(self):
+        super().__init__()
 
     def deploy(self):
         """
@@ -5325,8 +5314,8 @@ class MDRMultiClusterDROperatorsDeploy(MultiClusterDROperatorsDeploy):
     A class for Metro-DR deployments
     """
 
-    def __init__(self, dr_conf):
-        super().__init__(dr_conf)
+    def __init__(self):
+        super().__init__()
 
     def deploy(self):
         # We need multicluster orchestrator on both the active/passive ACM clusters

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -5269,6 +5269,9 @@ class RDRMultiClusterDROperatorsDeploy(MultiClusterDROperatorsDeploy):
             )
             return
 
+        logger.info("Create thanos secret yaml")
+        self.thanos_secret()
+
         logger.info(
             "Enabling ACM MultiClusterObservability for DR monitoring dashboard"
         )
@@ -5289,9 +5292,6 @@ class RDRMultiClusterDROperatorsDeploy(MultiClusterDROperatorsDeploy):
         )
 
         exec_cmd(f"oc create -f {multiclusterobservability_data_yaml.name}")
-
-        logger.info("Create thanos secret yaml")
-        self.thanos_secret()
 
         # Ensure we're in ACM context after thanos_secret() completes
         # (in case context was switched during ODF bucket creation)

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -5043,13 +5043,15 @@ class RDRMultiClusterDROperatorsDeploy(MultiClusterDROperatorsDeploy):
         rbddops.deploy()
 
         self.apply_custom_ramen_image()
-
+        logger.info("Deploying DR policy")
+        self.deploy_dr_policy()
+        logger.info("Adding CA cert to Ramen configmap")
+        self.add_cacert_ramen_configmap()
         multicluster_observability = ocp.OCP(kind="MultiClusterObservability")
         if not multicluster_observability.get()["items"]:
             # TODO: Check whether this need to be enabled for each pair of RDR clusters
             self.enable_acm_observability()
 
-        self.deploy_dr_policy()
         if odf_running_version >= version.VERSION_4_19:
             # validate storage cluster peer state
             validate_storage_cluster_peer_state()
@@ -5128,8 +5130,6 @@ class RDRMultiClusterDROperatorsDeploy(MultiClusterDROperatorsDeploy):
         config.switch_acm_ctx()
         if config.ENV_DATA["platform"] == constants.IBMCLOUD_PLATFORM:
             apply_oadp_workaround(namespace=constants.ACM_HUB_BACKUP_NAMESPACE)
-        # Adding Ca Cert
-        self.add_cacert_ramen_configmap()
         # Only on the active hub enable managedserviceaccount-preview
         managed_clusters = get_non_acm_cluster_config()
         for cluster in managed_clusters:

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -1086,7 +1086,6 @@ class Deployment(object):
 
         """
         dr_conf = dict()
-        dr_conf["rbd_dr_scenario"] = config.ENV_DATA.get("rbd_dr_scenario", False)
         dr_conf["dr_metadata_store"] = config.ENV_DATA.get("dr_metadata_store", "awss3")
         return dr_conf
 
@@ -4956,10 +4955,6 @@ class RDRMultiClusterDROperatorsDeploy(MultiClusterDROperatorsDeploy):
 
     def __init__(self, dr_conf):
         super().__init__(dr_conf)
-        # DR use case could be RBD or CephFS or Both
-        self.rbd = dr_conf.get("rbd_dr_scenario", False)
-        # CephFS For future usecase
-        self.cephfs = dr_conf.get("cephfs_dr_scenario", False)
 
     def deploy(self):
         """
@@ -5061,20 +5056,24 @@ class RDRMultiClusterDROperatorsDeploy(MultiClusterDROperatorsDeploy):
             # create service exporter
             create_service_exporter()
 
-        # RBD specific dr deployment
-        if self.rbd:
-            rbddops = RBDDRDeployOps()
-            self.configure_mirror_peer()
-            rbddops.deploy()
+        # RBD DR deployment
+        rbddops = RBDDRDeployOps()
+        self.configure_mirror_peer()
+        rbddops.deploy()
 
         self.apply_custom_ramen_image()
+
+        logger.info("Creating Drpolicy")
+        self.deploy_dr_policy()
+
+        # Adding Ca Cert
+        self.add_cacert_ramen_configmap()
 
         multicluster_observability = ocp.OCP(kind="MultiClusterObservability")
         if not multicluster_observability.get()["items"]:
             # TODO: Check whether this need to be enabled for each pair of RDR clusters
             self.enable_acm_observability()
 
-        self.deploy_dr_policy()
         if odf_running_version >= version.VERSION_4_19:
             # validate storage cluster peer state
             validate_storage_cluster_peer_state()
@@ -5153,8 +5152,7 @@ class RDRMultiClusterDROperatorsDeploy(MultiClusterDROperatorsDeploy):
         config.switch_acm_ctx()
         if config.ENV_DATA["platform"] == constants.IBMCLOUD_PLATFORM:
             apply_oadp_workaround(namespace=constants.ACM_HUB_BACKUP_NAMESPACE)
-        # Adding Ca Cert
-        self.add_cacert_ramen_configmap()
+
         # Only on the active hub enable managedserviceaccount-preview
         managed_clusters = get_non_acm_cluster_config()
         for cluster in managed_clusters:

--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -1652,7 +1652,7 @@ def get_all_drpolicy():
         drpolicy_obj = ocp.OCP(kind=constants.DRPOLICY)
         drpolicy_list = drpolicy_obj.get(all_namespaces=True).get("items")
     # Build list of managed clusters for DR
-    # Include clusters with rbd_dr_scenario (RDR) or in metro-dr mode (MDR)
+    # Include clusters in RDR or MDR mode
     # Exclude all ACM hubs (both active and passive) as they are not managed clusters
     multicluster_mode = config.MULTICLUSTER.get("multicluster_mode")
     acm_indexes = get_all_acm_indexes()
@@ -1663,10 +1663,7 @@ def get_all_drpolicy():
         if cluster_index in acm_indexes:
             continue
 
-        if (
-            cluster_name.ENV_DATA.get("rbd_dr_scenario")
-            or multicluster_mode == constants.MDR_MODE
-        ):
+        if multicluster_mode in (constants.RDR_MODE, constants.MDR_MODE):
             current_managed_clusters_list.append(
                 cluster_name.ENV_DATA.get("cluster_name")
             )
@@ -3199,8 +3196,9 @@ def get_cluster_set_name(switch_ctx=None):
     restore_index = config.cur_index
     config.switch_ctx(switch_ctx) if switch_ctx else config.switch_acm_ctx()
     managed_clusters = ocp.OCP(kind=constants.ACM_MANAGEDCLUSTER).get().get("items", [])
+    multicluster_mode = config.MULTICLUSTER.get("multicluster_mode")
     for cluster_name in config.clusters:
-        if cluster_name.ENV_DATA.get("rbd_dr_scenario"):
+        if multicluster_mode == constants.RDR_MODE:
             current_managed_clusters_list.append(
                 cluster_name.ENV_DATA.get("cluster_name")
             )

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -3651,6 +3651,7 @@ OADP_SUBSCRIPTION_YAML = os.path.join(
 )
 OADP_NS_YAML = os.path.join(TEMPLATE_DIR, "oadp-deployment", "namespace_opg_oadp.yaml")
 ACM_HUB_BACKUP_NAMESPACE = "open-cluster-management-backup"
+ACM_OBSERVABILITY_NAMESPACE = "open-cluster-management-observability"
 ACM_HUB_RESTORE = "Restore"
 ACM_BACKUP_SCHEDULE = "BackupSchedule"
 KLUSTERLET_CONFIG = "KlusterletConfig"

--- a/tests/functional/disaster-recovery/regional-dr/test_deploy_rdr.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_deploy_rdr.py
@@ -32,7 +32,7 @@ Required config parameters in multicluster_mode_rdr.yaml:
         skip_post_deployment_validation: false  # Skip post-deployment validation
 
         # Optional parameters
-        dr_metadata_store: "awss3"           # Metadata store type (awss3 or mcg)
+        rbd_dr_scenario: true                # For RBD DR scenario
 """
 
 import logging
@@ -94,9 +94,7 @@ def test_deploy_rdr():
     log.info(f"  - Multicluster mode: {multicluster_mode}")
     log.info(f"  - Multicluster enabled: {config.multicluster}")
     log.info(f"  - Number of clusters: {config.nclusters}")
-    log.info(
-        f"  - DR metadata store: {config.ENV_DATA.get('dr_metadata_store', 'awss3')}"
-    )
+    log.info(f"  - RBD DR scenario: {config.ENV_DATA.get('rbd_dr_scenario', False)}")
 
     # ========================================================================
     # STEP 2: Detect and Deploy ACM Hub (if needed)

--- a/tests/functional/disaster-recovery/regional-dr/test_deploy_rdr.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_deploy_rdr.py
@@ -31,8 +31,6 @@ Required config parameters in multicluster_mode_rdr.yaml:
         skip_dr_deployment: false            # Skip RDR deployment
         skip_post_deployment_validation: false  # Skip post-deployment validation
 
-        # Optional parameters
-        rbd_dr_scenario: true                # For RBD DR scenario
 """
 
 import logging
@@ -94,8 +92,6 @@ def test_deploy_rdr():
     log.info(f"  - Multicluster mode: {multicluster_mode}")
     log.info(f"  - Multicluster enabled: {config.multicluster}")
     log.info(f"  - Number of clusters: {config.nclusters}")
-    log.info(f"  - RBD DR scenario: {config.ENV_DATA.get('rbd_dr_scenario', False)}")
-
     # ========================================================================
     # STEP 2: Detect and Deploy ACM Hub (if needed)
     # ========================================================================

--- a/tests/functional/disaster-recovery/regional-dr/test_deploy_rdr.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_deploy_rdr.py
@@ -32,7 +32,6 @@ Required config parameters in multicluster_mode_rdr.yaml:
         skip_post_deployment_validation: false  # Skip post-deployment validation
 
         # Optional parameters
-        rbd_dr_scenario: true                # For RBD DR scenario
         dr_metadata_store: "awss3"           # Metadata store type (awss3 or mcg)
 """
 
@@ -95,7 +94,6 @@ def test_deploy_rdr():
     log.info(f"  - Multicluster mode: {multicluster_mode}")
     log.info(f"  - Multicluster enabled: {config.multicluster}")
     log.info(f"  - Number of clusters: {config.nclusters}")
-    log.info(f"  - RBD DR scenario: {config.ENV_DATA.get('rbd_dr_scenario', False)}")
     log.info(
         f"  - DR metadata store: {config.ENV_DATA.get('dr_metadata_store', 'awss3')}"
     )


### PR DESCRIPTION

- Remove rbd_dr_scenario and cephfs_dr_scenario feature flags; RBD mirroring is always required for RDR so the conditional was dead code
- Make RBD deploy block (configure_mirror_peer + RBDDRDeployOps) unconditional
- Replace per-cluster rbd_dr_scenario ENV_DATA checks in dr_helpers.py with multicluster_mode checks (RDR_MODE/MDR_MODE)
- Move deploy_dr_policy() and add_cacert_ramen_configmap() earlier in RDR deploy sequence, before observability and OADP setup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Regional disaster recovery deployments now consistently configure RBD mirroring and related policies.
  * Managed clusters are selected according to the configured multicluster mode for more predictable disaster recovery behavior.
  * Disaster recovery setup requires fewer configuration settings.
  * Deployment sequencing for policies, certificates, and observability has been improved for more reliable setup.
  * ACM observability setup now uses a consistent namespace configuration.

* **Documentation**
  * Removed outdated RBD scenario and metadata store configuration references from deployment guidance and validation output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->