### PR TITLE
[release-4.16] Cherry-pick PR #14281 - Support path extraction from tarball must-gather logs

### DIFF
--- a/ocs_ci/ocs/must_gather/must_gather.py
+++ b/ocs_ci/ocs/must_gather/must_gather.py
@@ -268,15 +268,54 @@ class MustGather(object):
                 logger.error("noobaa_diagnostics.tar.gz does not exist")
                 self.files_not_exist.append("noobaa_diagnostics.tar.gz")
 
-    def get_all_paths(self):
+    def _get_paths_from_tarball(self, tarball_path):
         """
-        Get all paths in must gather dir
+        Collect all member paths from a must-gather tar.gz archive.
+
+        Args:
+            tarball_path (str): path to the .tar.gz file
+
+        Returns:
+            list: paths of all members (files and dirs) in the archive
 
         """
-        for root, dirs, files in os.walk(self.root):
+        paths = []
+        try:
+            with tarfile.open(tarball_path, "r:*") as tar:
+                for member in tar.getmembers():
+                    # Add the member path (files and dirs)
+                    paths.append(member.name)
+                    # Ensure parent directory paths are included for substring
+                    # matching in verify_paths_in_dir / verify_paths_not_in_dir
+                    parts = member.name.replace("\\", "/").split("/")
+                    for i in range(1, len(parts)):
+                        parent = "/".join(parts[:i])
+                        if parent and parent not in paths:
+                            paths.append(parent)
+        except (tarfile.TarError, OSError) as e:
+            logger.warning(f"Could not read tarball {tarball_path}: {e}")
+        return paths
+
+    def get_all_paths(self):
+        """
+        Get all paths in must gather dir (directory and/or tar.gz archives).
+
+        When REPORTING["tarball_mg_logs"] is used, must-gather may be packed
+        into a .tar.gz; this method collects paths from both directory trees
+        and from inside such tarballs.
+
+        """
+        self.full_paths = []
+
+        for root_dir, dirs, files in os.walk(self.root):
             for name in files + dirs:
-                full_path = os.path.join(root, name)
+                full_path = os.path.join(root_dir, name)
                 self.full_paths.append(full_path)
+            # Collect paths from must-gather tarballs found under root
+            for name in files:
+                if name.endswith(".tar.gz"):
+                    tarball_path = os.path.join(root_dir, name)
+                    self.full_paths.extend(self._get_paths_from_tarball(tarball_path))
 
     def verify_paths_in_dir(self, paths):
         """


### PR DESCRIPTION
## Summary
This PR cherry-picks commit `69d3155f1` (PR #14281) from `master` to `release-4.16`.

- Added `_get_paths_from_tarball()` method to collect all member paths from a must-gather `.tar.gz` archive
- Updated `get_all_paths()` to extract and read paths from `.tar.gz` must-gather archives
- Enabled path retrieval when the original must-gather directory has been removed due to the `tarball_mg_logs` configuration

## Business Impact
This ensures that path discovery continues to function correctly for archived must-gather logs and maintains compatibility with environments where original must-gather directories are deleted after tarball creation.

Fixes: https://github.com/red-hat-storage/ocs-ci/issues/14276

## Validation
- Cherry-pick applied cleanly (no conflicts)
- All pre-commit hooks passed (black, flake8, trailing whitespace, end-of-file)

## Test plan
- [ ] Verify `_get_paths_from_tarball()` correctly extracts paths from `.tar.gz` archives
- [ ] Verify `get_all_paths()` handles both directory trees and tarball archives
- [ ] Run `test_must_gather.py` functional tests against a cluster
