### PR TITLE
[FDF]: update ITMS

### DIFF
--- a/ocs_ci/templates/fusion-data-foundation/image-tag-mirror-set.yaml
+++ b/ocs_ci/templates/fusion-data-foundation/image-tag-mirror-set.yaml
@@ -5,8 +5,7 @@ metadata:
 spec:
   imageTagMirrors:
   - mirrors:
-    - preprod.icr.io/cp/df/isf-data-foundation-catalog
-    - cp.stg.icr.io/cp/df/isf-data-foundation-catalog
+    - preprod.icr.io/cpopen/isf-data-foundation-catalog
     source: icr.io/cpopen/isf-data-foundation-catalog
   mirrorSourcePolicy:
     AllowContactingSource 0


### PR DESCRIPTION
This chnage is due to FDF testing builds moving from cp.stg.icr.io to preprod.icr.io

Signed-off-by: vavuthu [vavuthu@redhat.com](mailto:vavuthu@redhat.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Updates**
  - Updated container image mirroring for IBM Spectrum Scale, OpenShift Data Foundation, OpenShift, Ceph, PostgreSQL, and related components to use the preproduction registry.
  - Expanded mirror coverage for additional IBM and OpenShift images.
  - Updated the Data Foundation catalog mirror path to the preproduction registry.
  - Removed obsolete image sources, legacy Artifactory-based mappings, and the staging catalog mirror.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->