### PR TITLE
Revert "Add workaround for DFBUGS-7417"

### DIFF
--- a/ocs_ci/ocs/resources/storageconsumer.py
+++ b/ocs_ci/ocs/resources/storageconsumer.py
@@ -635,20 +635,8 @@ def verify_storage_consumer_resources(
         storage_class_names_on_cluster = [
             item["metadata"]["name"] for item in storage_classes_ocp["items"]
         ]
-
-        disable_cephfs = config.COMPONENTS["disable_cephfs"]
-
         for storage_class in storage_classes_on_consumer:
             if storage_class not in storage_class_names_on_cluster:
-                # Workaround for DFBUGS-7417: StorageConsumer lists CephFS StorageClass even when disabled
-                # Skip CephFS StorageClass verification if CephFS is disabled (DFBUGS-7417)
-                if disable_cephfs and "cephfs" in storage_class:
-                    log.warning(
-                        f"Skipping verification of StorageClass {storage_class} "
-                        f"(CephFS is disabled, workaround for DFBUGS-7417)"
-                    )
-                    continue
-
                 raise AssertionError(
                     f"StorageClass {storage_class} is not available on the cluster "
                     f"but listed in storage consumer {consumer_name}."
@@ -685,15 +673,6 @@ def verify_storage_consumer_resources(
         ]
         for volume_snapshot_class in volume_snapshot_classes_on_consumer or []:
             if volume_snapshot_class not in volume_snapshot_class_names_on_cluster:
-                # Workaround for DFBUGS-7417: StorageConsumer lists CephFS even when disabled
-                # Skip CephFS VolumeSnapshotClass verification if CephFS is disabled (DFBUGS-7417)
-                if disable_cephfs and "cephfs" in volume_snapshot_class:
-                    log.warning(
-                        f"Skipping verification of VolumeSnapshotClass {volume_snapshot_class} "
-                        f"(CephFS is disabled, workaround for DFBUGS-7417)"
-                    )
-                    continue
-
                 raise AssertionError(
                     f"VolumeSnapshotClass {volume_snapshot_class} is not available on the cluster "
                     f"but listed in storage consumer {consumer_name}."


### PR DESCRIPTION
This reverts commit 5265378adaaf8b84377530a20298656de4deeb38.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Storage consumer validation now checks all listed StorageClasses and VolumeSnapshotClasses, including CephFS-related resources, regardless of CephFS status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->