### PR TITLE
cephfs EC snapshot cycle tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1364,7 +1364,19 @@ def storageclass_factory_fixture(
                     else:
                         interface_name = pool_name
             elif interface == constants.CEPHFILESYSTEM:
-                interface_name = helpers.get_cephfs_data_pool_name()
+                if erasure_coded:
+                    from ocs_ci.ocs.cluster import get_ec_profile
+
+                    data_chunks, coding_chunks = get_ec_profile()
+                    ec_pool_short = sc_name or f"ec-fs-{len(instances)}"
+                    interface_name = helpers.create_cephfs_ec_pool(
+                        ec_pool_short, data_chunks, coding_chunks
+                    )
+                    request.addfinalizer(
+                        lambda n=ec_pool_short: helpers.delete_cephfs_ec_pool(n)
+                    )
+                else:
+                    interface_name = helpers.get_cephfs_data_pool_name()
 
             sc_obj = helpers.create_storage_class(
                 interface_type=interface,

--- a/tests/functional/storageclass/test_cross_sc_clone_snap_restore.py
+++ b/tests/functional/storageclass/test_cross_sc_clone_snap_restore.py
@@ -269,6 +269,91 @@ class TestCrossScCloneSnapRestore(ManageTest):
                     ),
                 ],
             ),
+            # CephFS: SC1=replicated data0, SC2=EC data pool
+            pytest.param(
+                *[constants.CEPHFILESYSTEM],
+                "",
+                "",
+                False,
+                True,
+                False,
+                marks=[
+                    ec_allowed,
+                    pytest.mark.polarion_id("OCS-8240"),
+                    pytest.mark.skipif(
+                        not is_ec_pool_supported(),
+                        reason="Erasure coded pools are not supported on this cluster",
+                    ),
+                ],
+            ),
+            # CephFS: SC1=replicated replica3, SC2=EC data pool
+            pytest.param(
+                *[constants.CEPHFILESYSTEM],
+                3,
+                "",
+                False,
+                True,
+                False,
+                marks=[
+                    ec_allowed,
+                    pytest.mark.polarion_id("OCS-8241"),
+                    pytest.mark.skipif(
+                        not is_ec_pool_supported(),
+                        reason="Erasure coded pools are not supported on this cluster",
+                    ),
+                ],
+            ),
+            # CephFS: SC1=replicated replica2, SC2=EC data pool
+            pytest.param(
+                *[constants.CEPHFILESYSTEM],
+                2,
+                "",
+                False,
+                True,
+                False,
+                marks=[
+                    ec_allowed,
+                    pytest.mark.polarion_id("OCS-8242"),
+                    pytest.mark.skipif(
+                        not is_ec_pool_supported(),
+                        reason="Erasure coded pools are not supported on this cluster",
+                    ),
+                ],
+            ),
+            # CephFS: SC1=EC data pool, SC2=replicated replica3
+            pytest.param(
+                *[constants.CEPHFILESYSTEM],
+                "",
+                3,
+                False,
+                False,
+                True,
+                marks=[
+                    ec_allowed,
+                    pytest.mark.polarion_id("OCS-8244"),
+                    pytest.mark.skipif(
+                        not is_ec_pool_supported(),
+                        reason="Erasure coded pools are not supported on this cluster",
+                    ),
+                ],
+            ),
+            # CephFS: SC1=EC data pool, SC2=replicated replica2
+            pytest.param(
+                *[constants.CEPHFILESYSTEM],
+                "",
+                2,
+                False,
+                False,
+                True,
+                marks=[
+                    ec_allowed,
+                    pytest.mark.polarion_id("OCS-8245"),
+                    pytest.mark.skipif(
+                        not is_ec_pool_supported(),
+                        reason="Erasure coded pools are not supported on this cluster",
+                    ),
+                ],
+            ),
         ],
     )
     @skipif_mcg_only


### PR DESCRIPTION
extend snapshot, clone and restore tests. Include EC option. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Expanded coverage for cross-storage-class clone, snapshot, and restore workflows involving CephFS erasure-coded pools.
  - Added validation for combinations of replicated and erasure-coded storage configurations, including multiple replica counts.
  - Added environment checks so these scenarios run only on clusters that support erasure-coded pools.
  - Improved test setup and cleanup for temporary CephFS erasure-coded pools, helping ensure reliable and isolated test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->