### PR TITLE
RHSTOR-8840- cnsa operator fix for fdf standalone deployment

### DIFF
--- a/ocs_ci/deployment/fdf_standalone.py
+++ b/ocs_ci/deployment/fdf_standalone.py
@@ -48,6 +48,7 @@ import tempfile
 from ocs_ci.framework import config
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.resources.catalog_source import CatalogSource
+from ocs_ci.ocs.resources.ocs import OCP
 from ocs_ci.utility import templating
 from ocs_ci.utility.deployment import get_and_apply_idms_from_catalog
 from ocs_ci.utility.utils import exec_cmd
@@ -275,6 +276,71 @@ def _validate_catalog_image():
     return catalog_image
 
 
+def create_cnsa_operator_subscription():
+    """
+    Create the ``ibm-spectrum-scale-operator`` Subscription in the
+    ``ibm-spectrum-scale`` namespace.
+
+    The ``cnsa-dependencies`` bundle (channel ``stable-4.23``) declares a
+    bundle-level dependency on ``ibm-spectrum-scale-operator >= 60.1.100``.
+    OLM's namespace-scoped resolver requires an *explicit* Subscription for
+    every required package — it will not auto-create one even when a
+    compatible version is visible in the catalog.  Without this Subscription
+    the ``cnsa-dependencies`` Subscription stays in ``ResolutionFailed``
+    indefinitely and no CNSA pods ever start.
+
+    The ``ibm-spectrum-scale`` namespace and its OperatorGroup are created
+    by the ``ocs-operator`` reconciler before this function is called; both
+    are labeled ``odf.openshift.io/managed-by-odf-operator``.
+
+    This function is idempotent: calling it on a cluster that already has
+    the Subscription is a no-op.
+    """
+    namespace = constants.IBM_STORAGE_SCALE_NAMESPACE
+    package = constants.IBM_STORAGE_SCALE_OPERATOR_PACKAGE
+    channel = constants.IBM_STORAGE_SCALE_OPERATOR_CHANNEL
+
+    sub_ocp = OCP(kind=constants.SUBSCRIPTION_COREOS, namespace=namespace)
+    if sub_ocp.is_exist(resource_name=package):
+        logger.info(
+            "Subscription '%s' already exists in namespace '%s', skipping",
+            package,
+            namespace,
+        )
+        return
+
+    logger.info(
+        "Creating Subscription '%s' (channel '%s') in namespace '%s'",
+        package,
+        channel,
+        namespace,
+    )
+    subscription_data = {
+        "apiVersion": "operators.coreos.com/v1alpha1",
+        "kind": "Subscription",
+        "metadata": {
+            "name": package,
+            "namespace": namespace,
+        },
+        "spec": {
+            "channel": channel,
+            "name": package,
+            "source": constants.FDF_STANDALONE_CATALOG_SOURCE_NAME,
+            "sourceNamespace": constants.MARKETPLACE_NAMESPACE,
+        },
+    }
+    kubeconfig = config.RUN["kubeconfig"]
+    with tempfile.NamedTemporaryFile(
+        mode="w+", suffix=".yaml", prefix="cnsa_sub_", delete=False
+    ) as sub_file:
+        templating.dump_data_to_temp_yaml(subscription_data, sub_file.name)
+        exec_cmd(
+            f"oc --kubeconfig {kubeconfig} apply -f {sub_file.name}",
+            timeout=60,
+        )
+    logger.info("Subscription '%s' created in namespace '%s'", package, namespace)
+
+
 def create_fdf_standalone_catalog_source():
     """
     Entry-point called from :func:`deploy_ocs_via_operator` when
@@ -291,10 +357,14 @@ def create_fdf_standalone_catalog_source():
     3. Create (or verify) the ``ibm-operators`` CatalogSource and wait
        for READY so that the standard ODF Subscription can resolve
        ``odf-operator`` from it.
+    4. Create the ``ibm-spectrum-scale-operator`` Subscription in the
+       ``ibm-spectrum-scale`` namespace so that OLM can resolve the
+       bundle dependency declared by ``cnsa-dependencies``.
     """
     catalog_image = _validate_catalog_image()
     _apply_fdf_mirror_sets(catalog_image)
     StandaloneFDFCatalogSource().create_catalog_source()
+    create_cnsa_operator_subscription()
 
 
 def is_fdf_standalone_deployment() -> bool:

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -2907,6 +2907,8 @@ RHCOS = "RHCOS"
 
 # Scale constants
 IBM_STORAGE_SCALE_NAMESPACE = "ibm-spectrum-scale"
+IBM_STORAGE_SCALE_OPERATOR_PACKAGE = "ibm-spectrum-scale-operator"
+IBM_STORAGE_SCALE_OPERATOR_CHANNEL = "stable-v60.2"
 IBM_ENTITLEMENT_SECRET_NAME = "ibm-entitlement-key"
 IBM_QUAYIO_SECRET_NAME = "quayio-secret"
 REMOTE_CLUSTER = "RemoteCluster"

--- a/ocs_ci/templates/fusion-data-foundation/image-digest-mirror-set.yaml
+++ b/ocs_ci/templates/fusion-data-foundation/image-digest-mirror-set.yaml
@@ -135,10 +135,13 @@ spec:
           source: registry.redhat.io/rhel9/postgresql-15
         - mirrors:
             - cp.stg.icr.io/cp/gpfs
+            - preprod.icr.io/cp/gpfs
           source: cp.icr.io/cp/gpfs
         - mirrors:
             - cp.stg.icr.io/cp/spectrum/scale
+            - preprod.icr.io/cp/spectrum/scale
           source: cp.icr.io/cp/spectrum/scale
         - mirrors:
             - cp.stg.icr.io/cp
+            - preprod.icr.io/cpopen
           source: icr.io/cpopen


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic creation of the IBM Spectrum Scale operator subscription during Fusion Data Foundation standalone setup.
  - Added support for the Spectrum Scale operator’s stable channel.

- **Bug Fixes**
  - Improved image mirroring coverage by adding pre-production registry sources for GPFS, Spectrum Scale, and related platform images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->