### PR TITLE
Skip odf-cli fixtures for test_deploy_rdr

### DIFF
--- a/tests/functional/disaster-recovery/regional-dr/conftest.py
+++ b/tests/functional/disaster-recovery/regional-dr/conftest.py
@@ -117,6 +117,12 @@ def rdr_health_check(request):
     if config.MULTICLUSTER.get("multicluster_mode") != constants.RDR_MODE:
         return
 
+    if request.session.items:
+        for item in request.session.items:
+            if "test_deploy_rdr" in item.nodeid:
+                log.info("Skipping rdr_health_check fixture for test_deploy_rdr")
+                return
+
     if config.RUN["cli_params"].get("dev_mode"):
         log.info("Skipping RDR health checks for development mode")
         return

--- a/tests/functional/disaster-recovery/regional-dr/conftest.py
+++ b/tests/functional/disaster-recovery/regional-dr/conftest.py
@@ -62,16 +62,28 @@ def pytest_collection_modifyitems(items):
 
 
 @pytest.fixture(autouse=True, scope="session")
-def setup_odf_cli_binary():
+def setup_odf_cli_binary(request):
     if config.MULTICLUSTER.get("multicluster_mode") != constants.RDR_MODE:
         return
+    if request.session.items:
+        for item in request.session.items:
+            if "test_deploy_rdr" in item.nodeid:
+                log.info("Skipping setup_odf_cli_binary fixture for test_deploy_rdr")
+                return
     odf_cli_setup_helper()
 
 
 @pytest.fixture(autouse=True, scope="session")
-def update_odf_cli_dr_kubeconfigs(setup_odf_cli_binary):
+def update_odf_cli_dr_kubeconfigs(request, setup_odf_cli_binary):
     if config.MULTICLUSTER.get("multicluster_mode") != constants.RDR_MODE:
         return
+    if request.session.items:
+        for item in request.session.items:
+            if "test_deploy_rdr" in item.nodeid:
+                log.info(
+                    "Skipping update_odf_cli_dr_kubeconfigs fixture for test_deploy_rdr"
+                )
+                return
     update_odf_cli_dr_config_kubeconfigs()
 
 


### PR DESCRIPTION
Add early-return guard to setup_odf_cli_binary and update_odf_cli_dr_kubeconfigs fixtures so they are skipped when test_deploy_rdr is in the session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved regional disaster-recovery test handling by skipping unnecessary CLI and kubeconfig preparation when deployment recovery tests are included.
  * Added clearer logging to indicate when these setup steps are skipped, helping test results and execution behavior remain easier to understand.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->