### PR TITLE
Update fdf_pre_release_registry to preprod.icr.io

### DIFF
--- a/ocs_ci/framework/conf/fdf_version/fdf-4.18.yaml
+++ b/ocs_ci/framework/conf/fdf_version/fdf-4.18.yaml
@@ -2,7 +2,7 @@
 DEPLOYMENT:
   fdf_pre_release: true
   fdf_image_tag: v4.18
-  fdf_pre_release_registry: cp.stg.icr.io/cp/df
+  fdf_pre_release_registry: preprod.icr.io/cpopen
   fdf_pre_release_image_digest: null
 REPORTING:
   default_ocs_must_gather_latest_tag: 'v4.18'

--- a/ocs_ci/framework/conf/fdf_version/fdf-4.19.yaml
+++ b/ocs_ci/framework/conf/fdf_version/fdf-4.19.yaml
@@ -2,7 +2,7 @@
 DEPLOYMENT:
   fdf_pre_release: true
   fdf_image_tag: v4.19
-  fdf_pre_release_registry: cp.stg.icr.io/cp/df
+  fdf_pre_release_registry: preprod.icr.io/cpopen
   fdf_pre_release_image_digest: null
 REPORTING:
   default_ocs_must_gather_latest_tag: 'v4.19'

--- a/ocs_ci/framework/conf/fdf_version/fdf-4.20.yaml
+++ b/ocs_ci/framework/conf/fdf_version/fdf-4.20.yaml
@@ -2,7 +2,7 @@
 DEPLOYMENT:
   fdf_pre_release: true
   fdf_image_tag: v4.20
-  fdf_pre_release_registry: cp.stg.icr.io/cp/df
+  fdf_pre_release_registry: preprod.icr.io/cpopen
   fdf_pre_release_image_digest: null
 REPORTING:
   default_ocs_must_gather_latest_tag: 'v4.20'

--- a/ocs_ci/framework/conf/fdf_version/fdf-4.21.yaml
+++ b/ocs_ci/framework/conf/fdf_version/fdf-4.21.yaml
@@ -2,7 +2,7 @@
 DEPLOYMENT:
   fdf_pre_release: true
   fdf_image_tag: v4.21
-  fdf_pre_release_registry: cp.stg.icr.io/cp/df
+  fdf_pre_release_registry: preprod.icr.io/cpopen
   fdf_pre_release_image_digest: null
 REPORTING:
   default_ocs_must_gather_latest_tag: 'v4.21'

--- a/ocs_ci/framework/conf/fdf_version/fdf-4.22.yaml
+++ b/ocs_ci/framework/conf/fdf_version/fdf-4.22.yaml
@@ -2,7 +2,7 @@
 DEPLOYMENT:
   fdf_pre_release: true
   fdf_image_tag: v4.22
-  fdf_pre_release_registry: cp.stg.icr.io/cp/df
+  fdf_pre_release_registry: preprod.icr.io/cpopen
   fdf_pre_release_image_digest: null
 REPORTING:
   default_ocs_must_gather_latest_tag: 'v4.22'

--- a/ocs_ci/framework/conf/fdf_version/fdf-4.23.yaml
+++ b/ocs_ci/framework/conf/fdf_version/fdf-4.23.yaml
@@ -2,7 +2,7 @@
 DEPLOYMENT:
   fdf_pre_release: true
   fdf_image_tag: v4.23
-  fdf_pre_release_registry: cp.stg.icr.io/cp/df
+  fdf_pre_release_registry: preprod.icr.io/cpopen
   fdf_pre_release_image_digest: null
 REPORTING:
   default_ocs_must_gather_latest_tag: 'v4.23'

--- a/ocs_ci/framework/conf/fdf_version/fdf-5.0.yaml
+++ b/ocs_ci/framework/conf/fdf_version/fdf-5.0.yaml
@@ -2,7 +2,7 @@
 DEPLOYMENT:
   fdf_pre_release: true
   fdf_image_tag: v5.0
-  fdf_pre_release_registry: cp.stg.icr.io/cp/df
+  fdf_pre_release_registry: preprod.icr.io/cpopen
   fdf_pre_release_image_digest: null
 REPORTING:
   default_ocs_must_gather_latest_tag: 'v5.0'


### PR DESCRIPTION
Signed-off-by: vavuthu [vavuthu@redhat.com](mailto:vavuthu@redhat.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated the pre-release image registry for FDF versions 4.18 through 5.0.
  * Deployments now reference the `preprod.icr.io/cpopen` registry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->