### PR TITLE
[release-4.22] cherry pick #16042 fix: check_pool_replicas fails on ODF 4.22/5.0 due to renamed field

### DIFF
--- a/ocs_ci/ocs/ui/block_pool.py
+++ b/ocs_ci/ocs/ui/block_pool.py
@@ -1,4 +1,5 @@
 import logging
+import re
 import time
 
 from ocs_ci.ocs.ui.page_objects.page_navigator import PageNavigator
@@ -218,8 +219,15 @@ class BlockPoolUI(PageNavigator):
         self.navigate_storage_pools_page()
         self.do_click((f"a[data-test={pool_name}]", By.CSS_SELECTOR))
         block_pool_replica = self.get_element_text(self.bp_loc["block_pool_replica"])
-        logger.info(f"Pool name {pool_name} existence is {block_pool_replica}")
-        return int(block_pool_replica)
+        logger.info(
+            f"Pool name {pool_name} replicas field value is {block_pool_replica}"
+        )
+        match = re.search(r"\d+", block_pool_replica)
+        if not match:
+            raise ValueError(
+                f"Could not extract replica count from '{block_pool_replica}'"
+            )
+        return int(match.group())
 
     def check_pool_used_capacity(self, pool_name):
         """

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -2196,6 +2196,11 @@ block_pool_4_22 = {
         'span[data-test$="-replicas"]',
         By.CSS_SELECTOR,
     ),
+    "block_pool_replica": (
+        "//dt[normalize-space()='Data protection policy']"
+        "/following-sibling::dd[@data-test='detail-item-value']",
+        By.XPATH,
+    ),
 }
 
 storageclass = {


### PR DESCRIPTION
Backport of #16042 to release-4.22.

## Problem
On ODF 4.22/5.0 the block pool details page renamed the **Replicas** field to **Data protection policy**, and its value is now rendered as text like `Replica 2`. `check_pool_replicas` located the old field and ran `int(text)` on the whole string, raising `ValueError`.

## Fix
- Add a `block_pool_replica` locator for the **Data protection policy** field in `block_pool_4_22` (merged last, so it overrides the old `block_pool_4_13` locator for 4.22).
- Extract the replica count with a regex so the number is parsed from strings like `Replica 2`.

## Testing
Verified on a live ODF 4.22 cluster — `check_pool_replicas` returns the correct replica count.

Cherry-pick of #16042.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved block pool replica-count validation to accurately read numeric values from UI text.
  - Added clearer handling when a replica count cannot be identified.

- **Compatibility**
  - Added support for locating block pool replica information in the OCP 4.22 block-pool details view.

- **User Interface**
  - Improved lifecycle management navigation and creation controls in the bucket workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->