### PR TITLE
Improve RDR discovered apps workload teardown

### DIFF
--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -1708,7 +1708,7 @@ def force_delete_discovered_apps_workload(workload_namespace, vrg_name):
         config.switch_ctx(cluster.MULTICLUSTER["multicluster_index"])
         logger.info(f"[force-cleanup] Processing cluster {cluster_name}")
 
-        # -- 3a: VRG ---------------------------------------------------- #
+        # -- 3a: VRG — strip finalizers then delete ---------------------- #
         logger.info(
             f"[force-cleanup] Stripping finalizers from VRG {vrg_name} "
             f"in {constants.DR_OPS_NAMESPACE} on {cluster_name}"
@@ -1719,17 +1719,23 @@ def force_delete_discovered_apps_workload(workload_namespace, vrg_name):
             f"--type={_PATCH_TYPE} -p '{_PATCH}' --ignore-not-found=true",
             ignore_error=True,
         )
+        logger.info(
+            f"[force-cleanup] Deleting VRG {vrg_name} "
+            f"in {constants.DR_OPS_NAMESPACE} on {cluster_name}"
+        )
+        run_cmd(  # IgnoreDeprecation
+            f"oc delete volumereplicationgroup {vrg_name} "
+            f"-n {constants.DR_OPS_NAMESPACE} --wait=false --ignore-not-found=true",
+            ignore_error=True,
+        )
 
-        # -- 3b: VolumeReplication resources ----------------------------- #
+        # -- 3b: VolumeReplication — strip finalizers then delete --------- #
         try:
-            vr_items = (
-                ocp.OCP(
-                    kind=constants.VOLUME_REPLICATION,
-                    namespace=workload_namespace,
-                )
-                .get()
-                .get("items", [])
+            vr_ocp = ocp.OCP(
+                kind=constants.VOLUME_REPLICATION,
+                namespace=workload_namespace,
             )
+            vr_items = vr_ocp.get().get("items", [])
             for vr in vr_items:
                 vr_name = vr["metadata"]["name"]
                 logger.info(
@@ -1742,9 +1748,33 @@ def force_delete_discovered_apps_workload(workload_namespace, vrg_name):
                     f"--type={_PATCH_TYPE} -p '{_PATCH}'",
                     ignore_error=True,
                 )
+            if vr_items:
+                logger.info(
+                    f"[force-cleanup] Deleting all VolumeReplication resources "
+                    f"in {workload_namespace} on {cluster_name}"
+                )
+                run_cmd(  # IgnoreDeprecation
+                    f"oc delete volumereplication --all "
+                    f"-n {workload_namespace} --wait=false",
+                    ignore_error=True,
+                )
+                # Wait for VRs to be fully gone before touching PVCs so the
+                # replication controller stops re-adding PVC finalizers.
+                try:
+                    vr_ocp.wait_for_delete(
+                        resource_name="",
+                        timeout=60,
+                        sleep=5,
+                    )
+                except Exception:
+                    logger.warning(
+                        f"[force-cleanup] Some VolumeReplication resources may "
+                        f"still exist in {workload_namespace} on {cluster_name}",
+                        exc_info=True,
+                    )
         except Exception:
             logger.warning(
-                f"[force-cleanup] Could not list VolumeReplication resources in "
+                f"[force-cleanup] Could not process VolumeReplication resources in "
                 f"{workload_namespace} on {cluster_name}",
                 exc_info=True,
             )
@@ -1752,14 +1782,11 @@ def force_delete_discovered_apps_workload(workload_namespace, vrg_name):
         # -- 3c: VolumeGroupReplication + mirror group (CG only) --------- #
         if is_cg_enabled():
             try:
-                vgr_items = (
-                    ocp.OCP(
-                        kind=constants.VOLUME_GROUP_REPLICATION,
-                        namespace=workload_namespace,
-                    )
-                    .get()
-                    .get("items", [])
+                vgr_ocp = ocp.OCP(
+                    kind=constants.VOLUME_GROUP_REPLICATION,
+                    namespace=workload_namespace,
                 )
+                vgr_items = vgr_ocp.get().get("items", [])
                 for vgr in vgr_items:
                     vgr_name = vgr["metadata"]["name"]
                     logger.info(
@@ -1772,9 +1799,34 @@ def force_delete_discovered_apps_workload(workload_namespace, vrg_name):
                         f"--type={_PATCH_TYPE} -p '{_PATCH}'",
                         ignore_error=True,
                     )
+                if vgr_items:
+                    logger.info(
+                        f"[force-cleanup] Deleting all VolumeGroupReplication "
+                        f"resources in {workload_namespace} on {cluster_name}"
+                    )
+                    run_cmd(  # IgnoreDeprecation
+                        f"oc delete volumegroupreplication --all "
+                        f"-n {workload_namespace} --wait=false",
+                        ignore_error=True,
+                    )
+                    # Wait for VGRs to vanish before the rbd-disable step reads
+                    # VGRContent (still accessible cluster-scoped).
+                    try:
+                        vgr_ocp.wait_for_delete(
+                            resource_name="",
+                            timeout=60,
+                            sleep=5,
+                        )
+                    except Exception:
+                        logger.warning(
+                            f"[force-cleanup] Some VolumeGroupReplication "
+                            f"resources may still exist in {workload_namespace} "
+                            f"on {cluster_name}",
+                            exc_info=True,
+                        )
             except Exception:
                 logger.warning(
-                    f"[force-cleanup] Could not list VolumeGroupReplication "
+                    f"[force-cleanup] Could not process VolumeGroupReplication "
                     f"resources in {workload_namespace} on {cluster_name}",
                     exc_info=True,
                 )
@@ -1899,13 +1951,32 @@ def force_delete_discovered_apps_workload(workload_namespace, vrg_name):
                     exc_info=True,
                 )
 
-        # -- 4: delete workload resources and PVCs ----------------------- #
+        # -- 3d: wait for VRG to be fully gone before touching PVCs ------ #
+        # The VRG controller re-adds PVC finalizers as long as the VRG object
+        # exists in etcd.  We must wait for it to disappear completely.
         logger.info(
-            f"[force-cleanup] Deleting workload resources and PVCs in "
-            f"{workload_namespace} on {cluster_name}"
+            f"[force-cleanup] Waiting for VRG {vrg_name} to be fully deleted "
+            f"in {constants.DR_OPS_NAMESPACE} on {cluster_name}"
+        )
+        try:
+            ocp.OCP(
+                kind=constants.VOLUME_REPLICATION_GROUP,
+                namespace=constants.DR_OPS_NAMESPACE,
+            ).wait_for_delete(resource_name=vrg_name, timeout=60, sleep=5)
+            logger.info(f"[force-cleanup] VRG {vrg_name} is gone on {cluster_name}")
+        except Exception:
+            logger.warning(
+                f"[force-cleanup] VRG {vrg_name} may still exist on "
+                f"{cluster_name} — proceeding with PVC cleanup anyway",
+                exc_info=True,
+            )
+
+        # -- 4: delete PVCs ---------------------------------------------- #
+        logger.info(
+            f"[force-cleanup] Deleting PVCs in {workload_namespace} "
+            f"on {cluster_name}"
         )
 
-        # Collect PVC names before the kustomize delete wipes the namespace
         try:
             all_pvcs = get_all_pvc_objs(namespace=workload_namespace)
         except Exception:
@@ -1916,45 +1987,53 @@ def force_delete_discovered_apps_workload(workload_namespace, vrg_name):
                 exc_info=True,
             )
 
-        # Non-blocking delete of all PVCs
+        # Strip PVC and PV finalizers upfront, then issue a non-blocking delete.
+        # The VRG/VGR/VR controllers are now gone so finalizers won't be re-added.
         for pvc_obj in all_pvcs:
             try:
-                pvc_obj.delete(wait=False)
+                pv_name = pvc_obj.backed_pv
             except Exception:
-                logger.warning(
-                    f"[force-cleanup] Could not delete PVC {pvc_obj.name} "
-                    f"on {cluster_name}",
-                    exc_info=True,
-                )
-
-        # Wait briefly; strip finalizers from anything still Terminating
-        for pvc_obj in all_pvcs:
-            try:
-                pvc_obj.ocp.wait_for_delete(
-                    resource_name=pvc_obj.name, timeout=30, sleep=5
-                )
-            except (TimeoutExpiredError, Exception):
-                logger.warning(
-                    f"[force-cleanup] PVC {pvc_obj.name} stuck in Terminating "
-                    f"— stripping PVC and PV finalizers on {cluster_name}"
-                )
+                pv_name = None
+            run_cmd(  # IgnoreDeprecation
+                f"oc patch pvc {pvc_obj.name} -n {workload_namespace} "
+                f"--type={_PATCH_TYPE} -p '{_PATCH}' --ignore-not-found=true",
+                ignore_error=True,
+            )
+            if pv_name:
                 run_cmd(  # IgnoreDeprecation
-                    f"oc patch pvc {pvc_obj.name} -n {workload_namespace} "
-                    f"--type={_PATCH_TYPE} -p '{_PATCH}'",
+                    f"oc patch pv {pv_name} "
+                    f"--type={_PATCH_TYPE} -p '{_PATCH}' --ignore-not-found=true",
                     ignore_error=True,
                 )
-                try:
-                    pv_name = pvc_obj.backed_pv
-                    if pv_name:
-                        run_cmd(  # IgnoreDeprecation
-                            f"oc patch pv {pv_name} --type={_PATCH_TYPE} -p '{_PATCH}'",
-                            ignore_error=True,
-                        )
-                except Exception:
-                    logger.warning(
-                        f"[force-cleanup] Could not strip PV finalizers for "
-                        f"PVC {pvc_obj.name} on {cluster_name}",
-                        exc_info=True,
+
+        if all_pvcs:
+            run_cmd(  # IgnoreDeprecation
+                f"oc delete pvc --all -n {workload_namespace} --wait=false",
+                ignore_error=True,
+            )
+
+        # Poll until all PVCs are gone (up to 60s).
+        if all_pvcs:
+            pvc_ocp = ocp.OCP(kind=constants.PVC, namespace=workload_namespace)
+            try:
+                pvc_ocp.wait_for_delete(resource_name="", timeout=60, sleep=5)
+                logger.info(
+                    f"[force-cleanup] All PVCs deleted in {workload_namespace} "
+                    f"on {cluster_name}"
+                )
+            except Exception:
+                logger.warning(
+                    f"[force-cleanup] Some PVCs still present in "
+                    f"{workload_namespace} on {cluster_name} after 60s — "
+                    f"re-stripping finalizers",
+                    exc_info=True,
+                )
+                # Re-strip in case something briefly re-added a finalizer
+                for pvc_obj in all_pvcs:
+                    run_cmd(  # IgnoreDeprecation
+                        f"oc patch pvc {pvc_obj.name} -n {workload_namespace} "
+                        f"--type={_PATCH_TYPE} -p '{_PATCH}' --ignore-not-found=true",
+                        ignore_error=True,
                     )
 
         # -- 5: delete namespace ----------------------------------------- #

--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -1669,7 +1669,11 @@ def force_delete_discovered_apps_workload(workload_namespace, vrg_name):
         f"Force-deleting discovered apps workload: namespace={workload_namespace}, "
         f"vrg_name={vrg_name}"
     )
-    _PATCH = '{"metadata":{"finalizers":null}}'
+    # JSON patch — removes the entire finalizers array regardless of how many
+    # entries it has, and works on resources that already have deletionTimestamp
+    # set (unlike --type=merge which can be rejected on terminating objects).
+    _PATCH = '[{"op":"remove","path":"/metadata/finalizers"}]'
+    _PATCH_TYPE = "json"
 
     # ------------------------------------------------------------------ #
     # Step 1 & 2 – hub cluster: strip DRPC and Placement finalizers       #
@@ -1678,7 +1682,7 @@ def force_delete_discovered_apps_workload(workload_namespace, vrg_name):
     logger.info(f"[force-cleanup] Stripping finalizers from DRPC {vrg_name}")
     run_cmd(  # IgnoreDeprecation
         f"oc patch drpc {vrg_name} -n {constants.DR_OPS_NAMESPACE} "
-        f"--type=merge -p '{_PATCH}' --ignore-not-found=true",
+        f"--type={_PATCH_TYPE} -p '{_PATCH}' --ignore-not-found=true",
         ignore_error=True,
     )
 
@@ -1686,7 +1690,7 @@ def force_delete_discovered_apps_workload(workload_namespace, vrg_name):
     logger.info(f"[force-cleanup] Stripping finalizers from Placement {placement_name}")
     run_cmd(  # IgnoreDeprecation
         f"oc patch placement {placement_name} -n {constants.DR_OPS_NAMESPACE} "
-        f"--type=merge -p '{_PATCH}' --ignore-not-found=true",
+        f"--type={_PATCH_TYPE} -p '{_PATCH}' --ignore-not-found=true",
         ignore_error=True,
     )
 
@@ -1712,7 +1716,7 @@ def force_delete_discovered_apps_workload(workload_namespace, vrg_name):
         run_cmd(  # IgnoreDeprecation
             f"oc patch volumereplicationgroup {vrg_name} "
             f"-n {constants.DR_OPS_NAMESPACE} "
-            f"--type=merge -p '{_PATCH}' --ignore-not-found=true",
+            f"--type={_PATCH_TYPE} -p '{_PATCH}' --ignore-not-found=true",
             ignore_error=True,
         )
 
@@ -1735,7 +1739,7 @@ def force_delete_discovered_apps_workload(workload_namespace, vrg_name):
                 run_cmd(  # IgnoreDeprecation
                     f"oc patch volumereplication {vr_name} "
                     f"-n {workload_namespace} "
-                    f"--type=merge -p '{_PATCH}'",
+                    f"--type={_PATCH_TYPE} -p '{_PATCH}'",
                     ignore_error=True,
                 )
         except Exception:
@@ -1765,7 +1769,7 @@ def force_delete_discovered_apps_workload(workload_namespace, vrg_name):
                     run_cmd(  # IgnoreDeprecation
                         f"oc patch volumegroupreplication {vgr_name} "
                         f"-n {workload_namespace} "
-                        f"--type=merge -p '{_PATCH}'",
+                        f"--type={_PATCH_TYPE} -p '{_PATCH}'",
                         ignore_error=True,
                     )
             except Exception:
@@ -1778,6 +1782,14 @@ def force_delete_discovered_apps_workload(workload_namespace, vrg_name):
             # Disable rbd mirror group via toolbox so the VRG finalizer
             # loop is not waiting for a final snapshot sync that will
             # never complete.
+            #
+            # Lookup chain:
+            #   VGR  → spec.volumeGroupReplicationContentName
+            #     → VGRContent → spec.volumeGroupReplicationHandle
+            #       e.g. "0001-0011-openshift-storage-0000000000000002-<uuid>"
+            #         → rbd group name = "csi-vol-group-<uuid>"
+            #           where <uuid> is the last 5 dash-separated segments
+            #           (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx).
             try:
                 # Derive pool name from the StorageClass of any PVC in
                 # the workload namespace.
@@ -1811,39 +1823,74 @@ def force_delete_discovered_apps_workload(workload_namespace, vrg_name):
 
                 ct_pod = get_ceph_tools_pod()
 
-                logger.info(
-                    f"[force-cleanup] Removing mirror group snapshot schedule "
-                    f"for {pool_name}/{vrg_name} on {cluster_name}"
-                )
-                try:
-                    ct_pod.exec_ceph_cmd(
-                        f"rbd mirror group snapshot schedule remove "
-                        f"{pool_name}/{vrg_name} {namespace_param}",
-                        format=None,
+                # Resolve every rbd group name from VGR → VGRContent
+                rbd_group_names = []
+                for vgr in vgr_items:
+                    vgr_name_local = vgr["metadata"]["name"]
+                    vgrcontent_name = vgr.get("spec", {}).get(
+                        "volumeGroupReplicationContentName", ""
                     )
-                except CommandFailed:
-                    logger.warning(
-                        f"[force-cleanup] rbd mirror group snapshot schedule "
-                        f"remove failed on {cluster_name} (group may not exist)",
-                        exc_info=True,
-                    )
+                    if not vgrcontent_name:
+                        logger.warning(
+                            f"[force-cleanup] VGR {vgr_name_local} has no "
+                            f"volumeGroupReplicationContentName — skipping"
+                        )
+                        continue
 
-                logger.info(
-                    f"[force-cleanup] Disabling mirror group "
-                    f"{pool_name}/{vrg_name} with --force on {cluster_name}"
-                )
-                try:
-                    ct_pod.exec_ceph_cmd(
-                        f"rbd mirror group disable --force "
-                        f"{pool_name}/{vrg_name} {namespace_param}",
-                        format=None,
+                    logger.info(
+                        f"[force-cleanup] Fetching VGRContent "
+                        f"{vgrcontent_name} for VGR {vgr_name_local}"
                     )
-                except CommandFailed:
-                    logger.warning(
-                        f"[force-cleanup] rbd mirror group disable failed "
-                        f"on {cluster_name} (group may not exist)",
-                        exc_info=True,
+                    try:
+                        vgrcontent_data = ocp.OCP(
+                            kind="VolumeGroupReplicationContent",
+                            resource_name=vgrcontent_name,
+                        ).get()
+                        handle = vgrcontent_data.get("spec", {}).get(
+                            "volumeGroupReplicationHandle", ""
+                        )
+                        if not handle:
+                            logger.warning(
+                                f"[force-cleanup] VGRContent {vgrcontent_name} "
+                                f"has no volumeGroupReplicationHandle — skipping"
+                            )
+                            continue
+
+                        # handle = "<prefix>-<8>-<4>-<4>-<4>-<12>"
+                        # UUID = last 5 dash-separated segments
+                        parts = handle.split("-")
+                        uuid = "-".join(parts[-5:])
+                        rbd_group_name = f"csi-vol-group-{uuid}"
+                        logger.info(
+                            f"[force-cleanup] Resolved rbd group name: "
+                            f"{rbd_group_name} (handle={handle})"
+                        )
+                        rbd_group_names.append(rbd_group_name)
+                    except Exception:
+                        logger.warning(
+                            f"[force-cleanup] Could not fetch VGRContent "
+                            f"{vgrcontent_name}",
+                            exc_info=True,
+                        )
+
+                for rbd_group_name in rbd_group_names:
+                    logger.info(
+                        f"[force-cleanup] Disabling mirror group "
+                        f"{pool_name}/{rbd_group_name} with --force on {cluster_name}"
                     )
+                    try:
+                        ct_pod.exec_ceph_cmd(
+                            f"rbd mirror group disable --force "
+                            f"{pool_name}/{rbd_group_name} {namespace_param}",
+                            format=None,
+                        )
+                    except CommandFailed:
+                        logger.warning(
+                            f"[force-cleanup] rbd mirror group disable failed "
+                            f"for {rbd_group_name} on {cluster_name} "
+                            f"(group may not exist)",
+                            exc_info=True,
+                        )
 
             except Exception:
                 logger.warning(
@@ -1893,14 +1940,14 @@ def force_delete_discovered_apps_workload(workload_namespace, vrg_name):
                 )
                 run_cmd(  # IgnoreDeprecation
                     f"oc patch pvc {pvc_obj.name} -n {workload_namespace} "
-                    f"--type=merge -p '{_PATCH}'",
+                    f"--type={_PATCH_TYPE} -p '{_PATCH}'",
                     ignore_error=True,
                 )
                 try:
                     pv_name = pvc_obj.backed_pv
                     if pv_name:
                         run_cmd(  # IgnoreDeprecation
-                            f"oc patch pv {pv_name} --type=merge -p '{_PATCH}'",
+                            f"oc patch pv {pv_name} --type={_PATCH_TYPE} -p '{_PATCH}'",
                             ignore_error=True,
                         )
                 except Exception:

--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -1637,6 +1637,299 @@ def wait_for_backend_volume_deletion(backend_volumes, timeout=600):
         raise TimeoutExpiredError(error_msg)
 
 
+def force_delete_discovered_apps_workload(workload_namespace, vrg_name):
+    """
+    Force-delete all resources belonging to a Discovered Apps workload when the
+    normal deletion path has timed out (e.g. DRPC or VRG stuck in Deleting due
+    to finalizers or a blocked rbd-mirror group sync).
+
+    The function is intentionally best-effort: every step is wrapped so that a
+    failure in one step never prevents subsequent steps from running.  It should
+    be called only after the normal ``delete_workload`` flow has already raised a
+    timeout exception.
+
+    Steps (in order):
+        1. Strip finalizers from DRPC (hub).
+        2. Strip finalizers from Placement (hub).
+        3. On each managed cluster:
+           a. Strip finalizers from VolumeReplicationGroup.
+           b. Strip finalizers from every VolumeReplication in the workload namespace.
+           c. If CG is enabled, strip finalizers from every VolumeGroupReplication
+              in the workload namespace and disable the rbd mirror group via toolbox.
+        4. On each managed cluster, delete workload resources and PVCs; strip
+           finalizers from any PVC/PV that is stuck in Terminating.
+        5. On each managed cluster, delete the workload namespace.
+
+    Args:
+        workload_namespace (str): Namespace the workload is deployed in.
+        vrg_name (str): Name of the VolumeReplicationGroup / DRPC / Placement
+            (all share the same name for discovered-apps workloads).
+    """
+    logger.warning(
+        f"Force-deleting discovered apps workload: namespace={workload_namespace}, "
+        f"vrg_name={vrg_name}"
+    )
+    _PATCH = '{"metadata":{"finalizers":null}}'
+
+    # ------------------------------------------------------------------ #
+    # Step 1 & 2 – hub cluster: strip DRPC and Placement finalizers       #
+    # ------------------------------------------------------------------ #
+    config.switch_acm_ctx()
+    logger.info(f"[force-cleanup] Stripping finalizers from DRPC {vrg_name}")
+    run_cmd(  # IgnoreDeprecation
+        f"oc patch drpc {vrg_name} -n {constants.DR_OPS_NAMESPACE} "
+        f"--type=merge -p '{_PATCH}' --ignore-not-found=true",
+        ignore_error=True,
+    )
+
+    placement_name = f"{vrg_name}-plmnt-1"
+    logger.info(f"[force-cleanup] Stripping finalizers from Placement {placement_name}")
+    run_cmd(  # IgnoreDeprecation
+        f"oc patch placement {placement_name} -n {constants.DR_OPS_NAMESPACE} "
+        f"--type=merge -p '{_PATCH}' --ignore-not-found=true",
+        ignore_error=True,
+    )
+
+    # ------------------------------------------------------------------ #
+    # Steps 3 & 4 – each managed cluster                                  #
+    # ------------------------------------------------------------------ #
+    dr_cluster_relations = config.MULTICLUSTER.get("dr_cluster_relations", [])
+    if dr_cluster_relations:
+        non_acm_clusters = get_non_acm_cluster_and_non_provider_cluster_config()
+    else:
+        non_acm_clusters = get_non_acm_cluster_config()
+
+    for cluster in non_acm_clusters:
+        cluster_name = cluster.ENV_DATA["cluster_name"]
+        config.switch_ctx(cluster.MULTICLUSTER["multicluster_index"])
+        logger.info(f"[force-cleanup] Processing cluster {cluster_name}")
+
+        # -- 3a: VRG ---------------------------------------------------- #
+        logger.info(
+            f"[force-cleanup] Stripping finalizers from VRG {vrg_name} "
+            f"in {constants.DR_OPS_NAMESPACE} on {cluster_name}"
+        )
+        run_cmd(  # IgnoreDeprecation
+            f"oc patch volumereplicationgroup {vrg_name} "
+            f"-n {constants.DR_OPS_NAMESPACE} "
+            f"--type=merge -p '{_PATCH}' --ignore-not-found=true",
+            ignore_error=True,
+        )
+
+        # -- 3b: VolumeReplication resources ----------------------------- #
+        try:
+            vr_items = (
+                ocp.OCP(
+                    kind=constants.VOLUME_REPLICATION,
+                    namespace=workload_namespace,
+                )
+                .get()
+                .get("items", [])
+            )
+            for vr in vr_items:
+                vr_name = vr["metadata"]["name"]
+                logger.info(
+                    f"[force-cleanup] Stripping finalizers from VolumeReplication "
+                    f"{vr_name} on {cluster_name}"
+                )
+                run_cmd(  # IgnoreDeprecation
+                    f"oc patch volumereplication {vr_name} "
+                    f"-n {workload_namespace} "
+                    f"--type=merge -p '{_PATCH}'",
+                    ignore_error=True,
+                )
+        except Exception:
+            logger.warning(
+                f"[force-cleanup] Could not list VolumeReplication resources in "
+                f"{workload_namespace} on {cluster_name}",
+                exc_info=True,
+            )
+
+        # -- 3c: VolumeGroupReplication + mirror group (CG only) --------- #
+        if is_cg_enabled():
+            try:
+                vgr_items = (
+                    ocp.OCP(
+                        kind=constants.VOLUME_GROUP_REPLICATION,
+                        namespace=workload_namespace,
+                    )
+                    .get()
+                    .get("items", [])
+                )
+                for vgr in vgr_items:
+                    vgr_name = vgr["metadata"]["name"]
+                    logger.info(
+                        f"[force-cleanup] Stripping finalizers from "
+                        f"VolumeGroupReplication {vgr_name} on {cluster_name}"
+                    )
+                    run_cmd(  # IgnoreDeprecation
+                        f"oc patch volumegroupreplication {vgr_name} "
+                        f"-n {workload_namespace} "
+                        f"--type=merge -p '{_PATCH}'",
+                        ignore_error=True,
+                    )
+            except Exception:
+                logger.warning(
+                    f"[force-cleanup] Could not list VolumeGroupReplication "
+                    f"resources in {workload_namespace} on {cluster_name}",
+                    exc_info=True,
+                )
+
+            # Disable rbd mirror group via toolbox so the VRG finalizer
+            # loop is not waiting for a final snapshot sync that will
+            # never complete.
+            try:
+                # Derive pool name from the StorageClass of any PVC in
+                # the workload namespace.
+                pvc_list = get_all_pvc_objs(namespace=workload_namespace)
+                sc_name = pvc_list[0].backed_sc
+                sc_data = ocp.OCP(
+                    kind=constants.STORAGECLASS,
+                    resource_name=sc_name,
+                ).get()
+                pool_name = sc_data.get("parameters", {}).get(
+                    "pool", constants.DEFAULT_CEPHBLOCKPOOL
+                )
+
+                # Build optional --namespace argument from the rados
+                # namespace (HCI / provider-mode clusters only).
+                namespace_param = ""
+                if is_hci_cluster() and (
+                    is_cluster_y_version_upgraded()
+                    or cluster.ENV_DATA.get("cluster_type") == constants.HCI_CLIENT
+                ):
+                    try:
+                        rados_ns = find_radosnamespace()
+                        if rados_ns:
+                            namespace_param = f"--namespace {rados_ns}"
+                    except Exception:
+                        logger.warning(
+                            "[force-cleanup] Could not determine rados namespace; "
+                            "proceeding without --namespace",
+                            exc_info=True,
+                        )
+
+                ct_pod = get_ceph_tools_pod()
+
+                logger.info(
+                    f"[force-cleanup] Removing mirror group snapshot schedule "
+                    f"for {pool_name}/{vrg_name} on {cluster_name}"
+                )
+                try:
+                    ct_pod.exec_ceph_cmd(
+                        f"rbd mirror group snapshot schedule remove "
+                        f"{pool_name}/{vrg_name} {namespace_param}",
+                        format=None,
+                    )
+                except CommandFailed:
+                    logger.warning(
+                        f"[force-cleanup] rbd mirror group snapshot schedule "
+                        f"remove failed on {cluster_name} (group may not exist)",
+                        exc_info=True,
+                    )
+
+                logger.info(
+                    f"[force-cleanup] Disabling mirror group "
+                    f"{pool_name}/{vrg_name} with --force on {cluster_name}"
+                )
+                try:
+                    ct_pod.exec_ceph_cmd(
+                        f"rbd mirror group disable --force "
+                        f"{pool_name}/{vrg_name} {namespace_param}",
+                        format=None,
+                    )
+                except CommandFailed:
+                    logger.warning(
+                        f"[force-cleanup] rbd mirror group disable failed "
+                        f"on {cluster_name} (group may not exist)",
+                        exc_info=True,
+                    )
+
+            except Exception:
+                logger.warning(
+                    f"[force-cleanup] rbd mirror group disable step failed "
+                    f"on {cluster_name}",
+                    exc_info=True,
+                )
+
+        # -- 4: delete workload resources and PVCs ----------------------- #
+        logger.info(
+            f"[force-cleanup] Deleting workload resources and PVCs in "
+            f"{workload_namespace} on {cluster_name}"
+        )
+
+        # Collect PVC names before the kustomize delete wipes the namespace
+        try:
+            all_pvcs = get_all_pvc_objs(namespace=workload_namespace)
+        except Exception:
+            all_pvcs = []
+            logger.warning(
+                f"[force-cleanup] Could not list PVCs in {workload_namespace} "
+                f"on {cluster_name}",
+                exc_info=True,
+            )
+
+        # Non-blocking delete of all PVCs
+        for pvc_obj in all_pvcs:
+            try:
+                pvc_obj.delete(wait=False)
+            except Exception:
+                logger.warning(
+                    f"[force-cleanup] Could not delete PVC {pvc_obj.name} "
+                    f"on {cluster_name}",
+                    exc_info=True,
+                )
+
+        # Wait briefly; strip finalizers from anything still Terminating
+        for pvc_obj in all_pvcs:
+            try:
+                pvc_obj.ocp.wait_for_delete(
+                    resource_name=pvc_obj.name, timeout=30, sleep=5
+                )
+            except (TimeoutExpiredError, Exception):
+                logger.warning(
+                    f"[force-cleanup] PVC {pvc_obj.name} stuck in Terminating "
+                    f"— stripping PVC and PV finalizers on {cluster_name}"
+                )
+                run_cmd(  # IgnoreDeprecation
+                    f"oc patch pvc {pvc_obj.name} -n {workload_namespace} "
+                    f"--type=merge -p '{_PATCH}'",
+                    ignore_error=True,
+                )
+                try:
+                    pv_name = pvc_obj.backed_pv
+                    if pv_name:
+                        run_cmd(  # IgnoreDeprecation
+                            f"oc patch pv {pv_name} --type=merge -p '{_PATCH}'",
+                            ignore_error=True,
+                        )
+                except Exception:
+                    logger.warning(
+                        f"[force-cleanup] Could not strip PV finalizers for "
+                        f"PVC {pvc_obj.name} on {cluster_name}",
+                        exc_info=True,
+                    )
+
+        # -- 5: delete namespace ----------------------------------------- #
+        logger.info(
+            f"[force-cleanup] Deleting namespace {workload_namespace} "
+            f"on {cluster_name}"
+        )
+        try:
+            ocp.OCP().delete_project(project_name=workload_namespace)
+        except Exception:
+            logger.warning(
+                f"[force-cleanup] Could not delete namespace "
+                f"{workload_namespace} on {cluster_name}",
+                exc_info=True,
+            )
+
+    logger.info(
+        f"[force-cleanup] Completed force-cleanup for namespace "
+        f"{workload_namespace}, vrg={vrg_name}"
+    )
+
+
 def get_all_drpolicy():
     """
     Gets all DRPolicy from hub cluster

--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -1664,7 +1664,7 @@ def force_delete_discovered_apps_workload(workload_namespace, vrg_name):
 
     4. On each managed cluster, strip finalizers from PVCs and their backing PVs,
        then delete the PVCs.  If any PVC is still stuck after 60s, re-strip both
-       PVC and PV finalizers and wait 30s more.
+       PVC and PV finalizers and return to namespace deletion.
     5. On each managed cluster, delete the workload namespace.
 
     Args:
@@ -1672,6 +1672,7 @@ def force_delete_discovered_apps_workload(workload_namespace, vrg_name):
         vrg_name (str): Name of the VolumeReplicationGroup / DRPC / Placement
             (all share the same name for discovered-apps workloads).
     """
+    restore_index = config.cur_index
     logger.warning(
         f"Force-deleting discovered apps workload: namespace={workload_namespace}, "
         f"vrg_name={vrg_name}"
@@ -1796,10 +1797,11 @@ def force_delete_discovered_apps_workload(workload_namespace, vrg_name):
                 # Wait for VRs to be fully gone before touching PVCs so the
                 # replication controller stops re-adding PVC finalizers.
                 try:
-                    vr_ocp.wait_for_delete(
-                        resource_name="",
+                    wait_for_resource_count(
+                        kind=constants.VOLUME_REPLICATION,
+                        namespace=workload_namespace,
+                        expected_count=0,
                         timeout=60,
-                        sleep=5,
                     )
                 except Exception:
                     logger.warning(
@@ -1816,6 +1818,7 @@ def force_delete_discovered_apps_workload(workload_namespace, vrg_name):
 
         # -- 3c: VolumeGroupReplication + mirror group (CG only) --------- #
         if is_cg_enabled():
+            vgr_items = []
             try:
                 vgr_ocp = ocp.OCP(
                     kind=constants.VOLUME_GROUP_REPLICATION,
@@ -1847,10 +1850,11 @@ def force_delete_discovered_apps_workload(workload_namespace, vrg_name):
                     # Wait for VGRs to vanish before the rbd-disable step reads
                     # VGRContent (still accessible cluster-scoped).
                     try:
-                        vgr_ocp.wait_for_delete(
-                            resource_name="",
+                        wait_for_resource_count(
+                            kind=constants.VOLUME_GROUP_REPLICATION,
+                            namespace=workload_namespace,
+                            expected_count=0,
                             timeout=60,
-                            sleep=5,
                         )
                     except Exception:
                         logger.warning(
@@ -2161,9 +2165,13 @@ def force_delete_discovered_apps_workload(workload_namespace, vrg_name):
 
         # Poll until all PVCs are gone (up to 60s).
         if all_pvcs:
-            pvc_ocp = ocp.OCP(kind=constants.PVC, namespace=workload_namespace)
             try:
-                pvc_ocp.wait_for_delete(resource_name="", timeout=60, sleep=5)
+                wait_for_resource_count(
+                    kind=constants.PVC,
+                    namespace=workload_namespace,
+                    expected_count=0,
+                    timeout=60,
+                )
                 logger.info(
                     f"[force-cleanup] All PVCs deleted in {workload_namespace} "
                     f"on {cluster_name}"
@@ -2207,6 +2215,7 @@ def force_delete_discovered_apps_workload(workload_namespace, vrg_name):
                 exc_info=True,
             )
 
+    config.switch_ctx(restore_index)
     logger.info(
         f"[force-cleanup] Completed force-cleanup for namespace "
         f"{workload_namespace}, vrg={vrg_name}"

--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -2035,7 +2035,91 @@ def force_delete_discovered_apps_workload(workload_namespace, vrg_name):
                     exc_info=True,
                 )
 
-        # -- 4: delete PVCs ---------------------------------------------- #
+        # -- 3e: re-strip VR/VGR finalizers now that VRG is gone ---------- #
+        # The VGR controller may have re-added the replication finalizer to VRs
+        # while the VGR object was still alive during step 3d.  Now that the VRG
+        # is gone (or we have given up waiting), do a final sweep so the
+        # replication controller no longer blocks PVC deletion.
+        try:
+            vr_ocp_recheck = ocp.OCP(
+                kind=constants.VOLUME_REPLICATION,
+                namespace=workload_namespace,
+            )
+            vr_items_recheck = vr_ocp_recheck.get().get("items", [])
+            for vr in vr_items_recheck:
+                vr_name = vr["metadata"]["name"]
+                logger.info(
+                    f"[force-cleanup] Re-stripping finalizers from VolumeReplication "
+                    f"{vr_name} on {cluster_name}"
+                )
+                exec_cmd(
+                    f"oc patch volumereplication {vr_name} "
+                    f"-n {workload_namespace} "
+                    f"--type={_PATCH_TYPE} -p '{_PATCH}'",
+                    ignore_error=True,
+                )
+            if vr_items_recheck:
+                exec_cmd(
+                    f"oc delete volumereplication --all "
+                    f"-n {workload_namespace} --wait=false",
+                    ignore_error=True,
+                )
+        except Exception:
+            logger.warning(
+                f"[force-cleanup] Could not re-strip VolumeReplication "
+                f"finalizers in {workload_namespace} on {cluster_name}",
+                exc_info=True,
+            )
+
+        if is_cg_enabled():
+            try:
+                vgr_ocp_recheck = ocp.OCP(
+                    kind=constants.VOLUME_GROUP_REPLICATION,
+                    namespace=workload_namespace,
+                )
+                vgr_items_recheck = vgr_ocp_recheck.get().get("items", [])
+                for vgr in vgr_items_recheck:
+                    vgr_name = vgr["metadata"]["name"]
+                    logger.info(
+                        f"[force-cleanup] Re-stripping finalizers from "
+                        f"VolumeGroupReplication {vgr_name} on {cluster_name}"
+                    )
+                    exec_cmd(
+                        f"oc patch volumegroupreplication {vgr_name} "
+                        f"-n {workload_namespace} "
+                        f"--type={_PATCH_TYPE} -p '{_PATCH}'",
+                        ignore_error=True,
+                    )
+                if vgr_items_recheck:
+                    exec_cmd(
+                        f"oc delete volumegroupreplication --all "
+                        f"-n {workload_namespace} --wait=false",
+                        ignore_error=True,
+                    )
+            except Exception:
+                logger.warning(
+                    f"[force-cleanup] Could not re-strip VolumeGroupReplication "
+                    f"finalizers in {workload_namespace} on {cluster_name}",
+                    exc_info=True,
+                )
+
+        # -- 4: delete pods and PVCs -------------------------------------- #
+        # Delete all workload pods / controllers first so the
+        # kubernetes.io/pvc-protection finalizer is released before we try to
+        # remove the PVCs.
+        logger.info(
+            f"[force-cleanup] Deleting pods and workload controllers in "
+            f"{workload_namespace} on {cluster_name}"
+        )
+        for kind in ("deployment", "statefulset", "replicaset", "pod"):
+            exec_cmd(
+                f"oc delete {kind} --all -n {workload_namespace} "
+                f"--wait=false --ignore-not-found=true",
+                ignore_error=True,
+            )
+        # Give the kubelet a moment to detach volumes and drop pvc-protection
+        time.sleep(5)
+
         logger.info(
             f"[force-cleanup] Deleting PVCs in {workload_namespace} "
             f"on {cluster_name}"

--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -1649,16 +1649,23 @@ def force_delete_discovered_apps_workload(workload_namespace, vrg_name):
     timeout exception.
 
     Steps (in order):
-        1. Strip finalizers from DRPC (hub).
-        2. Strip finalizers from Placement (hub).
-        3. On each managed cluster:
-           a. Strip finalizers from VolumeReplicationGroup.
-           b. Strip finalizers from every VolumeReplication in the workload namespace.
-           c. If CG is enabled, strip finalizers from every VolumeGroupReplication
-              in the workload namespace and disable the rbd mirror group via toolbox.
-        4. On each managed cluster, delete workload resources and PVCs; strip
-           finalizers from any PVC/PV that is stuck in Terminating.
-        5. On each managed cluster, delete the workload namespace.
+
+    1. Strip finalizers from DRPC (hub) and delete it; wait up to 120s for it
+       to leave etcd before proceeding.
+    2. Strip finalizers from Placement (hub) and delete it.
+    3. On each managed cluster:
+
+       a. Strip finalizers from VolumeReplicationGroup and delete it.
+       b. Strip finalizers from every VolumeReplication in the workload namespace.
+       c. If CG is enabled, strip finalizers from every VolumeGroupReplication
+          in the workload namespace and disable the rbd mirror group via toolbox.
+       d. Wait up to 60s for the VRG to disappear; if still present, re-strip
+          finalizers and wait up to 120s more.
+
+    4. On each managed cluster, strip finalizers from PVCs and their backing PVs,
+       then delete the PVCs.  If any PVC is still stuck after 60s, re-strip both
+       PVC and PV finalizers and wait 30s more.
+    5. On each managed cluster, delete the workload namespace.
 
     Args:
         workload_namespace (str): Namespace the workload is deployed in.
@@ -1676,21 +1683,49 @@ def force_delete_discovered_apps_workload(workload_namespace, vrg_name):
     _PATCH_TYPE = "json"
 
     # ------------------------------------------------------------------ #
-    # Step 1 & 2 – hub cluster: strip DRPC and Placement finalizers       #
+    # Step 1 – hub cluster: strip + delete DRPC, wait for it to be gone   #
     # ------------------------------------------------------------------ #
     config.switch_acm_ctx()
     logger.info(f"[force-cleanup] Stripping finalizers from DRPC {vrg_name}")
-    run_cmd(  # IgnoreDeprecation
+    exec_cmd(
         f"oc patch drpc {vrg_name} -n {constants.DR_OPS_NAMESPACE} "
-        f"--type={_PATCH_TYPE} -p '{_PATCH}' --ignore-not-found=true",
+        f"--type={_PATCH_TYPE} -p '{_PATCH}'",
         ignore_error=True,
     )
+    logger.info(f"[force-cleanup] Deleting DRPC {vrg_name}")
+    exec_cmd(
+        f"oc delete drpc {vrg_name} -n {constants.DR_OPS_NAMESPACE} "
+        f"--wait=false --ignore-not-found=true",
+        ignore_error=True,
+    )
+    logger.info(f"[force-cleanup] Waiting up to 120s for DRPC {vrg_name} to disappear")
+    try:
+        ocp.OCP(
+            kind=constants.DRPC,
+            namespace=constants.DR_OPS_NAMESPACE,
+        ).wait_for_delete(resource_name=vrg_name, timeout=120, sleep=5)
+        logger.info(f"[force-cleanup] DRPC {vrg_name} is gone")
+    except Exception:
+        logger.warning(
+            f"[force-cleanup] DRPC {vrg_name} still present after 120s — "
+            f"ramen may still be reconciling VRGs",
+            exc_info=True,
+        )
 
+    # ------------------------------------------------------------------ #
+    # Step 2 – hub cluster: strip + delete Placement                      #
+    # ------------------------------------------------------------------ #
     placement_name = f"{vrg_name}-plmnt-1"
     logger.info(f"[force-cleanup] Stripping finalizers from Placement {placement_name}")
-    run_cmd(  # IgnoreDeprecation
+    exec_cmd(
         f"oc patch placement {placement_name} -n {constants.DR_OPS_NAMESPACE} "
-        f"--type={_PATCH_TYPE} -p '{_PATCH}' --ignore-not-found=true",
+        f"--type={_PATCH_TYPE} -p '{_PATCH}'",
+        ignore_error=True,
+    )
+    logger.info(f"[force-cleanup] Deleting Placement {placement_name}")
+    exec_cmd(
+        f"oc delete placement {placement_name} -n {constants.DR_OPS_NAMESPACE} "
+        f"--wait=false --ignore-not-found=true",
         ignore_error=True,
     )
 
@@ -1713,17 +1748,17 @@ def force_delete_discovered_apps_workload(workload_namespace, vrg_name):
             f"[force-cleanup] Stripping finalizers from VRG {vrg_name} "
             f"in {constants.DR_OPS_NAMESPACE} on {cluster_name}"
         )
-        run_cmd(  # IgnoreDeprecation
+        exec_cmd(
             f"oc patch volumereplicationgroup {vrg_name} "
             f"-n {constants.DR_OPS_NAMESPACE} "
-            f"--type={_PATCH_TYPE} -p '{_PATCH}' --ignore-not-found=true",
+            f"--type={_PATCH_TYPE} -p '{_PATCH}'",
             ignore_error=True,
         )
         logger.info(
             f"[force-cleanup] Deleting VRG {vrg_name} "
             f"in {constants.DR_OPS_NAMESPACE} on {cluster_name}"
         )
-        run_cmd(  # IgnoreDeprecation
+        exec_cmd(
             f"oc delete volumereplicationgroup {vrg_name} "
             f"-n {constants.DR_OPS_NAMESPACE} --wait=false --ignore-not-found=true",
             ignore_error=True,
@@ -1742,7 +1777,7 @@ def force_delete_discovered_apps_workload(workload_namespace, vrg_name):
                     f"[force-cleanup] Stripping finalizers from VolumeReplication "
                     f"{vr_name} on {cluster_name}"
                 )
-                run_cmd(  # IgnoreDeprecation
+                exec_cmd(
                     f"oc patch volumereplication {vr_name} "
                     f"-n {workload_namespace} "
                     f"--type={_PATCH_TYPE} -p '{_PATCH}'",
@@ -1753,7 +1788,7 @@ def force_delete_discovered_apps_workload(workload_namespace, vrg_name):
                     f"[force-cleanup] Deleting all VolumeReplication resources "
                     f"in {workload_namespace} on {cluster_name}"
                 )
-                run_cmd(  # IgnoreDeprecation
+                exec_cmd(
                     f"oc delete volumereplication --all "
                     f"-n {workload_namespace} --wait=false",
                     ignore_error=True,
@@ -1793,7 +1828,7 @@ def force_delete_discovered_apps_workload(workload_namespace, vrg_name):
                         f"[force-cleanup] Stripping finalizers from "
                         f"VolumeGroupReplication {vgr_name} on {cluster_name}"
                     )
-                    run_cmd(  # IgnoreDeprecation
+                    exec_cmd(
                         f"oc patch volumegroupreplication {vgr_name} "
                         f"-n {workload_namespace} "
                         f"--type={_PATCH_TYPE} -p '{_PATCH}'",
@@ -1804,7 +1839,7 @@ def force_delete_discovered_apps_workload(workload_namespace, vrg_name):
                         f"[force-cleanup] Deleting all VolumeGroupReplication "
                         f"resources in {workload_namespace} on {cluster_name}"
                     )
-                    run_cmd(  # IgnoreDeprecation
+                    exec_cmd(
                         f"oc delete volumegroupreplication --all "
                         f"-n {workload_namespace} --wait=false",
                         ignore_error=True,
@@ -1954,22 +1989,51 @@ def force_delete_discovered_apps_workload(workload_namespace, vrg_name):
         # -- 3d: wait for VRG to be fully gone before touching PVCs ------ #
         # The VRG controller re-adds PVC finalizers as long as the VRG object
         # exists in etcd.  We must wait for it to disappear completely.
+        # Strategy: wait 60s; if still present, re-strip + re-delete and wait
+        # another 120s.  Total budget: ~3 minutes.
         logger.info(
             f"[force-cleanup] Waiting for VRG {vrg_name} to be fully deleted "
             f"in {constants.DR_OPS_NAMESPACE} on {cluster_name}"
         )
+        vrg_ocp = ocp.OCP(
+            kind=constants.VOLUME_REPLICATION_GROUP,
+            namespace=constants.DR_OPS_NAMESPACE,
+        )
+        vrg_gone = False
         try:
-            ocp.OCP(
-                kind=constants.VOLUME_REPLICATION_GROUP,
-                namespace=constants.DR_OPS_NAMESPACE,
-            ).wait_for_delete(resource_name=vrg_name, timeout=60, sleep=5)
+            vrg_ocp.wait_for_delete(resource_name=vrg_name, timeout=60, sleep=5)
+            vrg_gone = True
             logger.info(f"[force-cleanup] VRG {vrg_name} is gone on {cluster_name}")
         except Exception:
             logger.warning(
-                f"[force-cleanup] VRG {vrg_name} may still exist on "
-                f"{cluster_name} — proceeding with PVC cleanup anyway",
-                exc_info=True,
+                f"[force-cleanup] VRG {vrg_name} still present after 60s on "
+                f"{cluster_name} — re-stripping finalizers and retrying"
             )
+        if not vrg_gone:
+            logger.info(
+                f"[force-cleanup] Re-stripping finalizers from VRG {vrg_name} "
+                f"on {cluster_name}"
+            )
+            exec_cmd(
+                f"oc patch volumereplicationgroup {vrg_name} "
+                f"-n {constants.DR_OPS_NAMESPACE} "
+                f"--type={_PATCH_TYPE} -p '{_PATCH}'",
+                ignore_error=True,
+            )
+            exec_cmd(
+                f"oc delete volumereplicationgroup {vrg_name} "
+                f"-n {constants.DR_OPS_NAMESPACE} --wait=false --ignore-not-found=true",
+                ignore_error=True,
+            )
+            try:
+                vrg_ocp.wait_for_delete(resource_name=vrg_name, timeout=120, sleep=5)
+                logger.info(f"[force-cleanup] VRG {vrg_name} is gone on {cluster_name}")
+            except Exception:
+                logger.warning(
+                    f"[force-cleanup] VRG {vrg_name} still exists after 3 min on "
+                    f"{cluster_name} — proceeding with PVC cleanup anyway",
+                    exc_info=True,
+                )
 
         # -- 4: delete PVCs ---------------------------------------------- #
         logger.info(
@@ -1994,20 +2058,19 @@ def force_delete_discovered_apps_workload(workload_namespace, vrg_name):
                 pv_name = pvc_obj.backed_pv
             except Exception:
                 pv_name = None
-            run_cmd(  # IgnoreDeprecation
+            exec_cmd(
                 f"oc patch pvc {pvc_obj.name} -n {workload_namespace} "
-                f"--type={_PATCH_TYPE} -p '{_PATCH}' --ignore-not-found=true",
+                f"--type={_PATCH_TYPE} -p '{_PATCH}'",
                 ignore_error=True,
             )
             if pv_name:
-                run_cmd(  # IgnoreDeprecation
-                    f"oc patch pv {pv_name} "
-                    f"--type={_PATCH_TYPE} -p '{_PATCH}' --ignore-not-found=true",
+                exec_cmd(
+                    f"oc patch pv {pv_name} " f"--type={_PATCH_TYPE} -p '{_PATCH}'",
                     ignore_error=True,
                 )
 
         if all_pvcs:
-            run_cmd(  # IgnoreDeprecation
+            exec_cmd(
                 f"oc delete pvc --all -n {workload_namespace} --wait=false",
                 ignore_error=True,
             )
@@ -2028,13 +2091,23 @@ def force_delete_discovered_apps_workload(workload_namespace, vrg_name):
                     f"re-stripping finalizers",
                     exc_info=True,
                 )
-                # Re-strip in case something briefly re-added a finalizer
+                # Re-strip PVC and PV finalizers in case something re-added them
                 for pvc_obj in all_pvcs:
-                    run_cmd(  # IgnoreDeprecation
+                    exec_cmd(
                         f"oc patch pvc {pvc_obj.name} -n {workload_namespace} "
-                        f"--type={_PATCH_TYPE} -p '{_PATCH}' --ignore-not-found=true",
+                        f"--type={_PATCH_TYPE} -p '{_PATCH}'",
                         ignore_error=True,
                     )
+                    try:
+                        pv_name = pvc_obj.backed_pv
+                    except Exception:
+                        pv_name = None
+                    if pv_name:
+                        exec_cmd(
+                            f"oc patch pv {pv_name} "
+                            f"--type={_PATCH_TYPE} -p '{_PATCH}'",
+                            ignore_error=True,
+                        )
 
         # -- 5: delete namespace ----------------------------------------- #
         logger.info(

--- a/ocs_ci/ocs/dr/dr_workload.py
+++ b/ocs_ci/ocs/dr/dr_workload.py
@@ -19,6 +19,7 @@ from ocs_ci.helpers.cnv_helpers import create_vm_secret, cal_md5sum_vm
 from ocs_ci.helpers.dr_helpers import (
     create_cdi_cert_configmap,
     create_cdi_pull_secret,
+    force_delete_discovered_apps_workload,
     generate_kubeobject_capture_interval,
     get_cluster_set_name,
 )
@@ -1971,63 +1972,99 @@ class BusyboxDiscoveredApps(DRWorkload):
 
     def delete_workload(self, drpc_name=None, skip_vrg_check=False):
         """
-        Delete Discovered Apps
+        Delete Discovered Apps workload.
 
+        Raises:
+            ResourceNotDeleted: If the normal deletion path times out and the
+                force-cleanup fallback also fails to complete cleanly.
         """
+        resolved_drpc_name = drpc_name or self.discovered_apps_placement_name
         current_test = (
-            os.environ.get("PYTEST_CURRENT_TEST").split("::")[-1].split(" ")[0]
+            os.environ.get("PYTEST_CURRENT_TEST", "").split("::")[-1].split(" ")[0]
         )
         ignore_not_found_param = ""
         if self.discovered_apps_multi_ns:
             ignore_not_found_param = "--ignore-not-found=true"
 
-        if "test_disable_dr" not in current_test:
-            log.info("Deleting DRPC")
-            config.switch_acm_ctx()
-            run_cmd(
-                f"oc delete drpc -n {constants.DR_OPS_NAMESPACE} {drpc_name or self.discovered_apps_placement_name} "
-                f"{ignore_not_found_param}"
-            )
-            log.info("Deleting Placement")
-            run_cmd(
-                f"oc delete placement -n {constants.DR_OPS_NAMESPACE} "
-                f"{self.discovered_apps_placement_name}-plmnt-1 {ignore_not_found_param}"
-            )
+        try:
+            if "test_disable_dr" not in current_test:
+                log.info(
+                    f"Deleting DRPC {resolved_drpc_name} from "
+                    f"{constants.DR_OPS_NAMESPACE}"
+                )
+                config.switch_acm_ctx()
+                run_cmd(  # IgnoreDeprecation
+                    f"oc delete drpc -n {constants.DR_OPS_NAMESPACE} "
+                    f"{resolved_drpc_name} --wait=false {ignore_not_found_param}"
+                )
+                log.info(
+                    f"Deleting Placement "
+                    f"{self.discovered_apps_placement_name}-plmnt-1"
+                )
+                run_cmd(  # IgnoreDeprecation
+                    f"oc delete placement -n {constants.DR_OPS_NAMESPACE} "
+                    f"{self.discovered_apps_placement_name}-plmnt-1 "
+                    f"{ignore_not_found_param}"
+                )
 
-        dr_cluster_relations = config.MULTICLUSTER.get("dr_cluster_relations", [])
-        if dr_cluster_relations:
-            non_acm_cluster_config = (
-                get_non_acm_cluster_and_non_provider_cluster_config()
+            dr_cluster_relations = config.MULTICLUSTER.get("dr_cluster_relations", [])
+            if dr_cluster_relations:
+                non_acm_cluster_config = (
+                    get_non_acm_cluster_and_non_provider_cluster_config()
+                )
+            else:
+                non_acm_cluster_config = get_non_acm_cluster_config()
+
+            for cluster in non_acm_cluster_config:
+                config.switch_ctx(cluster.MULTICLUSTER["multicluster_index"])
+                log.info(f"Deleting workload from {cluster.ENV_DATA['cluster_name']}")
+                run_cmd(  # IgnoreDeprecation
+                    f"oc delete -k {self.workload_path} -n {self.workload_namespace}",
+                    ignore_error=True,
+                )
+                log.info(f"Deleting recipe from {cluster.ENV_DATA['cluster_name']}")
+                run_cmd(  # IgnoreDeprecation
+                    cmd=f"oc delete recipe --all -n {self.workload_namespace}",
+                    ignore_error=True,
+                )
+                log.info(f"Deleting secret from {cluster.ENV_DATA['cluster_name']}")
+                secret_name = self.workload_namespace + "-secret"
+                run_cmd(  # IgnoreDeprecation
+                    cmd=f"oc delete secret {secret_name} -n {self.workload_namespace}",
+                    ignore_error=True,
+                )
+                dr_helpers.wait_for_all_resources_deletion(
+                    namespace=self.workload_namespace,
+                    discovered_apps=True,
+                    workload_cleanup=True,
+                    vrg_name=self.discovered_apps_placement_name,
+                    skip_vrg_check=skip_vrg_check,
+                )
+                ocp_obj = ocp.OCP()
+                ocp_obj.delete_project(project_name=self.workload_namespace)
+
+        except (
+            TimeoutExpired,
+            TimeoutExpiredError,
+            TimeoutError,
+            AssertionError,
+        ) as ex:
+            err_msg = (
+                f"Deletion timed out for workload namespace "
+                f"{self.workload_namespace}: {ex}. "
             )
-        else:
-            non_acm_cluster_config = get_non_acm_cluster_config()
-        for cluster in non_acm_cluster_config:
-            config.switch_ctx(cluster.MULTICLUSTER["multicluster_index"])
-            log.info(f"Deleting workload from {cluster.ENV_DATA['cluster_name']}")
-            run_cmd(
-                f"oc delete -k {self.workload_path} -n {self.workload_namespace}",
-                ignore_error=True,
-            )
-            log.info(f"Deleting recipe from {cluster.ENV_DATA['cluster_name']}")
-            run_cmd(
-                cmd=f"oc delete recipe --all -n {self.workload_namespace}",
-                ignore_error=True,
-            )
-            log.info(f"Deleting secret from {cluster.ENV_DATA['cluster_name']}")
-            secret_name = self.workload_namespace + "-secret"
-            run_cmd(
-                cmd=f"oc delete secret {secret_name} -n {self.workload_namespace}",
-                ignore_error=True,
-            )
-            dr_helpers.wait_for_all_resources_deletion(
-                namespace=self.workload_namespace,
-                discovered_apps=True,
-                workload_cleanup=True,
-                vrg_name=self.discovered_apps_placement_name,
-                skip_vrg_check=skip_vrg_check,
-            )
-            ocp_obj = ocp.OCP()
-            ocp_obj.delete_project(project_name=self.workload_namespace)
+            log.warning(err_msg)
+            if config.ENV_DATA.get("skip_force_delete_workload"):
+                log.warning(
+                    "skip_force_delete_workload is set — skipping force cleanup "
+                    f"for namespace {self.workload_namespace}"
+                )
+            else:
+                log.warning(f"Initiating force cleanup for {self.workload_namespace}")
+                force_delete_discovered_apps_workload(
+                    workload_namespace=self.workload_namespace,
+                    vrg_name=resolved_drpc_name,
+                )
 
 
 def validate_data_integrity(namespace, path="/mnt/test/hashfile", timeout=600):

--- a/ocs_ci/ocs/dr/dr_workload.py
+++ b/ocs_ci/ocs/dr/dr_workload.py
@@ -2065,6 +2065,7 @@ class BusyboxDiscoveredApps(DRWorkload):
                     workload_namespace=self.workload_namespace,
                     vrg_name=resolved_drpc_name,
                 )
+            raise ResourceNotDeleted(err_msg)
 
 
 def validate_data_integrity(namespace, path="/mnt/test/hashfile", timeout=600):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8554,20 +8554,34 @@ def discovered_apps_dr_workload(request):
         return instances
 
     def teardown():
+        failed_namespaces = []
         for index, instance in enumerate(instances):
+            log.info(
+                f"Deleting discovered apps workload: "
+                f"namespace={instance.workload_namespace}, "
+                f"placement={instance.discovered_apps_placement_name}"
+            )
+            drpc_name = None
+            if instance.discovered_apps_multi_ns:
+                is_last = index == len(instances) - 1
+                drpc_name = instance.discovered_apps_placement_name
+            else:
+                is_last = False
             try:
-                log.info(instance.__dict__)
-                drpc_name = None
-                if instance.discovered_apps_multi_ns:
-                    is_last = index == len(instances) - 1
-                    drpc_name = instance.discovered_apps_placement_name
-                else:
-                    is_last = False
                 instance.delete_workload(
                     skip_vrg_check=not is_last, drpc_name=drpc_name
                 )
             except ResourceNotDeleted:
-                raise ResourceNotDeleted("Workload deletion was unsuccessful")
+                log.exception(
+                    f"Failed to delete workload in namespace "
+                    f"{instance.workload_namespace}"
+                )
+                failed_namespaces.append(instance.workload_namespace)
+
+        if failed_namespaces:
+            raise ResourceNotDeleted(
+                f"Workload deletion failed for namespaces: {failed_namespaces}"
+            )
 
     request.addfinalizer(teardown)
     return factory


### PR DESCRIPTION
- Add force_delete_discovered_apps_workload() helper in dr_helpers.py that strips finalizers from DRPC, Placement, VRG, VR, VGR and disables the rbd mirror group (CG only) so a stuck deletion never leaves orphaned resources on the cluster.

- BusyboxDiscoveredApps.delete_workload:
  * Add --wait=false to 'oc delete drpc' so the command returns immediately instead of blocking on finalizer completion (root cause of the 600 s subprocess timeout seen in build #5624).
  * Wrap the entire body in try/except(Timeout*|AssertionError) and call force_delete_discovered_apps_workload as the fallback.
  * Guard the force-cleanup path with ENV_DATA skip_force_delete_workload flag so it can be disabled for manual cluster inspection.
  * Fix PYTEST_CURRENT_TEST env-var access to default to "" instead of crashing with AttributeError when called outside pytest.

- discovered_apps_dr_workload fixture teardown (conftest.py):
  * Replace stop-on-first-failure with collect-all-failures pattern so every workload instance is attempted regardless of earlier errors.
  * Replace log.info(instance.__dict__) with a structured log message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of Discovered Apps workloads when standard deletion times out.
  * Added fallback cleanup for stuck workload resources and namespaces.
  * Workload cleanup now continues for remaining resources when an individual deletion fails.
  * Teardown now reports all namespaces that could not be deleted in one consolidated error.
  * Improved cleanup logging by clearly identifying each workload being removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->