### PR TITLE
dr_helpers: skip VolumeSnapshot check when skip_vs_check is set

### DIFF
--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -1275,12 +1275,17 @@ def wait_for_replication_resources_deletion(
             )
 
         if "cephfs" in namespace and workload_cleanup:
-            wait_for_resource_count(
-                kind=constants.VOLUMESNAPSHOT,
-                namespace=namespace,
-                expected_count=0,
-                timeout=timeout,
-            )
+            if config.ENV_DATA.get("skip_vs_check"):
+                logger.warning(
+                    "Skipping VolumeSnapshot count check (skip_vs_check is set)"
+                )
+            else:
+                wait_for_resource_count(
+                    kind=constants.VOLUMESNAPSHOT,
+                    namespace=namespace,
+                    expected_count=0,
+                    timeout=timeout,
+                )
 
 
 def wait_for_all_resources_creation(

--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -1196,7 +1196,10 @@ def wait_for_replication_resources_deletion(
         vrg_name (str): Name of VRG
         skip_vrg_check (bool): If true vrg check will be skipped
         workload_cleanup (bool): Set to True during final workload teardown.
-            For CephFS workloads, wait for all VolumeSnapshots to be deleted.
+            For CephFS workloads, waits for all VolumeSnapshots to reach
+            count zero before returning. This wait is skipped (with a warning)
+            when ``config.ENV_DATA["skip_vs_check"]`` is enabled, allowing
+            CephFS cleanup to continue without blocking on snapshot deletion.
 
     Raises:
         TimeoutExpiredError: In case replication resources not deleted


### PR DESCRIPTION
Skip the VolumeSnapshot count check in wait_for_all_resources_deletion if config.ENV_DATA.get("skip_vs_check") is set, logging a warning instead. Follows the same pattern as skip_mirroring_status_check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CephFS workload cleanup can now skip the VolumeSnapshot deletion-count check when configured to do so.
  * When skipping is not enabled, cleanup continues waiting until all VolumeSnapshots are deleted.
  * This preserves the existing cleanup behavior by default while allowing configured environments to proceed without the additional VolumeSnapshot check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->