### PR TITLE
Exclude NVMeoF pools from consumer RNS validation

### DIFF
--- a/ocs_ci/ocs/resources/storageconsumer.py
+++ b/ocs_ci/ocs/resources/storageconsumer.py
@@ -1119,18 +1119,14 @@ def check_consumer_rns(consumer_name, pool_list, rns_list):
     """
     log.info(f"Verifying Rados namespaces for consumer {consumer_name}")
     # Pools that do not get a per-consumer Rados namespace for remote clients.
-    # NVMeoF pools exist when NVMeoF is enabled on the provider, but consumer
-    # RNS is only created for ocs-storagecluster-cephblockpool.
-    excluded_pools = {
-        "builtin-mgr",
-        "builtin-nvmeof",
-        "ocs-storagecluster-cephnfs-builtin-pool",
-        "ocs-storagecluster-nvmeof",
-    }
+    # NVMeoF pools (name contains "nvmeof") exist when NVMeoF is enabled on
+    # the provider, but consumer RNS is only created for block pools used by
+    # remote clients (e.g. ocs-storagecluster-cephblockpool).
+    excluded_pools = {"builtin-mgr", "ocs-storagecluster-cephnfs-builtin-pool"}
     consumer_rns_valid = {}
 
     for pool in pool_list:
-        if pool in excluded_pools:
+        if pool in excluded_pools or "nvmeof" in pool:
             continue
         expected_rns_name = (
             f"{pool}-builtin-implicit"

--- a/ocs_ci/ocs/resources/storageconsumer.py
+++ b/ocs_ci/ocs/resources/storageconsumer.py
@@ -1118,7 +1118,15 @@ def check_consumer_rns(consumer_name, pool_list, rns_list):
 
     """
     log.info(f"Verifying Rados namespaces for consumer {consumer_name}")
-    excluded_pools = {"builtin-mgr", "ocs-storagecluster-cephnfs-builtin-pool"}
+    # Pools that do not get a per-consumer Rados namespace for remote clients.
+    # NVMeoF pools exist when NVMeoF is enabled on the provider, but consumer
+    # RNS is only created for ocs-storagecluster-cephblockpool.
+    excluded_pools = {
+        "builtin-mgr",
+        "builtin-nvmeof",
+        "ocs-storagecluster-cephnfs-builtin-pool",
+        "ocs-storagecluster-nvmeof",
+    }
     consumer_rns_valid = {}
 
     for pool in pool_list:


### PR DESCRIPTION
## Summary
  - In provider-client setups, `check_consumer_rns` expects a per-consumer Rados namespace on each CephBlockPool
  - When NVMeoF is enabled, pools such as `builtin-nvmeof` and `ocs-storagecluster-nvmeof` appear in the pool list,
  but ODF does not create consumer RNS on them
  - That caused false failures during client deploy / consumer RNS checks
  - Fix: skip any pool whose name contains `nvmeof`, alongside the existing exclusions for `builtin-mgr` and the
  NFS builtin pool
  ## Test plan
  - [ ] Re-run provider-client deploy (or consumer RNS validation) on a cluster with NVMeoF enabled
  - [ ] Confirm the check still validates block-pool namespaces and no longer fails on NVMeoF pools


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated storage consumer checks to correctly exclude NVMeoF pools that do not provide per-consumer namespaces for remote clients.
  * Prevents false failures when validating storage consumers with NVMeoF pools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->