### PR TITLE
Update Submariner to 0.24.1 for OCP 4.23 and 5.0

### DIFF
--- a/conf/examples/submariner_unreleased_image.yaml
+++ b/conf/examples/submariner_unreleased_image.yaml
@@ -1,3 +1,3 @@
 ---
 ENV_DATA:
-  submariner_image: "quay.io/redhat-user-workloads/submariner-tenant/submariner-fbc-4-22@sha256:1a666c3c2c99b1148f184f54efcee293f45cfff32cf9ca7a239097fe574ff700"
+  submariner_image: "quay.io/redhat-user-workloads/submariner-tenant/submariner-fbc-4-22@sha256:d086e72ace45a2af7b25d418724f050d9d5bc84e4f4a2e9c3f2888c4116f345c"

--- a/ocs_ci/framework/conf/ocp_version/ocp-4.23-config.yaml
+++ b/ocs_ci/framework/conf/ocp_version/ocp-4.23-config.yaml
@@ -22,6 +22,6 @@ ENV_DATA:
   mce_version: "5.0"
   # Remove below line for GAed config
   unreleased_mce: true
-  submariner_version: "0.24.0"
-  submariner_image: "quay.io/redhat-user-workloads/submariner-tenant/submariner-fbc-4-22@sha256:1a666c3c2c99b1148f184f54efcee293f45cfff32cf9ca7a239097fe574ff700"
+  submariner_version: "0.24.1"
+  submariner_image: "quay.io/redhat-user-workloads/submariner-tenant/submariner-fbc-4-22@sha256:d086e72ace45a2af7b25d418724f050d9d5bc84e4f4a2e9c3f2888c4116f345c"
   oadp_version: "1.6"

--- a/ocs_ci/framework/conf/ocp_version/ocp-5.0-config.yaml
+++ b/ocs_ci/framework/conf/ocp_version/ocp-5.0-config.yaml
@@ -23,6 +23,6 @@ ENV_DATA:
   mce_version: "5.0"
     # Remove below line for GAed config
   unreleased_mce: true
-  submariner_version: "0.24.0"
-  submariner_image: "quay.io/redhat-user-workloads/submariner-tenant/submariner-fbc-4-22@sha256:1a666c3c2c99b1148f184f54efcee293f45cfff32cf9ca7a239097fe574ff700"
+  submariner_version: "0.24.1"
+  submariner_image: "quay.io/redhat-user-workloads/submariner-tenant/submariner-fbc-4-22@sha256:d086e72ace45a2af7b25d418724f050d9d5bc84e4f4a2e9c3f2888c4116f345c"
   oadp_version: "1.6"


### PR DESCRIPTION
Bump submariner_version to 0.24.1, update submariner_image in the 4.23 and 5.0 configs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Updated the Submariner image reference to a newer pinned build.
  * Upgraded Submariner from version 0.24.0 to 0.24.1 for OCP 4.23 and 5.0.
  * Updated the pinned Submariner image digest in the OCP 4.23 and 5.0 configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->