### PR TITLE
add mds scenario test case

### DIFF
--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -7903,7 +7903,7 @@ def count_pvc_volume_health_events(pvc_obj, reason, event_type, message_substr):
         field_selector=f"involvedObject.name={pvc_obj.name}",
     )["items"]
     return sum(
-        1
+        e.get("count", 1)
         for e in events
         if (
             e.get("reason") == reason

--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -7877,43 +7877,6 @@ def verify_file_ownership(pod_obj, file_path, expected_uid, expected_gid):
     return file_uid, file_gid
 
 
-def count_pvc_volume_health_events(pvc_obj, reason, event_type, message_substr):
-    """
-    Return the count of K8s events matching the given criteria for the PVC,
-    with ``source.component == 'CSI-Addons'``.
-
-    No assertion is made — zero is a valid return value.  Use this when you
-    need a baseline count before an action (e.g. to detect new events after
-    recovery) without requiring any events to already exist.
-
-    Args:
-        pvc_obj: PVC object
-        reason (str): Event reason
-            (e.g. 'VolumeConditionHealthy', 'VolumeConditionAbnormal')
-        event_type (str): Event type ('Normal' or 'Warning')
-        message_substr (str): Substring expected in the event message
-
-    Returns:
-        int: Number of matching events (may be 0)
-    """
-    from ocs_ci.ocs.ocp import OCP
-
-    event_ocp = OCP(kind="Event", namespace=pvc_obj.namespace)
-    events = event_ocp.get(
-        field_selector=f"involvedObject.name={pvc_obj.name}",
-    )["items"]
-    return sum(
-        e.get("count", 1)
-        for e in events
-        if (
-            e.get("reason") == reason
-            and message_substr in e.get("message", "")
-            and e.get("type") == event_type
-            and e.get("source", {}).get("component") == "CSI-Addons"
-        )
-    )
-
-
 def create_custom_secret_for_cnsa_rm(name, namespace, data_dict, secret_type="Opaque"):
     """
     Helper to create a Kubernetes Secret using OCP class and temporary YAML files.

--- a/ocs_ci/helpers/helpers.py
+++ b/ocs_ci/helpers/helpers.py
@@ -7877,6 +7877,43 @@ def verify_file_ownership(pod_obj, file_path, expected_uid, expected_gid):
     return file_uid, file_gid
 
 
+def count_pvc_volume_health_events(pvc_obj, reason, event_type, message_substr):
+    """
+    Return the count of K8s events matching the given criteria for the PVC,
+    with ``source.component == 'CSI-Addons'``.
+
+    No assertion is made — zero is a valid return value.  Use this when you
+    need a baseline count before an action (e.g. to detect new events after
+    recovery) without requiring any events to already exist.
+
+    Args:
+        pvc_obj: PVC object
+        reason (str): Event reason
+            (e.g. 'VolumeConditionHealthy', 'VolumeConditionAbnormal')
+        event_type (str): Event type ('Normal' or 'Warning')
+        message_substr (str): Substring expected in the event message
+
+    Returns:
+        int: Number of matching events (may be 0)
+    """
+    from ocs_ci.ocs.ocp import OCP
+
+    event_ocp = OCP(kind="Event", namespace=pvc_obj.namespace)
+    events = event_ocp.get(
+        field_selector=f"involvedObject.name={pvc_obj.name}",
+    )["items"]
+    return sum(
+        1
+        for e in events
+        if (
+            e.get("reason") == reason
+            and message_substr in e.get("message", "")
+            and e.get("type") == event_type
+            and e.get("source", {}).get("component") == "CSI-Addons"
+        )
+    )
+
+
 def create_custom_secret_for_cnsa_rm(name, namespace, data_dict, secret_type="Opaque"):
     """
     Helper to create a Kubernetes Secret using OCP class and temporary YAML files.

--- a/ocs_ci/ocs/resources/events.py
+++ b/ocs_ci/ocs/resources/events.py
@@ -1,0 +1,43 @@
+"""
+Event-related utility functions for OCS-CI
+"""
+
+import logging
+from ocs_ci.ocs import constants
+from ocs_ci.ocs.ocp import OCP
+
+log = logging.getLogger(__name__)
+
+
+def count_pvc_volume_health_events(
+    pvc_obj, reason=None, event_type=None, message_substring=None
+):
+    """
+    Count Kubernetes events for a PVC matching specified criteria.
+
+    Args:
+        pvc_obj (OCS): PVC object to query events for
+        reason (str): Optional event reason filter
+        event_type (str): Optional event type filter ("Normal" or "Warning")
+        message_substring (str): Optional substring to match in event message
+
+    Returns:
+        int: Total count of matching events (may be zero)
+
+    """
+    event_obj = OCP(
+        kind=constants.EVENT,
+        namespace=pvc_obj.namespace,
+        field_selector=f"involvedObject.name={pvc_obj.name}",
+    )
+    events = event_obj.get().get("items", [])
+    events = [e for e in events if e.get("source", {}).get("component") == "csi-addons"]
+    if reason:
+        events = [e for e in events if e.get("reason") == reason]
+    if event_type:
+        events = [e for e in events if e.get("type") == event_type]
+    if message_substring:
+        events = [e for e in events if message_substring in e.get("message", "")]
+    total_count = sum(e.get("count", 1) for e in events)
+    log.info(f"Found {total_count} events for PVC {pvc_obj.name}")
+    return total_count

--- a/ocs_ci/ocs/resources/events.py
+++ b/ocs_ci/ocs/resources/events.py
@@ -3,41 +3,38 @@ Event-related utility functions for OCS-CI
 """
 
 import logging
-from ocs_ci.ocs import constants
 from ocs_ci.ocs.ocp import OCP
 
 log = logging.getLogger(__name__)
 
 
-def count_pvc_volume_health_events(
-    pvc_obj, reason=None, event_type=None, message_substring=None
-):
+def count_pvc_volume_health_events(pvc_obj, reason, event_type, message_substr):
     """
-    Count Kubernetes events for a PVC matching specified criteria.
+    Return the total occurrence count of K8s core v1 events matching the
+    given criteria for the PVC, with ``source.component == 'CSI-Addons'``.
+    No assertion is made — zero is a valid return value.
 
     Args:
-        pvc_obj (OCS): PVC object to query events for
-        reason (str): Optional event reason filter
-        event_type (str): Optional event type filter ("Normal" or "Warning")
-        message_substring (str): Optional substring to match in event message
+        pvc_obj: PVC object
+        reason (str): Event reason
+            (e.g. 'VolumeConditionHealthy', 'VolumeConditionAbnormal')
+        event_type (str): Event type ('Normal' or 'Warning')
+        message_substr (str): Substring expected in the event message
 
     Returns:
-        int: Total count of matching events (may be zero)
-
+        int: Sum of ``count`` fields across all matching events (may be 0)
     """
-    event_obj = OCP(
-        kind=constants.EVENT,
-        namespace=pvc_obj.namespace,
+    event_ocp = OCP(kind="Event", namespace=pvc_obj.namespace)
+    events = event_ocp.get(
         field_selector=f"involvedObject.name={pvc_obj.name}",
+    )["items"]
+    return sum(
+        e.get("count", 1)
+        for e in events
+        if (
+            e.get("reason") == reason
+            and message_substr in e.get("message", "")
+            and e.get("type") == event_type
+            and e.get("source", {}).get("component") == "CSI-Addons"
+        )
     )
-    events = event_obj.get().get("items", [])
-    events = [e for e in events if e.get("source", {}).get("component") == "csi-addons"]
-    if reason:
-        events = [e for e in events if e.get("reason") == reason]
-    if event_type:
-        events = [e for e in events if e.get("type") == event_type]
-    if message_substring:
-        events = [e for e in events if message_substring in e.get("message", "")]
-    total_count = sum(e.get("count", 1) for e in events)
-    log.info(f"Found {total_count} events for PVC {pvc_obj.name}")
-    return total_count

--- a/tests/functional/pv/pv_services/test_pvc_volume_health_annotation.py
+++ b/tests/functional/pv/pv_services/test_pvc_volume_health_annotation.py
@@ -13,20 +13,26 @@ from ocs_ci.framework.pytest_customization.marks import (
     green_squad,
     skipif_ocs_version,
     jira,
+    skipif_mcg_only,
+    skipif_managed_service,
+    skipif_rosa_hcp,
+    skipif_external_mode,
 )
-from ocs_ci.framework.testlib import ManageTest, tier1
+from ocs_ci.framework.testlib import ManageTest, tier1, tier2
 from ocs_ci.framework import config
 from ocs_ci.helpers.helpers import (
     assert_pvc_volume_health_event,
     blocklist_cephfs_client,
     remove_cephfs_client_blocklist,
+    modify_deployment_replica_count,
 )
 from ocs_ci.ocs import constants, ocp, node
 from ocs_ci.ocs.resources import pod
 from ocs_ci.ocs.resources.csi_addons import (
     get_csi_addon_pod_on_node,
 )
-from ocs_ci.utility.utils import ceph_health_check
+from ocs_ci.ocs.exceptions import TimeoutExpiredError
+from ocs_ci.utility.utils import ceph_health_check, TimeoutSampler
 
 logger = logging.getLogger(__name__)
 
@@ -39,6 +45,10 @@ RECOVERY_POLL_TIMEOUT = 300
 
 @tier1
 @green_squad
+@skipif_mcg_only
+@skipif_managed_service
+@skipif_rosa_hcp
+@skipif_external_mode
 @skipif_ocs_version("<4.23")
 @jira("DFBUGS-9421", run=False)
 @pytest.mark.parametrize(
@@ -237,9 +247,12 @@ class TestPVCVolumeHealthAnnotation(ManageTest):
         logger.info(f"{driver.upper()} PVC volume health annotation test passed")
 
 
-@tier1
 @green_squad
 @skipif_ocs_version("<4.23")
+@skipif_mcg_only
+@skipif_managed_service
+@skipif_rosa_hcp
+@skipif_external_mode
 @jira("DFBUGS-9421", run=False)
 class TestPVCVolumeHealthUnhealthy(ManageTest):
     """
@@ -280,6 +293,27 @@ class TestPVCVolumeHealthUnhealthy(ManageTest):
         logger.info("FIO I/O completed")
         return pvc_obj, pod_obj
 
+    def _restart_cephfs_nodeplugin_on_nodes(self, node_names):
+        """
+        Restart the CephFS RPC nodeplugin pods on the given nodes for unhealthy
+        transition to happen quickly.
+
+        Args:
+            node_names (list): Node names whose CephFS nodeplugin pods to
+                restart.
+        """
+        plugin_pods = pod.get_plugin_pods(constants.CEPHFILESYSTEM)
+        targets = set(node_names)
+        for plugin_pod in plugin_pods:
+            plugin_node = plugin_pod.get()["spec"]["nodeName"]
+            if plugin_node in targets:
+                logger.info(
+                    f"Restarting CephFS nodeplugin pod {plugin_pod.name} "
+                    f"on node {plugin_node} to force the health-check probe"
+                )
+                plugin_pod.delete(wait=True)
+
+    @tier1
     @pytest.mark.polarion_id("OCS-8228")
     def test_pvc_health_unhealthy_via_ceph_blocklist(
         self, pvc_factory, pod_factory, request
@@ -359,3 +393,185 @@ class TestPVCVolumeHealthUnhealthy(ManageTest):
             message_substr="volume is in a healthy condition",
         )
         logger.info("PVC health unhealthy via ceph blocklist test passed")
+
+    @tier2
+    @pytest.mark.polarion_id("OCS-8261")
+    def test_pvc_health_unhealthy_via_mds_scaledown(
+        self, pvc_factory, pod_factory, request
+    ):
+        """
+        Verify RWX PVC per-node health transitions to unhealthy when both
+        CephFS MDS daemons are scaled down, and recovers when restored.
+
+        Steps:
+            1. Create CephFS RWX PVC, 2 pods on different nodes, run I/O.
+            2. Wait for reporter tick; assert 2 per-node annotation keys are
+               healthy and snapshot 'since' per key
+            3. Scale down both MDS deployments (a & b) to 0, then restart the
+               CephFS nodeplugin pods on the pod nodes to trigger the probe.
+            4. Assert both per-node keys report state == 'unhealthy'.
+            5. Assert 'since' timestamp advanced vs the healthy snapshot.
+            6. Assert VolumeConditionAbnormal Warning event fired.
+            7. Restore both MDS deployments to replicas=1.
+            8. Assert both keys return to state == 'healthy'.
+            9. Assert new VolumeConditionHealthy Normal event on recovery.
+        """
+        logger.test_step("Verify Ceph health is HEALTH_OK")
+        ceph_health_check(tries=3, delay=10)
+
+        logger.test_step("Create CephFS RWX PVC (5Gi)")
+        pvc_obj = pvc_factory(
+            interface=constants.CEPHFILESYSTEM,
+            size=5,
+            access_mode=constants.ACCESS_MODE_RWX,
+        )
+        logger.info(f"PVC {pvc_obj.name} created and Bound")
+
+        logger.test_step("Create 2 pods on different nodes")
+        worker_nodes = node.get_worker_nodes()
+        logger.assertion(
+            f"Worker node count: expected >= 2, actual={len(worker_nodes)}"
+        )
+        assert (
+            len(worker_nodes) >= 2
+        ), f"Need >= 2 worker nodes, found {len(worker_nodes)}"
+        pod_objs = []
+        for i in range(2):
+            p = pod_factory(
+                pvc=pvc_obj,
+                interface=constants.CEPHFILESYSTEM,
+                node_name=worker_nodes[i],
+            )
+            pod_objs.append(p)
+        pod_node_names = [p.get()["spec"]["nodeName"] for p in pod_objs]
+        logger.info(
+            f"Pod {pod_objs[0].name} on {pod_node_names[0]}, "
+            f"Pod {pod_objs[1].name} on {pod_node_names[1]}"
+        )
+        logger.assertion(
+            f"Pods on different nodes: {pod_node_names[0]} != {pod_node_names[1]}"
+        )
+        assert (
+            pod_node_names[0] != pod_node_names[1]
+        ), f"Both pods on same node: {pod_node_names[0]}"
+
+        logger.test_step("Run FIO I/O on both pods")
+        for p in pod_objs:
+            p.run_io(
+                storage_type="fs",
+                size="512M",
+                fio_filename=p.name,
+            )
+        for p in pod_objs:
+            pod.get_fio_rw_iops(p)
+        logger.info("FIO I/O completed")
+
+        logger.test_step("Poll for 2 healthy per-node annotation keys")
+        health_annotations = pvc_obj.wait_for_volume_health_state(
+            expected_state="healthy",
+            timeout=ANNOTATION_POLL_TIMEOUT,
+            interval=ANNOTATION_POLL_INTERVAL,
+            expected_count=2,
+        )
+        healthy_since = {}
+        for node_name in pod_node_names:
+            uid = ocp.OCP(kind="node", resource_name=node_name).get()["metadata"]["uid"]
+            key = f"{constants.VOLUME_HEALTH_ANNOTATION_PREFIX}{uid}"
+            healthy_since[key] = json.loads(health_annotations[key]).get("since", "")
+        logger.info(f"Healthy 'since' snapshot: {healthy_since}")
+
+        logger.test_step("Scale down both MDS deployments (a & b) to 0 replicas")
+        mds_deployments = [
+            constants.MDS_DAEMON_DEPLOYMENT_ONE,
+            constants.MDS_DAEMON_DEPLOYMENT_TWO,
+        ]
+
+        def finalizer():
+            logger.info("Finalizer: restore both MDS deployments to 1")
+            for dep in mds_deployments:
+                modify_deployment_replica_count(dep, 1)
+            ceph_health_check(tries=20, delay=30)
+
+        request.addfinalizer(finalizer)
+
+        for dep in mds_deployments:
+            modify_deployment_replica_count(dep, 0)
+            logger.info(f"Scaled deployment {dep} to 0")
+
+        logger.test_step(
+            "Restart CephFS nodeplugin pods on the pod nodes to trigger the "
+            "unhealthy probe"
+        )
+        self._restart_cephfs_nodeplugin_on_nodes(pod_node_names)
+
+        logger.test_step("Assert both per-node keys report 'unhealthy'")
+        unhealthy_annotations = pvc_obj.wait_for_volume_health_state(
+            expected_state="unhealthy",
+            timeout=UNHEALTHY_POLL_TIMEOUT,
+            interval=ANNOTATION_POLL_INTERVAL,
+            expected_count=2,
+        )
+
+        logger.test_step("Assert 'since' timestamp advanced for both keys")
+        for key, healthy_ts in healthy_since.items():
+            logger.assertion(f"Annotation key {key} present while unhealthy")
+            assert key in unhealthy_annotations, (
+                f"Key {key} missing from unhealthy annotations: "
+                f"{list(unhealthy_annotations.keys())}"
+            )
+            parsed = json.loads(unhealthy_annotations[key])
+            logger.assertion(
+                f"Annotation state for {key}: expected='unhealthy', "
+                f"actual='{parsed.get('state')}'"
+            )
+            assert (
+                parsed.get("state") == "unhealthy"
+            ), f"Expected 'unhealthy' for {key}, got '{parsed.get('state')}'"
+            new_ts = parsed.get("since", "")
+            dt_healthy = datetime.fromisoformat(healthy_ts.replace("Z", "+00:00"))
+            dt_unhealthy = datetime.fromisoformat(new_ts.replace("Z", "+00:00"))
+            logger.assertion(f"'since' advanced for {key}: {new_ts} > {healthy_ts}")
+            assert dt_unhealthy > dt_healthy, (
+                f"'since' did not advance for {key}: "
+                f"healthy={healthy_ts}, unhealthy={new_ts}"
+            )
+
+        logger.test_step("Assert VolumeConditionAbnormal Warning event fired")
+        try:
+            for _ in TimeoutSampler(
+                timeout=ANNOTATION_POLL_TIMEOUT,
+                sleep=ANNOTATION_POLL_INTERVAL,
+                func=assert_pvc_volume_health_event,
+                pvc_obj=pvc_obj,
+                reason="VolumeConditionAbnormal",
+                event_type="Warning",
+                message_substr="health-check has not responded",
+            ):
+                break
+        except TimeoutExpiredError:
+            pytest.fail(
+                "VolumeConditionAbnormal event not found for "
+                f"PVC {pvc_obj.name} within {ANNOTATION_POLL_TIMEOUT}s"
+            )
+
+        logger.test_step("Restore both MDS deployments to 1 replica")
+        for dep in mds_deployments:
+            modify_deployment_replica_count(dep, 1)
+            logger.info(f"Scaled deployment {dep} to 1")
+
+        logger.test_step("Assert both per-node keys return to 'healthy'")
+        pvc_obj.wait_for_volume_health_state(
+            expected_state="healthy",
+            timeout=RECOVERY_POLL_TIMEOUT,
+            interval=ANNOTATION_POLL_INTERVAL,
+            expected_count=2,
+        )
+
+        logger.test_step("Assert VolumeConditionHealthy Normal event")
+        assert_pvc_volume_health_event(
+            pvc_obj,
+            reason="VolumeConditionHealthy",
+            event_type="Normal",
+            message_substr="volume is in a healthy condition",
+        )
+        logger.info("PVC health unhealthy via MDS scale-down test passed")

--- a/tests/functional/pv/pv_services/test_pvc_volume_health_annotation.py
+++ b/tests/functional/pv/pv_services/test_pvc_volume_health_annotation.py
@@ -22,10 +22,10 @@ from ocs_ci.framework import config
 from ocs_ci.helpers.helpers import (
     assert_pvc_volume_health_event,
     blocklist_cephfs_client,
-    count_pvc_volume_health_events,
     remove_cephfs_client_blocklist,
     modify_deployment_replica_count,
 )
+from ocs_ci.ocs.resources.events import count_pvc_volume_health_events
 from ocs_ci.ocs import constants, ocp, node
 from ocs_ci.ocs.resources import pod
 from ocs_ci.ocs.resources.csi_addons import (
@@ -46,8 +46,6 @@ RECOVERY_POLL_TIMEOUT = 300
 @tier1
 @green_squad
 @skipif_mcg_only
-@skipif_managed_service
-@skipif_rosa_hcp
 @skipif_external_mode
 @skipif_ocs_version("<4.23")
 @pytest.mark.parametrize(
@@ -249,9 +247,6 @@ class TestPVCVolumeHealthAnnotation(ManageTest):
 @green_squad
 @skipif_ocs_version("<4.23")
 @skipif_mcg_only
-@skipif_managed_service
-@skipif_rosa_hcp
-@skipif_external_mode
 class TestPVCVolumeHealthUnhealthy(ManageTest):
     """
     Test PVC volume health annotation transitions to unhealthy state
@@ -403,6 +398,9 @@ class TestPVCVolumeHealthUnhealthy(ManageTest):
         logger.info("PVC health unhealthy via ceph blocklist test passed")
 
     @tier2
+    @skipif_managed_service
+    @skipif_rosa_hcp
+    @skipif_external_mode
     @pytest.mark.polarion_id("OCS-8261")
     def test_pvc_health_unhealthy_via_mds_scaledown(
         self, pvc_factory, pod_factory, request

--- a/tests/functional/pv/pv_services/test_pvc_volume_health_annotation.py
+++ b/tests/functional/pv/pv_services/test_pvc_volume_health_annotation.py
@@ -477,7 +477,20 @@ class TestPVCVolumeHealthUnhealthy(ManageTest):
         for node_name in pod_node_names:
             uid = ocp.OCP(kind="node", resource_name=node_name).get()["metadata"]["uid"]
             key = f"{constants.VOLUME_HEALTH_ANNOTATION_PREFIX}{uid}"
-            healthy_since[key] = json.loads(health_annotations[key]).get("since", "")
+            logger.assertion(
+                f"Healthy annotation key present for node {node_name} (uid={uid})"
+            )
+            assert key in health_annotations, (
+                f"No volume health annotation for node {node_name} (key {key}). "
+                f"Present keys: {list(health_annotations.keys())}"
+            )
+            parsed = json.loads(health_annotations[key])
+            since = parsed.get("since")
+            logger.assertion(
+                f"'since' field present for annotation key {key}: actual={since}"
+            )
+            assert since, f"Annotation {key} has no 'since' field: {parsed}"
+            healthy_since[key] = since
         logger.info(f"Healthy 'since' snapshot: {healthy_since}")
 
         logger.test_step("Scale down both MDS deployments (a & b) to 0 replicas")
@@ -489,13 +502,18 @@ class TestPVCVolumeHealthUnhealthy(ManageTest):
         def finalizer():
             logger.info("Finalizer: restore both MDS deployments to 1")
             for dep in mds_deployments:
-                modify_deployment_replica_count(dep, 1)
+                assert modify_deployment_replica_count(
+                    dep, 1
+                ), f"Failed to restore deployment {dep} to 1 replica"
             ceph_health_check(tries=20, delay=30)
 
         request.addfinalizer(finalizer)
 
         for dep in mds_deployments:
-            modify_deployment_replica_count(dep, 0)
+            logger.assertion(f"Deployment {dep} scaled to 0 replicas")
+            assert modify_deployment_replica_count(
+                dep, 0
+            ), f"Failed to scale deployment {dep} to 0 replicas"
             logger.info(f"Scaled deployment {dep} to 0")
 
         logger.test_step(
@@ -554,6 +572,20 @@ class TestPVCVolumeHealthUnhealthy(ManageTest):
                 f"PVC {pvc_obj.name} within {ANNOTATION_POLL_TIMEOUT}s"
             )
 
+        logger.test_step("Capture pre-recovery healthy event count")
+        pre_recovery_healthy_count = len(
+            assert_pvc_volume_health_event(
+                pvc_obj,
+                reason="VolumeConditionHealthy",
+                event_type="Normal",
+                message_substr="volume is in a healthy condition",
+            )
+        )
+        logger.info(
+            f"Pre-recovery VolumeConditionHealthy event count: "
+            f"{pre_recovery_healthy_count}"
+        )
+
         logger.test_step("Restore both MDS deployments to 1 replica")
         for dep in mds_deployments:
             modify_deployment_replica_count(dep, 1)
@@ -567,11 +599,35 @@ class TestPVCVolumeHealthUnhealthy(ManageTest):
             expected_count=2,
         )
 
-        logger.test_step("Assert VolumeConditionHealthy Normal event")
-        assert_pvc_volume_health_event(
-            pvc_obj,
-            reason="VolumeConditionHealthy",
-            event_type="Normal",
-            message_substr="volume is in a healthy condition",
+        logger.test_step(
+            "Poll for a new VolumeConditionHealthy event after recovery "
+            "(event count must increase)"
         )
+
+        def new_healthy_event():
+            return (
+                len(
+                    assert_pvc_volume_health_event(
+                        pvc_obj,
+                        reason="VolumeConditionHealthy",
+                        event_type="Normal",
+                        message_substr="volume is in a healthy condition",
+                    )
+                )
+                > pre_recovery_healthy_count
+            )
+
+        try:
+            for is_new in TimeoutSampler(
+                timeout=RECOVERY_POLL_TIMEOUT,
+                sleep=ANNOTATION_POLL_INTERVAL,
+                func=new_healthy_event,
+            ):
+                if is_new:
+                    break
+        except TimeoutExpiredError:
+            pytest.fail(
+                "No new VolumeConditionHealthy event for "
+                f"PVC {pvc_obj.name} within {RECOVERY_POLL_TIMEOUT}s"
+            )
         logger.info("PVC health unhealthy via MDS scale-down test passed")

--- a/tests/functional/pv/pv_services/test_pvc_volume_health_annotation.py
+++ b/tests/functional/pv/pv_services/test_pvc_volume_health_annotation.py
@@ -23,6 +23,7 @@ from ocs_ci.framework import config
 from ocs_ci.helpers.helpers import (
     assert_pvc_volume_health_event,
     blocklist_cephfs_client,
+    count_pvc_volume_health_events,
     remove_cephfs_client_blocklist,
     modify_deployment_replica_count,
 )
@@ -304,6 +305,7 @@ class TestPVCVolumeHealthUnhealthy(ManageTest):
         """
         plugin_pods = pod.get_plugin_pods(constants.CEPHFILESYSTEM)
         targets = set(node_names)
+        restarted = []
         for plugin_pod in plugin_pods:
             plugin_node = plugin_pod.get()["spec"]["nodeName"]
             if plugin_node in targets:
@@ -312,6 +314,15 @@ class TestPVCVolumeHealthUnhealthy(ManageTest):
                     f"on node {plugin_node} to force the health-check probe"
                 )
                 plugin_pod.delete(wait=True)
+                restarted.append(plugin_node)
+        logger.assertion(
+            f"CephFS nodeplugin pods restarted on nodes: "
+            f"expected={sorted(targets)}, actual={sorted(restarted)}"
+        )
+        assert set(restarted) == targets, (
+            f"No CephFS nodeplugin pod found on nodes: "
+            f"{sorted(targets - set(restarted))}"
+        )
 
     @tier1
     @pytest.mark.polarion_id("OCS-8228")
@@ -501,11 +512,17 @@ class TestPVCVolumeHealthUnhealthy(ManageTest):
 
         def finalizer():
             logger.info("Finalizer: restore both MDS deployments to 1")
+            failed = []
             for dep in mds_deployments:
-                assert modify_deployment_replica_count(
-                    dep, 1
-                ), f"Failed to restore deployment {dep} to 1 replica"
+                if not modify_deployment_replica_count(dep, 1):
+                    logger.error(f"Failed to restore deployment {dep} to 1 replica")
+                    failed.append(dep)
+                else:
+                    logger.info(f"Restored deployment {dep} to 1 replica")
             ceph_health_check(tries=20, delay=30)
+            assert (
+                not failed
+            ), f"Failed to restore MDS deployments to 1 replica: {failed}"
 
         request.addfinalizer(finalizer)
 
@@ -573,13 +590,11 @@ class TestPVCVolumeHealthUnhealthy(ManageTest):
             )
 
         logger.test_step("Capture pre-recovery healthy event count")
-        pre_recovery_healthy_count = len(
-            assert_pvc_volume_health_event(
-                pvc_obj,
-                reason="VolumeConditionHealthy",
-                event_type="Normal",
-                message_substr="volume is in a healthy condition",
-            )
+        pre_recovery_healthy_count = count_pvc_volume_health_events(
+            pvc_obj,
+            reason="VolumeConditionHealthy",
+            event_type="Normal",
+            message_substr="volume is in a healthy condition",
         )
         logger.info(
             f"Pre-recovery VolumeConditionHealthy event count: "
@@ -606,13 +621,11 @@ class TestPVCVolumeHealthUnhealthy(ManageTest):
 
         def new_healthy_event():
             return (
-                len(
-                    assert_pvc_volume_health_event(
-                        pvc_obj,
-                        reason="VolumeConditionHealthy",
-                        event_type="Normal",
-                        message_substr="volume is in a healthy condition",
-                    )
+                count_pvc_volume_health_events(
+                    pvc_obj,
+                    reason="VolumeConditionHealthy",
+                    event_type="Normal",
+                    message_substr="volume is in a healthy condition",
                 )
                 > pre_recovery_healthy_count
             )

--- a/tests/functional/pv/pv_services/test_pvc_volume_health_annotation.py
+++ b/tests/functional/pv/pv_services/test_pvc_volume_health_annotation.py
@@ -12,7 +12,6 @@ import pytest
 from ocs_ci.framework.pytest_customization.marks import (
     green_squad,
     skipif_ocs_version,
-    jira,
     skipif_mcg_only,
     skipif_managed_service,
     skipif_rosa_hcp,
@@ -51,7 +50,6 @@ RECOVERY_POLL_TIMEOUT = 300
 @skipif_rosa_hcp
 @skipif_external_mode
 @skipif_ocs_version("<4.23")
-@jira("DFBUGS-9421", run=False)
 @pytest.mark.parametrize(
     argnames=["interface"],
     argvalues=[
@@ -254,7 +252,6 @@ class TestPVCVolumeHealthAnnotation(ManageTest):
 @skipif_managed_service
 @skipif_rosa_hcp
 @skipif_external_mode
-@jira("DFBUGS-9421", run=False)
 class TestPVCVolumeHealthUnhealthy(ManageTest):
     """
     Test PVC volume health annotation transitions to unhealthy state

--- a/tests/functional/pv/pv_services/test_pvc_volume_health_annotation.py
+++ b/tests/functional/pv/pv_services/test_pvc_volume_health_annotation.py
@@ -589,7 +589,7 @@ class TestPVCVolumeHealthUnhealthy(ManageTest):
             pvc_obj,
             reason="VolumeConditionHealthy",
             event_type="Normal",
-            message_substr="volume is in a healthy condition",
+            message_substring="volume is in a healthy condition",
         )
         logger.info(
             f"Pre-recovery VolumeConditionHealthy event count: "
@@ -620,7 +620,7 @@ class TestPVCVolumeHealthUnhealthy(ManageTest):
                     pvc_obj,
                     reason="VolumeConditionHealthy",
                     event_type="Normal",
-                    message_substr="volume is in a healthy condition",
+                    message_substring="volume is in a healthy condition",
                 )
                 > pre_recovery_healthy_count
             )

--- a/tests/functional/pv/pv_services/test_pvc_volume_health_annotation.py
+++ b/tests/functional/pv/pv_services/test_pvc_volume_health_annotation.py
@@ -589,7 +589,7 @@ class TestPVCVolumeHealthUnhealthy(ManageTest):
             pvc_obj,
             reason="VolumeConditionHealthy",
             event_type="Normal",
-            message_substring="volume is in a healthy condition",
+            message_substr="volume is in a healthy condition",
         )
         logger.info(
             f"Pre-recovery VolumeConditionHealthy event count: "
@@ -620,7 +620,7 @@ class TestPVCVolumeHealthUnhealthy(ManageTest):
                     pvc_obj,
                     reason="VolumeConditionHealthy",
                     event_type="Normal",
-                    message_substring="volume is in a healthy condition",
+                    message_substr="volume is in a healthy condition",
                 )
                 > pre_recovery_healthy_count
             )


### PR DESCRIPTION
Add test case to verify PVC health annotation transition in case mds is down and up as part of feature [RHSTOR-7596](https://redhat.atlassian.net/browse/RHSTOR-7596)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for PVC volume health annotations during CephFS metadata service outages and recovery.
  * Added validation for healthy and unhealthy per-node states, warning events, and recovery events.
  * Added scenarios covering node plugin restarts and CephFS metadata service scale-down and restoration.

* **Improvements**
  * Enhanced event validation for PVC volume health notifications, including filtering by event reason, type, and message content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->