### PR TITLE
Skip CephBlockPool replica 2/3 params on stretch clusters

### DIFF
--- a/tests/functional/storageclass/test_cross_sc_clone_snap_restore.py
+++ b/tests/functional/storageclass/test_cross_sc_clone_snap_restore.py
@@ -2,7 +2,11 @@ import pytest
 import logging
 from ocs_ci.helpers import helpers
 from ocs_ci.ocs import constants
-from ocs_ci.framework.pytest_customization.marks import green_squad, ec_allowed
+from ocs_ci.framework.pytest_customization.marks import (
+    green_squad,
+    ec_allowed,
+    skipif_stretch_cluster,
+)
 from ocs_ci.ocs.cluster import is_ec_pool_supported
 from ocs_ci.framework.testlib import (
     ManageTest,
@@ -179,13 +183,47 @@ class TestCrossScCloneSnapRestore(ManageTest):
             "sc1_erasure_coded",
         ],
         argvalues=[
-            pytest.param(*[constants.CEPHBLOCKPOOL], "", "", False, False, False),
+            # Stretch/arbiter requires CephBlockPool replica size 4. These
+            # params create size 2/3 (or default 3) pools via new_rbd_pool.
+            pytest.param(
+                *[constants.CEPHBLOCKPOOL],
+                "",
+                "",
+                False,
+                False,
+                False,
+                marks=skipif_stretch_cluster,
+            ),
             pytest.param(*[constants.CEPHFILESYSTEM], "", "", False, False, False),
-            pytest.param(*[constants.CEPHBLOCKPOOL], "", "", True, False, False),
+            pytest.param(
+                *[constants.CEPHBLOCKPOOL],
+                "",
+                "",
+                True,
+                False,
+                False,
+                marks=skipif_stretch_cluster,
+            ),
             pytest.param(*[constants.CEPHFILESYSTEM], "", "", True, False, False),
-            pytest.param(*[constants.CEPHBLOCKPOOL], 3, 2, False, False, False),
+            pytest.param(
+                *[constants.CEPHBLOCKPOOL],
+                3,
+                2,
+                False,
+                False,
+                False,
+                marks=skipif_stretch_cluster,
+            ),
             pytest.param(*[constants.CEPHFILESYSTEM], 3, 2, False, False, False),
-            pytest.param(*[constants.CEPHBLOCKPOOL], 2, 3, False, False, False),
+            pytest.param(
+                *[constants.CEPHBLOCKPOOL],
+                2,
+                3,
+                False,
+                False,
+                False,
+                marks=skipif_stretch_cluster,
+            ),
             pytest.param(*[constants.CEPHFILESYSTEM], 2, 3, False, False, False),
             # SC1=replicated, SC2=EC
             pytest.param(
@@ -196,6 +234,7 @@ class TestCrossScCloneSnapRestore(ManageTest):
                 True,
                 False,
                 marks=[
+                    skipif_stretch_cluster,
                     ec_allowed,
                     pytest.mark.polarion_id("OCS-7966"),
                     pytest.mark.skipif(
@@ -212,6 +251,7 @@ class TestCrossScCloneSnapRestore(ManageTest):
                 True,
                 False,
                 marks=[
+                    skipif_stretch_cluster,
                     ec_allowed,
                     pytest.mark.polarion_id("OCS-7967"),
                     pytest.mark.skipif(
@@ -228,6 +268,7 @@ class TestCrossScCloneSnapRestore(ManageTest):
                 True,
                 False,
                 marks=[
+                    skipif_stretch_cluster,
                     ec_allowed,
                     pytest.mark.polarion_id("OCS-7968"),
                     pytest.mark.skipif(
@@ -245,6 +286,7 @@ class TestCrossScCloneSnapRestore(ManageTest):
                 False,
                 True,
                 marks=[
+                    skipif_stretch_cluster,
                     ec_allowed,
                     pytest.mark.polarion_id("OCS-7969"),
                     pytest.mark.skipif(
@@ -261,6 +303,7 @@ class TestCrossScCloneSnapRestore(ManageTest):
                 False,
                 True,
                 marks=[
+                    skipif_stretch_cluster,
                     ec_allowed,
                     pytest.mark.polarion_id("OCS-7970"),
                     pytest.mark.skipif(


### PR DESCRIPTION
## Summary
- Rook on arbiter/stretch clusters requires custom `CephBlockPool` replica size 4 and rejects size 2/3 (`pools in a stretch cluster must have replication size 4`).
- `test_cross_class_different_pool_clone_snap_restore` CephBlockPool params create those invalid pools via `new_rbd_pool=True`, so they fail in setup instead of testing cross-SC clone/restore.
- Mark those CephBlockPool params with `skipif_stretch_cluster`. CephFS params are unchanged.

## Test plan
- [ ] On a stretch/arbiter cluster, CephBlockPool params of `test_cross_class_different_pool_clone_snap_restore` are skipped at collection
- [ ] On a standard replica-3 cluster, the same params still run
- [ ] CephFS params of this test still collect and run on stretch


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Updated cross-storage-class clone, snapshot, and restore test coverage to skip unsupported scenarios on stretch or arbiter clusters.
  - Documented the requirement for replica size 4 on these cluster configurations; replica sizes 2 and 3, as well as unsupported default configurations, are rejected.
  - Preserved coverage for supported CephFS scenarios while applying the appropriate exclusions to CephBlockPool scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->