### PR TITLE
Use incompressible fio data in FillPoolJob to raise Ceph used capacity

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -3214,6 +3214,7 @@ LOGICALVOLUME = "logicalvolume"
 
 PERF_IMAGE = "quay.io/ocsci/perf:latest"
 NGINX_FIO_IMAGE = "quay.io/ocsci/nginx:fio"
+FEDORA_FIO_IMAGE = "quay.io/ocsci/fedora:fio"
 
 ROOK_CEPH_CONFIG_VALUES = """
 [global]

--- a/ocs_ci/ocs/fill_pool_job.py
+++ b/ocs_ci/ocs/fill_pool_job.py
@@ -13,6 +13,20 @@ from ocs_ci.utility.utils import exec_cmd
 
 log = logging.getLogger(__name__)
 
+# RBD discards actual zero writes (discard_on_zeroed_write_same). /dev/urandom is
+# CPU-bound under the default CPU cap. fio libaio with scrambled buffers is stored
+# as real used capacity and can issue multiple outstanding IOs.
+FILL_MODES = ("zero", "random", "incompressible")
+
+
+def _fio_size_from_pvc_storage(storage):
+    """92% of a Gi PVC, so fio --size fits on the filesystem (fill_fs OOMs this image)."""
+    text = str(storage).strip().lower()
+    if not text.endswith("gi"):
+        raise ValueError(f"incompressible fill expects storage in Gi, got {storage!r}")
+    gib = float(text[:-2])
+    return f"{max(1, int(gib * 1024 * 0.92))}M"
+
 
 class FillPoolJob(object):
     """
@@ -45,16 +59,31 @@ class FillPoolJob(object):
         """
         Create a Job that fills up cluster storage by writing data to a PVC.
         Assumes manifest is a Job (pod spec under spec.template.spec).
+
+        Args:
+            fill_mode (str): How to generate write data:
+                'zero' - dd from /dev/zero (does not increase Ceph used-raw on RBD).
+                'random' - dd from /dev/urandom (slow; CPU-bound).
+                'incompressible' - fio libaio write (queue depth 16). Prefer this
+                to increase Ceph used-raw capacity on RBD.
         """
         self.name = name or create_unique_resource_name("fill-pool", "job")
         sc_name = sc_name or constants.DEFAULT_STORAGECLASS_RBD
         proj_obj = helpers.create_project()
         self.namespace = proj_obj.namespace
 
-        if fill_mode not in ["zero", "random"]:
-            raise ValueError("fill_mode must be either 'zero' or 'random'")
+        if fill_mode not in FILL_MODES:
+            raise ValueError(f"fill_mode must be one of {FILL_MODES}")
 
-        input_source = "/dev/zero" if fill_mode == "zero" else "/dev/urandom"
+        # fio 3.21 in fedora:fio is OOMKilled at 1Gi; 2Gi is the measured floor.
+        if fill_mode == "incompressible":
+            cpu_request, cpu_limit = "500m", "2"
+            mem_request, mem_limit = "512Mi", "2Gi"
+
+        log.info(
+            f"Creating FillPoolJob {self.name} fill_mode={fill_mode} "
+            f"storage={storage} block_size={block_size}"
+        )
 
         # Load Job manifest and apply metadata
         job_data = templating.load_yaml(base_yaml_path)
@@ -70,6 +99,7 @@ class FillPoolJob(object):
 
         container = pod_spec["containers"][0]
         volume = pod_spec["volumes"][0]
+        container["image"] = constants.FEDORA_FIO_IMAGE
 
         # Prepare PVC name and update volume claim
         pvc_name = pvc_name or create_unique_resource_name("fill-pool", "pvc")
@@ -87,18 +117,8 @@ class FillPoolJob(object):
             "limits": {"cpu": cpu_limit, "memory": mem_limit},
         }
 
-        # Ensure the container will run the dd command
-        # Insure to handle the case of "No space left on device" error gracefully
-        dd_cmd = (
-            f'echo "Filling PVC with {fill_mode} data..."; '
-            f"dd if={input_source} of=/mnt/fill/testfile bs=${{BLOCK_SIZE:-{block_size}}} 2>/tmp/dd_err; "
-            f"EXIT_STATUS=$?; "
-            f"if [ $EXIT_STATUS -ne 0 ] && grep -q 'No space left on device' /tmp/dd_err; then "
-            f"  cat /tmp/dd_err; echo 'Capacity reached. Exiting successfully.'; exit 0; "
-            f"fi; "
-            f"cat /tmp/dd_err; exit $EXIT_STATUS"
-        )
-        container["command"] = ["sh", "-c", dd_cmd]
+        fill_cmd = self._build_fill_command(fill_mode, block_size, storage)
+        container["command"] = ["sh", "-c", fill_cmd]
         container.pop("args", None)
 
         # Prepare PVC manifest
@@ -129,6 +149,44 @@ class FillPoolJob(object):
                 timeout=180,
                 sleep=10,
             )
+
+    @staticmethod
+    def _build_fill_command(fill_mode, block_size, storage="50Gi"):
+        """
+        Build the container shell command for the given fill mode.
+
+        incompressible: fio libaio, iodepth 16, scrambled buffers, explicit --size.
+        ENOSPC is treated as success for every mode.
+        """
+        bs = f"${{BLOCK_SIZE:-{block_size}}}"
+        enospc_handler = (
+            "EXIT_STATUS=$?; "
+            "if [ $EXIT_STATUS -ne 0 ] && grep -qE "
+            "'No space left on device|ENOSPC|OS error: 28' /tmp/fill_err /tmp/fill_out; then "
+            "  cat /tmp/fill_out /tmp/fill_err; "
+            "  echo 'Capacity reached. Exiting successfully.'; exit 0; "
+            "fi; "
+            "cat /tmp/fill_out /tmp/fill_err; exit $EXIT_STATUS"
+        )
+        if fill_mode == "incompressible":
+            fio_size = _fio_size_from_pvc_storage(storage)
+            return (
+                'echo "Filling PVC with incompressible fio data..."; '
+                "touch /tmp/fill_out /tmp/fill_err; "
+                "fio --name=fill --filename=/mnt/fill/testfile --rw=write "
+                f"--bs={bs} --size={fio_size} --direct=1 --ioengine=libaio "
+                "--iodepth=16 --scramble_buffers=1 --end_fsync=1 "
+                "--output=/tmp/fill_out 2>/tmp/fill_err; "
+                f"{enospc_handler}"
+            )
+        input_source = "/dev/zero" if fill_mode == "zero" else "/dev/urandom"
+        return (
+            f'echo "Filling PVC with {fill_mode} data..."; '
+            "touch /tmp/fill_out /tmp/fill_err; "
+            f"dd if={input_source} of=/mnt/fill/testfile bs={bs} "
+            f">/tmp/fill_out 2>/tmp/fill_err; "
+            f"{enospc_handler}"
+        )
 
     def wait_for_completion(self, timeout=3600, sleep=30):
         """

--- a/ocs_ci/ocs/fill_pool_job.py
+++ b/ocs_ci/ocs/fill_pool_job.py
@@ -1,4 +1,5 @@
 import logging
+import re
 
 from ocs_ci.helpers.helpers import create_unique_resource_name
 from ocs_ci.ocs.exceptions import CommandFailed
@@ -8,7 +9,7 @@ from ocs_ci.utility import templating
 from ocs_ci.helpers import helpers
 from ocs_ci.ocs.resources.pvc import PVC
 from ocs_ci.ocs.resources.pod import Pod, get_pods_having_label
-from ocs_ci.utility.utils import convert_device_size, exec_cmd
+from ocs_ci.utility.utils import exec_cmd
 
 
 log = logging.getLogger(__name__)
@@ -24,6 +25,12 @@ INCOMPRESSIBLE_MIN_CPU_REQUEST = "500m"
 INCOMPRESSIBLE_MIN_CPU_LIMIT = "2"
 INCOMPRESSIBLE_MIN_MEM_REQUEST = "512Mi"
 INCOMPRESSIBLE_MIN_MEM_LIMIT = "2Gi"
+_MEMORY_UNIT_BYTES = {
+    "Ki": 1024,
+    "Mi": 1024**2,
+    "Gi": 1024**3,
+    "Ti": 1024**4,
+}
 
 
 def _fio_size_from_pvc_storage(storage):
@@ -44,11 +51,24 @@ def _cpu_millicores(quantity):
 
 
 def _memory_bytes(quantity):
-    """Convert a Kubernetes binary memory quantity (Ki/Mi/Gi/Ti) to bytes."""
-    return convert_device_size(str(quantity).strip(), "BY", convert_size=1024)
+    """
+    Convert a Kubernetes binary memory quantity (Ki/Mi/Gi/Ti) to bytes.
+
+    Accepts fractional values such as 1.5Gi. convert_device_size() cannot,
+    because it parses the number with int().
+    """
+    memory_quantity_regex = re.compile(
+        r"^(?P<value>\d+(?:\.\d+)?)(?P<unit>Ki|Mi|Gi|Ti)$"
+    )
+    match = memory_quantity_regex.fullmatch(str(quantity).strip())
+    if not match:
+        raise ValueError(
+            f"incompressible memory expects a Ki/Mi/Gi/Ti quantity, got {quantity!r}"
+        )
+    return float(match.group("value")) * _MEMORY_UNIT_BYTES[match.group("unit")]
 
 
-def _at_least(value, floor, to_number):
+def _raise_to_floor(value, floor, to_number):
     """Return value when it already meets the floor; otherwise return floor."""
     return value if to_number(value) >= to_number(floor) else floor
 
@@ -62,12 +82,16 @@ def _apply_incompressible_resource_floors(
     Callers may pass larger values; those are kept. If a floored request would
     exceed its limit, the limit is raised to match so the pod spec stays valid.
     """
-    cpu_request = _at_least(
+    cpu_request = _raise_to_floor(
         cpu_request, INCOMPRESSIBLE_MIN_CPU_REQUEST, _cpu_millicores
     )
-    cpu_limit = _at_least(cpu_limit, INCOMPRESSIBLE_MIN_CPU_LIMIT, _cpu_millicores)
-    mem_request = _at_least(mem_request, INCOMPRESSIBLE_MIN_MEM_REQUEST, _memory_bytes)
-    mem_limit = _at_least(mem_limit, INCOMPRESSIBLE_MIN_MEM_LIMIT, _memory_bytes)
+    cpu_limit = _raise_to_floor(
+        cpu_limit, INCOMPRESSIBLE_MIN_CPU_LIMIT, _cpu_millicores
+    )
+    mem_request = _raise_to_floor(
+        mem_request, INCOMPRESSIBLE_MIN_MEM_REQUEST, _memory_bytes
+    )
+    mem_limit = _raise_to_floor(mem_limit, INCOMPRESSIBLE_MIN_MEM_LIMIT, _memory_bytes)
     if _cpu_millicores(cpu_request) > _cpu_millicores(cpu_limit):
         cpu_limit = cpu_request
     if _memory_bytes(mem_request) > _memory_bytes(mem_limit):

--- a/ocs_ci/ocs/fill_pool_job.py
+++ b/ocs_ci/ocs/fill_pool_job.py
@@ -8,7 +8,7 @@ from ocs_ci.utility import templating
 from ocs_ci.helpers import helpers
 from ocs_ci.ocs.resources.pvc import PVC
 from ocs_ci.ocs.resources.pod import Pod, get_pods_having_label
-from ocs_ci.utility.utils import exec_cmd
+from ocs_ci.utility.utils import convert_device_size, exec_cmd
 
 
 log = logging.getLogger(__name__)
@@ -18,6 +18,13 @@ log = logging.getLogger(__name__)
 # as real used capacity and can issue multiple outstanding IOs.
 FILL_MODES = ("zero", "random", "incompressible")
 
+# fio 3.21 in fedora:fio is OOMKilled at 1Gi. incompressible mode raises the
+# caller-supplied resources to at least these values; larger requests are kept.
+INCOMPRESSIBLE_MIN_CPU_REQUEST = "500m"
+INCOMPRESSIBLE_MIN_CPU_LIMIT = "2"
+INCOMPRESSIBLE_MIN_MEM_REQUEST = "512Mi"
+INCOMPRESSIBLE_MIN_MEM_LIMIT = "2Gi"
+
 
 def _fio_size_from_pvc_storage(storage):
     """92% of a Gi PVC, so fio --size fits on the filesystem (fill_fs OOMs this image)."""
@@ -26,6 +33,46 @@ def _fio_size_from_pvc_storage(storage):
         raise ValueError(f"incompressible fill expects storage in Gi, got {storage!r}")
     gib = float(text[:-2])
     return f"{max(1, int(gib * 1024 * 0.92))}M"
+
+
+def _cpu_millicores(quantity):
+    """Convert a Kubernetes CPU quantity to millicores."""
+    text = str(quantity).strip().lower()
+    if text.endswith("m"):
+        return float(text[:-1])
+    return float(text) * 1000
+
+
+def _memory_bytes(quantity):
+    """Convert a Kubernetes binary memory quantity (Ki/Mi/Gi/Ti) to bytes."""
+    return convert_device_size(str(quantity).strip(), "BY", convert_size=1024)
+
+
+def _at_least(value, floor, to_number):
+    """Return value when it already meets the floor; otherwise return floor."""
+    return value if to_number(value) >= to_number(floor) else floor
+
+
+def _apply_incompressible_resource_floors(
+    cpu_request, cpu_limit, mem_request, mem_limit
+):
+    """
+    Raise incompressible FillPoolJob CPU/memory to the measured fio floors.
+
+    Callers may pass larger values; those are kept. If a floored request would
+    exceed its limit, the limit is raised to match so the pod spec stays valid.
+    """
+    cpu_request = _at_least(
+        cpu_request, INCOMPRESSIBLE_MIN_CPU_REQUEST, _cpu_millicores
+    )
+    cpu_limit = _at_least(cpu_limit, INCOMPRESSIBLE_MIN_CPU_LIMIT, _cpu_millicores)
+    mem_request = _at_least(mem_request, INCOMPRESSIBLE_MIN_MEM_REQUEST, _memory_bytes)
+    mem_limit = _at_least(mem_limit, INCOMPRESSIBLE_MIN_MEM_LIMIT, _memory_bytes)
+    if _cpu_millicores(cpu_request) > _cpu_millicores(cpu_limit):
+        cpu_limit = cpu_request
+    if _memory_bytes(mem_request) > _memory_bytes(mem_limit):
+        mem_limit = mem_request
+    return cpu_request, cpu_limit, mem_request, mem_limit
 
 
 class FillPoolJob(object):
@@ -66,6 +113,14 @@ class FillPoolJob(object):
                 'random' - dd from /dev/urandom (slow; CPU-bound).
                 'incompressible' - fio libaio write (queue depth 16). Prefer this
                 to increase Ceph used-raw capacity on RBD.
+            cpu_request (str): CPU request. Incompressible mode raises this to
+                at least 500m.
+            cpu_limit (str): CPU limit. Incompressible mode raises this to
+                at least 2.
+            mem_request (str): Memory request (Ki/Mi/Gi/Ti). Incompressible
+                mode raises this to at least 512Mi.
+            mem_limit (str): Memory limit (Ki/Mi/Gi/Ti). Incompressible mode
+                raises this to at least 2Gi (fio 3.21 OOMKills below that).
         """
         self.name = name or create_unique_resource_name("fill-pool", "job")
         sc_name = sc_name or constants.DEFAULT_STORAGECLASS_RBD
@@ -75,14 +130,17 @@ class FillPoolJob(object):
         if fill_mode not in FILL_MODES:
             raise ValueError(f"fill_mode must be one of {FILL_MODES}")
 
-        # fio 3.21 in fedora:fio is OOMKilled at 1Gi; 2Gi is the measured floor.
         if fill_mode == "incompressible":
-            cpu_request, cpu_limit = "500m", "2"
-            mem_request, mem_limit = "512Mi", "2Gi"
+            cpu_request, cpu_limit, mem_request, mem_limit = (
+                _apply_incompressible_resource_floors(
+                    cpu_request, cpu_limit, mem_request, mem_limit
+                )
+            )
 
         log.info(
             f"Creating FillPoolJob {self.name} fill_mode={fill_mode} "
-            f"storage={storage} block_size={block_size}"
+            f"storage={storage} block_size={block_size} "
+            f"cpu={cpu_request}/{cpu_limit} memory={mem_request}/{mem_limit}"
         )
 
         # Load Job manifest and apply metadata

--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -9,6 +9,7 @@ from datetime import datetime, timedelta
 import logging
 import os
 import re
+import shlex
 import yaml
 import tempfile
 import time
@@ -47,7 +48,6 @@ from ocs_ci.utility.utils import (
     TimeoutSampler,
     exec_cmd,
 )
-from ocs_ci.utility.utils import check_if_executable_in_path
 from ocs_ci.utility.retry import retry
 from ocs_ci.ocs.constants import CSI_RBD_ADDON_NODEPLUGIN_LABEL_420
 
@@ -594,9 +594,9 @@ class Pod(OCS):
         if isinstance(packages, list):
             packages = " ".join(packages)
 
-        # Detect OS inside pod
+        # oc rsh does not invoke a shell, so compound commands need bash -c.
         os_release = self.exec_cmd_on_pod(
-            "cat /etc/os-release || true", out_yaml_format=False
+            "bash -c 'cat /etc/os-release || true'", out_yaml_format=False
         )
 
         os_release_lower = os_release.lower() if os_release else ""
@@ -621,7 +621,7 @@ class Pod(OCS):
                 f"Unsupported OS for package install. /etc/os-release:\n{os_release}"
             )
 
-        self.exec_cmd_on_pod(cmd, out_yaml_format=False)
+        self.exec_cmd_on_pod(f"bash -c {shlex.quote(cmd)}", out_yaml_format=False)
 
     def copy_to_server(self, server, authkey, localpath, remotepath, user=None):
         """
@@ -1363,7 +1363,7 @@ def list_ceph_images(pool_name="rbd"):
     return ct_pod.exec_ceph_cmd(ceph_cmd=f"rbd ls {pool_name}", format="json")
 
 
-@retry(TypeError, tries=5, delay=2, backoff=1)
+@retry((TypeError, CommandFailed), tries=5, delay=2, backoff=1)
 def check_file_existence(pod_obj, file_path):
     """
     Check if file exists inside the pod
@@ -1376,14 +1376,14 @@ def check_file_existence(pod_obj, file_path):
     Returns:
         bool: True if the file exist, False otherwise
     """
-    try:
-        check_if_executable_in_path(pod_obj.exec_cmd_on_pod("which find"))
-    except CommandFailed:
-        pod_obj.install_packages("findutils")
-    ret = pod_obj.exec_cmd_on_pod(f'bash -c "find {file_path}"')
-    if re.search(file_path, ret):
-        return True
-    return False
+    existence_script = (
+        f"if [ -e {shlex.quote(file_path)} ]; then echo EXISTS; else echo MISSING; fi"
+    )
+    ret = pod_obj.exec_cmd_on_pod(
+        f"bash -c {shlex.quote(existence_script)}",
+        out_yaml_format=False,
+    )
+    return "EXISTS" in str(ret)
 
 
 def get_file_path(pod_obj, file_name):

--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -594,9 +594,11 @@ class Pod(OCS):
         if isinstance(packages, list):
             packages = " ".join(packages)
 
-        # oc rsh does not invoke a shell, so compound commands need bash -c.
+        # oc rsh does not invoke a shell, so compound commands need sh -c.
+        # Use POSIX sh (not bash) so Alpine/busybox images can still run this.
         os_release = self.exec_cmd_on_pod(
-            "bash -c 'cat /etc/os-release || true'", out_yaml_format=False
+            f"sh -c {shlex.quote('cat /etc/os-release || true')}",
+            out_yaml_format=False,
         )
 
         os_release_lower = os_release.lower() if os_release else ""
@@ -621,7 +623,7 @@ class Pod(OCS):
                 f"Unsupported OS for package install. /etc/os-release:\n{os_release}"
             )
 
-        self.exec_cmd_on_pod(f"bash -c {shlex.quote(cmd)}", out_yaml_format=False)
+        self.exec_cmd_on_pod(f"sh -c {shlex.quote(cmd)}", out_yaml_format=False)
 
     def copy_to_server(self, server, authkey, localpath, remotepath, user=None):
         """

--- a/ocs_ci/templates/workloads/fio/fill_pool_job.yaml
+++ b/ocs_ci/templates/workloads/fio/fill_pool_job.yaml
@@ -13,24 +13,23 @@ spec:
       restartPolicy: Never
       containers:
       - name: filler
-        image: quay.io/ocsci/busybox:latest
+        # fedora:fio provides GNU dd and fio. FillPoolJob.create overrides command.
+        image: quay.io/ocsci/fedora:fio
         imagePullPolicy: IfNotPresent
         command:
           - sh
           - -c
-          - |
-            echo "Filling PVC with zeros..."
-            dd if=${INPUT_FILE:-/dev/zero} of=/mnt/fill/testfile bs=${BLOCK_SIZE:-1M}
+          - echo "Filling PVC..."
         env:
         - name: BLOCK_SIZE
-          value: "1M"
+          value: "4M"
         resources:
           requests:
-            cpu: "100m"
-            memory: "128Mi"
-          limits:
             cpu: "500m"
-            memory: "256Mi"
+            memory: "512Mi"
+          limits:
+            cpu: "2"
+            memory: "2Gi"
         volumeMounts:
           - name: volume
             mountPath: /mnt/fill

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12402,12 +12402,13 @@ def fill_job_factory(request):
 
         Args:
             name (str): Name of the Pod to create.
-            block_size (str): Block size for the dd command.
+            block_size (str): Block size for the fill command.
             cpu_request (str): CPU request for the Pod.
             mem_request (str): Memory request for the Pod.
             cpu_limit (str): CPU limit for the Pod.
             mem_limit (str): Memory limit for the Pod.
-            fill_mode (str): Mode of filling data, either 'zero' or 'random'.
+            fill_mode (str): Data generator: 'zero', 'random', or 'incompressible'.
+                Use 'incompressible' to increase Ceph used-raw capacity on RBD.
             base_yaml_path (str): Path to the base Job YAML manifest.
             pvc_name (str): Name of the PVC to create and attach to the Pod.
             sc_name (str): StorageClass name for the PVC.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12403,10 +12403,14 @@ def fill_job_factory(request):
         Args:
             name (str): Name of the Pod to create.
             block_size (str): Block size for the fill command.
-            cpu_request (str): CPU request for the Pod.
-            mem_request (str): Memory request for the Pod.
-            cpu_limit (str): CPU limit for the Pod.
-            mem_limit (str): Memory limit for the Pod.
+            cpu_request (str): CPU request for the Pod. Incompressible mode
+                raises this to at least 500m.
+            mem_request (str): Memory request for the Pod. Incompressible mode
+                raises this to at least 512Mi.
+            cpu_limit (str): CPU limit for the Pod. Incompressible mode raises
+                this to at least 2.
+            mem_limit (str): Memory limit for the Pod. Incompressible mode
+                raises this to at least 2Gi.
             fill_mode (str): Data generator: 'zero', 'random', or 'incompressible'.
                 Use 'incompressible' to increase Ceph used-raw capacity on RBD.
             base_yaml_path (str): Path to the base Job YAML manifest.

--- a/tests/functional/z_cluster/cluster_expansion/test_storage_auto_scaling.py
+++ b/tests/functional/z_cluster/cluster_expansion/test_storage_auto_scaling.py
@@ -176,45 +176,29 @@ class TestStorageAutoscalerBase(ManageTest):
 
     def fill_up_cluster(self, target_percentage, is_completed=True):
         """
-        Fill up the cluster to a target percentage of total storage capacity using FIO-based load.
+        Fill up the cluster to a target percentage of total storage capacity.
 
-        This method invokes the benchmark operator to prefill the cluster up to a specified
-        usage level. If `fast_fill_up` is enabled, more aggressive FIO settings are applied
-        to increase fill speed, and the `target_percentage` is reduced slightly to compensate
-        for potential overshoot.
+        Uses FillPoolJob with incompressible fio data so Ceph used-raw increases.
 
         Args:
             target_percentage (int): Desired percentage of used cluster storage to reach.
-            is_completed (bool): Whether to wait until the benchmark workload completes.
+            is_completed (bool): Whether to wait until the fill workload completes.
 
         """
         storage_to_fill = get_file_size(
             expected_used_capacity_percent=target_percentage
         )
-        # Divide the storage to fill between zero and random modes. The random mode will
-        # fill 25% of the total. This is to optimize the time taken to fill the cluster,
-        # as the zero mode is faster.
-        storage_to_fill_random_mode = int(storage_to_fill // 4)
-        storage_to_fill_zero_mode = storage_to_fill - storage_to_fill_random_mode
-        logger.info(
-            f"Total storage to fill the cluster: {storage_to_fill}Gi, "
-            f"Storage to fill in zero mode: {storage_to_fill_zero_mode}Gi, "
-            f"Storage to fill in random mode: {storage_to_fill_random_mode}Gi"
-        )
+        logger.info(f"Total storage to fill the cluster: {storage_to_fill}Gi")
         fill_job_obj = self.fill_job_factory(
-            fill_mode="zero",
-            storage=f"{storage_to_fill_zero_mode}Gi",
-        )
-        self.fill_job_objs.append(fill_job_obj)
-        fill_job_obj = self.fill_job_factory(
-            fill_mode="random",
-            storage=f"{storage_to_fill_random_mode}Gi",
+            fill_mode="incompressible",
+            storage=f"{storage_to_fill}Gi",
+            block_size="4M",
         )
         self.fill_job_objs.append(fill_job_obj)
 
         if is_completed:
             for fill_job in self.fill_job_objs:
-                fill_job.wait_for_completion(timeout=1800, sleep=30)
+                fill_job.wait_for_completion(timeout=3600, sleep=30)
 
     def cleanup_cluster(self):
         """

--- a/tests/libtest/test_fill_pool_job.py
+++ b/tests/libtest/test_fill_pool_job.py
@@ -27,18 +27,32 @@ class TestFillPoolJob(ManageTest):
 
     def test_memory_bytes_fractional_binary_units(self):
         """_memory_bytes must parse fractional Ki/Mi/Gi/Ti quantities."""
-        assert _memory_bytes("1.5Ki") == 1.5 * 1024
-        assert _memory_bytes("1.5Mi") == 1.5 * 1024**2
-        assert _memory_bytes("1.5Gi") == 1.5 * 1024**3
-        assert _memory_bytes("1.5Ti") == 1.5 * 1024**4
-        assert _memory_bytes("512Mi") == 512 * 1024**2
-        assert _memory_bytes("2Gi") == 2 * 1024**3
+        quantity_per_expected_bytes = {
+            "1.5Ki": 1.5 * 1024,
+            "1.5Mi": 1.5 * 1024**2,
+            "1.5Gi": 1.5 * 1024**3,
+            "1.5Ti": 1.5 * 1024**4,
+            "512Mi": 512 * 1024**2,
+            "2Gi": 2 * 1024**3,
+        }
+        for quantity, expected_bytes in quantity_per_expected_bytes.items():
+            actual_bytes = _memory_bytes(quantity)
+            assert actual_bytes == expected_bytes, (
+                f"_memory_bytes must parse {quantity} as {expected_bytes} bytes; "
+                f"got {actual_bytes}"
+            )
 
         _, _, mem_request, mem_limit = _apply_incompressible_resource_floors(
             "100m", "500m", "1.5Gi", "1.5Gi"
         )
-        assert mem_request == "1.5Gi"
-        assert mem_limit == "2Gi"
+        assert mem_request == "1.5Gi", (
+            "incompressible mem_request of 1.5Gi already exceeds the 512Mi floor "
+            f"and must be kept; got {mem_request}"
+        )
+        assert mem_limit == "2Gi", (
+            "incompressible mem_limit of 1.5Gi is below the 2Gi floor "
+            f"and must be raised to 2Gi; got {mem_limit}"
+        )
 
     def test_fill_pool_job_incompressible(self, fill_job_factory):
         """

--- a/tests/libtest/test_fill_pool_job.py
+++ b/tests/libtest/test_fill_pool_job.py
@@ -21,10 +21,10 @@ class TestFillPoolJob(ManageTest):
     Test the Fill Pool Job functionalities
     """
 
-    def test_fill_pool_job_with_both_modes(self, fill_job_factory):
+    def test_fill_pool_job_incompressible(self, fill_job_factory):
         """
-        Run Fill Pool Job using both modes to fill the cluster to a target usage.
-        Verifies that the workload completes, logs capacity usage and elapsed time.
+        Run Fill Pool Job with incompressible data to fill the cluster to a
+        target usage. Verifies that used capacity increases and logs elapsed time.
 
         """
         ceph_cluster = CephCluster()
@@ -36,30 +36,19 @@ class TestFillPoolJob(ManageTest):
         )
         if ceph_capacity > 500:
             storage_to_fill = 240  # in GiB
-            timeout = 1200
+            # 240Gi at ~220MiB/s is ~18min; 40min leaves margin for slower clusters.
+            timeout = 2400
         else:
             storage_to_fill = ceph_capacity / 2  # in GiB
-            timeout = 600
+            timeout = 1800
 
-        # Divide the storage to fill between zero and random modes. The random mode will
-        # fill 25% of the total. This is to optimize the time taken to fill the cluster,
-        # as the zero mode is faster.
-        storage_to_fill_random_mode = int(storage_to_fill // 4)
-        storage_to_fill_zero_mode = storage_to_fill - storage_to_fill_random_mode
-        log.info(
-            f"Total storage to fill the cluster: {storage_to_fill}Gi, "
-            f"Storage to fill in zero mode: {storage_to_fill_zero_mode}Gi, "
-            f"Storage to fill in random mode: {storage_to_fill_random_mode}Gi"
-        )
+        log.info(f"Total storage to fill the cluster: {storage_to_fill}Gi")
 
         start = time.time()
         fill_job_factory(
-            fill_mode="zero",
-            storage=f"{storage_to_fill_zero_mode}Gi",
-        )
-        fill_job_factory(
-            fill_mode="random",
-            storage=f"{storage_to_fill_random_mode}Gi",
+            fill_mode="incompressible",
+            storage=f"{int(storage_to_fill)}Gi",
+            block_size="4M",
         )
 
         gap_difference = storage_to_fill * 0.1  # 10% gap

--- a/tests/libtest/test_fill_pool_job.py
+++ b/tests/libtest/test_fill_pool_job.py
@@ -10,6 +10,10 @@ from ocs_ci.helpers.ceph_helpers import (
     wait_for_ceph_used_capacity_reached,
 )
 from ocs_ci.ocs.cluster import CephCluster, get_ceph_used_capacity
+from ocs_ci.ocs.fill_pool_job import (
+    _apply_incompressible_resource_floors,
+    _memory_bytes,
+)
 
 log = logging.getLogger(__name__)
 
@@ -20,6 +24,21 @@ class TestFillPoolJob(ManageTest):
     """
     Test the Fill Pool Job functionalities
     """
+
+    def test_memory_bytes_fractional_binary_units(self):
+        """_memory_bytes must parse fractional Ki/Mi/Gi/Ti quantities."""
+        assert _memory_bytes("1.5Ki") == 1.5 * 1024
+        assert _memory_bytes("1.5Mi") == 1.5 * 1024**2
+        assert _memory_bytes("1.5Gi") == 1.5 * 1024**3
+        assert _memory_bytes("1.5Ti") == 1.5 * 1024**4
+        assert _memory_bytes("512Mi") == 512 * 1024**2
+        assert _memory_bytes("2Gi") == 2 * 1024**3
+
+        _, _, mem_request, mem_limit = _apply_incompressible_resource_floors(
+            "100m", "500m", "1.5Gi", "1.5Gi"
+        )
+        assert mem_request == "1.5Gi"
+        assert mem_limit == "2Gi"
 
     def test_fill_pool_job_incompressible(self, fill_job_factory):
         """


### PR DESCRIPTION
## Summary
  RBD discards `/dev/zero` writes, so FillPoolJob never raised Ceph used-raw and autoscaler tests never hit the
  scale threshold.
  Add `fill_mode=incompressible` (fio libaio, scrambled buffers, iodepth 16) on `quay.io/ocsci/fedora:fio`, and use
  it for autoscaler fill and the FillPoolJob libtest. `zero` and `random` (dd) are unchanged.
  ## Test plan
  - [ ] `tests/libtest/test_fill_pool_job.py` — used-raw increases, job completes
  - [ ] Storage autoscaler fill reaches the intended used-capacity percent


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added zero, random, and incompressible storage fill modes.
  - Incompressible mode uses Fedora FIO tooling to increase reported raw storage usage.
  - Fill jobs now recognize expected “no space left” conditions as successful completion.
  - Updated fill-job resource defaults and block sizes for larger workloads.

- **Bug Fixes**
  - Improved validation for unsupported fill modes and invalid storage sizes.
  - Improved reliability of package installation and file checks in pods.

- **Tests**
  - Updated storage scaling and fill-job tests for incompressible data generation and longer completion times.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->