### PR TITLE
[release-4.18] Handle missing resource_checker RUN config in FDF deployments

### DIFF
--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -401,7 +401,7 @@ class OCP(object):
         command = "create "
         if yaml_file:
             command += f"-f {yaml_file}"
-            if config.RUN["resource_checker"]:
+            if config.RUN.get("resource_checker"):
                 yaml_dct = load_yaml(yaml_file)
                 kind = yaml_dct["kind"]
                 if kind == "PersistentVolume":
@@ -440,7 +440,7 @@ class OCP(object):
         elif resource_name:
             # e.g "oc namespace my-project"
             command += f"{self.kind} {resource_name}"
-            if config.RUN["resource_checker"]:
+            if config.RUN.get("resource_checker"):
                 config.RUN["RESOURCE_DICT_TEST"][self.kind] = resource_name
         if out_yaml_format:
             command += " -o yaml"

--- a/ocs_ci/utility/framework/fusion_fdf_init.py
+++ b/ocs_ci/utility/framework/fusion_fdf_init.py
@@ -69,6 +69,10 @@ class Initializer(object):
         """
         framework.config.init_cluster_configs()
         load_config(args.conf)
+
+        # Updating resource_checker to False since it's not needed
+        config.RUN["resource_checker"] = False
+
         logger.debug("Verifying cluster_name and cluster_path")
         cluster_name = args.cluster_name
         cluster_path = os.path.expanduser(args.cluster_path)


### PR DESCRIPTION
The resource_checker RUN config key is not populated by the deploy-fdf entry point, causing a KeyError when creating resources via a yaml file. Set resource_checker to False during FDF init (mirroring the approach on release-4.20) and use .get() in ocp.py so a missing key is treated as falsy instead of raising.