### PR TITLE
Prefer staging FDF catalog mirror for hosted spoke clusters.

### DIFF
--- a/ocs_ci/deployment/helpers/hypershift_base.py
+++ b/ocs_ci/deployment/helpers/hypershift_base.py
@@ -1131,7 +1131,9 @@ class HyperShiftBase:
         Args:
             name (str): name of the cluster
             cluster_path (str): path to create auth_path folder and download kubeconfig there
-            from_hcp (bool): if True, use hcp binary to download kubeconfig, otherwise use ocp secret
+            from_hcp (bool): If True, try hcp first; fall back to extracting the
+                admin-kubeconfig secret if hcp fails or writes an empty file.
+                If False, extract the secret only.
 
         Returns:
             str: path to the downloaded kubeconfig, None if failed
@@ -1148,10 +1150,6 @@ class HyperShiftBase:
             )
             os.remove(kubeconfig_path)
 
-        # touch the file
-        time.sleep(0.5)
-        open(kubeconfig_path, "a").close()
-
         logger.info(
             f"Downloading kubeconfig for HyperShift hosted cluster {name} to {kubeconfig_path}"
         )
@@ -1163,22 +1161,42 @@ class HyperShiftBase:
                         f"{self.hcp_binary_path} create kubeconfig --name {name} > {kubeconfig_path}",
                         shell=True,
                     )
-                else:
+                if not from_hcp or not (
+                    os.path.isfile(kubeconfig_path)
+                    and os.stat(kubeconfig_path).st_size > 0
+                ):
+                    if from_hcp:
+                        logger.warning(
+                            "hcp kubeconfig download for '%s' failed or was "
+                            "empty; falling back to admin-kubeconfig secret",
+                            name,
+                        )
+                        if os.path.isfile(kubeconfig_path):
+                            os.remove(kubeconfig_path)
                     # kubeconfig will be stored with name 'kubeconfig'
                     OCP().exec_oc_cmd(
                         f"extract secret/admin-kubeconfig -n clusters-{name} "
-                        f"--to {os.path.dirname(kubeconfig_path)} --confirm"
+                        f"--to {auth_path} --confirm"
                     )
         except Exception as e:
             logger.error(
                 f"Failed to download kubeconfig for HyperShift hosted cluster {name}\n{e}"
             )
+            if (
+                os.path.isfile(kubeconfig_path)
+                and os.stat(kubeconfig_path).st_size == 0
+            ):
+                os.remove(kubeconfig_path)
             return
 
-        if not os.stat(kubeconfig_path).st_size > 0:
+        if not (
+            os.path.isfile(kubeconfig_path) and os.stat(kubeconfig_path).st_size > 0
+        ):
             logger.error(
                 f"Failed to download kubeconfig for HyperShift hosted cluster {name}"
             )
+            if os.path.isfile(kubeconfig_path):
+                os.remove(kubeconfig_path)
             return
         return kubeconfig_path
 

--- a/ocs_ci/deployment/helpers/hypershift_base.py
+++ b/ocs_ci/deployment/helpers/hypershift_base.py
@@ -1136,8 +1136,10 @@ class HyperShiftBase:
                 If False, extract the secret only.
 
         Returns:
-            str: path to the downloaded kubeconfig, None if failed
+            str: path to the downloaded kubeconfig
 
+        Raises:
+            CommandFailed: If kubeconfig could not be downloaded
         """
         path_abs = os.path.expanduser(cluster_path)
         auth_path = os.path.join(path_abs, "auth")
@@ -1154,50 +1156,67 @@ class HyperShiftBase:
             f"Downloading kubeconfig for HyperShift hosted cluster {name} to {kubeconfig_path}"
         )
 
-        try:
-            with config.RunWithProviderConfigContextIfAvailable():
-                if from_hcp:
+        def _kubeconfig_ready():
+            return (
+                os.path.isfile(kubeconfig_path) and os.stat(kubeconfig_path).st_size > 0
+            )
+
+        with config.RunWithProviderConfigContextIfAvailable():
+            if from_hcp:
+                try:
                     exec_cmd(
-                        f"{self.hcp_binary_path} create kubeconfig --name {name} > {kubeconfig_path}",
+                        f"{self.hcp_binary_path} create kubeconfig --name {name} "
+                        f"> {kubeconfig_path}",
                         shell=True,
                     )
-                if not from_hcp or not (
-                    os.path.isfile(kubeconfig_path)
-                    and os.stat(kubeconfig_path).st_size > 0
-                ):
-                    if from_hcp:
-                        logger.warning(
-                            "hcp kubeconfig download for '%s' failed or was "
-                            "empty; falling back to admin-kubeconfig secret",
-                            name,
-                        )
-                        if os.path.isfile(kubeconfig_path):
-                            os.remove(kubeconfig_path)
-                    # kubeconfig will be stored with name 'kubeconfig'
-                    OCP().exec_oc_cmd(
-                        f"extract secret/admin-kubeconfig -n clusters-{name} "
-                        f"--to {auth_path} --confirm"
+                except Exception as e:
+                    logger.warning(
+                        "hcp kubeconfig download for '%s' failed: %s",
+                        name,
+                        e,
                     )
-        except Exception as e:
-            logger.error(
-                f"Failed to download kubeconfig for HyperShift hosted cluster {name}\n{e}"
-            )
-            if (
-                os.path.isfile(kubeconfig_path)
-                and os.stat(kubeconfig_path).st_size == 0
-            ):
-                os.remove(kubeconfig_path)
-            return
+                if _kubeconfig_ready():
+                    return kubeconfig_path
+                logger.warning(
+                    "hcp kubeconfig download for '%s' failed or was empty; "
+                    "falling back to admin-kubeconfig secret",
+                    name,
+                )
+                if os.path.isfile(kubeconfig_path):
+                    os.remove(kubeconfig_path)
 
-        if not (
-            os.path.isfile(kubeconfig_path) and os.stat(kubeconfig_path).st_size > 0
-        ):
+            try:
+                # kubeconfig will be stored with name 'kubeconfig'
+                OCP().exec_oc_cmd(
+                    f"extract secret/admin-kubeconfig -n clusters-{name} "
+                    f"--to {auth_path} --confirm"
+                )
+            except Exception as e:
+                logger.error(
+                    "Failed to extract admin-kubeconfig for HyperShift "
+                    "hosted cluster %s\n%s",
+                    name,
+                    e,
+                )
+                if os.path.isfile(kubeconfig_path) and (
+                    os.stat(kubeconfig_path).st_size == 0
+                ):
+                    os.remove(kubeconfig_path)
+                raise CommandFailed(
+                    f"Failed to download kubeconfig for HyperShift hosted "
+                    f"cluster {name}"
+                ) from e
+
+        if not _kubeconfig_ready():
             logger.error(
                 f"Failed to download kubeconfig for HyperShift hosted cluster {name}"
             )
             if os.path.isfile(kubeconfig_path):
                 os.remove(kubeconfig_path)
-            return
+            raise CommandFailed(
+                f"Failed to download kubeconfig for HyperShift hosted "
+                f"cluster {name}"
+            )
         return kubeconfig_path
 
     @staticmethod
@@ -1617,6 +1636,9 @@ def create_kubeconfig_file_hosted_cluster():
 
     This function is wrapped with retry decorator to handle CommandFailed errors.
     It will retry up to 5 times with 30 sec  delay between attempts.
+
+    Raises:
+        CommandFailed: if the kubeconfig file could not be downloaded
     """
     cluster_path = config.ENV_DATA["cluster_path"]
     cluster_name = config.ENV_DATA["cluster_name"]

--- a/ocs_ci/deployment/helpers/hypershift_base.py
+++ b/ocs_ci/deployment/helpers/hypershift_base.py
@@ -1122,6 +1122,64 @@ class HyperShiftBase:
             if sample == "Completed":
                 return True
 
+    @staticmethod
+    def _is_nonempty_kubeconfig(kubeconfig_path):
+        """
+        Return True if kubeconfig_path exists and has content.
+        """
+        return os.path.isfile(kubeconfig_path) and os.stat(kubeconfig_path).st_size > 0
+
+    def _download_hosted_kubeconfig_via_hcp(self, name, kubeconfig_path):
+        """
+        Download hosted cluster kubeconfig using the hcp binary.
+
+        Runs hcp without shell=True so path/name are not interpolated into a
+        shell command, and writes stdout to kubeconfig_path only after success.
+
+        Args:
+            name (str): Hosted cluster name
+            kubeconfig_path (str): Destination kubeconfig path
+
+        Returns:
+            bool: True if a non-empty kubeconfig was written
+        """
+        try:
+            completed = exec_cmd(
+                [
+                    self.hcp_binary_path,
+                    "create",
+                    "kubeconfig",
+                    "--name",
+                    name,
+                ],
+            )
+            kubeconfig_data = completed.stdout
+            if kubeconfig_data:
+                if isinstance(kubeconfig_data, bytes):
+                    kubeconfig_data = kubeconfig_data.decode("utf-8")
+                with open(kubeconfig_path, "w") as kubeconfig_file:
+                    kubeconfig_file.write(kubeconfig_data)
+        except Exception as e:
+            logger.warning(
+                "hcp kubeconfig download for '%s' failed: %s",
+                name,
+                e,
+            )
+            if os.path.isfile(kubeconfig_path):
+                os.remove(kubeconfig_path)
+            return False
+
+        if self._is_nonempty_kubeconfig(kubeconfig_path):
+            return True
+
+        logger.warning(
+            "hcp kubeconfig download for '%s' produced an empty file",
+            name,
+        )
+        if os.path.isfile(kubeconfig_path):
+            os.remove(kubeconfig_path)
+        return False
+
     def download_hosted_cluster_kubeconfig(
         self, name: str, cluster_path: str, from_hcp: bool = True
     ):
@@ -1156,34 +1214,15 @@ class HyperShiftBase:
             f"Downloading kubeconfig for HyperShift hosted cluster {name} to {kubeconfig_path}"
         )
 
-        def _kubeconfig_ready():
-            return (
-                os.path.isfile(kubeconfig_path) and os.stat(kubeconfig_path).st_size > 0
-            )
-
         with config.RunWithProviderConfigContextIfAvailable():
             if from_hcp:
-                try:
-                    exec_cmd(
-                        f"{self.hcp_binary_path} create kubeconfig --name {name} "
-                        f"> {kubeconfig_path}",
-                        shell=True,
-                    )
-                except Exception as e:
-                    logger.warning(
-                        "hcp kubeconfig download for '%s' failed: %s",
-                        name,
-                        e,
-                    )
-                if _kubeconfig_ready():
+                if self._download_hosted_kubeconfig_via_hcp(name, kubeconfig_path):
                     return kubeconfig_path
                 logger.warning(
                     "hcp kubeconfig download for '%s' failed or was empty; "
                     "falling back to admin-kubeconfig secret",
                     name,
                 )
-                if os.path.isfile(kubeconfig_path):
-                    os.remove(kubeconfig_path)
 
             try:
                 # kubeconfig will be stored with name 'kubeconfig'
@@ -1207,7 +1246,7 @@ class HyperShiftBase:
                     f"cluster {name}"
                 ) from e
 
-        if not _kubeconfig_ready():
+        if not self._is_nonempty_kubeconfig(kubeconfig_path):
             logger.error(
                 f"Failed to download kubeconfig for HyperShift hosted cluster {name}"
             )

--- a/ocs_ci/deployment/helpers/hypershift_base.py
+++ b/ocs_ci/deployment/helpers/hypershift_base.py
@@ -2,6 +2,7 @@ import logging
 import os
 import re
 import shutil
+import subprocess
 import tempfile
 import time
 from datetime import datetime
@@ -1134,7 +1135,8 @@ class HyperShiftBase:
         Download hosted cluster kubeconfig using the hcp binary.
 
         Runs hcp without shell=True so path/name are not interpolated into a
-        shell command, and writes stdout to kubeconfig_path only after success.
+        shell command. Writes stdout directly to kubeconfig_path so the
+        kubeconfig (credentials) is never logged via exec_cmd DEBUG stdout.
 
         Args:
             name (str): Hosted cluster name
@@ -1144,21 +1146,40 @@ class HyperShiftBase:
             bool: True if a non-empty kubeconfig was written
         """
         try:
-            completed = exec_cmd(
-                [
-                    self.hcp_binary_path,
-                    "create",
-                    "kubeconfig",
-                    "--name",
+            env = os.environ.copy()
+            provider_kubeconfig = config.RUN.get("kubeconfig")
+            if provider_kubeconfig:
+                env["KUBECONFIG"] = provider_kubeconfig
+            with open(kubeconfig_path, "w") as out_f:
+                completed = subprocess.run(
+                    [
+                        self.hcp_binary_path,
+                        "create",
+                        "kubeconfig",
+                        "--name",
+                        name,
+                    ],
+                    stdout=out_f,
+                    stderr=subprocess.PIPE,
+                    timeout=600,
+                    env=env,
+                    check=False,
+                )
+            if completed.returncode != 0:
+                stderr = (
+                    completed.stderr.decode(errors="replace")
+                    if completed.stderr
+                    else ""
+                )
+                logger.warning(
+                    "hcp kubeconfig download for '%s' failed (rc=%s): %s",
                     name,
-                ],
-            )
-            kubeconfig_data = completed.stdout
-            if kubeconfig_data:
-                if isinstance(kubeconfig_data, bytes):
-                    kubeconfig_data = kubeconfig_data.decode("utf-8")
-                with open(kubeconfig_path, "w") as kubeconfig_file:
-                    kubeconfig_file.write(kubeconfig_data)
+                    completed.returncode,
+                    stderr,
+                )
+                if os.path.isfile(kubeconfig_path):
+                    os.remove(kubeconfig_path)
+                return False
         except Exception as e:
             logger.warning(
                 "hcp kubeconfig download for '%s' failed: %s",

--- a/ocs_ci/deployment/hub_spoke.py
+++ b/ocs_ci/deployment/hub_spoke.py
@@ -521,6 +521,27 @@ def is_fdf_on_provider():
 _fdf_catalog_image_cache = None
 
 
+def _image_ref_matches_repository(image, repository):
+    """
+    Return True if image is exactly repository or repository with a tag/digest.
+
+    Avoids prefix collisions such as repository ``.../catalog`` matching
+    image ``.../catalog-extra:tag``.
+    """
+    if not image or not repository:
+        return False
+    if image == repository:
+        return True
+    if not image.startswith(repository):
+        return False
+    return image[len(repository)] in (":", "@")
+
+
+def _mirror_registry_host(mirror):
+    """Return the registry host from a mirror repository path."""
+    return mirror.split("/", 1)[0] if mirror else ""
+
+
 def _resolve_image_through_itms(image):
     """
     Resolve a container image reference through ImageTagMirrorSet on the
@@ -553,7 +574,9 @@ def _resolve_image_through_itms(image):
         for entry in itms.get("spec", {}).get("imageTagMirrors", []):
             source = entry.get("source", "")
             mirrors = entry.get("mirrors", [])
-            if not (source and mirrors and image.startswith(source)):
+            if not (
+                source and mirrors and _image_ref_matches_repository(image, source)
+            ):
                 continue
 
             chosen_mirror = None
@@ -566,7 +589,10 @@ def _resolve_image_through_itms(image):
                         break
             if not chosen_mirror:
                 for mirror in mirrors:
-                    if "cp.stg.icr.io" in mirror:
+                    if (
+                        _mirror_registry_host(mirror)
+                        == constants.FDF_PRE_RELEASE_REGISTRY_HOST
+                    ):
                         chosen_mirror = mirror
                         break
             if not chosen_mirror:

--- a/ocs_ci/deployment/hub_spoke.py
+++ b/ocs_ci/deployment/hub_spoke.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import random
+import re
 import subprocess
 import tempfile
 import time
@@ -525,27 +526,22 @@ def _image_ref_matches_repository(image, repository) -> bool:
     """
     Return True if image matches an ITMS ``source`` boundary.
 
-    Checks, in order:
-    1. Both image and repository are non-empty.
-    2. image equals repository exactly -> match.
-    3. image does not start with repository -> no match.
-    4. image starts with repository -> match only if the next character
-       is ``:`` (tag), ``@`` (digest), or ``/`` (registry/namespace prefix).
+    image must equal repository, or start with repository followed
+    immediately by one of:
+    - ``@`` (digest boundary), e.g. repository + "@sha256:abc"
+    - ``/`` (registry/namespace prefix boundary), e.g. repository + "/name:tag"
+    - ``:`` followed by a tag with no further ``/`` (tag boundary), e.g.
+      repository + ":v4.21"
 
-    Example:
-        repository="icr.io/cpopen" matches image
-        "icr.io/cpopen/isf-data-foundation-catalog:v4.21".
-
-        repository=".../catalog" does NOT match image
-        ".../catalog-extra:tag" (near-match name, not a real boundary).
+    This rejects near-match names, e.g. repository ``.../catalog`` must not
+    match image ``.../catalog-extra:tag``. It also rejects a registry port
+    masquerading as a tag, e.g. repository ``icr.io`` must not match image
+    ``icr.io:5000/cpopen/catalog:v1`` since ``:5000`` is followed by ``/``.
     """
     if not image or not repository:
         return False
-    if image == repository:
-        return True
-    if not image.startswith(repository):
-        return False
-    return image[len(repository)] in (":", "@", "/")
+    pattern = re.escape(repository) + r"(?:[@/].*|:[^/]*)?$"
+    return re.match(pattern, image) is not None
 
 
 def _mirror_registry_host(mirror) -> str:

--- a/ocs_ci/deployment/hub_spoke.py
+++ b/ocs_ci/deployment/hub_spoke.py
@@ -528,6 +528,10 @@ def _resolve_image_through_itms(image):
     the source with the mirror URL so it is pullable from spoke clusters
     that lack ITMS support (e.g. HyperShift hosted clusters).
 
+    Prefer ``fdf_pre_release_registry`` / ``cp.stg.icr.io`` over the first
+    ITMS mirror. The first entry is often ``preprod.icr.io``, which may not
+    publish unreleased tags (manifest unknown), while staging does.
+
     Args:
         image (str): Original image reference (e.g. icr.io/cpopen/catalog:v4.21)
 
@@ -542,14 +546,35 @@ def _resolve_image_through_itms(image):
         logger.debug("No ImageTagMirrorSet resources found on management cluster")
         return image
 
+    fdf_pre_release_registry = config.DEPLOYMENT.get("fdf_pre_release_registry") or ""
+    preferred_registry = fdf_pre_release_registry.rstrip("/")
+
     for itms in itms_list.get("items", []):
         for entry in itms.get("spec", {}).get("imageTagMirrors", []):
             source = entry.get("source", "")
             mirrors = entry.get("mirrors", [])
-            if source and mirrors and image.startswith(source):
-                resolved = image.replace(source, mirrors[0], 1)
-                logger.info(f"Resolved image through ITMS: {image} -> {resolved}")
-                return resolved
+            if not (source and mirrors and image.startswith(source)):
+                continue
+
+            chosen_mirror = None
+            if preferred_registry:
+                for mirror in mirrors:
+                    if mirror == preferred_registry or mirror.startswith(
+                        preferred_registry + "/"
+                    ):
+                        chosen_mirror = mirror
+                        break
+            if not chosen_mirror:
+                for mirror in mirrors:
+                    if "cp.stg.icr.io" in mirror:
+                        chosen_mirror = mirror
+                        break
+            if not chosen_mirror:
+                chosen_mirror = mirrors[0]
+
+            resolved = image.replace(source, chosen_mirror, 1)
+            logger.info("Resolved image through ITMS: %s -> %s", image, resolved)
+            return resolved
     return image
 
 

--- a/ocs_ci/deployment/hub_spoke.py
+++ b/ocs_ci/deployment/hub_spoke.py
@@ -521,12 +521,23 @@ def is_fdf_on_provider():
 _fdf_catalog_image_cache = None
 
 
-def _image_ref_matches_repository(image, repository):
+def _image_ref_matches_repository(image, repository) -> bool:
     """
-    Return True if image is exactly repository or repository with a tag/digest.
+    Return True if image matches an ITMS ``source`` boundary.
 
-    Avoids prefix collisions such as repository ``.../catalog`` matching
-    image ``.../catalog-extra:tag``.
+    Checks, in order:
+    1. Both image and repository are non-empty.
+    2. image equals repository exactly -> match.
+    3. image does not start with repository -> no match.
+    4. image starts with repository -> match only if the next character
+       is ``:`` (tag), ``@`` (digest), or ``/`` (registry/namespace prefix).
+
+    Example:
+        repository="icr.io/cpopen" matches image
+        "icr.io/cpopen/isf-data-foundation-catalog:v4.21".
+
+        repository=".../catalog" does NOT match image
+        ".../catalog-extra:tag" (near-match name, not a real boundary).
     """
     if not image or not repository:
         return False
@@ -534,10 +545,10 @@ def _image_ref_matches_repository(image, repository):
         return True
     if not image.startswith(repository):
         return False
-    return image[len(repository)] in (":", "@")
+    return image[len(repository)] in (":", "@", "/")
 
 
-def _mirror_registry_host(mirror):
+def _mirror_registry_host(mirror) -> str:
     """Return the registry host from a mirror repository path."""
     return mirror.split("/", 1)[0] if mirror else ""
 

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -4027,6 +4027,8 @@ SPECTRUM_FUSION_CR = os.path.join(
 FDF_ODFCLUSTER_CR = os.path.join(FDF_TEMPLATE_DIR, "odfcluster.yaml")
 FDF_CATSRC_CR = os.path.join(FDF_TEMPLATE_DIR, "isf_datafoundation_catsrc.yaml")
 FDF_CATSRC_IMAGE_PATH = "icr.io/cpopen/isf-data-foundation-catalog"
+# Host for pre-release FDF catalog mirrors (see fdf_pre_release_registry)
+FDF_PRE_RELEASE_REGISTRY_HOST = "cp.stg.icr.io"
 FDF_NAMESPACE = "ibm-spectrum-fusion-ns"
 FUSION_NAMESPACE = "ibm-spectrum-fusion-ns"
 ISF_CATALOG_SOURCE_NAME = "isf-catalog"

--- a/ocs_ci/templates/fusion-data-foundation/image-tag-mirror-set.yaml
+++ b/ocs_ci/templates/fusion-data-foundation/image-tag-mirror-set.yaml
@@ -5,8 +5,9 @@ metadata:
 spec:
   imageTagMirrors:
   - mirrors:
-    - preprod.icr.io/cp/df/isf-data-foundation-catalog
+    # Prefer staging: preprod often lacks unreleased version tags
     - cp.stg.icr.io/cp/df/isf-data-foundation-catalog
+    - preprod.icr.io/cp/df/isf-data-foundation-catalog
     source: icr.io/cpopen/isf-data-foundation-catalog
   mirrorSourcePolicy:
     AllowContactingSource 0


### PR DESCRIPTION
## Summary
  - When resolving the FDF CatalogSource image for HyperShift spoke clusters, prefer `fdf_pre_release_registry` /
  `cp.stg.icr.io` over the first ITMS mirror (`preprod.icr.io`).
  - Spoke clusters do not have ITMS, so using `preprod` caused `ImagePullBackOff` (`manifest unknown`) and the
  client operator never installed.
  - Reorder the FDF ITMS template to list staging before preprod.
  ## Test plan
  - [x] `temp_tests/test_temp_fdf_spoke_catalog_itms_mirror.py` (local mocked cases)
  - [ ] Re-run hosted FDF client deploy and confirm CatalogSource pulls successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container image mirror selection to avoid incorrect repository matches and provide more reliable image resolution.
  * Pre-release and staging registry mirrors are now prioritized according to the configured preference.
  * Invalid mirror entries and entries without matching images are skipped.
  * Resolved image mappings are now logged for improved visibility.
  * Improved hosted cluster kubeconfig downloads with a fallback method when the primary download fails.
  * Empty kubeconfig files are no longer accepted, and download failures are reported clearly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->