### PR TITLE
Add Prometheus CLI fallback for ApplicationCleanupPending alert verification

### DIFF
--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -4773,3 +4773,149 @@ def validate_cluster_odf_cli(retries=5, retry_interval=60):
         f"ODF DR validate clusters did not report success after {retries} attempts. "
         f"Output:\n{last_stdout}"
     )
+
+
+def verify_pending_cleanup_alert_firing_cli(
+    operation="Failover", drpc_name=None, namespace=None, timeout=120
+):
+    """
+    Verify that the ApplicationCleanupPending alert is firing via Prometheus CLI.
+
+    This is a CLI-based alternative to the Selenium UI check.  The alert is
+    queried directly from the Prometheus API on the ACM hub cluster.
+
+    Args:
+        operation (str): DR operation name used only for log messages
+            (``"Failover"`` or ``"Relocate"``).
+        drpc_name (str): When provided, the alert must carry a label
+            ``drpc_name=<drpc_name>`` to be considered a match.
+        namespace (str): Namespace used only for log context.  Defaults to
+            ``constants.DR_OPS_NAMESPACE``.
+        timeout (int): Seconds to wait for the alert to appear in firing state.
+
+    Raises:
+        AssertionError: If the alert does not reach firing state within
+            ``timeout`` seconds.
+    """
+    import threading
+
+    from ocs_ci.utility.prometheus import PrometheusAPI, wait_for_alert_firing
+
+    namespace = namespace or constants.DR_OPS_NAMESPACE
+    restore_index = config.cur_index
+    try:
+        config.switch_acm_ctx()
+        logger.info(
+            f"[CLI] Verifying '{constants.ALERT_APPLICATION_CLEANUP_PENDING}' "
+            f"alert is firing via Prometheus after {operation}"
+            + (
+                f" for DRPC '{drpc_name}' in namespace '{namespace}'"
+                if drpc_name
+                else ""
+            )
+        )
+        prometheus_api = PrometheusAPI(threading_lock=threading.Lock())
+        alerts = wait_for_alert_firing(
+            api=prometheus_api,
+            alert_name=constants.ALERT_APPLICATION_CLEANUP_PENDING,
+            timeout=timeout,
+        )
+        # If a specific DRPC name is expected, confirm at least one matching instance
+        if drpc_name:
+            matching = [
+                a
+                for a in alerts
+                if a.get("labels", {}).get("drpc_name") == drpc_name
+                or a.get("labels", {}).get("name") == drpc_name
+            ]
+            assert matching, (
+                f"'{constants.ALERT_APPLICATION_CLEANUP_PENDING}' alert fired but "
+                f"no instance matched DRPC '{drpc_name}'. Got labels: "
+                + str([a.get("labels") for a in alerts])
+            )
+            logger.info(
+                f"[CLI] Alert '{constants.ALERT_APPLICATION_CLEANUP_PENDING}' "
+                f"confirmed firing for DRPC '{drpc_name}' after {operation}"
+            )
+        else:
+            logger.info(
+                f"[CLI] Alert '{constants.ALERT_APPLICATION_CLEANUP_PENDING}' "
+                f"confirmed firing after {operation}"
+            )
+    finally:
+        config.switch_ctx(restore_index)
+
+
+def verify_pending_cleanup_alert_resolved_cli(
+    operation="Failover", drpc_name=None, namespace=None, timeout=120
+):
+    """
+    Verify that the ApplicationCleanupPending alert is no longer firing via Prometheus CLI.
+
+    Args:
+        operation (str): DR operation name used only for log messages.
+        drpc_name (str): When provided, only alerts whose ``drpc_name`` label
+            matches this value are considered.  The check passes when no such
+            alert is still active.
+        namespace (str): Namespace used only for log context.  Defaults to
+            ``constants.DR_OPS_NAMESPACE``.
+        timeout (int): Seconds to wait for the alert to disappear.
+
+    Raises:
+        AssertionError: If the alert is still firing after ``timeout`` seconds.
+    """
+    import threading
+    import time as _time
+
+    from ocs_ci.utility.prometheus import PrometheusAPI, wait_for_alert_cleared
+
+    namespace = namespace or constants.DR_OPS_NAMESPACE
+    restore_index = config.cur_index
+    try:
+        config.switch_acm_ctx()
+        logger.info(
+            f"[CLI] Verifying '{constants.ALERT_APPLICATION_CLEANUP_PENDING}' "
+            f"alert is cleared via Prometheus after {operation} cleanup"
+            + (f" for DRPC '{drpc_name}'" if drpc_name else "")
+        )
+        prometheus_api = PrometheusAPI(threading_lock=threading.Lock())
+        if drpc_name:
+            # Poll until no firing instance matches the specific DRPC
+            deadline = _time.time() + timeout
+            while _time.time() < deadline:
+                alerts = prometheus_api.get_alerts_by_labels(
+                    alert_name=constants.ALERT_APPLICATION_CLEANUP_PENDING,
+                    labels_dict={"drpc_name": drpc_name},
+                )
+                if not alerts:
+                    # Also check by 'name' label as some versions use that key
+                    alerts = prometheus_api.get_alerts_by_labels(
+                        alert_name=constants.ALERT_APPLICATION_CLEANUP_PENDING,
+                        labels_dict={"name": drpc_name},
+                    )
+                if not alerts:
+                    logger.info(
+                        f"[CLI] Alert '{constants.ALERT_APPLICATION_CLEANUP_PENDING}' "
+                        f"cleared for DRPC '{drpc_name}' after {operation} cleanup"
+                    )
+                    return
+                logger.info(
+                    f"[CLI] Alert still present for DRPC '{drpc_name}', waiting..."
+                )
+                _time.sleep(10)
+            raise AssertionError(
+                f"'{constants.ALERT_APPLICATION_CLEANUP_PENDING}' alert for DRPC "
+                f"'{drpc_name}' did not clear within {timeout}s after {operation} cleanup"
+            )
+        else:
+            wait_for_alert_cleared(
+                api=prometheus_api,
+                alert_name=constants.ALERT_APPLICATION_CLEANUP_PENDING,
+                timeout=timeout,
+            )
+            logger.info(
+                f"[CLI] Alert '{constants.ALERT_APPLICATION_CLEANUP_PENDING}' "
+                f"cleared after {operation} cleanup"
+            )
+    finally:
+        config.switch_ctx(restore_index)

--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -4827,6 +4827,7 @@ def verify_pending_cleanup_alert_firing_cli(
                 for a in alerts
                 if a.get("labels", {}).get("drpc_name") == drpc_name
                 or a.get("labels", {}).get("name") == drpc_name
+                or a.get("labels", {}).get("obj_name") == drpc_name
             ]
             assert matching, (
                 f"'{constants.ALERT_APPLICATION_CLEANUP_PENDING}' alert fired but "

--- a/ocs_ci/ocs/ui/acm_ui.py
+++ b/ocs_ci/ocs/ui/acm_ui.py
@@ -225,7 +225,10 @@ class AcmPageNavigator(BaseUI):
             log.error(
                 "Couldn't navigate to Disaster recovery Overview page under 'Data Services' on ACM console"
             )
-            raise NoSuchElementException
+            raise NoSuchElementException(
+                "Data Services nav element not found on ACM console; "
+                "page may not have loaded or the UI layout changed"
+            )
 
     def navigate_from_ocp_to_acm_cluster_page(self, locator="click-local-cluster"):
         """

--- a/tests/functional/disaster-recovery/regional-dr/test_failover_and_relocate_discovered_apps.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_failover_and_relocate_discovered_apps.py
@@ -11,6 +11,8 @@ from ocs_ci.helpers.dr_helpers import (
     wait_for_replication_destinations_creation,
     wait_for_replication_destinations_deletion,
     is_cg_cephfs_enabled,
+    verify_pending_cleanup_alert_firing_cli,
+    verify_pending_cleanup_alert_resolved_cli,
 )
 from ocs_ci.ocs.node import get_node_objs, wait_for_nodes_status
 from ocs_ci.ocs.resources.drpc import DRPC
@@ -199,11 +201,21 @@ class TestFailoverAndRelocateWithDiscoveredApps:
 
             # Verify alert firing for each workload
             for rdr_workload in rdr_workloads:
-                verify_pending_cleanup_alert_firing(
-                    acm_obj,
-                    "Failover",
-                    drpc_name=rdr_workload.discovered_apps_placement_name,
-                )
+                try:
+                    verify_pending_cleanup_alert_firing(
+                        acm_obj,
+                        "Failover",
+                        drpc_name=rdr_workload.discovered_apps_placement_name,
+                    )
+                except Exception as ui_exc:
+                    logger.warning(
+                        f"UI alert verification failed ({ui_exc}); "
+                        "falling back to Prometheus CLI check"
+                    )
+                    verify_pending_cleanup_alert_firing_cli(
+                        operation="Failover",
+                        drpc_name=rdr_workload.discovered_apps_placement_name,
+                    )
 
         for rdr_workload in rdr_workloads:
             logger.info("Doing Cleanup Operations")
@@ -219,11 +231,21 @@ class TestFailoverAndRelocateWithDiscoveredApps:
         if get_semantic_ocs_version_from_config() >= Version("4.22", partial=True):
             # Verify alert resolved for each workload
             for rdr_workload in rdr_workloads:
-                verify_pending_cleanup_alert_resolved(
-                    acm_obj,
-                    "Failover",
-                    drpc_name=rdr_workload.discovered_apps_placement_name,
-                )
+                try:
+                    verify_pending_cleanup_alert_resolved(
+                        acm_obj,
+                        "Failover",
+                        drpc_name=rdr_workload.discovered_apps_placement_name,
+                    )
+                except Exception as ui_exc:
+                    logger.warning(
+                        f"UI alert-resolved verification failed ({ui_exc}); "
+                        "falling back to Prometheus CLI check"
+                    )
+                    verify_pending_cleanup_alert_resolved_cli(
+                        operation="Failover",
+                        drpc_name=rdr_workload.discovered_apps_placement_name,
+                    )
 
         # Verify resources creation on secondary cluster (failoverCluster)
         config.switch_to_cluster_by_name(secondary_cluster_name)
@@ -315,11 +337,21 @@ class TestFailoverAndRelocateWithDiscoveredApps:
 
             # Verify alert firing for each workload
             for rdr_workload in rdr_workloads:
-                verify_pending_cleanup_alert_firing(
-                    acm_obj,
-                    "Relocate",
-                    drpc_name=rdr_workload.discovered_apps_placement_name,
-                )
+                try:
+                    verify_pending_cleanup_alert_firing(
+                        acm_obj,
+                        "Relocate",
+                        drpc_name=rdr_workload.discovered_apps_placement_name,
+                    )
+                except Exception as ui_exc:
+                    logger.warning(
+                        f"UI alert verification failed ({ui_exc}); "
+                        "falling back to Prometheus CLI check"
+                    )
+                    verify_pending_cleanup_alert_firing_cli(
+                        operation="Relocate",
+                        drpc_name=rdr_workload.discovered_apps_placement_name,
+                    )
 
             # Manual cleanup after relocate
             for rdr_workload in rdr_workloads:
@@ -334,11 +366,21 @@ class TestFailoverAndRelocateWithDiscoveredApps:
 
             # Verify alert resolved for each workload
             for rdr_workload in rdr_workloads:
-                verify_pending_cleanup_alert_resolved(
-                    acm_obj,
-                    "Relocate",
-                    drpc_name=rdr_workload.discovered_apps_placement_name,
-                )
+                try:
+                    verify_pending_cleanup_alert_resolved(
+                        acm_obj,
+                        "Relocate",
+                        drpc_name=rdr_workload.discovered_apps_placement_name,
+                    )
+                except Exception as ui_exc:
+                    logger.warning(
+                        f"UI alert-resolved verification failed ({ui_exc}); "
+                        "falling back to Prometheus CLI check"
+                    )
+                    verify_pending_cleanup_alert_resolved_cli(
+                        operation="Relocate",
+                        drpc_name=rdr_workload.discovered_apps_placement_name,
+                    )
 
         # Verify resources creation on primary cluster (preferredCluster)
         config.switch_to_cluster_by_name(primary_cluster_name_before_failover)

--- a/tests/functional/disaster-recovery/regional-dr/test_failover_and_relocate_discovered_apps.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_failover_and_relocate_discovered_apps.py
@@ -26,6 +26,11 @@ from ocs_ci.helpers.dr_helpers_ui import (
     verify_pending_cleanup_alert_resolved,
 )
 from ocs_ci.ocs.acm.acm import AcmAddClusters
+from ocs_ci.ocs.exceptions import UnexpectedBehaviour
+from selenium.common.exceptions import (
+    NoSuchElementException,
+    StaleElementReferenceException,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -207,7 +212,11 @@ class TestFailoverAndRelocateWithDiscoveredApps:
                         "Failover",
                         drpc_name=rdr_workload.discovered_apps_placement_name,
                     )
-                except Exception as ui_exc:
+                except (
+                    NoSuchElementException,
+                    StaleElementReferenceException,
+                    UnexpectedBehaviour,
+                ) as ui_exc:
                     logger.warning(
                         f"UI alert verification failed ({ui_exc}); "
                         "falling back to Prometheus CLI check"
@@ -237,7 +246,11 @@ class TestFailoverAndRelocateWithDiscoveredApps:
                         "Failover",
                         drpc_name=rdr_workload.discovered_apps_placement_name,
                     )
-                except Exception as ui_exc:
+                except (
+                    NoSuchElementException,
+                    StaleElementReferenceException,
+                    UnexpectedBehaviour,
+                ) as ui_exc:
                     logger.warning(
                         f"UI alert-resolved verification failed ({ui_exc}); "
                         "falling back to Prometheus CLI check"
@@ -343,7 +356,11 @@ class TestFailoverAndRelocateWithDiscoveredApps:
                         "Relocate",
                         drpc_name=rdr_workload.discovered_apps_placement_name,
                     )
-                except Exception as ui_exc:
+                except (
+                    NoSuchElementException,
+                    StaleElementReferenceException,
+                    UnexpectedBehaviour,
+                ) as ui_exc:
                     logger.warning(
                         f"UI alert verification failed ({ui_exc}); "
                         "falling back to Prometheus CLI check"
@@ -372,7 +389,11 @@ class TestFailoverAndRelocateWithDiscoveredApps:
                         "Relocate",
                         drpc_name=rdr_workload.discovered_apps_placement_name,
                     )
-                except Exception as ui_exc:
+                except (
+                    NoSuchElementException,
+                    StaleElementReferenceException,
+                    UnexpectedBehaviour,
+                ) as ui_exc:
                     logger.warning(
                         f"UI alert-resolved verification failed ({ui_exc}); "
                         "falling back to Prometheus CLI check"


### PR DESCRIPTION

Wrap UI alert checks in try/except and fall back to Prometheus CLI (verify_pending_cleanup_alert_firing/resolved_cli) when Selenium fails with NoSuchElementException. CLI helpers added to dr_helpers.py. Also fix navigate_data_services() to raise NoSuchElementException with a message instead of the bare class.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved verification of application cleanup alerts during disaster recovery failover and relocate operations.
  * Added Prometheus-based fallback checks when UI alert verification is unavailable or encounters supported errors.
  * Improved validation that cleanup alerts transition correctly to firing and resolved states.
  * Added clearer error messages when Data Services navigation cannot be found.
  * Improved handling of alert verification timeouts and matching workload details for more reliable recovery operation checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->