### PR TITLE
Enable CephX key rotation tests on ODF 5.0

### DIFF
--- a/tests/functional/cephx_keyrotation/test_cephx_keyrotation_bootstrap_cleanup.py
+++ b/tests/functional/cephx_keyrotation/test_cephx_keyrotation_bootstrap_cleanup.py
@@ -33,7 +33,7 @@ pytestmark = pytest.mark.skip(
 
 
 @skipif_external_mode
-@skipif_ocs_version(["<4.21", ">=4.23"])
+@skipif_ocs_version("<4.21")
 @green_squad
 @pytest.mark.order("last")
 class TestCephXBootstrapKeyCleanup:

--- a/tests/functional/cephx_keyrotation/test_cephx_keyrotation_configuration.py
+++ b/tests/functional/cephx_keyrotation/test_cephx_keyrotation_configuration.py
@@ -28,7 +28,7 @@ EXPECTED_INITIAL_GENERATION = 2
 
 
 @skipif_external_mode
-@skipif_ocs_version(["<4.21", ">=4.23"])
+@skipif_ocs_version("<4.21")
 @skipif_ibm_hci_platform
 @green_squad
 @pytest.mark.order("first")
@@ -110,7 +110,7 @@ class TestCephXKeyRotationPolicyDisabled:
 
 
 @skipif_external_mode
-@skipif_ocs_version(["<4.21", ">=4.23"])
+@skipif_ocs_version("<4.21")
 @skipif_ibm_hci_platform
 @green_squad
 class TestCephXAllowedCiphers:

--- a/tests/functional/cephx_keyrotation/test_cephx_keyrotation_daemon_rotation.py
+++ b/tests/functional/cephx_keyrotation/test_cephx_keyrotation_daemon_rotation.py
@@ -41,7 +41,7 @@ POST_ROTATION_PVC_SIZE = 5
 
 
 @skipif_external_mode
-@skipif_ocs_version(["<4.21", ">=4.23"])
+@skipif_ocs_version("<4.21")
 @green_squad
 class TestCephXKeyRotation:
     @pytest.mark.polarion_id("OCS-8128")
@@ -388,7 +388,7 @@ class TestCephXKeyRotation:
 
 
 @skipif_external_mode
-@skipif_ocs_version(["<4.21", ">=4.23"])
+@skipif_ocs_version("<4.21")
 @green_squad
 class TestCephXKeyRotationIdempotency:
     @pytest.mark.polarion_id("OCS-8131")
@@ -463,7 +463,7 @@ class TestCephXKeyRotationIdempotency:
 
 
 @skipif_external_mode
-@skipif_ocs_version(["<4.21", ">=4.23"])
+@skipif_ocs_version("<4.21")
 @green_squad
 class TestCephXKeyRotationIOContinuity:
     @pytest.mark.polarion_id("OCS-8132")

--- a/tests/functional/cephx_keyrotation/test_cephx_keyrotation_metrics_exporter.py
+++ b/tests/functional/cephx_keyrotation/test_cephx_keyrotation_metrics_exporter.py
@@ -24,7 +24,7 @@ log = logging.getLogger(__name__)
 
 
 @skipif_external_mode
-@skipif_ocs_version(["<4.21", ">=4.23"])
+@skipif_ocs_version("<4.21")
 @green_squad
 class TestCephXMetricsExporterRotation:
     @pytest.mark.polarion_id("OCS-8136")

--- a/tests/functional/cephx_keyrotation/test_cephx_keyrotation_mismatch_alert.py
+++ b/tests/functional/cephx_keyrotation/test_cephx_keyrotation_mismatch_alert.py
@@ -483,7 +483,7 @@ def _induce_daemon_key_mismatch(rotator, namespace):
 
 
 @skipif_external_mode
-@skipif_ocs_version(["<4.21", ">=4.23"])
+@skipif_ocs_version("<4.21")
 @green_squad
 class TestCephXKeyRotationMismatchMetric:
     """TC1–TC2: mismatch metric emission and in-sync (value 0) state."""
@@ -549,7 +549,7 @@ class TestCephXKeyRotationMismatchMetric:
 
 
 @skipif_external_mode
-@skipif_ocs_version(["<4.21", ">=4.23"])
+@skipif_ocs_version("<4.21")
 @green_squad
 @ignore_leftovers
 class TestCephXKeyRotationMismatchAlertLifecycle:
@@ -864,7 +864,7 @@ class TestCephXKeyRotationMismatchAlertLifecycle:
 
 
 @skipif_external_mode
-@skipif_ocs_version(["<4.21", ">=4.23"])
+@skipif_ocs_version("<4.21")
 @green_squad
 class TestCephXKeyRotationMismatchNoFilesystem:
     """TC7: MDS mismatch metric is 0 when no CephFilesystem exists."""
@@ -894,7 +894,7 @@ class TestCephXKeyRotationMismatchNoFilesystem:
 
 
 @skipif_external_mode
-@skipif_ocs_version(["<4.21", ">=4.23"])
+@skipif_ocs_version("<4.21")
 @green_squad
 class TestCephXCephClusterReconciliation:
     """TC8–TC13: CephCluster annotations and daemon keyGeneration reconciliation."""
@@ -1171,7 +1171,7 @@ class TestCephXCephClusterReconciliation:
 
 
 @skipif_external_mode
-@skipif_ocs_version(["<4.21", ">=4.23"])
+@skipif_ocs_version("<4.21")
 @green_squad
 class TestCephXCephClientAnnotations:
     """TC14–TC15: CephClient created-with-cephx-features and keyType."""
@@ -1259,7 +1259,7 @@ class TestCephXCephClientAnnotations:
 
 
 @skipif_external_mode
-@skipif_ocs_version(["<4.21", ">=4.23"])
+@skipif_ocs_version("<4.21")
 @green_squad
 @ignore_leftovers
 class TestCephXDesiredKeyGenNegative:

--- a/tests/functional/cephx_keyrotation/test_cephx_keyrotation_negative.py
+++ b/tests/functional/cephx_keyrotation/test_cephx_keyrotation_negative.py
@@ -50,7 +50,7 @@ CSI_POST_ROTATION_PVC_SIZE = 5
 
 
 @skipif_external_mode
-@skipif_ocs_version(["<4.21", ">=4.23"])
+@skipif_ocs_version("<4.21")
 @green_squad
 @ignore_leftovers
 class TestCephXKeyRotationNegative:
@@ -318,7 +318,7 @@ class TestCephXKeyRotationNegative:
 
     @pytest.mark.polarion_id("OCS-8157")
     @tier2
-    @skipif_ocs_version(["<4.21", ">=4.23"])
+    @skipif_ocs_version("<4.21")
     def test_cephx_daemon_key_generation_decrease_rejected(
         self, cephx_keyrotation_setup
     ):
@@ -426,7 +426,7 @@ class TestCephXKeyRotationNegative:
 
 
 @skipif_external_mode
-@skipif_ocs_version(["<4.21", ">=4.23"])
+@skipif_ocs_version("<4.21")
 @green_squad
 @ignore_leftovers
 class TestCephXKeyRotationNegativeOSD:
@@ -607,7 +607,7 @@ class TestCephXKeyRotationNegativeOSD:
 
 
 @skipif_external_mode
-@skipif_ocs_version(["<4.21", ">=4.23"])
+@skipif_ocs_version("<4.21")
 @green_squad
 @ignore_leftovers
 class TestCephXKeyRotationNegativeEncryptedCSI:

--- a/tests/functional/cephx_keyrotation/test_cephx_keyrotation_node_cordon.py
+++ b/tests/functional/cephx_keyrotation/test_cephx_keyrotation_node_cordon.py
@@ -32,7 +32,7 @@ MIN_OSD_NODES = 3
 
 
 @skipif_external_mode
-@skipif_ocs_version(["<4.21", ">=4.23"])
+@skipif_ocs_version("<4.21")
 @green_squad
 @ignore_leftovers
 class TestCephXKeyRotationNodeCordon:

--- a/tests/functional/cephx_keyrotation/test_cephx_keyrotation_osd_lockbox.py
+++ b/tests/functional/cephx_keyrotation/test_cephx_keyrotation_osd_lockbox.py
@@ -27,7 +27,7 @@ MIN_ENCRYPTED_OSD_COUNT = 1
 
 
 @skipif_external_mode
-@skipif_ocs_version(["<4.21", ">=4.23"])
+@skipif_ocs_version("<4.21")
 @green_squad
 class TestCephXKeyRotationOSDLockbox:
     @pytest.mark.polarion_id("OCS-8135")


### PR DESCRIPTION
## Summary
- Enable all CephX key rotation tests on ODF 5.0 by changing `@skipif_ocs_version(["<4.21", ">=4.23"])` to `@skipif_ocs_version("<4.21")`.
- The previous `>=4.23` upper bound also skipped 5.0; 5.0 is the current latest version, so only versions below 4.21 need to be skipped.

## Test plan
- [x] Confirm CephX tests are collected (not skipped) when `ocs_version` is `5.0`
- [x] Confirm CephX tests still skip when `ocs_version` is below `4.21`
- [x] Confirm CephX tests still collect on 4.21 and 4.22


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded CephX key-rotation test coverage for OCS 4.23 and later.
  * Updated version compatibility checks so these tests continue to run on supported OCS releases.
  * Retained skips for OCS versions earlier than 4.21.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->