### PR TITLE
Add ceph_deep marker for targeted Ceph layer validation

### DIFF
--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -110,6 +110,7 @@ mdr = pytest.mark.mdr
 resiliency = pytest.mark.resiliency
 chaos = pytest.mark.chaos
 ec_allowed = pytest.mark.ec_allowed
+ceph_deep = pytest.mark.ceph_deep
 
 tier_marks = [
     tier1,

--- a/ocs_ci/framework/pytest_customization/marks.py
+++ b/ocs_ci/framework/pytest_customization/marks.py
@@ -55,7 +55,6 @@ from ocs_ci.deployment.hub_spoke import hypershift_cluster_factory
 from ocs_ci.utility.nfs_utils import check_cluster_resources_for_nfs
 from ocs_ci.ocs.node import check_cluster_resources
 
-
 # tier marks
 
 tier1 = pytest.mark.tier1(value=1)
@@ -254,6 +253,21 @@ skipif_aws_creds_are_missing = pytest.mark.skipif(
     ),
     reason=(
         "AWS credentials weren't found in the local auth.yaml "
+        "and couldn't be fetched from the cloud"
+    ),
+)
+
+skipif_azure_with_logs_creds_are_missing = pytest.mark.skipif(
+    (
+        load_auth_config()
+        .get("AUTH", {})
+        .get("AZURE_WITH_LOGS", {})
+        .get("LOGS_ANALYTICS_WORKSPACE_ID")
+        is None
+        and update_config_from_s3() is None
+    ),
+    reason=(
+        "Azure with logs credentials weren't found in the local auth.yaml "
         "and couldn't be fetched from the cloud"
     ),
 )

--- a/ocs_ci/ocs/resources/mcg_replication_policy.py
+++ b/ocs_ci/ocs/resources/mcg_replication_policy.py
@@ -105,6 +105,38 @@ class AzureLogBasedReplicationPolicy(LogBasedReplicationPolicy):
         return dict
 
 
+class NoobaaLogBasedReplicationPolicy(LogBasedReplicationPolicy):
+    """
+    A class to handle the NooBaa-to-NooBaa log-based bucket replication policy JSON structure.
+
+    NooBaa log-based replication uses the same logs_location structure as AWS,
+    where a NooBaa bucket serves as the logs bucket via the guaranteed bucket logging feature.
+
+    """
+
+    def __init__(
+        self,
+        destination_bucket,
+        sync_deletions=False,
+        logs_bucket="",
+        prefix="",
+        logs_location_prefix="",
+        sync_versions=False,
+    ):
+        super().__init__(destination_bucket, sync_deletions, sync_versions, prefix)
+        self.logs_bucket = logs_bucket
+        self.logs_location_prefix = logs_location_prefix
+
+    def to_dict(self):
+        dict = super().to_dict()
+        dict["log_replication_info"]["logs_location"] = {
+            "logs_bucket": self.logs_bucket,
+            "prefix": self.logs_location_prefix,
+        }
+
+        return dict
+
+
 class ReplicationPolicyWithVersioning(McgReplicationPolicy):
     """
     A class to handle the MCG bucket replication policy JSON structure with versioning.

--- a/pytest.ini
+++ b/pytest.ini
@@ -83,6 +83,7 @@ markers =
     ignore_leftover_label: marker for ignoring lefotover of resources having specific label
     ignore_resource_not_found_error_label: ignore resource_not_found error such as when deleting a resource that was already deleted
     stretchcluster_required: maker to select stretch ceph cluster related tests
+    ceph_deep: marker for tests that exercise the Ceph layer in depth
     ec_allowed: marker for tests that support erasure coded RBD pool variants
     skip_rdr_health_check: skip the autouse rdr_health_check fixture for tests that don't need it
 # Clusterctx used without hyphen, to keep the original format if it's None

--- a/tests/cross_functional/kcs/test_mon_crash_recovery_scenario.py
+++ b/tests/cross_functional/kcs/test_mon_crash_recovery_scenario.py
@@ -26,6 +26,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     tier3,
     skipif_external_mode,
     magenta_squad,
+    ceph_deep,
 )
 from ocs_ci.ocs.defaults import OCS_OPERATOR_NAME
 from ocs_ci.helpers.helpers import wait_for_resource_state
@@ -35,6 +36,7 @@ logger = logging.getLogger(__name__)
 
 
 @magenta_squad
+@ceph_deep
 @tier3
 @pytest.mark.polarion_id("OCS-4942")
 @skipif_external_mode

--- a/tests/cross_functional/kcs/test_monitor_recovery.py
+++ b/tests/cross_functional/kcs/test_monitor_recovery.py
@@ -15,6 +15,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     system_test,
     skipif_ocp_version,
     magenta_squad,
+    ceph_deep,
 )
 from ocs_ci.helpers.sanity_helpers import Sanity
 from ocs_ci.ocs.ocp import OCP, switch_to_project
@@ -73,6 +74,7 @@ NODE_RESTART_COOLDOWN = 300
 
 
 @magenta_squad
+@ceph_deep
 @system_test
 @ignore_leftovers
 @pytest.mark.order("last")

--- a/tests/cross_functional/resilience/test_storage_component_failure_scenarios.py
+++ b/tests/cross_functional/resilience/test_storage_component_failure_scenarios.py
@@ -5,6 +5,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     green_squad,
     resiliency,
     polarion_id,
+    ceph_deep,
 )
 from ocs_ci.resiliency.resiliency_helper import Resiliency
 from ocs_ci.ocs.exceptions import UnexpectedBehaviour
@@ -13,6 +14,7 @@ log = logging.getLogger(__name__)
 
 
 @green_squad
+@ceph_deep
 @resiliency
 class TestStorageClusterComponentFailurescenarios:
     """

--- a/tests/cross_functional/system_test/mon/test_restore_ceph_mon_quorum.py
+++ b/tests/cross_functional/system_test/mon/test_restore_ceph_mon_quorum.py
@@ -10,6 +10,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     ignore_leftovers,
     skipif_external_mode,
     magenta_squad,
+    ceph_deep,
 )
 from ocs_ci.framework.testlib import E2ETest
 from ocs_ci.ocs import constants
@@ -32,6 +33,7 @@ logger = logging.getLogger(__name__)
 
 
 @magenta_squad
+@ceph_deep
 @ignore_leftovers
 @system_test
 @skipif_ocs_version("<4.9")

--- a/tests/cross_functional/system_test/test_full_cluster_health.py
+++ b/tests/cross_functional/system_test/test_full_cluster_health.py
@@ -18,6 +18,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     system_test,
     polarion_id,
     magenta_squad,
+    ceph_deep,
 )
 from ocs_ci.ocs.exceptions import TimeoutExpiredError
 from ocs_ci.ocs.benchmark_operator_fio import get_file_size, BenchmarkOperatorFIO
@@ -29,6 +30,7 @@ logger = logging.getLogger(__name__)
 
 
 @magenta_squad
+@ceph_deep
 class TestFullClusterHealth(PASTest):
     """
     Test Cluster health when storage is ~82%

--- a/tests/functional/cephx_keyrotation/test_cephx_keyrotation_bootstrap_cleanup.py
+++ b/tests/functional/cephx_keyrotation/test_cephx_keyrotation_bootstrap_cleanup.py
@@ -11,6 +11,7 @@ import pytest
 
 from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import (
+    ceph_deep,
     green_squad,
     skipif_external_mode,
     skipif_ocs_version,
@@ -35,6 +36,7 @@ pytestmark = pytest.mark.skip(
 @skipif_external_mode
 @skipif_ocs_version(["<4.21", ">=4.23"])
 @green_squad
+@ceph_deep
 @pytest.mark.order("last")
 class TestCephXBootstrapKeyCleanup:
     @pytest.mark.polarion_id("OCS-8161")

--- a/tests/functional/cephx_keyrotation/test_cephx_keyrotation_configuration.py
+++ b/tests/functional/cephx_keyrotation/test_cephx_keyrotation_configuration.py
@@ -10,6 +10,7 @@ import pytest
 
 from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import (
+    ceph_deep,
     green_squad,
     skipif_external_mode,
     skipif_ocs_version,
@@ -29,6 +30,7 @@ EXPECTED_INITIAL_GENERATION = 2
 @skipif_external_mode
 @skipif_ocs_version(["<4.21", ">=4.23"])
 @green_squad
+@ceph_deep
 @pytest.mark.order("first")
 class TestCephXKeyRotationPolicyDisabled:
     @pytest.mark.polarion_id("OCS-8133")
@@ -110,6 +112,7 @@ class TestCephXKeyRotationPolicyDisabled:
 @skipif_external_mode
 @skipif_ocs_version(["<4.21", ">=4.23"])
 @green_squad
+@ceph_deep
 class TestCephXAllowedCiphers:
     @pytest.fixture(autouse=True)
     def _teardown(self, request):

--- a/tests/functional/cephx_keyrotation/test_cephx_keyrotation_daemon_rotation.py
+++ b/tests/functional/cephx_keyrotation/test_cephx_keyrotation_daemon_rotation.py
@@ -12,6 +12,7 @@ import pytest
 
 from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import (
+    ceph_deep,
     green_squad,
     skipif_external_mode,
     skipif_ocs_version,
@@ -43,6 +44,7 @@ POST_ROTATION_PVC_SIZE = 5
 @skipif_external_mode
 @skipif_ocs_version(["<4.21", ">=4.23"])
 @green_squad
+@ceph_deep
 class TestCephXKeyRotation:
     @pytest.mark.polarion_id("OCS-8128")
     @tier1
@@ -390,6 +392,7 @@ class TestCephXKeyRotation:
 @skipif_external_mode
 @skipif_ocs_version(["<4.21", ">=4.23"])
 @green_squad
+@ceph_deep
 class TestCephXKeyRotationIdempotency:
     @pytest.mark.polarion_id("OCS-8131")
     @tier1
@@ -465,6 +468,7 @@ class TestCephXKeyRotationIdempotency:
 @skipif_external_mode
 @skipif_ocs_version(["<4.21", ">=4.23"])
 @green_squad
+@ceph_deep
 class TestCephXKeyRotationIOContinuity:
     @pytest.mark.polarion_id("OCS-8132")
     @tier1

--- a/tests/functional/cephx_keyrotation/test_cephx_keyrotation_metrics_exporter.py
+++ b/tests/functional/cephx_keyrotation/test_cephx_keyrotation_metrics_exporter.py
@@ -11,6 +11,7 @@ import pytest
 
 from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import (
+    ceph_deep,
     green_squad,
     skipif_external_mode,
     skipif_ocs_version,
@@ -26,6 +27,7 @@ log = logging.getLogger(__name__)
 @skipif_external_mode
 @skipif_ocs_version(["<4.21", ">=4.23"])
 @green_squad
+@ceph_deep
 class TestCephXMetricsExporterRotation:
     @pytest.mark.polarion_id("OCS-8136")
     @tier1

--- a/tests/functional/cephx_keyrotation/test_cephx_keyrotation_mismatch_alert.py
+++ b/tests/functional/cephx_keyrotation/test_cephx_keyrotation_mismatch_alert.py
@@ -15,6 +15,7 @@ import time
 import pytest
 from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import (
+    ceph_deep,
     green_squad,
     ignore_leftovers,
     skipif_external_mode,
@@ -485,6 +486,7 @@ def _induce_daemon_key_mismatch(rotator, namespace):
 @skipif_external_mode
 @skipif_ocs_version(["<4.21", ">=4.23"])
 @green_squad
+@ceph_deep
 class TestCephXKeyRotationMismatchMetric:
     """TC1–TC2: mismatch metric emission and in-sync (value 0) state."""
 
@@ -551,6 +553,7 @@ class TestCephXKeyRotationMismatchMetric:
 @skipif_external_mode
 @skipif_ocs_version(["<4.21", ">=4.23"])
 @green_squad
+@ceph_deep
 @ignore_leftovers
 class TestCephXKeyRotationMismatchAlertLifecycle:
     """TC3–TC6, TC18: induce mismatch, fire alert, recover, check MDS + health mutes."""
@@ -866,6 +869,7 @@ class TestCephXKeyRotationMismatchAlertLifecycle:
 @skipif_external_mode
 @skipif_ocs_version(["<4.21", ">=4.23"])
 @green_squad
+@ceph_deep
 class TestCephXKeyRotationMismatchNoFilesystem:
     """TC7: MDS mismatch metric is 0 when no CephFilesystem exists."""
 
@@ -896,6 +900,7 @@ class TestCephXKeyRotationMismatchNoFilesystem:
 @skipif_external_mode
 @skipif_ocs_version(["<4.21", ">=4.23"])
 @green_squad
+@ceph_deep
 class TestCephXCephClusterReconciliation:
     """TC8–TC13: CephCluster annotations and daemon keyGeneration reconciliation."""
 
@@ -1173,6 +1178,7 @@ class TestCephXCephClusterReconciliation:
 @skipif_external_mode
 @skipif_ocs_version(["<4.21", ">=4.23"])
 @green_squad
+@ceph_deep
 class TestCephXCephClientAnnotations:
     """TC14–TC15: CephClient created-with-cephx-features and keyType."""
 
@@ -1261,6 +1267,7 @@ class TestCephXCephClientAnnotations:
 @skipif_external_mode
 @skipif_ocs_version(["<4.21", ">=4.23"])
 @green_squad
+@ceph_deep
 @ignore_leftovers
 class TestCephXDesiredKeyGenNegative:
     """TC16: DESIRED_CEPHX_KEY_GEN env; TC17: StorageCluster keyGeneration types."""

--- a/tests/functional/cephx_keyrotation/test_cephx_keyrotation_negative.py
+++ b/tests/functional/cephx_keyrotation/test_cephx_keyrotation_negative.py
@@ -21,6 +21,7 @@ import pytest
 
 from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import (
+    ceph_deep,
     encryption_at_rest_required,
     green_squad,
     ignore_leftovers,
@@ -52,6 +53,7 @@ CSI_POST_ROTATION_PVC_SIZE = 5
 @skipif_external_mode
 @skipif_ocs_version(["<4.21", ">=4.23"])
 @green_squad
+@ceph_deep
 @ignore_leftovers
 class TestCephXKeyRotationNegative:
     @pytest.mark.polarion_id("OCS-8149")
@@ -428,6 +430,7 @@ class TestCephXKeyRotationNegative:
 @skipif_external_mode
 @skipif_ocs_version(["<4.21", ">=4.23"])
 @green_squad
+@ceph_deep
 @ignore_leftovers
 class TestCephXKeyRotationNegativeOSD:
     @pytest.mark.polarion_id("OCS-8153")
@@ -609,6 +612,7 @@ class TestCephXKeyRotationNegativeOSD:
 @skipif_external_mode
 @skipif_ocs_version(["<4.21", ">=4.23"])
 @green_squad
+@ceph_deep
 @ignore_leftovers
 class TestCephXKeyRotationNegativeEncryptedCSI:
     @pytest.mark.polarion_id("OCS-8155")

--- a/tests/functional/cephx_keyrotation/test_cephx_keyrotation_node_cordon.py
+++ b/tests/functional/cephx_keyrotation/test_cephx_keyrotation_node_cordon.py
@@ -12,6 +12,7 @@ import pytest
 
 from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import (
+    ceph_deep,
     green_squad,
     ignore_leftovers,
     skipif_external_mode,
@@ -34,6 +35,7 @@ MIN_OSD_NODES = 3
 @skipif_external_mode
 @skipif_ocs_version(["<4.21", ">=4.23"])
 @green_squad
+@ceph_deep
 @ignore_leftovers
 class TestCephXKeyRotationNodeCordon:
     @pytest.fixture(autouse=True)

--- a/tests/functional/cephx_keyrotation/test_cephx_keyrotation_osd_lockbox.py
+++ b/tests/functional/cephx_keyrotation/test_cephx_keyrotation_osd_lockbox.py
@@ -12,6 +12,7 @@ import pytest
 
 from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import (
+    ceph_deep,
     green_squad,
     skipif_external_mode,
     skipif_ocs_version,
@@ -29,6 +30,7 @@ MIN_ENCRYPTED_OSD_COUNT = 1
 @skipif_external_mode
 @skipif_ocs_version(["<4.21", ">=4.23"])
 @green_squad
+@ceph_deep
 class TestCephXKeyRotationOSDLockbox:
     @pytest.mark.polarion_id("OCS-8135")
     @tier1

--- a/tests/functional/disaster-recovery/sc_arbiter/test_device_replacement.py
+++ b/tests/functional/disaster-recovery/sc_arbiter/test_device_replacement.py
@@ -8,6 +8,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     tier4a,
     tier4,
     jira,
+    ceph_deep,
 )
 from ocs_ci.helpers.cnv_helpers import cal_md5sum_vm
 from ocs_ci.helpers.stretchcluster_helper import (
@@ -26,6 +27,7 @@ logger = logging.getLogger(__name__)
 @tier4
 @stretchcluster_required
 @turquoise_squad
+@ceph_deep
 @jira("DFBUGS-1273")
 class TestDeviceReplacementInStretchCluster:
 

--- a/tests/functional/disaster-recovery/sc_arbiter/test_graceful_restart.py
+++ b/tests/functional/disaster-recovery/sc_arbiter/test_graceful_restart.py
@@ -6,6 +6,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     tier1,
     polarion_id,
     turquoise_squad,
+    ceph_deep,
 )
 from ocs_ci.helpers.cnv_helpers import cal_md5sum_vm
 from ocs_ci.helpers.stretchcluster_helper import (
@@ -33,6 +34,7 @@ log = logging.getLogger(__name__)
 
 @tier1
 @turquoise_squad
+@ceph_deep
 @stretchcluster_required
 class TestGracefulRestart:
 

--- a/tests/functional/disaster-recovery/sc_arbiter/test_mon_osd_failures.py
+++ b/tests/functional/disaster-recovery/sc_arbiter/test_mon_osd_failures.py
@@ -11,6 +11,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     stretchcluster_required,
     turquoise_squad,
     tier2,
+    ceph_deep,
 )
 from ocs_ci.helpers.cnv_helpers import cal_md5sum_vm
 from ocs_ci.helpers.helpers import modify_deployment_replica_count
@@ -145,6 +146,7 @@ def setup_cnv_workload(request, cnv_workload_class, setup_cnv):
 
 @tier2
 @turquoise_squad
+@ceph_deep
 @stretchcluster_required
 @pytest.mark.usefixtures("setup_cnv_workload")
 @pytest.mark.usefixtures("setup_logwriter_workloads")

--- a/tests/functional/disaster-recovery/sc_arbiter/test_netsplit.py
+++ b/tests/functional/disaster-recovery/sc_arbiter/test_netsplit.py
@@ -8,6 +8,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     turquoise_squad,
     tier1,
     stretchcluster_required,
+    ceph_deep,
 )
 from ocs_ci.helpers.cnv_helpers import cal_md5sum_vm
 from ocs_ci.helpers.stretchcluster_helper import (
@@ -33,6 +34,7 @@ logger = logging.getLogger(__name__)
 @tier1
 @stretchcluster_required
 @turquoise_squad
+@ceph_deep
 class TestNetSplit:
 
     @pytest.mark.parametrize(

--- a/tests/functional/disaster-recovery/sc_arbiter/test_node_drain.py
+++ b/tests/functional/disaster-recovery/sc_arbiter/test_node_drain.py
@@ -9,6 +9,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     tier2,
     polarion_id,
     turquoise_squad,
+    ceph_deep,
 )
 from ocs_ci.helpers.cnv_helpers import cal_md5sum_vm
 from ocs_ci.helpers.stretchcluster_helper import (
@@ -27,6 +28,7 @@ log = logging.getLogger(__name__)
 
 @tier2
 @turquoise_squad
+@ceph_deep
 @stretchcluster_required
 class TestNodeDrain:
 

--- a/tests/functional/disaster-recovery/sc_arbiter/test_zone_shutdown_and_crash.py
+++ b/tests/functional/disaster-recovery/sc_arbiter/test_zone_shutdown_and_crash.py
@@ -30,6 +30,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     turquoise_squad,
     stretchcluster_required,
     jira,
+    ceph_deep,
 )
 from ocs_ci.utility.retry import retry
 
@@ -40,6 +41,7 @@ log = logging.getLogger(__name__)
 @tier1
 @stretchcluster_required
 @turquoise_squad
+@ceph_deep
 class TestZoneShutdownsAndCrashes:
 
     zones = constants.DATA_ZONE_LABELS

--- a/tests/functional/encryption/test_encryption_keyrotation.py
+++ b/tests/functional/encryption/test_encryption_keyrotation.py
@@ -4,6 +4,7 @@ import json
 from time import sleep
 
 from ocs_ci.framework.pytest_customization.marks import (
+    ceph_deep,
     tier1,
     tier2,
     green_squad,
@@ -38,6 +39,7 @@ log = logging.getLogger(__name__)
 @encryption_at_rest_required
 @skipif_kms_deployment
 @green_squad
+@ceph_deep
 class TestEncryptionKeyrotation:
     @pytest.fixture(autouse=True)
     def teardown(self, request):
@@ -283,6 +285,7 @@ class TestEncryptionKeyrotation:
 
 
 @green_squad
+@ceph_deep
 @tier1
 @encryption_at_rest_required
 @vault_kms_deployment_required

--- a/tests/functional/object/mcg/test_log_based_bucket_replication.py
+++ b/tests/functional/object/mcg/test_log_based_bucket_replication.py
@@ -2,7 +2,12 @@ import logging
 
 import pytest
 
-from ocs_ci.framework.pytest_customization.marks import mcg, red_squad
+from ocs_ci.framework.pytest_customization.marks import (
+    mcg,
+    red_squad,
+    skipif_azure_with_logs_creds_are_missing,
+    skipif_external_mode,
+)
 from ocs_ci.framework.testlib import (
     MCGTest,
     ignore_leftover_label,
@@ -19,10 +24,16 @@ from ocs_ci.framework.testlib import (
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.bucket_utils import (
     compare_bucket_object_list,
+    craft_s3_command,
     update_replication_policy,
     write_random_test_objects_to_bucket,
 )
-from ocs_ci.ocs.resources.mcg_replication_policy import AwsLogBasedReplicationPolicy
+from ocs_ci.ocs.resources.bucket_logging_manager import BucketLoggingManager
+from ocs_ci.ocs.resources.mcg_replication_policy import (
+    AwsLogBasedReplicationPolicy,
+    AzureLogBasedReplicationPolicy,
+    NoobaaLogBasedReplicationPolicy,
+)
 from ocs_ci.ocs.resources.mockup_bucket_logger import MockupBucketLogger
 from ocs_ci.ocs.resources.pod import get_noobaa_pods, get_pod_node
 from ocs_ci.ocs.scale_noobaa_lib import noobaa_running_node_restart
@@ -515,3 +526,323 @@ def delete_objects_from_source_and_wait_for_deletion_sync(
         target_bucket.name,
         timeout=timeout,
     ), f"Deletion sync failed to complete in {timeout} seconds"
+
+
+@mcg
+@red_squad
+@runs_on_provider
+@skipif_azure_with_logs_creds_are_missing
+@skipif_disconnected_cluster
+class TestAzureLogBasedBucketReplication(MCGTest):
+    """
+    Test log-based replication for Azure-backed namespace store buckets.
+
+    Azure log-based replication uses Azure's native change feed mechanism
+    rather than S3 access logs. No MockupBucketLogger or logs_bucket is needed;
+    the AzureLogBasedReplicationPolicy sets endpoint_type to "AZURE" and
+    NooBaa reads change events directly from the Azure storage account.
+
+    """
+
+    DEFAULT_TIMEOUT = 10 * 60
+
+    @pytest.fixture(scope="class", autouse=True)
+    def reduce_replication_delay_setup(self, add_env_vars_to_noobaa_core_class):
+        new_delay_in_milliseconds = 60 * 1000
+        new_env_var_tuples = [
+            (constants.BUCKET_REPLICATOR_DELAY_PARAM, new_delay_in_milliseconds),
+            (constants.BUCKET_LOG_REPLICATOR_DELAY_PARAM, new_delay_in_milliseconds),
+        ]
+        add_env_vars_to_noobaa_core_class(new_env_var_tuples)
+
+    @pytest.fixture()
+    def azure_log_based_replication_setup(self, mcg_obj_session, bucket_factory):
+        """
+        Set up Azure log-based replication with deletion sync.
+
+        Returns:
+            tuple: (source_bucket, target_bucket)
+
+        """
+        bucketclass_dict = {
+            "interface": "OC",
+            "namespace_policy_dict": {
+                "type": "Single",
+                "namespacestore_dict": {
+                    constants.AZURE_WITH_LOGS_PLATFORM: [(1, None)]
+                },
+            },
+        }
+        target_bucket = bucket_factory(bucketclass=bucketclass_dict)[0]
+
+        replication_policy = AzureLogBasedReplicationPolicy(
+            destination_bucket=target_bucket.name,
+            sync_deletions=True,
+        )
+
+        source_bucket = bucket_factory(
+            1, bucketclass=bucketclass_dict, replication_policy=replication_policy
+        )[0]
+
+        return source_bucket, target_bucket
+
+    @tier1
+    @polarion_id("OCS-XXXX")
+    def test_azure_log_based_deletion_sync(
+        self,
+        mcg_obj_session,
+        awscli_pod_session,
+        azure_log_based_replication_setup,
+    ):
+        """
+        Test Azure log-based replication with deletion sync.
+
+        1. Upload objects to the source bucket
+        2. Wait for replication to the target bucket
+        3. Delete objects from the source bucket
+        4. Wait for deletion sync to the target bucket
+
+        """
+        source_bucket, target_bucket = azure_log_based_replication_setup
+
+        write_random_test_objects_to_bucket(
+            io_pod=awscli_pod_session,
+            bucket_to_write=source_bucket.name,
+            file_dir=constants.AWSCLI_TEST_OBJ_DIR,
+            amount=3,
+            mcg_obj=mcg_obj_session,
+        )
+
+        assert compare_bucket_object_list(
+            mcg_obj_session,
+            source_bucket.name,
+            target_bucket.name,
+            timeout=self.DEFAULT_TIMEOUT,
+        ), f"Replication failed to complete in {self.DEFAULT_TIMEOUT} seconds"
+
+        awscli_pod_session.exec_cmd_on_pod(
+            craft_s3_command(
+                f"rm s3://{source_bucket.name} --recursive",
+                mcg_obj=mcg_obj_session,
+            )
+        )
+
+        assert compare_bucket_object_list(
+            mcg_obj_session,
+            source_bucket.name,
+            target_bucket.name,
+            timeout=self.DEFAULT_TIMEOUT,
+        ), f"Deletion sync failed to complete in {self.DEFAULT_TIMEOUT} seconds"
+
+    @tier2
+    @polarion_id("OCS-XXXX")
+    def test_azure_log_based_patch_deletion_sync(
+        self, mcg_obj_session, awscli_pod_session, bucket_factory
+    ):
+        """
+        Test patching Azure log-based deletion sync onto an existing bucket.
+
+        1. Create source and target buckets without replication
+        2. Patch the source with an AzureLogBasedReplicationPolicy
+        3. Upload objects and verify replication
+
+        """
+        bucketclass_dict = {
+            "interface": "OC",
+            "namespace_policy_dict": {
+                "type": "Single",
+                "namespacestore_dict": {
+                    constants.AZURE_WITH_LOGS_PLATFORM: [(1, None)]
+                },
+            },
+        }
+        target_bucket = bucket_factory(bucketclass=bucketclass_dict)[0]
+        source_bucket = bucket_factory(bucketclass=bucketclass_dict)[0]
+
+        replication_policy = AzureLogBasedReplicationPolicy(
+            destination_bucket=target_bucket.name,
+            sync_deletions=True,
+        )
+        update_replication_policy(source_bucket.name, replication_policy.to_dict())
+
+        write_random_test_objects_to_bucket(
+            io_pod=awscli_pod_session,
+            bucket_to_write=source_bucket.name,
+            file_dir=constants.AWSCLI_TEST_OBJ_DIR,
+            amount=3,
+            mcg_obj=mcg_obj_session,
+        )
+
+        assert compare_bucket_object_list(
+            mcg_obj_session,
+            source_bucket.name,
+            target_bucket.name,
+            timeout=self.DEFAULT_TIMEOUT,
+        ), f"Replication failed to complete in {self.DEFAULT_TIMEOUT} seconds"
+
+
+@mcg
+@red_squad
+@runs_on_provider
+@skipif_external_mode
+@skipif_disconnected_cluster
+class TestNoobaaLogBasedBucketReplication(MCGTest):
+    """
+    Test log-based replication between plain NooBaa buckets.
+
+    Uses NooBaa's guaranteed bucket logging feature to generate access logs
+    into a NooBaa logs bucket. The replication policy references this logs
+    bucket the same way as AWS log-based replication (via logs_location.logs_bucket).
+
+    No cloud credentials are needed - all buckets use the default NooBaa backing store.
+
+    """
+
+    DEFAULT_TIMEOUT = 10 * 60
+
+    @pytest.fixture(scope="class", autouse=True)
+    def reduce_replication_and_logging_delay_setup(
+        self, add_env_vars_to_noobaa_core_class
+    ):
+        new_delay_in_milliseconds = 60 * 1000
+        new_env_var_tuples = [
+            (constants.BUCKET_REPLICATOR_DELAY_PARAM, new_delay_in_milliseconds),
+            (constants.BUCKET_LOG_REPLICATOR_DELAY_PARAM, new_delay_in_milliseconds),
+            (constants.BUCKET_LOG_UPLOADER_DELAY_PARAM, new_delay_in_milliseconds),
+        ]
+        add_env_vars_to_noobaa_core_class(new_env_var_tuples)
+
+    @pytest.fixture(scope="class", autouse=True)
+    def enable_guaranteed_logging(self, enable_guaranteed_bucket_logging):
+        enable_guaranteed_bucket_logging()
+
+    @pytest.fixture()
+    def noobaa_log_based_replication_setup(
+        self, mcg_obj_session, awscli_pod_session, bucket_factory
+    ):
+        """
+        Set up NooBaa-to-NooBaa log-based replication with deletion sync.
+
+        Creates three plain NooBaa buckets (source, target, logs), enables
+        bucket logging on the source, and configures a NoobaaLogBasedReplicationPolicy.
+
+        Returns:
+            tuple: (source_bucket, target_bucket, logs_bucket)
+
+        """
+        target_bucket = bucket_factory()[0]
+        logs_bucket = bucket_factory()[0]
+        source_bucket = bucket_factory()[0]
+
+        logs_manager = BucketLoggingManager(mcg_obj_session, awscli_pod_session)
+        logs_manager.put_bucket_logging(source_bucket.name, logs_bucket.name)
+
+        replication_policy = NoobaaLogBasedReplicationPolicy(
+            destination_bucket=target_bucket.name,
+            sync_deletions=True,
+            logs_bucket=logs_bucket.name,
+        )
+        update_replication_policy(source_bucket.name, replication_policy.to_dict())
+
+        return source_bucket, target_bucket, logs_bucket
+
+    @tier1
+    @polarion_id("OCS-XXXX")
+    def test_noobaa_log_based_deletion_sync(
+        self,
+        mcg_obj_session,
+        awscli_pod_session,
+        noobaa_log_based_replication_setup,
+    ):
+        """
+        Test NooBaa-to-NooBaa log-based replication with deletion sync.
+
+        1. Upload objects to the source bucket
+        2. Wait for replication to the target bucket
+        3. Delete objects from the source bucket
+        4. Wait for deletion sync to the target bucket
+
+        """
+        source_bucket, target_bucket, _ = noobaa_log_based_replication_setup
+
+        write_random_test_objects_to_bucket(
+            io_pod=awscli_pod_session,
+            bucket_to_write=source_bucket.name,
+            file_dir=constants.AWSCLI_TEST_OBJ_DIR,
+            amount=3,
+            mcg_obj=mcg_obj_session,
+        )
+
+        assert compare_bucket_object_list(
+            mcg_obj_session,
+            source_bucket.name,
+            target_bucket.name,
+            timeout=self.DEFAULT_TIMEOUT,
+        ), f"Replication failed to complete in {self.DEFAULT_TIMEOUT} seconds"
+
+        awscli_pod_session.exec_cmd_on_pod(
+            craft_s3_command(
+                f"rm s3://{source_bucket.name} --recursive",
+                mcg_obj=mcg_obj_session,
+            )
+        )
+
+        assert compare_bucket_object_list(
+            mcg_obj_session,
+            source_bucket.name,
+            target_bucket.name,
+            timeout=self.DEFAULT_TIMEOUT,
+        ), f"Deletion sync failed to complete in {self.DEFAULT_TIMEOUT} seconds"
+
+    @tier2
+    @polarion_id("OCS-XXXX")
+    def test_noobaa_log_based_deletion_sync_opt_out(
+        self,
+        mcg_obj_session,
+        awscli_pod_session,
+        noobaa_log_based_replication_setup,
+    ):
+        """
+        Test that deletion sync can be disabled for NooBaa-to-NooBaa replication.
+
+        1. Upload objects and wait for replication
+        2. Disable deletion sync
+        3. Delete source objects
+        4. Verify objects remain on the target
+
+        """
+        source_bucket, target_bucket, _ = noobaa_log_based_replication_setup
+
+        write_random_test_objects_to_bucket(
+            io_pod=awscli_pod_session,
+            bucket_to_write=source_bucket.name,
+            file_dir=constants.AWSCLI_TEST_OBJ_DIR,
+            amount=3,
+            mcg_obj=mcg_obj_session,
+        )
+
+        assert compare_bucket_object_list(
+            mcg_obj_session,
+            source_bucket.name,
+            target_bucket.name,
+            timeout=self.DEFAULT_TIMEOUT,
+        ), f"Replication failed to complete in {self.DEFAULT_TIMEOUT} seconds"
+
+        logger.info("Disabling the deletion sync")
+        disabled_del_sync_policy = source_bucket.replication_policy
+        disabled_del_sync_policy["rules"][0]["sync_deletions"] = False
+        update_replication_policy(source_bucket.name, disabled_del_sync_policy)
+
+        awscli_pod_session.exec_cmd_on_pod(
+            craft_s3_command(
+                f"rm s3://{source_bucket.name} --recursive",
+                mcg_obj=mcg_obj_session,
+            )
+        )
+
+        assert not compare_bucket_object_list(
+            mcg_obj_session,
+            source_bucket.name,
+            target_bucket.name,
+            timeout=self.DEFAULT_TIMEOUT,
+        ), "Deletion sync completed even though the policy was disabled!"

--- a/tests/functional/pod_and_daemons/test_mds_cache_trim_standby.py
+++ b/tests/functional/pod_and_daemons/test_mds_cache_trim_standby.py
@@ -3,6 +3,7 @@ import pytest
 
 from ocs_ci.framework.pytest_customization.marks import (
     brown_squad,
+    ceph_deep,
 )
 from ocs_ci.framework.testlib import (
     E2ETest,
@@ -20,6 +21,7 @@ log = logging.getLogger(__name__)
 
 @tier2
 @brown_squad
+@ceph_deep
 @skipif_external_mode
 @skipif_vsphere_platform
 class TestMdsCacheTrimStandby(E2ETest):

--- a/tests/functional/pv/pv_services/test_ceph_capacity_recovery.py
+++ b/tests/functional/pv/pv_services/test_ceph_capacity_recovery.py
@@ -3,7 +3,7 @@ import time
 import pytest
 
 from ocs_ci.ocs.perftests import PASTest
-from ocs_ci.framework.pytest_customization.marks import green_squad
+from ocs_ci.framework.pytest_customization.marks import ceph_deep, green_squad
 from ocs_ci.framework.testlib import (
     tier2,
     skipif_ocs_version,
@@ -55,6 +55,7 @@ def check_health_status():
 
 @pytest.mark.skip(reason="Skipping this test temporarily due to ocs-ci 12263")
 @green_squad
+@ceph_deep
 @tier2
 @polarion_id("OCS-5399")
 @skipif_external_mode

--- a/tests/functional/z_cluster/nodes/test_automated_recovery_from_failed_nodes_proactive.py
+++ b/tests/functional/z_cluster/nodes/test_automated_recovery_from_failed_nodes_proactive.py
@@ -2,7 +2,7 @@ import logging
 import pytest
 
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, ceph_deep
 from ocs_ci.framework.testlib import (
     tier4,
     tier4b,
@@ -28,6 +28,7 @@ log = logging.getLogger(__name__)
 
 
 @brown_squad
+@ceph_deep
 @tier4
 @tier4b
 @ignore_leftovers

--- a/tests/functional/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive.py
+++ b/tests/functional/z_cluster/nodes/test_automated_recovery_from_failed_nodes_reactive.py
@@ -2,6 +2,7 @@ import logging
 import pytest
 from ocs_ci.framework.pytest_customization.marks import (
     brown_squad,
+    ceph_deep,
     skipif_compact_mode,
     skipif_ibm_power,
     skipif_azure_platform,
@@ -51,6 +52,7 @@ deployment_type = config.ENV_DATA["deployment_type"].lower()
 
 
 @brown_squad
+@ceph_deep
 @ignore_leftovers
 @tier4b
 class TestAutomatedRecoveryFromFailedNodes(ManageTest):
@@ -247,6 +249,7 @@ class TestAutomatedRecoveryFromFailedNodes(ManageTest):
 
 
 @brown_squad
+@ceph_deep
 @ignore_leftovers
 @tier4a
 @skipif_ibm_cloud

--- a/tests/functional/z_cluster/nodes/test_disk_failures.py
+++ b/tests/functional/z_cluster/nodes/test_disk_failures.py
@@ -4,7 +4,11 @@ import pytest
 
 from ocs_ci.ocs import node, constants
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import brown_squad, skipif_rosa_hcp
+from ocs_ci.framework.pytest_customization.marks import (
+    brown_squad,
+    ceph_deep,
+    skipif_rosa_hcp,
+)
 from ocs_ci.framework.testlib import (
     tier4a,
     ignore_leftovers,
@@ -40,6 +44,7 @@ logger = logging.getLogger(__name__)
 
 
 @brown_squad
+@ceph_deep
 @tier4a
 @ignore_leftovers
 class TestDiskFailures(ManageTest):

--- a/tests/functional/z_cluster/nodes/test_node_kernel_crash_ceph_fsync.py
+++ b/tests/functional/z_cluster/nodes/test_node_kernel_crash_ceph_fsync.py
@@ -6,6 +6,7 @@ from time import sleep
 from ocs_ci.ocs import constants, node
 from ocs_ci.framework.pytest_customization.marks import (
     brown_squad,
+    ceph_deep,
     skipif_hci_provider_and_client,
     skipif_tainted_nodes,
 )
@@ -19,6 +20,7 @@ log = logging.getLogger(__name__)
 
 
 @brown_squad
+@ceph_deep
 @skipif_tainted_nodes
 @skipif_hci_provider_and_client
 class TestKernelCrash(E2ETest):

--- a/tests/functional/z_cluster/nodes/test_node_replacement_proactive.py
+++ b/tests/functional/z_cluster/nodes/test_node_replacement_proactive.py
@@ -23,6 +23,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     skipif_hci_client,
     brown_squad,
     skipif_ibm_cloud_managed,
+    ceph_deep,
 )
 from ocs_ci.helpers.helpers import (
     verify_storagecluster_nodetopology,
@@ -202,6 +203,7 @@ def delete_and_create_osd_node(osd_node_name):
 
 
 @brown_squad
+@ceph_deep
 @tier4a
 @ignore_leftovers
 @ipi_deployment_required
@@ -285,6 +287,7 @@ class TestNodeReplacementWithIO(ManageTest):
 
 
 @brown_squad
+@ceph_deep
 @tier4a
 @ignore_leftovers
 @skipif_bmpsi
@@ -344,6 +347,7 @@ class TestNodeReplacement(ManageTest):
 
 @tier4a
 @brown_squad
+@ceph_deep
 @ignore_leftovers
 @pytest.mark.polarion_id("OCS-2535")
 @skipif_external_mode

--- a/tests/functional/z_cluster/test_add_mds_to_cluster.py
+++ b/tests/functional/z_cluster/test_add_mds_to_cluster.py
@@ -8,7 +8,7 @@ import pytest
 
 from ocs_ci.ocs import constants, defaults, ocp
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, ceph_deep
 from ocs_ci.framework.testlib import ManageTest
 from ocs_ci.ocs.resources.ocs import OCS
 from ocs_ci.utility.utils import TimeoutSampler
@@ -76,6 +76,7 @@ def get_mds_active_count():
 # @tier1
 # Test case is disabled, as per requirement not to support this scenario
 @brown_squad
+@ceph_deep
 class TestCephFilesystemCreation(ManageTest):
     """
     Testing creation of Ceph FileSystem

--- a/tests/functional/z_cluster/test_ceph_default_values_check.py
+++ b/tests/functional/z_cluster/test_ceph_default_values_check.py
@@ -5,6 +5,7 @@ import pytest
 from ocs_ci.framework.pytest_customization.marks import (
     skipif_ocs_version,
     brown_squad,
+    ceph_deep,
 )
 from ocs_ci.framework.testlib import (
     ManageTest,
@@ -35,6 +36,7 @@ log = logging.getLogger(__name__)
 
 
 @brown_squad
+@ceph_deep
 @tier1
 @skipif_external_mode
 @pytest.mark.polarion_id("OCS-2231")

--- a/tests/functional/z_cluster/test_ceph_mon_healthcheck.py
+++ b/tests/functional/z_cluster/test_ceph_mon_healthcheck.py
@@ -1,6 +1,7 @@
 import logging
 import pytest
 
+from ocs_ci.framework.pytest_customization.marks import ceph_deep
 from ocs_ci.framework.testlib import (
     ManageTest,
     ignore_leftovers,
@@ -34,6 +35,7 @@ log = logging.getLogger(__name__)
 
 
 @brown_squad
+@ceph_deep
 @ignore_leftovers
 class TestCephMonHealthCheck(ManageTest):
     """

--- a/tests/functional/z_cluster/test_ceph_pg_log_dups_trim.py
+++ b/tests/functional/z_cluster/test_ceph_pg_log_dups_trim.py
@@ -2,7 +2,7 @@ import logging
 import random
 import pytest
 
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, ceph_deep
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier2,
@@ -29,6 +29,7 @@ log = logging.getLogger(__name__)
 
 
 @brown_squad
+@ceph_deep
 @tier2
 @skipif_external_mode
 @skipif_managed_service

--- a/tests/functional/z_cluster/test_coredump_check_for_ceph_daemon_crash.py
+++ b/tests/functional/z_cluster/test_coredump_check_for_ceph_daemon_crash.py
@@ -6,7 +6,11 @@ from ocs_ci.utility.utils import TimeoutSampler
 from ocs_ci.helpers.disruption_helpers import Disruptions
 from ocs_ci.helpers.helpers import run_cmd_verify_cli_output
 from ocs_ci.utility.utils import ceph_health_check
-from ocs_ci.framework.pytest_customization.marks import skipif_rhel_os, brown_squad
+from ocs_ci.framework.pytest_customization.marks import (
+    skipif_rhel_os,
+    brown_squad,
+    ceph_deep,
+)
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier2,
@@ -27,6 +31,7 @@ log = logging.getLogger(__name__)
 
 @runs_on_provider
 @brown_squad
+@ceph_deep
 @tier2
 @skipif_external_mode
 @skipif_ocs_version("<4.7")

--- a/tests/functional/z_cluster/test_delete_osd_deployment.py
+++ b/tests/functional/z_cluster/test_delete_osd_deployment.py
@@ -1,6 +1,6 @@
 import logging
 import pytest
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, ceph_deep
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier4c,
@@ -20,6 +20,7 @@ logger = logging.getLogger(__name__)
 
 
 @brown_squad
+@ceph_deep
 @tier4c
 @skipif_ocs_version("<4.10")
 @ignore_leftover_label(constants.OSD_APP_LABEL)

--- a/tests/functional/z_cluster/test_delete_rook_ceph_mon_pod.py
+++ b/tests/functional/z_cluster/test_delete_rook_ceph_mon_pod.py
@@ -3,6 +3,7 @@ import pytest
 
 from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import (
+    ceph_deep,
     skipif_external_mode,
     brown_squad,
     runs_on_provider,
@@ -18,6 +19,7 @@ log = logging.getLogger(__name__)
 
 @runs_on_provider
 @brown_squad
+@ceph_deep
 @tier2
 @skipif_external_mode
 @pytest.mark.polarion_id("OCS-2481")

--- a/tests/functional/z_cluster/test_mon_data_avail_warn.py
+++ b/tests/functional/z_cluster/test_mon_data_avail_warn.py
@@ -9,7 +9,7 @@ import random
 import pytest
 
 from ocs_ci.framework import config
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, ceph_deep
 from ocs_ci.framework.testlib import (
     E2ETest,
     tier2,
@@ -31,6 +31,7 @@ DD_COUNT = 64
 
 
 @brown_squad
+@ceph_deep
 @tier2
 @pytest.mark.polarion_id("OCS-2733")
 @skipif_ocs_version("<4.9")

--- a/tests/functional/z_cluster/test_mon_healthcheck_passthrough.py
+++ b/tests/functional/z_cluster/test_mon_healthcheck_passthrough.py
@@ -3,6 +3,7 @@ import logging
 import pytest
 
 from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import ceph_deep
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier2,
@@ -83,6 +84,7 @@ def _healthcheck_matches(actual, desired):
 
 @tier2
 @brown_squad
+@ceph_deep
 @skipif_external_mode
 @pytest.mark.polarion_id("OCS-7403")
 class TestMonHealthcheckPassthrough(ManageTest):

--- a/tests/functional/z_cluster/test_mon_log_trimming.py
+++ b/tests/functional/z_cluster/test_mon_log_trimming.py
@@ -3,7 +3,7 @@ import random
 import threading
 import pytest
 from ocs_ci.ocs import constants
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, ceph_deep
 from ocs_ci.framework.testlib import E2ETest, tier2, skipif_external_mode
 from ocs_ci.ocs.resources import pod
 from ocs_ci.ocs.resources.pod import get_mon_pods
@@ -14,6 +14,7 @@ log = logging.getLogger(__name__)
 
 
 @brown_squad
+@ceph_deep
 @tier2
 @skipif_external_mode
 @pytest.mark.polarion_id("OCS-2526")

--- a/tests/functional/z_cluster/test_multiple_mds.py
+++ b/tests/functional/z_cluster/test_multiple_mds.py
@@ -9,6 +9,7 @@ import pytest
 
 from ocs_ci.framework.pytest_customization.marks import (
     brown_squad,
+    ceph_deep,
     ec_allowed,
     green_squad,
     tier2,
@@ -57,6 +58,7 @@ def verify_active_and_standby_mds_count(target_count, timeout=180):
 
 
 @brown_squad
+@ceph_deep
 @tier4c
 @skipif_external_mode
 @skipif_hci_client
@@ -245,6 +247,7 @@ def cephfs_ec_storageclass(request):
 
 @ec_allowed
 @green_squad
+@ceph_deep
 @runs_on_provider
 @skipif_hci_client
 @skipif_external_mode

--- a/tests/functional/z_cluster/test_osd_heap_profile.py
+++ b/tests/functional/z_cluster/test_osd_heap_profile.py
@@ -3,7 +3,7 @@ import pytest
 import time
 import random
 
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, ceph_deep
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier2,
@@ -20,6 +20,7 @@ log = logging.getLogger(__name__)
 
 @runs_on_provider
 @brown_squad
+@ceph_deep
 @tier2
 @skipif_ocs_version("<4.6")
 @pytest.mark.polarion_id("OCS-2512")

--- a/tests/functional/z_cluster/test_remove_mon_from_cluster.py
+++ b/tests/functional/z_cluster/test_remove_mon_from_cluster.py
@@ -9,7 +9,7 @@ Polarion-ID- OCS-355
 import logging
 import pytest
 from ocs_ci.ocs import ocp, constants
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, ceph_deep
 from ocs_ci.framework.testlib import ManageTest, ignore_leftovers
 from ocs_ci.framework import config
 from ocs_ci.ocs.resources import pod
@@ -63,6 +63,7 @@ def run_io_on_pool(pool_obj):
 # tier4c
 @ignore_leftovers
 @brown_squad
+@ceph_deep
 # @pytest.mark.polarion_id("OCS-355")
 class TestRemoveMonFromCluster(ManageTest):
     pool_obj = ""

--- a/tests/functional/z_cluster/test_restart_mgr_while_two_mons_down.py
+++ b/tests/functional/z_cluster/test_restart_mgr_while_two_mons_down.py
@@ -11,6 +11,7 @@ from ocs_ci.ocs.resources.pod import (
 )
 from ocs_ci.ocs.resources.pod import get_deployments_having_label
 from ocs_ci.framework.pytest_customization.marks import (
+    ceph_deep,
     skipif_external_mode,
     brown_squad,
 )
@@ -24,6 +25,7 @@ log = logging.getLogger(__name__)
 
 
 @brown_squad
+@ceph_deep
 @tier2
 @polarion_id("OCS-2696")
 @skipif_external_mode

--- a/tests/functional/z_cluster/test_rook_ceph_osd_flapping.py
+++ b/tests/functional/z_cluster/test_rook_ceph_osd_flapping.py
@@ -13,7 +13,7 @@ from ocs_ci.helpers.helpers import (
 )
 from ocs_ci.ocs.cluster import ceph_health_check
 from ocs_ci.ocs.resources import pod
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, ceph_deep
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier2,
@@ -26,6 +26,7 @@ log = logging.getLogger(__name__)
 
 
 @brown_squad
+@ceph_deep
 @tier2
 @ignore_leftovers
 @skipif_external_mode

--- a/tests/functional/z_cluster/test_rook_operator_restart_during_mon_failover.py
+++ b/tests/functional/z_cluster/test_rook_operator_restart_during_mon_failover.py
@@ -9,7 +9,7 @@ from ocs_ci.ocs.resources.pod import (
     get_operator_pods,
     wait_for_pods_to_be_running,
 )
-from ocs_ci.framework.pytest_customization.marks import brown_squad
+from ocs_ci.framework.pytest_customization.marks import brown_squad, ceph_deep
 from ocs_ci.framework.testlib import (
     ManageTest,
     tier4b,
@@ -23,6 +23,7 @@ log = logging.getLogger(__name__)
 
 
 @brown_squad
+@ceph_deep
 @tier4b
 @skipif_external_mode
 @skipif_ocs_version("<4.6")

--- a/tests/functional/z_cluster/test_scale_mon_pods.py
+++ b/tests/functional/z_cluster/test_scale_mon_pods.py
@@ -5,6 +5,7 @@ import time
 from ocs_ci.ocs import ocp, constants
 from ocs_ci.framework.pytest_customization.marks import (
     brown_squad,
+    ceph_deep,
     post_ocs_upgrade,
     skipif_less_than_five_workers,
 )
@@ -45,6 +46,7 @@ HEALTH_CHECK_RETRIES = 150  # number of retries for health check
 
 
 @brown_squad
+@ceph_deep
 @skipif_less_than_five_workers
 @skipif_ocs_version("<4.15")
 class TestFiveMonInCluster(ManageTest):


### PR DESCRIPTION
## Summary
- Registers a new `ceph_deep` pytest marker for tagging tests that exercise core Ceph internals (OSD failure/replacement, MON quorum/recovery, MDS management, PG log trimming, CephX key rotation, stretch cluster resilience, etc.)
- Applies `@ceph_deep` to 44 test files (~50 test classes) covering narrow Ceph data-path and resilience scenarios
- Enables running `run-ci tests/ -m ceph_deep` to validate the Ceph layer when a new Ceph image is introduced in ODF, without running the full suite

## Test plan
- [x] `tox -e flake8` passes on all modified files
- [x] `tox -e black` passes on all modified files
- [ ] `pytest --collect-only -m ceph_deep` collects only the intended tests
- [ ] Marker does not interfere with existing test selection (`-m tier1`, `-m brown_squad`, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for configuring log-based bucket replication with NooBaa buckets.
  - Expanded replication coverage for Azure change feeds and NooBaa-to-NooBaa scenarios, including deletion synchronization options.

- **Tests**
  - Added a `ceph_deep` test classification marker.
  - Applied the marker across Ceph deep functional, resilience, disaster recovery, encryption, recovery, and system test scenarios.
  - Added coverage for log-based replication behavior across supported platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->