### PR TITLE
Fix --csv-change and add targeted CSV image overrides

### DIFF
--- a/conf/README.md
+++ b/conf/README.md
@@ -86,6 +86,31 @@ anywhere else.
 * `default_latest_tag` - OCS latest tag to be used by default if one is not provided
 * `external_mode` - If OCS cluster is setup in external mode (Default: false)
 * `ocs_csv_channel` - Channel used to install OCS CSV
+* `csv_change_from` - List of patterns to be replaced in all the ODF CSVs, applied
+  after the CSVs are installed and before the StorageCluster is created. Has to be
+  used together with `csv_change_to`, and can be provided on the command line as
+  well via `--csv-change`. The replacement is done on the whole CSV, so the very
+  same string is replaced everywhere it appears. To replace an image in one
+  specific field only, use `csv_image_overrides`.
+* `csv_change_to` - List of the values to replace the `csv_change_from` patterns with
+* `csv_image_overrides` - Mapping of a CSV name prefix to the images which should be
+  set in specific fields of that CSV, applied after the CSVs are installed and before
+  the StorageCluster is created. Each entry supports the optional keys `containers`
+  (mapping a container name to an image) and `env` (mapping an environment variable
+  name to an image). Deployment fails if a container or environment variable listed
+  here is not defined in the CSV. Example:
+
+  ```yaml
+  DEPLOYMENT:
+    csv_image_overrides:
+      ocs-operator:
+        env:
+          PROVIDER_API_SERVER_IMAGE: quay.io/my-user/ocs:custom
+      ocs-client-operator:
+        containers:
+          manager: quay.io/my-user/ocs-client:custom
+  ```
+
 * `default_ocs_registry_image` - Default OCS registry image (e.g. "quay.io/rhceph-dev/ocs-olm-operator:latest-4.6")
 * `ocs_operator_nodes_to_label` - Number of OCS operator nodes to label
 * `ocs_operator_nodes_to_taint` - Number of OCS operator nodes to taint

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -111,6 +111,9 @@ to the pytest.
    like MCG or RHCS. The format should be:
    <pattern_to_replace_from::pattern_to_replace_to>, while '::' is the delimiter.
    This argument is repeatable and you can use it multiple times to change multiple images.
+   The replacement is done on the whole CSV, so the pattern is replaced everywhere it
+   appears. To replace an image in one specific field of a CSV only, use the
+   `csv_image_overrides` config option described in `conf/README.md`.
 * `--dev-mode` - Runs in development mode. Skip the checks like collecting
    cluster versions, collection ocs versions, health checks etc.
 * `--ceph-debug` - Deploy with Ceph in debug log level. This option is available starting OCS 4.7

--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -43,6 +43,7 @@ from ocs_ci.ocs.resources.storage_cluster import (
 )
 from ocs_ci.deployment.helpers.odf_deployment_helpers import (
     get_required_csvs,
+    modify_csv_images,
     set_ceph_config,
     is_storage_system_needed,
 )
@@ -1990,7 +1991,16 @@ class Deployment(object):
                             csv=_csv["metadata"]["name"],
                             replace_from=csv_change_from,
                             replace_to=csv_change_to,
+                            namespace=self.namespace,
                         )
+
+        # Override images in specific CSV fields, if required. Done here so
+        # that the custom images are already in place when the StorageCluster
+        # is created below.
+        csv_image_overrides = config.DEPLOYMENT.get("csv_image_overrides")
+        if csv_image_overrides:
+            logger.test_step("Overriding images in the ODF CSVs")
+            modify_csv_images(csv_image_overrides, namespace=self.namespace)
 
         # Create custom storage class early for Azure Performance Plus feature
         # This needs to be done before StorageSystem/StorageCluster creation

--- a/ocs_ci/deployment/helpers/odf_deployment_helpers.py
+++ b/ocs_ci/deployment/helpers/odf_deployment_helpers.py
@@ -4,10 +4,15 @@ ODF deployment.
 """
 
 import logging
+import tempfile
 
+from ocs_ci.framework import config
 from ocs_ci.ocs import defaults
+from ocs_ci.ocs.exceptions import ResourceNotFoundError
+from ocs_ci.ocs.resources.csv import get_csvs_start_with_prefix
 from ocs_ci.ocs.resources.pod import get_ceph_tools_pod, get_osd_pods, get_osd_pod_id
-from ocs_ci.utility import version
+from ocs_ci.utility import templating, version
+from ocs_ci.utility.utils import exec_cmd
 from ocs_ci.ocs.constants import (
     MCLOCK_HIGH_CLIENT_OPS,
     MCLOCK_BALANCED,
@@ -161,3 +166,114 @@ def set_ceph_mclock_high_recovery_profile(osd_ids=None):
 
     """
     set_ceph_mclock_config_profile(MCLOCK_HIGH_RECOVERY_OPS, osd_ids)
+
+
+def apply_csv_image_overrides(csv_data, overrides):
+    """
+    Apply image overrides to the deployments defined in a CSV.
+
+    The CSV data is modified in place, nothing is sent to the cluster.
+
+    Args:
+        csv_data (dict): Data of the CSV to modify
+        overrides (dict): Overrides to apply, see :func:`modify_csv_images`
+            for the supported structure
+
+    Returns:
+        dict: Mapping of the modified location to the image which was set
+
+    Raises:
+        ValueError: If a container or an environment variable requested to be
+            overridden is not defined in the CSV
+
+    """
+    container_overrides = overrides.get("containers") or {}
+    env_overrides = overrides.get("env") or {}
+    missing_containers = set(container_overrides)
+    missing_envs = set(env_overrides)
+    applied = {}
+
+    for deployment in csv_data["spec"]["install"]["spec"]["deployments"]:
+        deployment_name = deployment["name"]
+        for container in deployment["spec"]["template"]["spec"]["containers"]:
+            container_name = container["name"]
+            if container_name in container_overrides:
+                image = container_overrides[container_name]
+                container["image"] = image
+                applied[f"{deployment_name}/{container_name}/image"] = image
+                missing_containers.discard(container_name)
+            for env in container.get("env", []):
+                if env["name"] not in env_overrides:
+                    continue
+                image = env_overrides[env["name"]]
+                # An overridden variable is always a plain value, drop
+                # valueFrom to keep the resulting env entry valid.
+                env.pop("valueFrom", None)
+                env["value"] = image
+                applied[f"{deployment_name}/{container_name}/env/{env['name']}"] = image
+                missing_envs.discard(env["name"])
+
+    if missing_containers or missing_envs:
+        raise ValueError(
+            f"CSV {csv_data['metadata']['name']} doesn't define everything requested "
+            f"to be overridden. Missing containers: {sorted(missing_containers)}, "
+            f"missing environment variables: {sorted(missing_envs)}"
+        )
+    return applied
+
+
+def modify_csv_images(csv_image_overrides, namespace=None):
+    """
+    Override container images and image related environment variables in CSVs.
+
+    Compared to the plain string replacement done by
+    :func:`ocs_ci.utility.utils.modify_csv`, this targets specific fields of the
+    CSV. That makes it possible to replace an image in one place only, even when
+    the very same image is referenced by multiple fields, which is the case for
+    example for the ocs-operator image and the PROVIDER_API_SERVER_IMAGE
+    environment variable.
+
+    Args:
+        csv_image_overrides (dict): Mapping of a CSV name prefix to the
+            overrides which should be applied to it. Each override supports two
+            optional keys, ``containers`` mapping a container name to an image
+            and ``env`` mapping an environment variable name to an image.
+            Example::
+
+                {
+                    "ocs-operator": {
+                        "env": {
+                            "PROVIDER_API_SERVER_IMAGE": "quay.io/my/ocs:latest",
+                        },
+                    },
+                    "ocs-client-operator": {
+                        "containers": {"manager": "quay.io/my/client:latest"},
+                    },
+                }
+
+        namespace (str): Namespace of the CSVs. Defaults to the cluster
+            namespace configured in ENV_DATA.
+
+    Raises:
+        ResourceNotFoundError: If no CSV matching one of the prefixes is found
+        ValueError: If a container or an environment variable requested to be
+            overridden is not defined in the CSV
+
+    """
+    namespace = namespace or config.ENV_DATA["cluster_namespace"]
+    for csv_prefix, overrides in csv_image_overrides.items():
+        csvs = get_csvs_start_with_prefix(csv_prefix=csv_prefix, namespace=namespace)
+        if not csvs:
+            raise ResourceNotFoundError(
+                f"No CSV with prefix {csv_prefix} found in namespace {namespace}, "
+                "cannot override its images"
+            )
+        for csv_data in csvs:
+            csv_name = csv_data["metadata"]["name"]
+            applied = apply_csv_image_overrides(csv_data, overrides)
+            logger.info(f"CSV {csv_name} will be modified: {applied}")
+            with tempfile.NamedTemporaryFile(
+                mode="w+", prefix="csv_image_override", suffix=".yaml", delete=False
+            ) as csv_file:
+                templating.dump_data_to_temp_yaml(csv_data, csv_file.name)
+                exec_cmd(f"oc replace -f {csv_file.name}")

--- a/ocs_ci/deployment/tests/test_odf_deployment_helpers.py
+++ b/ocs_ci/deployment/tests/test_odf_deployment_helpers.py
@@ -1,0 +1,127 @@
+# -*- coding: utf8 -*-
+
+import copy
+
+import pytest
+
+from ocs_ci.deployment.helpers.odf_deployment_helpers import apply_csv_image_overrides
+
+
+CSV_DATA = {
+    "metadata": {"name": "ocs-operator.v4.19.0"},
+    "spec": {
+        "install": {
+            "spec": {
+                "deployments": [
+                    {
+                        "name": "ocs-operator",
+                        "spec": {
+                            "template": {
+                                "spec": {
+                                    "containers": [
+                                        {
+                                            "name": "ocs-operator",
+                                            "image": "registry.redhat.io/odf4/ocs:1",
+                                            "env": [
+                                                {
+                                                    "name": "WATCH_NAMESPACE",
+                                                    "value": "",
+                                                },
+                                                {
+                                                    "name": "PROVIDER_API_SERVER_IMAGE",
+                                                    "value": "registry.redhat.io/odf4/ocs:1",
+                                                },
+                                            ],
+                                        },
+                                    ],
+                                },
+                            },
+                        },
+                    },
+                ],
+            },
+        },
+    },
+}
+
+
+def test_apply_csv_image_overrides_env_only():
+    """
+    Test that overriding an environment variable doesn't touch the container
+    image, even though both reference the very same image.
+    """
+    csv_data = copy.deepcopy(CSV_DATA)
+    custom_image = "quay.io/my-user/ocs:custom"
+
+    applied = apply_csv_image_overrides(
+        csv_data, {"env": {"PROVIDER_API_SERVER_IMAGE": custom_image}}
+    )
+
+    container = csv_data["spec"]["install"]["spec"]["deployments"][0]["spec"][
+        "template"
+    ]["spec"]["containers"][0]
+    assert container["image"] == "registry.redhat.io/odf4/ocs:1"
+    assert container["env"][1]["value"] == custom_image
+    assert applied == {
+        "ocs-operator/ocs-operator/env/PROVIDER_API_SERVER_IMAGE": custom_image
+    }
+
+
+def test_apply_csv_image_overrides_container_and_env():
+    """
+    Test that both the container image and an environment variable can be
+    overridden at once, each one with a different image.
+    """
+    csv_data = copy.deepcopy(CSV_DATA)
+    container_image = "quay.io/my-user/ocs:container"
+    env_image = "quay.io/my-user/ocs:server"
+
+    applied = apply_csv_image_overrides(
+        csv_data,
+        {
+            "containers": {"ocs-operator": container_image},
+            "env": {"PROVIDER_API_SERVER_IMAGE": env_image},
+        },
+    )
+
+    container = csv_data["spec"]["install"]["spec"]["deployments"][0]["spec"][
+        "template"
+    ]["spec"]["containers"][0]
+    assert container["image"] == container_image
+    assert container["env"][1]["value"] == env_image
+    assert len(applied) == 2
+
+
+def test_apply_csv_image_overrides_drops_value_from():
+    """
+    Test that valueFrom is removed from an overridden environment variable, as
+    value and valueFrom are mutually exclusive.
+    """
+    csv_data = copy.deepcopy(CSV_DATA)
+    env = csv_data["spec"]["install"]["spec"]["deployments"][0]["spec"]["template"][
+        "spec"
+    ]["containers"][0]["env"][0]
+    del env["value"]
+    env["valueFrom"] = {"fieldRef": {"fieldPath": "metadata.namespace"}}
+
+    apply_csv_image_overrides(csv_data, {"env": {"WATCH_NAMESPACE": "some-image"}})
+
+    assert env == {"name": "WATCH_NAMESPACE", "value": "some-image"}
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        pytest.param({"containers": {"no-such-container": "image"}}, id="container"),
+        pytest.param({"env": {"NO_SUCH_ENV": "image"}}, id="env"),
+    ],
+)
+def test_apply_csv_image_overrides_missing_target(overrides):
+    """
+    Test that overriding something which is not defined in the CSV fails
+    instead of silently deploying the default images.
+    """
+    csv_data = copy.deepcopy(CSV_DATA)
+
+    with pytest.raises(ValueError):
+        apply_csv_image_overrides(csv_data, overrides)

--- a/ocs_ci/framework/pytest_customization/ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/ocscilib.py
@@ -584,6 +584,43 @@ def get_cli_param(config, name_of_param, default=None):
     return cli_param
 
 
+def store_csv_changes(csv_changes):
+    """
+    Store the CSV changes passed via the --csv-change cli parameter in the
+    DEPLOYMENT section of the config, appending them to the changes which are
+    already configured there.
+
+    Args:
+        csv_changes (list): Values of the --csv-change cli parameter, each one
+            in the '<replace-from>::<replace-to>' format
+
+    Raises:
+        ValueError: If any of the values is not in the expected format
+
+    """
+    csv_change_from = ocsci_config.DEPLOYMENT.get("csv_change_from") or []
+    csv_change_to = ocsci_config.DEPLOYMENT.get("csv_change_to") or []
+    # The values can be configured as a plain string when only one image needs
+    # to be changed, normalize them before appending the cli values.
+    if isinstance(csv_change_from, str):
+        csv_change_from = [csv_change_from]
+    if isinstance(csv_change_to, str):
+        csv_change_to = [csv_change_to]
+    for csv_change in csv_changes:
+        if "::" not in csv_change:
+            raise ValueError(
+                f"Invalid --csv-change value: '{csv_change}'. The expected "
+                "format is '<replace-from>::<replace-to>'."
+            )
+        change_from, change_to = csv_change.split("::", 1)
+        csv_change_from.append(change_from)
+        csv_change_to.append(change_to)
+    # The values have to be stored back, otherwise the changes are lost when
+    # the keys are not defined in any of the loaded config files.
+    ocsci_config.DEPLOYMENT["csv_change_from"] = csv_change_from
+    ocsci_config.DEPLOYMENT["csv_change_to"] = csv_change_to
+
+
 def set_cli_param(config, name_of_param, value):
     """
     This is helper function which set cli parameter in RUN section in
@@ -800,12 +837,7 @@ def process_cluster_cli_params(config):
         ocsci_config.RUN["client_version"] = ocp_installer_version
     csv_changes = get_cli_param(config, "--csv-change")
     if csv_changes:
-        csv_change_from = ocsci_config.DEPLOYMENT.get("csv_change_from", [])
-        csv_change_to = ocsci_config.DEPLOYMENT.get("csv_change_to", [])
-        for csv_change in csv_changes:
-            csv_change = csv_change.split("::")
-            csv_change_from.append(csv_change[0])
-            csv_change_to.append(csv_change[1])
+        store_csv_changes(csv_changes)
 
     collect_logs_on_success_run = get_cli_param(config, "collect_logs_on_success_run")
     if collect_logs_on_success_run:

--- a/ocs_ci/framework/pytest_customization/tests/test_ocscilib.py
+++ b/ocs_ci/framework/pytest_customization/tests/test_ocscilib.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+
+from ocs_ci import framework
+from ocs_ci.framework.pytest_customization.ocscilib import store_csv_changes
+
+
+@pytest.fixture(autouse=True)
+def reset_config():
+    framework.config.reset()
+
+
+def test_store_csv_changes_without_configured_values():
+    """
+    Test that the changes passed via cli are stored in the config even when
+    the DEPLOYMENT section doesn't define them yet.
+    """
+    store_csv_changes(["from-image::to-image"])
+
+    assert framework.config.DEPLOYMENT["csv_change_from"] == ["from-image"]
+    assert framework.config.DEPLOYMENT["csv_change_to"] == ["to-image"]
+
+
+def test_store_csv_changes_appends_to_configured_values():
+    """
+    Test that the changes passed via cli are appended to the ones already
+    configured in the DEPLOYMENT section.
+    """
+    framework.config.DEPLOYMENT["csv_change_from"] = ["configured-from"]
+    framework.config.DEPLOYMENT["csv_change_to"] = ["configured-to"]
+
+    store_csv_changes(["cli-from::cli-to"])
+
+    assert framework.config.DEPLOYMENT["csv_change_from"] == [
+        "configured-from",
+        "cli-from",
+    ]
+    assert framework.config.DEPLOYMENT["csv_change_to"] == ["configured-to", "cli-to"]
+
+
+def test_store_csv_changes_normalizes_configured_string():
+    """
+    Test that values configured as a plain string are turned into a list.
+    """
+    framework.config.DEPLOYMENT["csv_change_from"] = "configured-from"
+    framework.config.DEPLOYMENT["csv_change_to"] = "configured-to"
+
+    store_csv_changes(["cli-from::cli-to"])
+
+    assert framework.config.DEPLOYMENT["csv_change_from"] == [
+        "configured-from",
+        "cli-from",
+    ]
+    assert framework.config.DEPLOYMENT["csv_change_to"] == ["configured-to", "cli-to"]
+
+
+def test_store_csv_changes_multiple_values():
+    """
+    Test that multiple --csv-change values are all stored, and that only the
+    first '::' is used as the separator.
+    """
+    store_csv_changes(
+        [
+            "quay.io/from/a:1::quay.io/to/a:2",
+            "registry.redhat.io/from/b@sha256:abc::quay.io/to/b:latest",
+        ]
+    )
+
+    assert framework.config.DEPLOYMENT["csv_change_from"] == [
+        "quay.io/from/a:1",
+        "registry.redhat.io/from/b@sha256:abc",
+    ]
+    assert framework.config.DEPLOYMENT["csv_change_to"] == [
+        "quay.io/to/a:2",
+        "quay.io/to/b:latest",
+    ]
+
+
+def test_store_csv_changes_invalid_value():
+    """
+    Test that a value without the '::' separator is rejected.
+    """
+    with pytest.raises(ValueError):
+        store_csv_changes(["missing-separator"])

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -5827,7 +5827,7 @@ def configure_chrony_and_wait_for_machineconfig_status(
         wait_for_machineconfigpool_status(role, timeout=timeout)
 
 
-def modify_csv(csv, replace_from, replace_to):
+def modify_csv(csv, replace_from, replace_to, namespace=None):
     """
     Modify the CSV
 
@@ -5835,10 +5835,13 @@ def modify_csv(csv, replace_from, replace_to):
         csv (str): The CSV name
         replace_from (str): The pattern to replace from in the CSV
         replace_to (str): The pattern to replace to in the CSV
+        namespace (str): Namespace of the CSV. Defaults to the cluster
+            namespace configured in ENV_DATA.
 
     """
+    namespace = namespace or config.ENV_DATA["cluster_namespace"]
     data = (
-        f"oc -n openshift-storage get csv {csv} -o yaml | sed"
+        f"oc -n {namespace} get csv {csv} -o yaml | sed"
         f" 's,{replace_from},{replace_to},g' | oc replace -f -"
     )
     log.info(


### PR DESCRIPTION
## Problem

Two separate issues make it hard to deploy ODF with custom operator images.

**1. `--csv-change` is silently ignored.**

```python
csv_change_from = ocsci_config.DEPLOYMENT.get("csv_change_from", [])
csv_change_to = ocsci_config.DEPLOYMENT.get("csv_change_to", [])
for csv_change in csv_changes:
    csv_change = csv_change.split("::")
    csv_change_from.append(csv_change[0])
```

When the keys are not defined in any of the loaded config files, `.get()` returns a brand new list which is appended to and then thrown away. The keys stay undefined, so the guard in `deploy_ocs_via_operator()`

```python
if all(key in config.DEPLOYMENT for key in ("csv_change_from", "csv_change_to")):
```

is never satisfied and the CSV modification is skipped. There is no error and no log message - the deployment just continues with the default images, and this is only noticed afterwards by inspecting the CSVs on the cluster.

**2. The replacement cannot target a single field.**

`modify_csv()` runs `sed` over the whole CSV, so a pattern is replaced everywhere it appears. Several ODF images are referenced by more than one field of the same CSV, for instance in ODF 4.19/5.0:

| CSV | Field | Value |
| --- | --- | --- |
| `ocs-operator` | `containers[0].image` | `ocs-rhel9-operator@sha256:...` |
| `ocs-operator` | env `PROVIDER_API_SERVER_IMAGE` | *same digest* |
| `ocs-operator` | env `ONBOARDING_VALIDATION_KEYS_GENERATOR_IMAGE` | *same digest* |
| `ocs-client-operator` | `containers[0].image` | `ocs-client-rhel9-operator@sha256:...` |
| `ocs-client-operator` | env `STATUS_REPORTER_IMAGE` | *same digest* |

Replacing only the provider server image, or only the client operator image, cannot be expressed with the current mechanism.

## Changes

* `--csv-change` values are stored back into the `DEPLOYMENT` section. The parsing moved to a `store_csv_changes()` helper which also normalizes values configured as a plain string and rejects values without the `::` separator, instead of failing with an `IndexError`.
* New `csv_image_overrides` config option, applied after the CSVs reach `Succeeded` and before the StorageCluster is created:

  ```yaml
  DEPLOYMENT:
    csv_image_overrides:
      ocs-operator:
        env:
          PROVIDER_API_SERVER_IMAGE: quay.io/my-user/ocs:custom
      ocs-client-operator:
        containers:
          manager: quay.io/my-user/ocs-client:custom
  ```

  Overriding a container or an environment variable which the CSV doesn't define fails the deployment, rather than silently deploying the default image.
* `modify_csv()` takes the namespace as an argument instead of using the hardcoded `openshift-storage`.

Existing behaviour of `csv_change_from` / `csv_change_to` is unchanged.

## Testing

* New unit tests for `store_csv_changes()` and `apply_csv_image_overrides()`.
* Full unit test suite passes: `657 passed`.
* `pre-commit run` passes on all changed files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration options to customize ODF CSV images and apply CSV value replacements during deployment.
  * Added support for overriding container images and image-related environment variables before StorageCluster creation.
  * CSV updates now support deployment-specific namespaces.

* **Bug Fixes**
  * Added validation for CSV replacement formats and image override targets, with clear errors for invalid values.

* **Documentation**
  * Documented the new deployment configuration parameters, including image override examples.

* **Tests**
  * Added coverage for CSV image overrides and replacement configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->