### PR TITLE
Increase timeout for OSD deployment readiness in "test_delete_rook_ceph_osd_deployment"

### DIFF
--- a/tests/functional/z_cluster/test_delete_osd_deployment.py
+++ b/tests/functional/z_cluster/test_delete_osd_deployment.py
@@ -58,12 +58,16 @@ class TestDeleteOSDDeployment(ManageTest):
                 if "NotFound" not in str(err):
                     raise
 
-            # Wait for new OSD deployment to be Ready
+            # Wait for new OSD deployment to be Ready.
+            # The replacement pod's "expand-bluefs" init container has been observed
+            # to stall for several minutes (up to ~4m) while re-reading the device
+            # labels of the underlying block PVC right after it is remapped from the
+            # deleted pod, so a generous timeout is needed to avoid false failures.
             deployment_obj.wait_for_resource(
                 condition="1/1",
                 resource_name=osd_deployment_name,
                 column="READY",
-                timeout=120,
+                timeout=420,
             )
 
             # Check if a new OSD pod is created


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved reliability of OSD deployment deletion validation by allowing additional time for replacement deployments to become ready.
  - Updated test guidance to account for occasional delays during replacement storage initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->