### PR TITLE
[release-4.18] FDF 2AZ Arbiter support (#14118)

### DIFF
--- a/conf/deployment/vsphere/upi_2az_rhcos_vsan_lso_vmdk_3m_4w_arbiter.yaml
+++ b/conf/deployment/vsphere/upi_2az_rhcos_vsan_lso_vmdk_3m_4w_arbiter.yaml
@@ -1,0 +1,37 @@
+---
+# This config is suppose to work on most of DCs we have.
+DEPLOYMENT:
+  allow_lower_instance_requirements: false
+  local_storage: true
+  local_storage_storagedeviceset_count: 2
+  type: 'VMDK'
+  provision_type: 'thick'
+  ocs_operator_nodes_to_label: 4
+  arbiter_deployment: true
+  arbiter_zone: 'arbiter'
+  arbiter_autodetect: false
+  dummy_zone_node_labels: true
+  network_split_setup: true
+  network_zone_latency: 5
+  host_network: true
+  provider_api_server_service_type: 'ClusterIP'
+ENV_DATA:
+  platform: 'vsphere'
+  deployment_type: 'upi'
+  worker_replicas: 4
+  master_replicas: 3
+  worker_availability_zones:
+    - 'data-1'
+    - 'data-2'
+  master_availability_zones:
+    - 'arbiter'
+    - 'data-1'
+    - 'data-2'
+  worker_num_cpus: '16'
+  master_num_cpus: '8'
+  master_memory: '16384'
+  compute_memory: '65536'
+  extra_disks: 2
+  fio_storageutilization_min_mbps: 10.0
+  mark_masters_schedulable: true
+  device_class: 'ssd'

--- a/ocs_ci/deployment/fusion_data_foundation.py
+++ b/ocs_ci/deployment/fusion_data_foundation.py
@@ -10,6 +10,7 @@ import tempfile
 import yaml
 
 from ocs_ci.deployment.helpers import storage_class
+from ocs_ci.deployment.helpers.lso_helpers import add_disks_lso
 from ocs_ci.deployment.helpers.storage_class import get_storageclass
 from ocs_ci.framework import config
 
@@ -38,6 +39,9 @@ class FusionDataFoundationDeployment:
         self.live_deployment = config.DEPLOYMENT.get("live_deployment", False)
         self.kubeconfig = config.RUN["kubeconfig"]
         self.lso_enabled = config.DEPLOYMENT.get("local_storage", False)
+        self.fdf_skip_storage_setup = config.DEPLOYMENT.get(
+            "fdf_skip_storage_setup", False
+        )
         self.storage_class = (
             storage_class.get_storageclass() or constants.DEFAULT_STORAGECLASS_LSO
         )
@@ -55,7 +59,8 @@ class FusionDataFoundationDeployment:
 
         self.create_fdf_service_cr()
         self.verify_fdf_installation()
-        self.setup_storage()
+        if not self.fdf_skip_storage_setup:
+            self.setup_storage()
 
     def create_image_tag_mirror_set(self):
         """
@@ -171,6 +176,7 @@ class FusionDataFoundationDeployment:
         """
         logger.info("Verifying FDF installation")
         fusion_service_instance_health_check()
+        wait_for_storageclusters_crd()
         self.get_installed_version()
         logger.info("FDF successfully installed")
 
@@ -208,8 +214,12 @@ class FusionDataFoundationDeployment:
             odfcluster_status_check()
         else:
             logger.info("Storage configuration for Fusion 2.11 or greater")
+            if self.lso_enabled:
+                add_disks_lso()
             clustersetup = StorageClusterSetup(self)
             create_lvs_resource(self.storage_class, self.storage_class)
+            if config.ENV_DATA.get("mark_masters_schedulable", False):
+                node.mark_masters_schedulable()
             add_storage_label()
             clustersetup.setup_storage_cluster()
             storagecluster_health_check()
@@ -329,11 +339,40 @@ def extract_image_digest_mirror_set(upgrade=False):
     return filename
 
 
+def is_not_arbiter_node(node_obj):
+    """
+    Determines if a node contains the arbiter zone label.
+    Used to filter arbiter node from node list.
+
+    Args:
+        node_obj (ocs_ci.ocs.ocp.OCP): OCP Node object
+
+    Returns:
+        bool: True if node doesn't contain the labelj, False if it does
+
+    """
+    arbiter_zone = config.DEPLOYMENT.get(
+        "arbiter_zone", constants.ARBITER_ZONE_LABEL[0]
+    )
+    zone_key = "topology.kubernetes.io/zone"
+    data = node_obj.data
+    metadata = data.get("metadata")
+    labels = metadata.get("labels")
+    return not labels.get(zone_key) == arbiter_zone
+
+
 def add_storage_label():
     """
-    Add storage label on worker nodes.
+    Add storage label on nodes.
     """
-    nodes = node.get_nodes(node_type="worker")
+    if config.ENV_DATA.get("mark_masters_schedulable", False):
+        all_nodes = node.get_all_nodes()
+        nodes = node.get_node_objs(all_nodes)
+        # Filter arbiter node if configured
+        if config.DEPLOYMENT.get("arbiter_deployment"):
+            nodes = list(filter(is_not_arbiter_node, nodes))
+    else:
+        nodes = node.get_nodes(node_type="worker")
     node.label_nodes(nodes)
 
 
@@ -372,6 +411,31 @@ def storagecluster_health_check():
     logger.info("StorageCluster is healthy and in Ready state.")
 
 
+def wait_for_storageclusters_crd():
+    """
+    Wait for the storageclusters CRD to exist.
+    """
+    logger.info("Waiting for the StorageClusters CRD to exist")
+
+    @retry((CommandFailed, AssertionError, KeyError), 30, 30, backoff=1)
+    def _wait_for_storageclusters_crd():
+        storageclusters_crd = CustomResourceDefinition(
+            resource_name="storageclusters.ocs.openshift.io",
+        )
+        status = storageclusters_crd.data.get("status", {})
+        conditions = status.get("conditions")
+        established_status_exists = False
+
+        for condition in conditions:
+            if condition.get("type") == "Established":
+                established_status_exists = True
+                assert condition.get("status") == "True"
+
+        assert established_status_exists
+
+    _wait_for_storageclusters_crd()
+
+
 class FusionServiceInstance(OCP):
     def __init__(self, resource_name="", *args, **kwargs):
         super(FusionServiceInstance, self).__init__(
@@ -383,4 +447,14 @@ class OdfCluster(OCP):
     def __init__(self, resource_name="", *args, **kwargs):
         super(OdfCluster, self).__init__(
             resource_name=resource_name, kind="OdfCluster", *args, **kwargs
+        )
+
+
+class CustomResourceDefinition(OCP):
+    def __init__(self, resource_name="", *args, **kwargs):
+        super(CustomResourceDefinition, self).__init__(
+            resource_name=resource_name,
+            kind="CustomResourceDefinition",
+            *args,
+            **kwargs,
         )

--- a/ocs_ci/deployment/fusion_data_foundation.py
+++ b/ocs_ci/deployment/fusion_data_foundation.py
@@ -217,7 +217,8 @@ class FusionDataFoundationDeployment:
             if self.lso_enabled:
                 add_disks_lso()
             clustersetup = StorageClusterSetup(self)
-            create_lvs_resource(self.storage_class, self.storage_class)
+            if self.lso_enabled:
+                create_lvs_resource(self.storage_class, self.storage_class)
             if config.ENV_DATA.get("mark_masters_schedulable", False):
                 node.mark_masters_schedulable()
             add_storage_label()

--- a/ocs_ci/deployment/helpers/lso_helpers.py
+++ b/ocs_ci/deployment/helpers/lso_helpers.py
@@ -108,11 +108,7 @@ def setup_local_storage(storageclass):
     platform = config.ENV_DATA.get("platform").lower()
     lso_type = config.DEPLOYMENT.get("type")
 
-    if platform == constants.VSPHERE_PLATFORM:
-        add_disk_for_vsphere_platform()
-
-    if platform == constants.RHV_PLATFORM:
-        add_disk_for_rhv_platform()
+    add_disks_lso()
 
     if (ocp_version >= version.VERSION_4_6) and (ocs_version >= version.VERSION_4_6):
         # Pull local volume discovery yaml data
@@ -237,6 +233,18 @@ def setup_local_storage(storageclass):
         verify_pvs_created(expected_pvs, storageclass, False)
     else:
         verify_pvs_created(expected_pvs, storageclass)
+
+
+def add_disks_lso():
+    """
+    Add disks based on which platform we are running on
+    """
+    platform = config.ENV_DATA.get("platform").lower()
+    if platform == constants.VSPHERE_PLATFORM:
+        add_disk_for_vsphere_platform()
+
+    if platform == constants.RHV_PLATFORM:
+        add_disk_for_rhv_platform()
 
 
 def create_optional_operators_catalogsource_non_ga(force=False):

--- a/ocs_ci/deployment/helpers/storage_class.py
+++ b/ocs_ci/deployment/helpers/storage_class.py
@@ -33,6 +33,11 @@ def get_storageclass() -> str:
 
     """
     logger.info("Getting storageclass")
+    if config.DEPLOYMENT.get("local_storage", False):
+        storage_class = constants.DEFAULT_STORAGECLASS_LSO
+        logger.info(f"LSO is enabled, using {storage_class}")
+        return storage_class
+
     platform = config.ENV_DATA.get("platform")
     customized_deployment_storage_class = config.DEPLOYMENT.get(
         "customized_deployment_storage_class"

--- a/ocs_ci/deployment/helpers/storage_class.py
+++ b/ocs_ci/deployment/helpers/storage_class.py
@@ -4,6 +4,7 @@ import yaml
 from ocs_ci.framework import config
 from ocs_ci.framework.logger_helper import log_step
 from ocs_ci.ocs import constants
+from ocs_ci.ocs.ocp import OCP
 from ocs_ci.utility.utils import run_cmd
 
 
@@ -67,6 +68,15 @@ def create_custom_storageclass(storage_class_path: str) -> str:
         custom_sc = yaml.load(custom_sc_fo, Loader=yaml.SafeLoader)
 
     storage_class_name = custom_sc["metadata"]["name"]
+
+    # Check if storage class already exists
+    sc_obj = OCP(kind=constants.STORAGECLASS)
+    if sc_obj.is_exist(resource_name=storage_class_name):
+        logger.info(
+            f"Storage class {storage_class_name} already exists, skipping creation"
+        )
+        return storage_class_name
+
     log_step(f"Creating custom storage class {storage_class_name}")
     run_cmd(f"oc create -f {storage_class_path}")
 

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -3287,6 +3287,7 @@ FDF_ODFCLUSTER_CR = os.path.join(FDF_TEMPLATE_DIR, "odfcluster.yaml")
 FDF_NAMESPACE = "ibm-spectrum-fusion-ns"
 ISF_CATALOG_SOURCE_NAME = "isf-catalog"
 ISF_OPERATOR_SOFTWARE_CATALOG_SOURCE_YAML = "catalog-source.yaml.j2"
+ISF_OPERATOR_IDMS_YAML = "image-digest-mirror-set.yaml.j2"
 FDF_IMAGE_DIGEST_MIRROR_SET_FILENAME = "idms.yaml"
 FDF_SERVICE_NAME = "odfmanager"
 

--- a/ocs_ci/ocs/node.py
+++ b/ocs_ci/ocs/node.py
@@ -3307,3 +3307,18 @@ def get_ceph_tools_running_node():
     ct_pod = pod.get_ceph_tools_pod(wait=True, skip_creating_pod=True)
     ct_pod_running_node = ct_pod.data["spec"].get("nodeName")
     return ct_pod_running_node
+
+
+def mark_masters_schedulable():
+    """
+    Mark master nodes as schedulable
+    """
+    path = "/spec/mastersSchedulable"
+    params = f"""[{{"op": "replace", "path": "{path}", "value": true}}]"""
+    scheduler_obj = OCP(
+        kind=constants.SCHEDULERS_CONFIG,
+        namespace=config.ENV_DATA["cluster_namespace"],
+    )
+    assert scheduler_obj.patch(
+        params=params, format_type="json"
+    ), "Failed to run patch command to update control nodes as scheduleable"

--- a/ocs_ci/templates/fusion/image-digest-mirror-set.yaml.j2
+++ b/ocs_ci/templates/fusion/image-digest-mirror-set.yaml.j2
@@ -1,0 +1,18 @@
+apiVersion: config.openshift.io/v1
+kind: ImageDigestMirrorSet
+metadata:
+    name: isf-operator-repo
+spec:
+  imageDigestMirrors:
+    - mirrors:
+        - docker-na-public.artifactory.swg-devops.com/hyc-abell-devops-team-mint-docker-local/isf-{{ sds_version }}/cp  # for mint HCI repo
+        - docker-na-public.artifactory.swg-devops.com/hyc-abell-devops-team-dev-docker-local/isf-{{ sds_version }}/cp  # for dev HCI repo
+        - docker-na-public.artifactory.swg-devops.com/hyc-abell-devops-team-mint-docker-local/sds-{{ sds_version }}/cp  # for mint SDS repo
+        - docker-na-public.artifactory.swg-devops.com/hyc-abell-devops-team-dev-docker-local/sds-{{ sds_version }}/cp  # for dev SDS repo
+      source: cp.icr.io/cp
+    - mirrors:
+        - docker-na-public.artifactory.swg-devops.com/hyc-abell-devops-team-mint-docker-local/isf-{{ sds_version }}/cpopen  # for mint repo
+        - docker-na-public.artifactory.swg-devops.com/hyc-abell-devops-team-dev-docker-local/isf-{{ sds_version }}/cpopen # for dev repo
+        - docker-na-public.artifactory.swg-devops.com/hyc-abell-devops-team-mint-docker-local/sds-{{ sds_version }}/cpopen  # for mint SDS repo
+        - docker-na-public.artifactory.swg-devops.com/hyc-abell-devops-team-dev-docker-local/sds-{{ sds_version }}/cpopen  # for dev SDS repo
+      source: icr.io/cpopen

--- a/ocs_ci/utility/storage_cluster_setup.py
+++ b/ocs_ci/utility/storage_cluster_setup.py
@@ -72,6 +72,11 @@ class StorageClusterSetup(object):
                 config.COMPONENTS[f"disable_{component}"] = True
                 logger.warning(f"disabling: {component}")
 
+        if config.DEPLOYMENT.get("provider_api_server_service_type"):
+            cluster_data["spec"]["providerAPIServerServiceType"] = (
+                config.DEPLOYMENT.get("provider_api_server_service_type")
+            )
+
         # Update cluster_data with respective component enable/disable
         for key in config.COMPONENTS.keys():
             comp_name = constants.OCS_COMPONENTS_MAP[key.split("_")[1]]

--- a/ocs_ci/utility/version.py
+++ b/ocs_ci/utility/version.py
@@ -68,6 +68,7 @@ VERSION_4_19 = get_semantic_version("4.19", True)
 
 # Fusion version constants
 VERSION_2_11 = get_semantic_version("2.11", True)
+VERSION_2_12 = get_semantic_version("2.12", True)
 
 
 def get_semantic_ocs_version_from_config(cluster_config=None):


### PR DESCRIPTION
* 2AZ Arbiter FDF deployment
* Add IDMS for Fusion 2.12 and later
* Add configurable way to skip storage setup for FDF deployments
* Add method to wait for storageclusters CRD to FDF install verification
* Use localblock for storageclass if lso_enabled
* Set device_class in 2az arbiter config
* Add disks for LSO FDF deployments
* label non-arbiter masters as storage nodes if configured