### PR TITLE
cephfs stress test monitoring fixes

### DIFF
--- a/ocs_ci/helpers/cephfs_stress_helpers.py
+++ b/ocs_ci/helpers/cephfs_stress_helpers.py
@@ -316,7 +316,9 @@ class CephFSStressTestManager:
         """
         wait_for_resource_state(resource, state=state, timeout=timeout)
 
-    def _read_env_var_from_spec(self, env_list, name, default=""):
+    def _read_env_var_from_spec(
+        self, env_list: list, name: str, default: str = ""
+    ) -> str:
         """
         Return the value of an env variable from a container env list.
 

--- a/ocs_ci/helpers/cephfs_stress_helpers.py
+++ b/ocs_ci/helpers/cephfs_stress_helpers.py
@@ -88,6 +88,10 @@ class CephFSStressTestManager:
         # Reuse PrometheusAPI instance to prevent memory leaks from creating new instances
         self.prometheus_api = PrometheusAPI(threading_lock=self.verification_lock)
         self.pod_restart_baseline = {}
+        # Mirrors the ENABLE_FS_MONITORING env-var set in the pod/job YAML.
+        # Updated by create_cephfs_stress_pod / create_cephfs_stress_job so that
+        # the watchdog skips filesystem hang checks when monitoring is disabled.
+        self.fs_monitoring_enabled = True
 
     def setup_stress_test_environment(self, pvc_size, storageclass_factory):
         """
@@ -180,6 +184,18 @@ class CephFSStressTestManager:
         ] = pvc_name
         logger.info("Set environment variables in the pod template")
         self._set_env_vars(cephfs_stress_pod_data, env_vars, type=constants.POD)
+        self.fs_monitoring_enabled = (
+            self._read_env_var_from_spec(
+                cephfs_stress_pod_data["spec"]["containers"][0].get("env", []),
+                "ENABLE_FS_MONITORING",
+                default="true",
+            ).lower()
+            == "true"
+        )
+        logger.info(
+            f"Filesystem monitoring {'enabled' if self.fs_monitoring_enabled else 'DISABLED'} "
+            "(ENABLE_FS_MONITORING)"
+        )
         cephfs_stress_pod_obj = pod.Pod(**cephfs_stress_pod_data)
         logger.info(f"Creating CephFS stress pod with PVC: {pvc_name}")
         created_resource = cephfs_stress_pod_obj.create()
@@ -247,8 +263,22 @@ class CephFSStressTestManager:
             cephfs_stress_job_data["spec"]["parallelism"] = parallelism
         if completions:
             cephfs_stress_job_data["spec"]["completions"] = completions
-        logger.info("Set environment variables in the pod template")
+        logger.info("Set environment variables in the job template")
         self._set_env_vars(cephfs_stress_job_data, env_vars, type=constants.JOB)
+        self.fs_monitoring_enabled = (
+            self._read_env_var_from_spec(
+                cephfs_stress_job_data["spec"]["template"]["spec"]["containers"][0].get(
+                    "env", []
+                ),
+                "ENABLE_FS_MONITORING",
+                default="true",
+            ).lower()
+            == "true"
+        )
+        logger.info(
+            f"Filesystem monitoring {'enabled' if self.fs_monitoring_enabled else 'DISABLED'} "
+            "(ENABLE_FS_MONITORING)"
+        )
         job_name = cephfs_stress_job_data["metadata"]["name"]
         job_ocs_obj = OCS(**cephfs_stress_job_data)
         created_resource = job_ocs_obj.create()
@@ -285,6 +315,24 @@ class CephFSStressTestManager:
 
         """
         wait_for_resource_state(resource, state=state, timeout=timeout)
+
+    def _read_env_var_from_spec(self, env_list, name, default=""):
+        """
+        Return the value of an env variable from a container env list.
+
+        Args:
+            env_list (list): The ``env`` list from the container spec.
+            name (str): The env variable name to look up.
+            default (str): Value to return when the variable is not found.
+
+        Returns:
+            str: The value string, or *default* if not present.
+
+        """
+        for item in env_list:
+            if item.get("name") == name:
+                return str(item.get("value", default))
+        return default
 
     def _set_env_vars(self, resource_data, env_vars, type):
         """
@@ -493,8 +541,14 @@ class CephFSStressTestManager:
         verifications_to_run = [
             check_ceph_health,
             verify_openshift_storage_ns_pods_in_running_state,
-            verify_no_filesystem_hangs,
         ]
+        if self.fs_monitoring_enabled:
+            verifications_to_run.append(verify_no_filesystem_hangs)
+        else:
+            logger.info(
+                "Skipping filesystem hang verification - "
+                "ENABLE_FS_MONITORING is disabled"
+            )
         try:
             for verification_func in verifications_to_run:
                 if self.stop_event.is_set():

--- a/ocs_ci/helpers/cephfs_stress_helpers.py
+++ b/ocs_ci/helpers/cephfs_stress_helpers.py
@@ -107,13 +107,20 @@ class CephFSStressTestManager:
         """
         sc_name = constants.CEPHFILESYSTEM_SC_SELINUX
         logger.info(f"Creating SELinux CephFS storageclass: {sc_name}")
-        sc_obj = storageclass_factory(
-            sc_name=sc_name,
-            interface=constants.CEPHFILESYSTEM,
-            kernelMountOptions='context="system_u:object_r:container_file_t:s0"',
-        )
+        try:
+            sc_obj = storageclass_factory(
+                sc_name=sc_name,
+                interface=constants.CEPHFILESYSTEM,
+                kernelMountOptions='context="system_u:object_r:container_file_t:s0"',
+            )
+            logger.info(f"Created SELinux CephFS StorageClass: {sc_name}")
+        except CommandFailed as e:
+            if "(AlreadyExists)" not in str(e):
+                raise
+            logger.warning(f"StorageClass '{sc_name}' already exists — reusing it")
+            sc_data = ocp.OCP(kind=constants.STORAGECLASS).get(resource_name=sc_name)
+            sc_obj = OCS(**sc_data)
         self.created_resources.append(sc_obj)
-        logger.info(f"Created SELinux CephFS StorageClass: {sc_name}")
 
         pvc_obj = create_pvc(
             sc_name=sc_name,

--- a/ocs_ci/helpers/cephfs_stress_helpers.py
+++ b/ocs_ci/helpers/cephfs_stress_helpers.py
@@ -114,13 +114,13 @@ class CephFSStressTestManager:
                 kernelMountOptions='context="system_u:object_r:container_file_t:s0"',
             )
             logger.info(f"Created SELinux CephFS StorageClass: {sc_name}")
+            self.created_resources.append(sc_obj)
         except CommandFailed as e:
             if "(AlreadyExists)" not in str(e):
                 raise
-            logger.warning(f"StorageClass '{sc_name}' already exists — reusing it")
+            logger.warning(f"StorageClass '{sc_name}' already exists")
             sc_data = ocp.OCP(kind=constants.STORAGECLASS).get(resource_name=sc_name)
             sc_obj = OCS(**sc_data)
-        self.created_resources.append(sc_obj)
 
         pvc_obj = create_pvc(
             sc_name=sc_name,

--- a/ocs_ci/templates/workloads/cephfs_stress/cephfs_stress_job.yaml
+++ b/ocs_ci/templates/workloads/cephfs_stress/cephfs_stress_job.yaml
@@ -129,6 +129,8 @@ spec:
         volumeMounts:
         - mountPath: /mnt
           name: mypvc
+      securityContext:
+        fsGroupChangePolicy: OnRootMismatch
       restartPolicy: Never
       volumes:
       - name: mypvc

--- a/ocs_ci/templates/workloads/cephfs_stress/cephfs_stress_job.yaml
+++ b/ocs_ci/templates/workloads/cephfs_stress/cephfs_stress_job.yaml
@@ -77,7 +77,7 @@ spec:
           - name: FILES_SIZE       # File size in KB
             value: "4"
           - name: OPERATIONS       # File and directory operations to perform, Pass as a comma-separated string
-            value: "create,append,rename,stat,chmod,ls-l"
+            value: "create,mkdir,symlink,readdir,delete,append,rename,stat,chmod,ls-l"
           - name: OUTPUT_DIR
             value: "/mnt/output"
           - name: THREADS

--- a/ocs_ci/templates/workloads/cephfs_stress/cephfs_stress_pod.yaml
+++ b/ocs_ci/templates/workloads/cephfs_stress/cephfs_stress_pod.yaml
@@ -117,6 +117,8 @@ spec:
     volumeMounts:
     - mountPath: /mnt
       name: mypvc
+  securityContext:
+    fsGroupChangePolicy: OnRootMismatch
   restartPolicy: Never
   volumes:
   - name: mypvc

--- a/ocs_ci/templates/workloads/cephfs_stress/cephfs_stress_pod.yaml
+++ b/ocs_ci/templates/workloads/cephfs_stress/cephfs_stress_pod.yaml
@@ -65,7 +65,7 @@ spec:
       - name: FILES_SIZE       # File size in KB
         value: "4"
       - name: OPERATIONS       # File and directory operations to perform, Pass as a comma-separated string
-        value: "create,append,rename,stat,chmod,ls-l"
+        value: "create,mkdir,symlink,readdir,delete,append,rename,stat,chmod,ls-l"
       - name: OUTPUT_DIR
         value: "/mnt/output"
       - name: THREADS

--- a/tests/cross_functional/stress/cephfs/test_cephfs_breakpoint.py
+++ b/tests/cross_functional/stress/cephfs/test_cephfs_breakpoint.py
@@ -59,10 +59,11 @@ class TestCephfsStress(E2ETest):
 
             cephfs_stress_job_obj = stress_mgr.create_cephfs_stress_job(
                 pvc_name=pvc_obj.name,
-                multiplication_factors="1,2,3,4",
+                multiplication_factors="1,2,4,6,8,10,8,6,4,2",
                 parallelism=6,
                 completions=6,
-                base_file_count=100,
+                base_file_count=5000000,
+                threads=16,
             )
             logger.info(
                 f"The CephFS-stress Job {cephfs_stress_job_obj.name} has been submitted"

--- a/tests/cross_functional/stress/cephfs/test_cephfs_breakpoint.py
+++ b/tests/cross_functional/stress/cephfs/test_cephfs_breakpoint.py
@@ -53,10 +53,6 @@ class TestCephfsStress(E2ETest):
                 pvc_size="500Gi", storageclass_factory=storageclass_factory
             )
 
-            stress_mgr.start_background_checks(
-                interval_minutes=CHECKS_RUNNER_INTERVAL_MINUTES
-            )
-
             cephfs_stress_job_obj = stress_mgr.create_cephfs_stress_job(
                 pvc_name=pvc_obj.name,
                 multiplication_factors="1,2,4,6,8,10,8,6,4,2",
@@ -64,6 +60,13 @@ class TestCephfsStress(E2ETest):
                 completions=6,
                 base_file_count=5000000,
                 threads=16,
+            )
+
+            # Start the watchdog only after resource creation so that
+            # fs_monitoring_enabled already reflects the ENABLE_FS_MONITORING
+            # value resolved from the job template.
+            stress_mgr.start_background_checks(
+                interval_minutes=CHECKS_RUNNER_INTERVAL_MINUTES
             )
             logger.info(
                 f"The CephFS-stress Job {cephfs_stress_job_obj.name} has been submitted"

--- a/tests/cross_functional/stress/cephfs/test_cephfs_incremental_bulk_ops_cleanup.py
+++ b/tests/cross_functional/stress/cephfs/test_cephfs_incremental_bulk_ops_cleanup.py
@@ -73,16 +73,19 @@ class TestCephfsStressCleanUp(E2ETest):
 
         teardown_factory(pods_list)
         try:
-            stress_mgr.start_background_checks(
-                interval_minutes=CHECKS_RUNNER_INTERVAL_MINUTES
-            )
-
             cephfs_stress_job_obj = stress_mgr.create_cephfs_stress_job(
                 pvc_name=pvc_obj.name,
                 multiplication_factors=m_factor,
                 parallelism=parallelism,
                 completions=completions,
                 base_file_count=100,
+            )
+
+            # Start the watchdog only after resource creation so that
+            # fs_monitoring_enabled already reflects the ENABLE_FS_MONITORING
+            # value resolved from the job template.
+            stress_mgr.start_background_checks(
+                interval_minutes=CHECKS_RUNNER_INTERVAL_MINUTES
             )
             logger.info(
                 f"The CephFS-stress Job {cephfs_stress_job_obj.name} has been submitted"

--- a/tests/cross_functional/stress/cephfs/test_cephfs_stress_with_component_failures.py
+++ b/tests/cross_functional/stress/cephfs/test_cephfs_stress_with_component_failures.py
@@ -126,16 +126,19 @@ class TestCephfsStressWithFailures(E2ETest):
                 pvc_size="500Gi", storageclass_factory=storageclass_factory
             )
 
-            stress_mgr.start_background_checks(
-                interval_minutes=CHECKS_RUNNER_INTERVAL_MINUTES
-            )
-
             cephfs_stress_job_obj = stress_mgr.create_cephfs_stress_job(
                 pvc_name=pvc_obj.name,
                 multiplication_factors=MULTIPLICATION_FACTORS,
                 parallelism=4,
                 completions=4,
                 base_file_count=50000,
+            )
+
+            # Start the watchdog only after resource creation so that
+            # fs_monitoring_enabled already reflects the ENABLE_FS_MONITORING
+            # value resolved from the job template.
+            stress_mgr.start_background_checks(
+                interval_minutes=CHECKS_RUNNER_INTERVAL_MINUTES
             )
             logger.info(
                 f"CephFS stress job {cephfs_stress_job_obj.name} has been submitted"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CephFS stress workloads now exercise `mkdir`, `symlink`, and `readdir` operations.
  * Filesystem hang verification follows the workload’s monitoring setting.
  * Workloads use improved volume-permission handling for more reliable startup.

* **Bug Fixes**
  * Stress environment setup now continues when the required SELinux StorageClass already exists.

* **Tests**
  * Expanded stress coverage with larger file-count scenarios, varied workload scaling, and 16 concurrent threads.
  * Monitoring behavior is resolved from the workload before background checks begin.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->