### PR TITLE
handy-pick-5.0-4.22-locators

### DIFF
--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -719,6 +719,77 @@ def get_pool_size_factor(pool_name):
     return factor
 
 
+def get_pool_data_protection_scheme(pool_name):
+    """
+    Return the data protection scheme of a Ceph pool, matching what the ODF
+    Storage Pools list shows in the "Data protection policy" column.
+
+    The scheme is read from the ``CephBlockPool`` CR (RBD pools) or, when no
+    such CR exists, from the matching entry in a ``CephFilesystem`` CR's
+    ``spec.dataPools`` (CephFS pools). CephFS data pools without an explicit
+    ``name`` follow Rook's ``<filesystem>-data<index>`` naming, while named
+    pools follow ``<filesystem>-<name>``. No Ceph toolbox commands are required.
+
+    Args:
+        pool_name (str): Full pool name as shown in the UI, e.g.
+            'ocs-storagecluster-cephblockpool' or
+            'ocs-storagecluster-cephfilesystem-data0'.
+
+    Returns:
+        dict: For an erasure coded pool
+              ``{"type": "erasure_coded", "data_chunks": k, "coding_chunks": m,
+              "scheme": "k+m"}``; for a replicated pool
+              ``{"type": "replicated", "replica": size}``.
+
+    Raises:
+        ResourceNotFoundError: if the pool is not found in any CephBlockPool or
+            CephFilesystem CR.
+    """
+    namespace = config.ENV_DATA["cluster_namespace"]
+
+    def _scheme_from_spec(spec):
+        ec_spec = spec.get("erasureCoded", {}) or {}
+        k = ec_spec.get("dataChunks", 0)
+        m = ec_spec.get("codingChunks", 0)
+        if k:
+            return {
+                "type": "erasure_coded",
+                "data_chunks": k,
+                "coding_chunks": m,
+                "scheme": f"{k}+{m}",
+            }
+        replica = spec.get("replicated", {}).get("size", 0)
+        return {"type": "replicated", "replica": int(replica)}
+
+    block_pools = (
+        ocp.OCP(kind=constants.CEPHBLOCKPOOL, namespace=namespace)
+        .get()
+        .get("items", [])
+    )
+    for pool in block_pools:
+        if pool["metadata"]["name"] == pool_name:
+            return _scheme_from_spec(pool.get("spec", {}))
+
+    filesystems = (
+        ocp.OCP(kind=constants.CEPHFILESYSTEM, namespace=namespace)
+        .get()
+        .get("items", [])
+    )
+    for filesystem in filesystems:
+        fs_name = filesystem["metadata"]["name"]
+        for index, data_pool in enumerate(
+            filesystem.get("spec", {}).get("dataPools", [])
+        ):
+            data_pool_name = data_pool.get("name") or f"data{index}"
+            if f"{fs_name}-{data_pool_name}" == pool_name:
+                return _scheme_from_spec(data_pool)
+
+    raise exceptions.ResourceNotFoundError(
+        f"Pool '{pool_name}' not found in any CephBlockPool or CephFilesystem "
+        f"CR in namespace '{namespace}'"
+    )
+
+
 def create_ceph_block_pool(
     pool_name=None,
     replica=3,

--- a/ocs_ci/ocs/ui/base_ui.py
+++ b/ocs_ci/ocs/ui/base_ui.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 from pathlib import Path
 import datetime
 import logging
@@ -682,6 +683,53 @@ class BaseUI:
 
         """
         self.driver.refresh()
+
+    @contextmanager
+    def run_in_new_tab(self, locator, timeout=15):
+        """
+        Click a locator that opens a new browser tab, switch to it, and
+        guarantee cleanup on exit.
+
+        Usage::
+
+            with self.run_in_new_tab(some_locator):
+                content = self.driver.find_element(By.TAG_NAME, "pre").text
+
+        Args:
+            locator: Selenium locator tuple that triggers a new tab on click.
+            timeout (int): Seconds to wait for the new tab to appear.
+
+        Yields:
+            The WebDriver instance, now focused on the new tab.
+
+        Raises:
+            TimeoutException: If no new tab opens within ``timeout`` seconds.
+
+        """
+        driver = SeleniumDriver()
+        parent_handle = driver.current_window_handle
+        original_handles = set(driver.window_handles)
+
+        self.do_click(locator, enable_screenshot=True)
+
+        try:
+            WebDriverWait(driver, timeout).until(
+                lambda d: len(d.window_handles) > len(original_handles)
+            )
+        except TimeoutException as err:
+            raise TimeoutException(
+                f"No new tab opened within {timeout}s after clicking {locator}"
+            ) from err
+
+        new_handle = (set(driver.window_handles) - original_handles).pop()
+        driver.switch_to.window(new_handle)
+        try:
+            yield driver
+        finally:
+            if new_handle in driver.window_handles:
+                driver.switch_to.window(new_handle)
+                driver.close()
+            driver.switch_to.window(parent_handle)
 
     def navigate_backward(self):
         """
@@ -1576,10 +1624,18 @@ def proceed_to_login_console():
 
 def navigate_to_local_cluster(**kwargs):
     """
-    Navigate to Local Cluster page, if not already there
+    Navigate to Local Cluster page, if not already there.
+
+    On multicluster-hub (MCE/ACM) consoles the perspective switcher is a real
+    dropdown, while on single-cluster consoles it is a static title. In both cases
+    its title reflects the currently selected perspective, so the current
+    perspective is read from that title to decide whether navigation is needed.
+    This avoids probing for absent elements, which would otherwise emit failure
+    screenshots and DOM dumps for the common "already local" case.
+
     :param kwargs: acm_page locators dict, timeout
 
-    :raises TimeoutException: if timeout occurs, and local clusters page is not loaded
+    :raises TimeoutException: if the perspective switcher is not found
     """
     if "acm_page" in kwargs:
         acm_page_loc = kwargs["acm_page"]
@@ -1590,32 +1646,42 @@ def navigate_to_local_cluster(**kwargs):
     else:
         timeout = 30
 
-    all_clusters_dropdown = acm_page_loc["all-clusters_dropdown"]
-    try:
-        logger.info("Navigate to Local Cluster page. Click all clusters dropdown")
-        acm_dropdown = wait_for_element_to_be_visible(all_clusters_dropdown, timeout)
-        acm_dropdown.click()
-        local_cluster_item = wait_for_element_to_be_visible(
-            acm_page_loc["local-cluster_dropdown_item"], timeout
-        )
-        logger.info("Navigate to Local Cluster page. Click local cluster item")
-        local_cluster_item.click()
-    except TimeoutException:
-        current_url = SeleniumDriver().current_url
-        logger.warning(
-            f"'All Clusters' dropdown not found within {timeout}s "
-            f"(current URL: {current_url}). "
-            "Checking whether local-cluster page is already loaded."
-        )
-        wait_for_element_to_be_visible(acm_page_loc["local-cluster_dropdown"], timeout)
+    switcher = wait_for_element_to_be_visible(
+        acm_page_loc["perspective-switcher-toggle"], timeout
+    )
+    current_perspective = switcher.text.strip()
+    logger.info(f"Current perspective switcher title: '{current_perspective}'")
+
+    if any(
+        title in current_perspective for title in ("Core platform", "local-cluster")
+    ):
+        logger.info("Already on local cluster — skipping cluster navigation.")
+        return
+
+    logger.info(
+        f"Perspective '{current_perspective}' is not the local cluster. "
+        "Opening the perspective switcher to select the local cluster."
+    )
+    switcher.click()
+    local_cluster_item = wait_for_element_to_be_visible(
+        acm_page_loc["local-cluster_dropdown_item"], timeout
+    )
+    logger.info("Selecting the local cluster from the perspective switcher")
+    local_cluster_item.click()
 
 
 def navigate_to_all_clusters(**kwargs):
     """
-    Navigate to All Clusters page, if not already there
+    Navigate to All Clusters (Fleet management) page, if not already there.
+
+    Mirrors navigate_to_local_cluster: the currently selected perspective is read
+    from the perspective switcher title before deciding whether to switch, so no
+    absent elements are searched (and no failure screenshots emitted) when the
+    page is already on the all-clusters view.
+
     :param kwargs: acm_page locators dict, timeout
 
-    :raises TimeoutException: if timeout occurs, and All clusters acm page is not loaded
+    :raises TimeoutException: if the perspective switcher is not found
     """
     if "acm_page" in kwargs:
         acm_page = kwargs["acm_page"]
@@ -1626,13 +1692,25 @@ def navigate_to_all_clusters(**kwargs):
     else:
         timeout = 30
 
-    local_clusters_dropdown = acm_page["local-cluster_dropdown"]
-    try:
-        acm_dropdown = wait_for_element_to_be_visible(local_clusters_dropdown, timeout)
-        acm_dropdown.click()
-        all_clusters_item = wait_for_element_to_be_visible(
-            acm_page["all-clusters_dropdown_item"]
-        )
-        all_clusters_item.click()
-    except TimeoutException:
-        wait_for_element_to_be_visible(acm_page["all-clusters_dropdown"])
+    switcher = wait_for_element_to_be_visible(
+        acm_page["perspective-switcher-toggle"], timeout
+    )
+    current_perspective = switcher.text.strip()
+    logger.info(f"Current perspective switcher title: '{current_perspective}'")
+
+    if any(
+        title in current_perspective for title in ("Fleet management", "All Clusters")
+    ):
+        logger.info("Already on all clusters — skipping cluster navigation.")
+        return
+
+    logger.info(
+        f"Perspective '{current_perspective}' is not all clusters. "
+        "Opening the perspective switcher to select all clusters."
+    )
+    switcher.click()
+    all_clusters_item = wait_for_element_to_be_visible(
+        acm_page["all-clusters_dropdown_item"], timeout
+    )
+    logger.info("Selecting all clusters from the perspective switcher")
+    all_clusters_item.click()

--- a/ocs_ci/ocs/ui/page_objects/block_pools.py
+++ b/ocs_ci/ocs/ui/page_objects/block_pools.py
@@ -350,3 +350,57 @@ class StoragePools(CreateResourceForm, EditLabelForm, ResourceList):
         has_ec = "Erasure coding" in replicas_text
         has_scheme = expected_scheme in replicas_text
         return has_ec and has_scheme
+
+    def get_displayed_pools(self):
+        """
+        Return the names of the pools currently displayed in the Storage Pools
+        list, read from the 'Data protection policy' column cells.
+
+        Returns:
+            list[str]: Pool names, e.g. ['ocs-storagecluster-cephblockpool', ...]
+        """
+        suffix = "-replicas"
+        spans = self.get_elements(self.bp_loc["pool_replicas_all_in_list"])
+        pool_names = []
+        for span in spans:
+            data_test = span.get_attribute("data-test") or ""
+            if data_test.endswith(suffix):
+                pool_names.append(data_test[: -len(suffix)])
+        logger.info(f"Pools displayed in Storage Pools list: {pool_names}")
+        return pool_names
+
+    def verify_existing_pools(self):
+        """
+        Verify the 'Data protection policy' column for every pool shown in the
+        Storage Pools list matches the pool's actual scheme (replicated or
+        erasure coded) read from the cluster CRs.
+
+        Works for both replicated and erasure coded clusters: replicated pools
+        must display 'Replication' and 'Replica <size>', erasure coded pools
+        must display 'Erasure coding' and the '<k>+<m>' scheme.
+
+        Returns:
+            dict: Mapping of pool_name -> bool, True when the displayed policy
+                matches the actual pool scheme.
+        """
+        from ocs_ci.helpers.helpers import get_pool_data_protection_scheme
+
+        results = {}
+        for pool_name in self.get_displayed_pools():
+            replicas_locator = format_locator(
+                self.bp_loc["pool_replicas_in_list"], pool_name
+            )
+            displayed_text = self.get_element_text(replicas_locator)
+            scheme = get_pool_data_protection_scheme(pool_name)
+            if scheme["type"] == "erasure_coded":
+                expected_tokens = ["Erasure coding", scheme["scheme"]]
+            else:
+                expected_tokens = ["Replication", f"Replica {scheme['replica']}"]
+            match = all(token in displayed_text for token in expected_tokens)
+            logger.info(
+                f"Pool '{pool_name}': displayed='{displayed_text}', "
+                f"actual scheme={scheme}, expected tokens={expected_tokens}, "
+                f"match={match}"
+            )
+            results[pool_name] = match
+        return results

--- a/ocs_ci/ocs/ui/validation_ui.py
+++ b/ocs_ci/ocs/ui/validation_ui.py
@@ -4,16 +4,22 @@ import pytest
 import time
 import pandas as pd
 from ocs_ci.framework import config
-from ocs_ci.framework.logger_helper import log_step
 from ocs_ci.ocs.cluster import (
     get_used_and_total_capacity_in_gibibytes,
     get_age_of_cluster_in_days,
 )
-from ocs_ci.ocs.exceptions import UnexpectedODFAccessException, CephHealthException
+from ocs_ci.ocs.exceptions import (
+    UnexpectedODFAccessException,
+    CephHealthException,
+    ResourceNotFoundError,
+)
 from ocs_ci.ocs.ui.page_objects.page_navigator import PageNavigator
 from ocs_ci.ocs.ui.base_ui import navigate_to_local_cluster
 from ocs_ci.ocs.ui.block_pool import BlockPoolUI
+from ocs_ci.ocs.ui.helpers_ui import format_locator
 from ocs_ci.ocs import constants
+from ocs_ci.ocs.defaults import ODF_OPERATOR_NAME
+from ocs_ci.ocs.resources.csv import get_csvs_start_with_prefix
 from ocs_ci.utility.utils import TimeoutSampler
 from selenium.common.exceptions import TimeoutException, WebDriverException
 from selenium.webdriver.common.by import By
@@ -241,7 +247,30 @@ class ValidationUI(PageNavigator):
             logger.info(
                 "Storage plugin is disabled, navigate to Operator details page further confirmation"
             )
-            self.do_click(self.validation_loc["odf-operator"])
+            # The ODF operator display name differs by product (e.g. it is
+            # 'IBM Storage Fusion Data Foundation' on FDF clusters), so read it
+            # from the operator CSV instead of hard-coding 'OpenShift Data Foundation'.
+            odf_csvs = get_csvs_start_with_prefix(
+                ODF_OPERATOR_NAME, config.ENV_DATA["cluster_namespace"]
+            )
+            odf_operator_display_name = (
+                odf_csvs[0].get("spec", {}).get("displayName") if odf_csvs else None
+            )
+            if not odf_operator_display_name:
+                raise ResourceNotFoundError(
+                    f"Could not resolve ODF operator display name from a "
+                    f"'{ODF_OPERATOR_NAME}' CSV in namespace "
+                    f"'{config.ENV_DATA['cluster_namespace']}'"
+                )
+            logger.info(
+                f"ODF operator display name from CSV: '{odf_operator_display_name}'"
+            )
+            self.do_click(
+                format_locator(
+                    self.validation_loc["odf-operator-by-display-name"],
+                    odf_operator_display_name,
+                )
+            )
             self.page_has_loaded(retries=15, sleep_time=5)
             console_plugin_status = self.get_element_text(
                 self.validation_loc["console_plugin_option"]
@@ -286,6 +315,8 @@ class ValidationUI(PageNavigator):
             - Verify that **Overview** navigates to the **Storage Cluster** page.
             - Ensure the **Used Raw Capacity** string is visible in the **System Capacity** card.
             - Verify that the **Block and File** tab is active.
+            - Verify that the **Data protection policy** of every existing storage
+              pool matches its actual scheme (replicated or erasure coded).
             - Verify that utilization is good in the **Block and File** tab.
             - Verify that resiliency is OK in the **Block and File** tab.
             - Verify that **CephBlockPool** status is **Ready**.
@@ -331,30 +362,32 @@ class ValidationUI(PageNavigator):
         storage_on_cluster = not external_mode
         multi_storagecluster = config.ENV_DATA.get("multi_storagecluster", False)
 
-        log_step("Validate ODF console plugin is enabled, if not enable it")
+        logger.test_step("Validate ODF console plugin is enabled, if not enable it")
         self.odf_console_plugin_check()
 
-        log_step(
+        logger.test_step(
             "Navigate to Data Foundation page via PageNavigator and Data Foundation"
         )
         overview_page = self.nav_storage_data_foundation_overview_page()
 
         if storage_on_cluster or multi_storagecluster:
-            log_step("Validate if legend for Available vs Used capacity is present")
+            logger.test_step(
+                "Validate if legend for Available vs Used capacity is present"
+            )
             overview_page.available_vs_used_capacity_present()
 
-            log_step("Verify if Overview navigates to Storage Cluster page")
+            logger.test_step("Verify if Overview navigates to Storage Cluster page")
             storage_cluster_page = overview_page.navigate_to_view_storage()
             res_dict["block_and_file_tab_is_active_1"] = (
                 storage_cluster_page.validate_block_and_file_tab_active()
             )
 
-            log_step("Ensure used raw capacity string in System Capacity card")
+            logger.test_step("Ensure used raw capacity string in System Capacity card")
             res_dict["system_raw_capacity_check_bz_2185042"] = self.check_element_text(
                 "Raw capacity"
             )
 
-            log_step("Verify if Block and File tab is active")
+            logger.test_step("Verify if Block and File tab is active")
             storage_cluster_page.validate_block_and_file_tab_active()
 
             block_and_file_tab = storage_cluster_page
@@ -368,7 +401,21 @@ class ValidationUI(PageNavigator):
 
             storage_pools_tab = storage_cluster_page.nav_storage_pools_tab()
 
-            log_step("Verify CephBlockPool status is Ready")
+            logger.test_step(
+                "Verify Data protection policy of every existing storage pool "
+                "matches its actual scheme (replicated or erasure coded)"
+            )
+            pools_verification = storage_pools_tab.verify_existing_pools()
+            res_dict["storage_pools_data_protection_policy_match"] = all(
+                pools_verification.values()
+            )
+            if not all(pools_verification.values()):
+                logger.error(
+                    "Data protection policy mismatch in the Storage Pools list "
+                    f"(pool -> matches actual scheme): {pools_verification}"
+                )
+
+            logger.test_step("Verify CephBlockPool status is Ready")
             try:
                 storage_pools_tab.verify_cephblockpool_status()
                 res_dict["cephblockpool_status_ready"] = True
@@ -377,7 +424,7 @@ class ValidationUI(PageNavigator):
                 self.take_screenshot("cephblockpool_status_not_ready")
                 res_dict["cephblockpool_status_ready"] = False
 
-            log_step("Verify cephfs data pool status is Ready")
+            logger.test_step("Verify cephfs data pool status is Ready")
             try:
                 storage_pools_tab.verify_cephfs_status()
                 res_dict["cephfs_data_pool_status_ready"] = True
@@ -386,7 +433,7 @@ class ValidationUI(PageNavigator):
                 self.take_screenshot("cephfs_data_pool_status_not_ready")
                 res_dict["cephfs_data_pool_status_ready"] = False
 
-            log_step("Navigate to default cephblockpool using searching filter")
+            logger.test_step("Navigate to default cephblockpool using searching filter")
             ceph_block_pool_page = storage_pools_tab.navigate_to_block_pool(
                 constants.DEFAULT_CEPHBLOCKPOOL
             )
@@ -394,7 +441,7 @@ class ValidationUI(PageNavigator):
                 ceph_block_pool_page.block_pool_ready()
             )
 
-            log_step("Verify if Performance Card is present")
+            logger.test_step("Verify if Performance Card is present")
             # BlockPoolUI is not a POM class, but helper class
             block_pool_helper = BlockPoolUI()
             res_dict["performance_card_header_present"] = (
@@ -404,11 +451,11 @@ class ValidationUI(PageNavigator):
             ceph_block_pool_page.navigate_storage_pools_via_breadcrumb()
             res_dict["block_pool_navigation_works"] = True
 
-            log_step(
+            logger.test_step(
                 "Navigate ODF Backing store tab via Object Storage tab or PageNavigator"
             )
 
-            log_step("Verify all tabs are working")
+            logger.test_step("Verify all tabs are working")
             try:
                 storage_cluster_page.nav_object_tab()
                 storage_cluster_page.nav_storage_pools_tab()
@@ -419,13 +466,15 @@ class ValidationUI(PageNavigator):
                 res_dict["storage_cluster_tabs_work"] = False
 
         if external_mode or multi_storagecluster:
-            log_step("Navigate to External Systems")
+            logger.test_step("Navigate to External Systems")
             storage_cluster_page = (
                 overview_page.navigate_to_external_storage_systems().nav_to_external_storage_cluster()
             )
-            log_step("Verify if Block and File tab is active")
+            logger.test_step("Verify if Block and File tab is active")
             storage_cluster_page.validate_block_and_file_tab_active()
-            log_step("verify content of External Storage Cluster / Block and File tab")
+            logger.test_step(
+                "verify content of External Storage Cluster / Block and File tab"
+            )
 
             logger.info(
                 "Check if PersistentVolumeClaims capacity breakdown is available"
@@ -457,31 +506,33 @@ class ValidationUI(PageNavigator):
         backing_store_tab = buckets_tab.nav_backing_store_tab()
         backing_store_tab.nav_to_backing_store(constants.DEFAULT_NOOBAA_BACKINGSTORE)
 
-        log_step(
+        logger.test_step(
             "Verify if Backing Store is present and link to Backing Store resource works"
         )
         res_dict["backing_store_status_ready"] = (
             backing_store_tab.validate_backing_store_ready()
         )
 
-        log_step("Navigate to Backing Store tab via breadcrumb")
+        logger.test_step("Navigate to Backing Store tab via breadcrumb")
         backing_store_tab.nav_backing_store_list_breadcrumb()
 
-        log_step("Navigate to Bucket class tab")
+        logger.test_step("Navigate to Bucket class tab")
         bucket_class_tab = backing_store_tab.nav_bucket_class_tab()
 
-        log_step("Navigate to the default Bucket Class details via Bucket Class tab")
+        logger.test_step(
+            "Navigate to the default Bucket Class details via Bucket Class tab"
+        )
         bucket_class_tab.nav_to_bucket_class(constants.DEFAULT_NOOBAA_BUCKETCLASS)
 
-        log_step(
+        logger.test_step(
             f"Verify the status of a default bucket class: '{constants.DEFAULT_NOOBAA_BUCKETCLASS}'"
         )
         res_dict["bucket_class_status"] = bucket_class_tab.validate_bucket_class_ready()
 
-        log_step("Navigate to Bucket class via breadcrumb")
+        logger.test_step("Navigate to Bucket class via breadcrumb")
         bucket_class_tab.nav_bucket_class_breadcrumb()
 
-        log_step(
+        logger.test_step(
             "Navigate to Namespace Store tab via Bucket Class tab, verify if it works"
         )
 
@@ -491,7 +542,7 @@ class ValidationUI(PageNavigator):
         )
 
         if storage_on_cluster or multi_storagecluster:
-            log_step("Navigate to ODF Storage Cluster via Page navigator")
+            logger.test_step("Navigate to ODF Storage Cluster via Page navigator")
             storage_cluster_page = PageNavigator().nav_storage_cluster_default_page()
             logger.info(f"Web Page title: {self.driver.title}")
             res_dict["block_and_file_tab_is_active_2"] = (
@@ -509,7 +560,7 @@ class ValidationUI(PageNavigator):
                 res_dict["external_systems_page_OK"] = False
 
         self.take_screenshot("summary_of_odf_ui_checks")
-        log_step("Process results")
+        logger.test_step("Process results")
         res_pd = pd.DataFrame.from_dict(res_dict, orient="index", columns=["check"])
         logger.info(res_pd.to_markdown(headers="keys", index=True, tablefmt="grid"))
 

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -210,7 +210,11 @@ deployment_4_9 = {
         By.CSS_SELECTOR,
     ),
     "choose_openshift-storage_project": (
-        "//span[text()='" + config.ENV_DATA["cluster_namespace"] + "']",
+        "//span[text()='" + config.ENV_DATA["cluster_namespace"] + "'] | "
+        "//a[@data-test='" + config.ENV_DATA["cluster_namespace"] + "'] | "
+        "//button[@role='menuitem'][normalize-space()='"
+        + config.ENV_DATA["cluster_namespace"]
+        + "']",
         By.XPATH,
     ),
     "choose_all_projects": ("//span[text()='All Projects']", By.XPATH),
@@ -383,6 +387,10 @@ deployment_4_21 = {
 }
 
 deployment_4_22 = {
+    "advanced_settings_step": (
+        "//*[contains(text(), 'Advanced settings')]",
+        By.XPATH,
+    ),
     "enable_forceful_deployment": (
         "input#enable-forceful-deployment",
         By.CSS_SELECTOR,
@@ -417,6 +425,10 @@ deployment_4_22 = {
         By.XPATH,
     ),
     # MCO operator locators for rebranding validation
+    "mco_search_operators": (
+        "//input[@data-test='name-filter-input']",
+        By.XPATH,
+    ),
     "mco_operator_row": (
         "//a[@data-test-operator-row='DF Multicluster Orchestrator']",
         By.XPATH,
@@ -652,11 +664,19 @@ mcg_stores = {
         "//label[@for='region']/../following-sibling::*",
         By.XPATH,
     ),
-    "store_secret_dropdown": (
-        "//span[@class='text-muted' and text()='Select Secret']/../..",
+    "store_switch_to_secret": (
+        "//*[normalize-space()='Switch to Secret']",
         By.XPATH,
     ),
-    "store_target_bucket_input": ("//input[@id='target-bucket']", By.XPATH),
+    "store_secret_dropdown": (
+        "//label[normalize-space()='Secret Key']/../following-sibling::*//button[contains(@class, 'c-menu-toggle')] | "
+        "//span[normalize-space()='Select Secret']/ancestor::button[contains(@class, 'c-menu-toggle')]",
+        By.XPATH,
+    ),
+    "store_target_bucket_input": (
+        "//input[@id='target-bucket']|//input[@aria-label='Target Bucket']",
+        By.XPATH,
+    ),
     "create_store_btn": (
         "//button[@type='submit']",
         By.XPATH,
@@ -1863,16 +1883,23 @@ acm_configuration_4_21 = {
 }
 
 acm_configuration_4_22 = {
-    "all-clusters_dropdown": (
-        "//button[@data-test-id='perspective-switcher-toggle']",
+    "perspective-switcher-toggle": (
+        "//*[@data-test-id='perspective-switcher-toggle']",
+        By.XPATH,
+    ),
+    "all-clusters_dropdown_item": (
+        "//button[@role='option'][normalize-space()='Fleet management'] | "
+        "//button[@role='option'][normalize-space()='All Clusters']",
         By.XPATH,
     ),
     "local-cluster_dropdown_item": (
-        "//button[@data-test-id='perspective-switcher-toggle']//*[normalize-space()='local-cluster']",
+        "//button[@role='option'][normalize-space()='local-cluster'] | "
+        "//button[@role='option'][normalize-space()='Core platform']",
         By.XPATH,
     ),
     "local-cluster_dropdown": (
-        "//h2[normalize-space()='Administrator']",
+        "//h2[normalize-space()='Administrator'] | "
+        "//*[@data-test-id='perspective-switcher-toggle']//h2[normalize-space()='Core platform']",
         By.XPATH,
     ),
     "click-local-cluster": (
@@ -2163,6 +2190,10 @@ block_pool_4_22 = {
     ),
     "pool_replicas_in_list": (
         'span[data-test="{}-replicas"]',
+        By.CSS_SELECTOR,
+    ),
+    "pool_replicas_all_in_list": (
+        'span[data-test$="-replicas"]',
         By.CSS_SELECTOR,
     ),
 }
@@ -2500,7 +2531,11 @@ validation_4_9 = {
         "//button[normalize-space()='Refresh web console']",
         By.XPATH,
     ),
-    "odf-operator": ("//h1[normalize-space()='OpenShift Data Foundation']", By.XPATH),
+    "odf-operator": (
+        "//h1[normalize-space()='OpenShift Data Foundation']",
+        By.XPATH,
+    ),
+    "odf-operator-by-display-name": ("//h1[normalize-space()='{}']", By.XPATH),
     # project-dropdown is different for Storage pages and generic such as Operators/Installed Operators
     "project-dropdown": (
         "//span[contains(@class, 'menu-toggle__text') and contains(text(), 'Project:')] | "
@@ -2958,6 +2993,14 @@ validation_4_22 = {
         "//div[@role='dialog'"
         " and .//header[normalize-space(.)='Related pods']]"
         "//a[normalize-space(.)='View all']",
+        By.XPATH,
+    ),
+    # {0} = namespace
+    "cephfs_subvolume_row_name_button_by_namespace": (
+        f"//div[contains(text(),'{constants.CEPHFS_SUBVOLUME_METRICS_CARD_TITLE}')]"
+        "/following::table[1]/tbody/tr"
+        "[.//td[@data-label='Namespace']//a[normalize-space(text())='{0}']]"
+        "//button[@aria-label='Show related pods']",
         By.XPATH,
     ),
     "cephfs_subvolume_row_by_namespace": (
@@ -3684,6 +3727,24 @@ bucket_tab = {
     ),
     "s3_login_selected_secret": (
         "//span[text()='Secret name']/ancestor::div[contains(@class, 'form__group')]//span[@class='odf-resource-item']",
+        By.XPATH,
+    ),
+    # Object row actions (object browser)
+    "object_row_kebab": (
+        "//tr[.//td[@data-label='Name' and contains(normalize-space(),'{}')]]"
+        "//button[@aria-label='Kebab toggle']",
+        By.XPATH,
+    ),
+    "object_action_preview": (
+        "//button[normalize-space()='Preview']",
+        By.XPATH,
+    ),
+    "folder_link_by_name": (
+        "//td[@data-label='Name']//a[contains(., '{}')]",
+        By.XPATH,
+    ),
+    "refresh_objects_button": (
+        "//button[.//span[text()='Refresh']]",
         By.XPATH,
     ),
 }


### PR DESCRIPTION
This handy pick should stabilize many UI tests on 4.22. Recent job, including ACM cluster navigation dropdown was merged to 5.0/4.23 but issue on 4.22 remained. 

Other changes should have extended helpers and handy locators base, but not cut off the functionality.  

Verified with test_dashboard_validation_ui, which performs most of the navigation tasks. 
https://url.corp.redhat.com/933c79d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added verification that storage pools’ displayed data protection policies match their actual replication or erasure-coding configuration.
  * Added support for opening links in a separate browser tab and automatically returning to the original tab.

* **Bug Fixes**
  * Improved navigation between local and all-cluster perspectives by recognizing the currently selected view.
  * Improved ODF operator selection across environments by resolving its displayed name dynamically.
  * Enhanced storage pool detection for block and filesystem-backed pools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->