### PR TITLE
Honor wait_for_resource timeout when column value is empty

### DIFF
--- a/ocs_ci/ocs/ocp.py
+++ b/ocs_ci/ocs/ocp.py
@@ -1127,12 +1127,27 @@ class OCP(object):
                 # Only 1 resource expected to be returned
                 if resource_name:
                     retry = int(timeout / sleep if sleep else timeout / 1)
-                    status = self.get_resource(
-                        resource_name,
-                        column,
-                        retry=retry,
-                        wait=sleep,
-                    )
+                    try:
+                        status = self.get_resource(
+                            resource_name,
+                            column,
+                            retry=retry,
+                            wait=sleep,
+                        )
+                    except IndexError:
+                        # The column header may be present while the row has no
+                        # value for it yet (e.g. a freshly created
+                        # ManagedCluster whose AVAILABLE/JOINED columns are
+                        # still empty during import). Treat this as "not ready
+                        # yet" and keep waiting until the real timeout instead
+                        # of aborting early.
+                        log.info(
+                            f"status of {resource_name} at column {column} is "
+                            "not populated yet, but we were waiting for "
+                            f"{condition}"
+                        )
+                        actual_status = None
+                        continue
                     if status == condition:
                         log.info(
                             f"status of {resource_name} at column {column}"


### PR DESCRIPTION
When waiting on a single resource's column (e.g. a freshly created ManagedCluster whose AVAILABLE/JOINED columns are still empty during ACM import), get_resource parses the table output and raises IndexError because the header exists but the row has no value yet. Its @Retry(IndexError, tries=4, delay=20) only survives ~80s, after which the IndexError propagates unhandled out of wait_for_resource's single-resource branch, killing the wait well before the real timeout.

Wrap the get_resource call in the single-resource branch with try/except IndexError, treating an unpopulated column as "not ready yet" and continuing the TimeoutSampler loop until the actual timeout is reached.

Signed-off-by: vavuthu [vavuthu@redhat.com](mailto:vavuthu@redhat.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource readiness checks when status information is temporarily unavailable.
  * The system now continues waiting and retries instead of stopping prematurely in this situation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->