### PR TITLE
Test fix for test_run_amq_respin_pod[rbdplugin_provisioner]

### DIFF
--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -2288,9 +2288,9 @@ def get_odf_external_snapshotter_leader(namespace=None):
     """
     namespace = namespace or config.ENV_DATA["cluster_namespace"]
 
-    non_leader_msg = "Failed to acquire lease"
-    lease_acq_msg = "Successfully acquired lease"
-    lease_renew_msg = "Successfully renewed lease"
+    non_leader_msg = "failed to acquire lease"
+    lease_acq_msg = "successfully acquired lease"
+    lease_renew_msg = "successfully renewed lease"
     leader_pod = ""
 
     # Get all ODF external snapshotter pods
@@ -2310,11 +2310,16 @@ def get_odf_external_snapshotter_leader(namespace=None):
         for log_msg in log_list:
             # Check for last occurrence of leader message
             # This will be the first occurrence in reversed list.
-            if (lease_renew_msg in log_msg) or (lease_acq_msg in log_msg):
+            # Use case-insensitive comparison to handle both old (lowercase)
+            # and new structured-logging (Title-case) leaderelection messages.
+            log_msg_lower = log_msg.lower()
+            if (lease_renew_msg in log_msg_lower) or (lease_acq_msg in log_msg_lower):
                 curr_index = log_list.index(log_msg)
                 # Ensure that there is no non leader message logged after
                 # the last occurrence of leader message
-                if not any(non_leader_msg in msg for msg in log_list[:curr_index]):
+                if not any(
+                    non_leader_msg in msg.lower() for msg in log_list[:curr_index]
+                ):
                     leader_pod = pod
                 break
     assert leader_pod, "Couldn't identify ODF external snapshotter leader pod."


### PR DESCRIPTION
What this PR does

Applies the same case-insensitive leaderelection log matching from #15567 to get_odf_external_snapshotter_leader() — the remaining case that was still pending after that PR was merged.

Background

#15567 fixed get_plugin_provisioner_leader() for the Kubernetes structured-logging change that switched leaderelection messages between lowercase and Title-case (e.g. successfully renewed lease ↔ Successfully renewed lease). get_odf_external_snapshotter_leader() had the identical case-sensitive matching and was left unfixed, so it still fails to identify the leader on affected clusters:

AssertionError: Couldn't identify ODF external snapshotter leader pod.

Fix

In ocs_ci/ocs/resources/pod.py, get_odf_external_snapshotter_leader():
- Lowercased the expected message constants (successfully acquired/renewed lease, failed to acquire lease).
- Lowercased each log line before the in comparison, for both the leader (acquire/renew) and non-leader checks.

Backward-compatible with both old (Title-case) and new (lowercase) log formats.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved external snapshotter leader detection to recognize both lowercase and title-case leader-election log messages.
  - Increased reliability when identifying the active leader pod across different structured logging formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->