### PR TITLE
odf-cli: update the odf-cli health validation

### DIFF
--- a/tests/functional/odf-cli/test_get_commands.py
+++ b/tests/functional/odf-cli/test_get_commands.py
@@ -4,6 +4,7 @@ import re
 import pytest
 
 from ocs_ci.ocs.resources.pod import get_mon_pods
+from ocs_ci.utility import version
 from ocs_ci.framework.testlib import (
     tier1,
     brown_squad,
@@ -29,12 +30,23 @@ class TestGetCommands:
     @polarion_id("OCS-6237")
     def test_get_health(self):
         output = self.odf_cli_runner.run_get_health()
-        self.validate_mon_pods(output)
-        self.validate_mon_quorum_and_health(output)
-        self.validate_osd_pods(output)
-        self.validate_running_pods(output)
-        self.validate_pg_status(output)
-        self.validate_mgr_pods(output)
+        if version.get_semantic_ocs_version_from_config() >= version.VERSION_4_23:
+            self.validate_mon_pods(output)
+            self.validate_mon_quorum_and_health(output)
+            self.validate_osd_pods(output)
+            self.validate_running_pods(output)
+            self.validate_pg_status(output)
+            self.validate_mgr_pods(output)
+            self.validate_cluster_capacity(output)
+            self.validate_node_pressure(output)
+            self.validate_noobaa(output)
+        else:
+            self.validate_mon_pods_legacy(output)
+            self.validate_mon_quorum_and_health_legacy(output)
+            self.validate_osd_pods_legacy(output)
+            self.validate_running_pods_legacy(output)
+            self.validate_pg_status_legacy(output)
+            self.validate_mgr_pods_legacy(output)
 
     @skipif_external_mode
     @runs_on_provider
@@ -79,6 +91,86 @@ class TestGetCommands:
             ), f"Invalid port number in endpoint: {endpoint}"
 
     def validate_mon_pods(self, output):
+        mon_status = re.search(
+            r"(\d+) mon pods running on (\d+) different nodes",
+            output.stderr.decode(),
+        )
+        assert mon_status, "Mon distribution status not found in output"
+        pod_count, node_count = int(mon_status.group(1)), int(mon_status.group(2))
+        assert pod_count >= 3, f"Expected at least 3 mon pods, found {pod_count}"
+        assert (
+            node_count >= 3
+        ), f"Mon pods should be on at least 3 different nodes, found {node_count}"
+
+    def validate_mon_quorum_and_health(self, output):
+        health_ok = "HEALTH_OK" in output.stderr.decode()
+        assert health_ok, "Ceph health is not OK"
+
+    def validate_osd_pods(self, output):
+        osd_status = re.search(
+            r"(\d+) osd pods running on (\d+) different nodes",
+            output.stderr.decode(),
+        )
+        assert osd_status, "OSD distribution status not found in output"
+        pod_count, node_count = int(osd_status.group(1)), int(osd_status.group(2))
+        assert pod_count >= 3, f"Expected at least 3 OSD pods, found {pod_count}"
+        assert (
+            node_count >= 3
+        ), f"OSD pods should be on at least 3 different nodes, found {node_count}"
+
+    def validate_running_pods(self, output):
+        pods_status = re.search(
+            r"All (\d+) pods are Running/Succeeded",
+            output.stderr.decode(),
+        )
+        assert pods_status, "Running pods status not found in output"
+        pod_count = int(pods_status.group(1))
+        assert pod_count > 0, f"Expected positive pod count, found {pod_count}"
+        log.info(f"Found {pod_count} running or succeeded pods")
+
+    def validate_pg_status(self, output):
+        pg_status = re.search(
+            r"PgState: (.*?), PgCount: (\d+)",
+            output.stderr.decode(),
+        )
+        assert pg_status, "Placement group status not found in output"
+        pg_state, pg_count = pg_status.groups()
+        assert (
+            pg_state == "active+clean"
+        ), f"Expected PG state to be 'active+clean', found '{pg_state}'"
+        assert int(pg_count) > 0, f"Expected positive PG count, found {pg_count}"
+
+    def validate_mgr_pods(self, output):
+        mgr_status = re.search(
+            r"(\d+) mgr pod\(s\) running",
+            output.stderr.decode(),
+        )
+        assert mgr_status, "MGR status not found in output"
+        mgr_count = int(mgr_status.group(1))
+        assert mgr_count >= 1, f"Expected at least 1 MGR pod, found {mgr_count}"
+        log.info(f"Found {mgr_count} running MGR pods")
+
+    def validate_cluster_capacity(self, output):
+        capacity_match = re.search(
+            r"Cluster capacity [\d.]+% used",
+            output.stderr.decode(),
+        )
+        assert capacity_match, "Cluster capacity not found in output"
+
+    def validate_node_pressure(self, output):
+        assert (
+            "[OK] Node Resource Pressure [OK]" in output.stderr.decode()
+        ), "Node resource pressure check did not pass"
+
+    def validate_noobaa(self, output):
+        stderr = output.stderr.decode()
+        if "NooBaa Health" not in stderr:
+            log.info("NooBaa not present in health output, skipping validation")
+            return
+        assert "[OK] NooBaa Health [OK]" in stderr, "NooBaa health check did not pass"
+
+    # Legacy validators for odf-cli < 4.23
+    def validate_mon_pods_legacy(self, output):
         mon_pods = [
             line
             for line in output.stdout.decode().split("\n")
@@ -96,11 +188,11 @@ class TestGetCommands:
             len(nodes) >= 3
         ), f"Mon pods should be on at least 3 different nodes, found {len(nodes)}"
 
-    def validate_mon_quorum_and_health(self, output):
+    def validate_mon_quorum_and_health_legacy(self, output):
         health_ok = "Info: HEALTH_OK" in output.stderr.decode()
         assert health_ok, "Ceph health is not OK"
 
-    def validate_osd_pods(self, output):
+    def validate_osd_pods_legacy(self, output):
         osd_pods = [
             line
             for line in output.stdout.decode().split("\n")
@@ -120,7 +212,7 @@ class TestGetCommands:
             len(nodes) >= 3
         ), f"OSD pods should be on at least 3 different nodes, found {len(nodes)}"
 
-    def validate_running_pods(self, output):
+    def validate_running_pods_legacy(self, output):
         pod_lines = output.stdout.decode().strip().split("\n")
         running_pods = [
             line
@@ -139,7 +231,7 @@ class TestGetCommands:
 
         log.info(f"Found {len(running_pods)} running or succeeded pods")
 
-    def validate_pg_status(self, output):
+    def validate_pg_status_legacy(self, output):
         pg_status = re.search(
             r"Info: Checking placement group status\nInfo:\s+PgState: (.*?), PgCount: (\d+)",
             output.stderr.decode(),
@@ -151,18 +243,16 @@ class TestGetCommands:
         ), f"Expected PG state to be 'active+clean', found '{pg_state}'"
         assert int(pg_count) > 0, f"Expected positive PG count, found {pg_count}"
 
-    def validate_mgr_pods(self, output):
+    def validate_mgr_pods_legacy(self, output):
         mgr_pods = [
             line
             for line in output.stdout.decode().split("\n")
             if "rook-ceph-mgr-" in line
         ]
-
         assert mgr_pods, "No MGR pods found in output"
 
         for pod in mgr_pods:
             assert "Running" in pod, f"MGR pod not in Running state: {pod}"
-
         nodes = set(pod.split()[-1] for pod in mgr_pods)
 
         log.info(f"Found {len(mgr_pods)} running MGR pods on {len(nodes)} nodes")


### PR DESCRIPTION
with 4.23/5.0 the odf-cli get health command output changed and new field were also added in the command output. This commit updates the odf-cli get health validation and cover this happy path testing only. With the new command mulitple flags were added for command o/p format like json, yaml, verbose. This commit check the standard output validation only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated health-check validation to support summarized command output for pod status, monitor and OSD distribution, placement groups, manager pods, and overall health.
  * Added checks for cluster capacity, node resource pressure, and NooBaa health on supported OCS versions.
  * Improved compatibility across OCS versions by applying version-appropriate health checks.
  * Expanded coverage for expected health indicators, including successful overall status and resource distribution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->