### PR TITLE
Fix pytest collection crash when ODF not installed (OCP-only upgrade)

### DIFF
--- a/ocs_ci/framework/pytest_customization/ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/ocscilib.py
@@ -517,8 +517,13 @@ def gather_version_info_for_report(config):
         clusterversion = get_cluster_version()
         config._metadata["Cluster Version"] = clusterversion
 
+        # Skip ODF version gathering if ODF is not deployed
+        skip_ocs = ocsci_config.ENV_DATA.get(
+            "skip_ocs_deployment", False
+        ) or ocsci_config.DEPLOYMENT.get("ocp_only_upgrade", False)
+
         # add ceph version
-        if not ocsci_config.ENV_DATA["mcg_only_deployment"]:
+        if not ocsci_config.ENV_DATA["mcg_only_deployment"] and not skip_ocs:
 
             managed_or_hcp_platform = (
                 ocsci_config.multicluster
@@ -540,14 +545,17 @@ def gather_version_info_for_report(config):
             config._metadata["cephfsplugin"] = csi_versions.get("csi-cephfsplugin")
             config._metadata["rbdplugin"] = csi_versions.get("csi-rbdplugin")
 
-        # add ocs operator version
-        config._metadata["OCS operator"] = get_ocs_build_number()
-        mods = {}
-        mods = get_version_info(namespace=ocsci_config.ENV_DATA["cluster_namespace"])
-        skip_list = ["ocs-operator"]
-        for key, val in mods.items():
-            if key not in skip_list:
-                config._metadata[key] = val.rsplit("/")[-1]
+        if not skip_ocs:
+            # add ocs operator version
+            config._metadata["OCS operator"] = get_ocs_build_number()
+            mods = {}
+            mods = get_version_info(
+                namespace=ocsci_config.ENV_DATA["cluster_namespace"]
+            )
+            skip_list = ["ocs-operator"]
+            for key, val in mods.items():
+                if key not in skip_list:
+                    config._metadata[key] = val.rsplit("/")[-1]
         gather_version_completed = True
     except ResourceNotFoundError:
         log.exception("Problem occurred when looking for some resource!")

--- a/ocs_ci/ocs/cluster.py
+++ b/ocs_ci/ocs/cluster.py
@@ -3591,6 +3591,17 @@ def check_clusters():
         )
         return
 
+    # OCP-only upgrades or skip_ocs_deployment have no CephCluster / StorageCluster
+    if config.ENV_DATA.get("skip_ocs_deployment", False) or config.DEPLOYMENT.get(
+        "ocp_only_upgrade", False
+    ):
+        config.RUN["cephcluster"] = False
+        logger.info(
+            "OCP-only cluster detected (skip_ocs_deployment or ocp_only_upgrade) — "
+            "skipping CephCluster check, setting cephcluster=False"
+        )
+        return
+
     try:
         cephcluster_obj = OCP(
             kind="cephcluster",
@@ -3606,7 +3617,9 @@ def check_clusters():
         logger.info(
             "This is deployment, will try to check from ENV_DATA and DEPLOYMENT"
         )
-        if config.ENV_DATA["skip_ocs_deployment"]:
+        if config.ENV_DATA["skip_ocs_deployment"] or config.DEPLOYMENT.get(
+            "ocp_only_upgrade", False
+        ):
             config.RUN["cephcluster"] = False
         else:
             config.RUN["cephcluster"] = True

--- a/ocs_ci/utility/kms.py
+++ b/ocs_ci/utility/kms.py
@@ -2433,19 +2433,33 @@ def is_kms_enabled(dont_raise=False):
     """
     Checks StorageCluster yaml if kms is configured.
 
+    Args:
+        dont_raise (bool): If True, catch all exceptions and return False instead
+            of raising. This prevents pytest collection crashes when ODF is not
+            installed or cluster is unreachable.
+
     Return:
         (bool): True if KMS is configured else False
 
     """
-    cluster = storage_cluster.get_storage_cluster()
-    logger.info("Checking if StorageCluster has configured KMS encryption")
-    resource_get = cluster.get(dont_raise=dont_raise)
-    if resource_get:
-        resource = resource_get["items"][0]
-        encryption = (
-            resource.get("spec").get("encryption", {}).get("kms", {}).get("enable")
-        )
-        return bool(encryption)
+    try:
+        cluster = storage_cluster.get_storage_cluster()
+        logger.info("Checking if StorageCluster has configured KMS encryption")
+        resource_get = cluster.get(dont_raise=dont_raise)
+        if resource_get and resource_get.get("items"):
+            resource = resource_get["items"][0]
+            encryption = (
+                resource.get("spec").get("encryption", {}).get("kms", {}).get("enable")
+            )
+            return bool(encryption)
+        return False
+    except Exception as e:
+        if dont_raise:
+            logger.warning(
+                f"Failed to check KMS status (ODF may not be installed): {e}"
+            )
+            return False
+        raise
 
 
 def vault_kv_list(path):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -527,17 +527,24 @@ def pytest_collection_modifyitems(session, config, items):
                     )
                     items.remove(item)
             if skipif_no_kms_marker:
-                try:
+                # Skip KMS check if ODF is not deployed (OCP-only upgrade or skip_ocs_deployment)
+                if not ocsci_config.ENV_DATA.get(
+                    "skip_ocs_deployment", False
+                ) and not ocsci_config.DEPLOYMENT.get("ocp_only_upgrade", False):
+                    # is_kms_enabled(dont_raise=True) is safe and won't crash pytest
                     if not is_kms_enabled(dont_raise=True):
                         log.debug(
                             f"Test: {item} it will be skipped because the OCS cluster"
                             " has not configured cluster-wide encryption with KMS"
                         )
                         items.remove(item)
-                except KeyError:
-                    log.warning(
-                        "Cluster is not yet installed. Skipping skipif_no_kms check."
+                else:
+                    # ODF not deployed, skip all KMS-requiring tests
+                    log.debug(
+                        f"Test: {item} will be skipped (ODF not deployed, "
+                        "skip_ocs_deployment or ocp_only_upgrade is set)"
                     )
+                    items.remove(item)
             if skipif_no_nvmeof_marker:
                 if not ocsci_config.DEPLOYMENT.get("nvmeof_enable"):
                     log.debug(
@@ -2277,11 +2284,20 @@ def health_checker(request, tier_marks_name, upgrade_marks_name):
     ceph_health_recovered_exception = None
     dev_mode = ocsci_config.RUN["cli_params"].get("dev_mode")
     mcg_only_deployment = ocsci_config.ENV_DATA["mcg_only_deployment"]
+    skip_ocs = ocsci_config.ENV_DATA.get(
+        "skip_ocs_deployment", False
+    ) or ocsci_config.DEPLOYMENT.get("ocp_only_upgrade", False)
+
     if mcg_only_deployment:
         log.info("Skipping health checks for MCG only mode")
         return
     if dev_mode:
         log.info("Skipping health checks for development mode")
+        return
+    if skip_ocs:
+        log.info(
+            "Skipping health checks (ODF not deployed: skip_ocs_deployment or ocp_only_upgrade)"
+        )
         return
 
     if ocsci_config.multicluster:


### PR DESCRIPTION
Pytest test collection crashes with INTERNALERROR when running on OCP clusters without ODF installed (e.g., during OCP-only upgrades in disconnected environments). The skipif_no_kms marker check calls is_kms_enabled() which queries StorageCluster resources, causing an IndexError when the items list is empty.

Root cause: The is_kms_enabled() function didn't handle missing ODF deployments gracefully, and conftest.py didn't check if ODF was deployed before querying for KMS configuration.

Changes:

1. ocs_ci/utility/kms.py:
   - Wrap entire function in try/except when dont_raise=True
   - Check for non-empty items list before accessing [0]
   - Add comprehensive error handling to prevent any exception when dont_raise=True is set
   - Log warning instead of crashing when ODF is not installed
   - Return False safely in all error cases

2. tests/conftest.py:
   - Check skip_ocs_deployment and ocp_only_upgrade config before calling is_kms_enabled()
   - Skip KMS check entirely when ODF is not deployed
   - Properly skip all KMS-requiring tests when running OCP-only upgrades

This prevents pytest INTERNALERROR during test collection on pure OCP clusters and enables OCP-only upgrade testing without ODF.

Usage: Set DEPLOYMENT.ocp_only_upgrade=true for OCP-only upgrades, or ENV_DATA.skip_ocs_deployment=true when deploying OCP without OCS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when KMS configuration or StorageCluster information is unavailable.
  * KMS checks now fail safely when configured to avoid raising errors, while preserving error reporting in strict mode.
  * KMS-dependent tests are excluded when the required storage deployment is not present.
  * Version reporting and health checks now skip ODF details when ODF is not deployed.
  * Improved cluster detection and test collection for OCP-only or not-yet-installed environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->