### PR TITLE
Fix empty hosted-cluster kubeconfig left after failed hcp download.

### DIFF
--- a/ocs_ci/deployment/helpers/hypershift_base.py
+++ b/ocs_ci/deployment/helpers/hypershift_base.py
@@ -1129,7 +1129,9 @@ class HyperShiftBase:
         Args:
             name (str): name of the cluster
             cluster_path (str): path to create auth_path folder and download kubeconfig there
-            from_hcp (bool): if True, use hcp binary to download kubeconfig, otherwise use ocp secret
+            from_hcp (bool): If True, try hcp first; fall back to extracting the
+                admin-kubeconfig secret if hcp fails or writes an empty file.
+                If False, extract the secret only.
 
         Returns:
             str: path to the downloaded kubeconfig, None if failed
@@ -1146,10 +1148,6 @@ class HyperShiftBase:
             )
             os.remove(kubeconfig_path)
 
-        # touch the file
-        time.sleep(0.5)
-        open(kubeconfig_path, "a").close()
-
         logger.info(
             f"Downloading kubeconfig for HyperShift hosted cluster {name} to {kubeconfig_path}"
         )
@@ -1161,22 +1159,42 @@ class HyperShiftBase:
                         f"{self.hcp_binary_path} create kubeconfig --name {name} > {kubeconfig_path}",
                         shell=True,
                     )
-                else:
+                if not from_hcp or not (
+                    os.path.isfile(kubeconfig_path)
+                    and os.stat(kubeconfig_path).st_size > 0
+                ):
+                    if from_hcp:
+                        logger.warning(
+                            "hcp kubeconfig download for '%s' failed or was "
+                            "empty; falling back to admin-kubeconfig secret",
+                            name,
+                        )
+                        if os.path.isfile(kubeconfig_path):
+                            os.remove(kubeconfig_path)
                     # kubeconfig will be stored with name 'kubeconfig'
                     OCP().exec_oc_cmd(
                         f"extract secret/admin-kubeconfig -n clusters-{name} "
-                        f"--to {os.path.dirname(kubeconfig_path)} --confirm"
+                        f"--to {auth_path} --confirm"
                     )
         except Exception as e:
             logger.error(
                 f"Failed to download kubeconfig for HyperShift hosted cluster {name}\n{e}"
             )
+            if (
+                os.path.isfile(kubeconfig_path)
+                and os.stat(kubeconfig_path).st_size == 0
+            ):
+                os.remove(kubeconfig_path)
             return
 
-        if not os.stat(kubeconfig_path).st_size > 0:
+        if not (
+            os.path.isfile(kubeconfig_path) and os.stat(kubeconfig_path).st_size > 0
+        ):
             logger.error(
                 f"Failed to download kubeconfig for HyperShift hosted cluster {name}"
             )
+            if os.path.isfile(kubeconfig_path):
+                os.remove(kubeconfig_path)
             return
         return kubeconfig_path
 

--- a/ocs_ci/deployment/helpers/hypershift_base.py
+++ b/ocs_ci/deployment/helpers/hypershift_base.py
@@ -1120,6 +1120,64 @@ class HyperShiftBase:
             if sample == "Completed":
                 return True
 
+    @staticmethod
+    def _is_nonempty_kubeconfig(kubeconfig_path):
+        """
+        Return True if kubeconfig_path exists and has content.
+        """
+        return os.path.isfile(kubeconfig_path) and os.stat(kubeconfig_path).st_size > 0
+
+    def _download_hosted_kubeconfig_via_hcp(self, name, kubeconfig_path):
+        """
+        Download hosted cluster kubeconfig using the hcp binary.
+
+        Runs hcp without shell=True so path/name are not interpolated into a
+        shell command, and writes stdout to kubeconfig_path only after success.
+
+        Args:
+            name (str): Hosted cluster name
+            kubeconfig_path (str): Destination kubeconfig path
+
+        Returns:
+            bool: True if a non-empty kubeconfig was written
+        """
+        try:
+            completed = exec_cmd(
+                [
+                    self.hcp_binary_path,
+                    "create",
+                    "kubeconfig",
+                    "--name",
+                    name,
+                ],
+            )
+            kubeconfig_data = completed.stdout
+            if kubeconfig_data:
+                if isinstance(kubeconfig_data, bytes):
+                    kubeconfig_data = kubeconfig_data.decode("utf-8")
+                with open(kubeconfig_path, "w") as kubeconfig_file:
+                    kubeconfig_file.write(kubeconfig_data)
+        except Exception as e:
+            logger.warning(
+                "hcp kubeconfig download for '%s' failed: %s",
+                name,
+                e,
+            )
+            if os.path.isfile(kubeconfig_path):
+                os.remove(kubeconfig_path)
+            return False
+
+        if self._is_nonempty_kubeconfig(kubeconfig_path):
+            return True
+
+        logger.warning(
+            "hcp kubeconfig download for '%s' produced an empty file",
+            name,
+        )
+        if os.path.isfile(kubeconfig_path):
+            os.remove(kubeconfig_path)
+        return False
+
     def download_hosted_cluster_kubeconfig(
         self, name: str, cluster_path: str, from_hcp: bool = True
     ):
@@ -1154,34 +1212,15 @@ class HyperShiftBase:
             f"Downloading kubeconfig for HyperShift hosted cluster {name} to {kubeconfig_path}"
         )
 
-        def _kubeconfig_ready():
-            return (
-                os.path.isfile(kubeconfig_path) and os.stat(kubeconfig_path).st_size > 0
-            )
-
         with config.RunWithProviderConfigContextIfAvailable():
             if from_hcp:
-                try:
-                    exec_cmd(
-                        f"{self.hcp_binary_path} create kubeconfig --name {name} "
-                        f"> {kubeconfig_path}",
-                        shell=True,
-                    )
-                except Exception as e:
-                    logger.warning(
-                        "hcp kubeconfig download for '%s' failed: %s",
-                        name,
-                        e,
-                    )
-                if _kubeconfig_ready():
+                if self._download_hosted_kubeconfig_via_hcp(name, kubeconfig_path):
                     return kubeconfig_path
                 logger.warning(
                     "hcp kubeconfig download for '%s' failed or was empty; "
                     "falling back to admin-kubeconfig secret",
                     name,
                 )
-                if os.path.isfile(kubeconfig_path):
-                    os.remove(kubeconfig_path)
 
             try:
                 # kubeconfig will be stored with name 'kubeconfig'
@@ -1205,7 +1244,7 @@ class HyperShiftBase:
                     f"cluster {name}"
                 ) from e
 
-        if not _kubeconfig_ready():
+        if not self._is_nonempty_kubeconfig(kubeconfig_path):
             logger.error(
                 f"Failed to download kubeconfig for HyperShift hosted cluster {name}"
             )

--- a/ocs_ci/deployment/helpers/hypershift_base.py
+++ b/ocs_ci/deployment/helpers/hypershift_base.py
@@ -1134,8 +1134,10 @@ class HyperShiftBase:
                 If False, extract the secret only.
 
         Returns:
-            str: path to the downloaded kubeconfig, None if failed
+            str: path to the downloaded kubeconfig
 
+        Raises:
+            CommandFailed: If kubeconfig could not be downloaded
         """
         path_abs = os.path.expanduser(cluster_path)
         auth_path = os.path.join(path_abs, "auth")
@@ -1152,50 +1154,67 @@ class HyperShiftBase:
             f"Downloading kubeconfig for HyperShift hosted cluster {name} to {kubeconfig_path}"
         )
 
-        try:
-            with config.RunWithProviderConfigContextIfAvailable():
-                if from_hcp:
+        def _kubeconfig_ready():
+            return (
+                os.path.isfile(kubeconfig_path) and os.stat(kubeconfig_path).st_size > 0
+            )
+
+        with config.RunWithProviderConfigContextIfAvailable():
+            if from_hcp:
+                try:
                     exec_cmd(
-                        f"{self.hcp_binary_path} create kubeconfig --name {name} > {kubeconfig_path}",
+                        f"{self.hcp_binary_path} create kubeconfig --name {name} "
+                        f"> {kubeconfig_path}",
                         shell=True,
                     )
-                if not from_hcp or not (
-                    os.path.isfile(kubeconfig_path)
-                    and os.stat(kubeconfig_path).st_size > 0
-                ):
-                    if from_hcp:
-                        logger.warning(
-                            "hcp kubeconfig download for '%s' failed or was "
-                            "empty; falling back to admin-kubeconfig secret",
-                            name,
-                        )
-                        if os.path.isfile(kubeconfig_path):
-                            os.remove(kubeconfig_path)
-                    # kubeconfig will be stored with name 'kubeconfig'
-                    OCP().exec_oc_cmd(
-                        f"extract secret/admin-kubeconfig -n clusters-{name} "
-                        f"--to {auth_path} --confirm"
+                except Exception as e:
+                    logger.warning(
+                        "hcp kubeconfig download for '%s' failed: %s",
+                        name,
+                        e,
                     )
-        except Exception as e:
-            logger.error(
-                f"Failed to download kubeconfig for HyperShift hosted cluster {name}\n{e}"
-            )
-            if (
-                os.path.isfile(kubeconfig_path)
-                and os.stat(kubeconfig_path).st_size == 0
-            ):
-                os.remove(kubeconfig_path)
-            return
+                if _kubeconfig_ready():
+                    return kubeconfig_path
+                logger.warning(
+                    "hcp kubeconfig download for '%s' failed or was empty; "
+                    "falling back to admin-kubeconfig secret",
+                    name,
+                )
+                if os.path.isfile(kubeconfig_path):
+                    os.remove(kubeconfig_path)
 
-        if not (
-            os.path.isfile(kubeconfig_path) and os.stat(kubeconfig_path).st_size > 0
-        ):
+            try:
+                # kubeconfig will be stored with name 'kubeconfig'
+                OCP().exec_oc_cmd(
+                    f"extract secret/admin-kubeconfig -n clusters-{name} "
+                    f"--to {auth_path} --confirm"
+                )
+            except Exception as e:
+                logger.error(
+                    "Failed to extract admin-kubeconfig for HyperShift "
+                    "hosted cluster %s\n%s",
+                    name,
+                    e,
+                )
+                if os.path.isfile(kubeconfig_path) and (
+                    os.stat(kubeconfig_path).st_size == 0
+                ):
+                    os.remove(kubeconfig_path)
+                raise CommandFailed(
+                    f"Failed to download kubeconfig for HyperShift hosted "
+                    f"cluster {name}"
+                ) from e
+
+        if not _kubeconfig_ready():
             logger.error(
                 f"Failed to download kubeconfig for HyperShift hosted cluster {name}"
             )
             if os.path.isfile(kubeconfig_path):
                 os.remove(kubeconfig_path)
-            return
+            raise CommandFailed(
+                f"Failed to download kubeconfig for HyperShift hosted "
+                f"cluster {name}"
+            )
         return kubeconfig_path
 
     @staticmethod
@@ -1615,6 +1634,9 @@ def create_kubeconfig_file_hosted_cluster():
 
     This function is wrapped with retry decorator to handle CommandFailed errors.
     It will retry up to 5 times with 30 sec  delay between attempts.
+
+    Raises:
+        CommandFailed: if the kubeconfig file could not be downloaded
     """
     cluster_path = config.ENV_DATA["cluster_path"]
     cluster_name = config.ENV_DATA["cluster_name"]

--- a/ocs_ci/deployment/helpers/hypershift_base.py
+++ b/ocs_ci/deployment/helpers/hypershift_base.py
@@ -2,6 +2,7 @@ import logging
 import os
 import re
 import shutil
+import subprocess
 import tempfile
 import time
 from datetime import datetime
@@ -1132,7 +1133,8 @@ class HyperShiftBase:
         Download hosted cluster kubeconfig using the hcp binary.
 
         Runs hcp without shell=True so path/name are not interpolated into a
-        shell command, and writes stdout to kubeconfig_path only after success.
+        shell command. Writes stdout directly to kubeconfig_path so the
+        kubeconfig (credentials) is never logged via exec_cmd DEBUG stdout.
 
         Args:
             name (str): Hosted cluster name
@@ -1142,21 +1144,40 @@ class HyperShiftBase:
             bool: True if a non-empty kubeconfig was written
         """
         try:
-            completed = exec_cmd(
-                [
-                    self.hcp_binary_path,
-                    "create",
-                    "kubeconfig",
-                    "--name",
+            env = os.environ.copy()
+            provider_kubeconfig = config.RUN.get("kubeconfig")
+            if provider_kubeconfig:
+                env["KUBECONFIG"] = provider_kubeconfig
+            with open(kubeconfig_path, "w") as out_f:
+                completed = subprocess.run(
+                    [
+                        self.hcp_binary_path,
+                        "create",
+                        "kubeconfig",
+                        "--name",
+                        name,
+                    ],
+                    stdout=out_f,
+                    stderr=subprocess.PIPE,
+                    timeout=600,
+                    env=env,
+                    check=False,
+                )
+            if completed.returncode != 0:
+                stderr = (
+                    completed.stderr.decode(errors="replace")
+                    if completed.stderr
+                    else ""
+                )
+                logger.warning(
+                    "hcp kubeconfig download for '%s' failed (rc=%s): %s",
                     name,
-                ],
-            )
-            kubeconfig_data = completed.stdout
-            if kubeconfig_data:
-                if isinstance(kubeconfig_data, bytes):
-                    kubeconfig_data = kubeconfig_data.decode("utf-8")
-                with open(kubeconfig_path, "w") as kubeconfig_file:
-                    kubeconfig_file.write(kubeconfig_data)
+                    completed.returncode,
+                    stderr,
+                )
+                if os.path.isfile(kubeconfig_path):
+                    os.remove(kubeconfig_path)
+                return False
         except Exception as e:
             logger.warning(
                 "hcp kubeconfig download for '%s' failed: %s",


### PR DESCRIPTION
## Summary
  - Stop pre-touching `auth/kubeconfig` before download (left a zero-byte file on failure)
  - If `hcp create kubeconfig` fails or writes an empty file, fall back to extracting the `admin-kubeconfig` secret
  - Remove any empty leftover kubeconfig so spoke `oc` calls do not hit "Missing or incomplete configuration info"
  ## Test plan
  - [ ] Re-run hosted client ODF deploy on provider-client (e.g. `c1-422-1`) and confirm kubeconfig under
  `hosted_cluster_path/auth/kubeconfig` is non-empty
  - [ ] Confirm FDF/ODF client install proceeds past CSV checks on the spoke cluster


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hosted cluster kubeconfig retrieval with automatic fallback when the primary method fails or returns empty output.
  * Validated kubeconfig files before use and removed incomplete artifacts after failed attempts.
  * Standardized the location of generated authentication files.
  * Improved error reporting when kubeconfig retrieval fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->