### PR TITLE
LSO UI depl. Fix NextBtn ElementClickInterceptedException

### DIFF
--- a/ocs_ci/ocs/ui/deployment_ui.py
+++ b/ocs_ci/ocs/ui/deployment_ui.py
@@ -23,7 +23,10 @@ from ocs_ci.ocs.node import (
     label_nodes,
 )
 from ocs_ci.utility.operators import LocalStorageOperator
-from selenium.common.exceptions import WebDriverException
+from selenium.common.exceptions import (
+    ElementClickInterceptedException,
+    WebDriverException,
+)
 from selenium.webdriver.common.by import By
 
 logger = logging.getLogger(__name__)
@@ -439,8 +442,18 @@ class DeploymentUI(PageNavigator):
         self.create_storage_cluster()
 
     def wait_next_button_lso(self):
+        next_loc = self.dep_loc.get("next_button_element", self.dep_loc["next"])
         try:
-            self.do_click(self.dep_loc["next"], enable_screenshot=True, timeout=20)
+            self.do_click(next_loc, enable_screenshot=True, copy_dom=True, timeout=20)
+        except ElementClickInterceptedException:
+            logger.warning(
+                "Next button click intercepted, retrying with JavaScript click"
+            )
+            try:
+                self.click_with_script(next_loc)
+            except Exception as e:
+                logger.error(f"JavaScript click on Next button also failed: {e}")
+                return False
         except Exception as e:
             logger.error(f"Next button on LSO error: {e}")
             return False


### PR DESCRIPTION
 1. Import ElementClickInterceptedException from selenium
 2. Updated wait_next_button_lso to:
    - Use "next_button_element" locator (//button[normalize-space(.)='Next']) which targets the
  <button> directly — so element_to_be_clickable correctly waits for the button to be enabled instead
  of finding the always-"clickable" inner <span>
    - Falls back to old "next" locator on OCP < 4.22
    - On ElementClickInterceptedException, retries via click_with_script (JS dispatchEvent, bypasses
  coordinate-based clicking)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when advancing through deployment steps.
  * Added fallback handling for cases where an overlay blocks the Next button.
  * Automatically retries the action when the initial click is intercepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->