### PR TITLE
newer versions of corebot uses --dns-<dns-plugin-name> parameter

### DIFF
--- a/ocs_ci/utility/ssl_certs.py
+++ b/ocs_ci/utility/ssl_certs.py
@@ -276,7 +276,7 @@ class LetsEncryptCertificate(Certificate):
             f"-n --no-autorenew --key-path {key_file} --csr {csr_file} --cert-path {cert_file} "
             f"--fullchain-path {fullchain_file} --chain-path {chain_file} "
             f"--config-dir {conf_dir} --work-dir {work_dir} --logs-dir {logs_dir} "
-            f"--{self.dns_plugin} "
+            f"--dns-{self.dns_plugin} "
         )
         result = exec_cmd(cmd)
         if result.returncode != 0:


### PR DESCRIPTION
instead of only `--<dns-plugin-name>`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SSL certificate issuance by correctly invoking Certbot DNS plugins with the required command-line option format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->