### PR TITLE
Cherry-pick #14374 to release-4.19: Fixes 13645: test enhancement to resolve flakyness

### DIFF
--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -675,6 +675,14 @@ MGR_APP_LABEL = "app=rook-ceph-mgr"
 OSD_APP_LABEL = "app=rook-ceph-osd"
 OSD_PREPARE_APP_LABEL = "app=rook-ceph-osd-prepare"
 RGW_APP_LABEL = "app=rook-ceph-rgw"
+# Map performance profile component name to pod label selector for Ceph daemons
+CEPH_DAEMON_LABEL_BY_COMPONENT = {
+    "mgr": MGR_APP_LABEL,
+    "mon": MON_APP_LABEL,
+    "osd": OSD_APP_LABEL,
+    "mds": MDS_APP_LABEL,
+    "rgw": RGW_APP_LABEL,
+}
 EXPORTER_APP_LABEL = "app=rook-ceph-exporter"
 OPERATOR_LABEL = "app=rook-ceph-operator"
 ODF_CONSOLE = "app=odf-console"

--- a/tests/functional/z_cluster/test_performance_profile_validation.py
+++ b/tests/functional/z_cluster/test_performance_profile_validation.py
@@ -88,7 +88,7 @@ class TestProfileDefaultValuesCheck(ManageTest):
             # Wait up to 600 seconds for performance changes to reflect
             sample = TimeoutSampler(
                 timeout=600,
-                sleep=300,
+                sleep=60,
                 func=verify_performance_profile_change,
                 perf_profile=self.perf_profile,
             )
@@ -129,32 +129,108 @@ class TestProfileDefaultValuesCheck(ManageTest):
 
         label_selector = list(expected_cpu_limit_values.keys())
 
+        def _all_pods_match_profile():
+            """Return True only when all Ceph daemon pods have expected resources."""
+
+            for label in label_selector:
+                pod_label = constants.CEPH_DAEMON_LABEL_BY_COMPONENT[label]
+                pods = get_pods_having_label(
+                    label=pod_label, namespace=config.ENV_DATA["cluster_namespace"]
+                )
+                if not pods:
+                    log.info(f"No pods yet for {label} (selector {pod_label})")
+                    return False
+                ocp_pod = OCP(
+                    namespace=config.ENV_DATA["cluster_namespace"], kind="pod"
+                )
+                for pod in pods:
+                    name = pod["metadata"]["name"]
+                    try:
+                        resource_dict = ocp_pod.get(resource_name=name)["spec"][
+                            "containers"
+                        ][0]["resources"]
+                    except (KeyError, TypeError):
+                        return False
+                    for key in ("limits", "requests"):
+                        if key not in resource_dict:
+                            return False
+                    if (
+                        resource_dict["limits"].get("cpu")
+                        != expected_cpu_limit_values[label]
+                        or resource_dict["limits"].get("memory")
+                        != expected_memory_limit_values[label]
+                        or resource_dict["requests"].get("cpu")
+                        != expected_cpu_request_values[label]
+                        or resource_dict["requests"].get("memory")
+                        != expected_memory_request_values[label]
+                    ):
+                        log.info(
+                            f"Pod {name} ({label}) resources not yet updated: "
+                            f"limits={resource_dict.get('limits')}, "
+                            f"requests={resource_dict.get('requests')}"
+                        )
+                        return False
+            return True
+
+        # Wait for operator to roll out daemon pods with new profile (up to 600s).
+        # verify_performance_profile_change only checks StorageCluster spec; pod
+        # resources can lag until deployments are updated and pods recreated.
+        sample = TimeoutSampler(
+            timeout=600,
+            sleep=30,
+            func=_all_pods_match_profile,
+        )
+        if not sample.wait_for_func_status(True):
+            log.warning(
+                f"Pod resources did not match {self.perf_profile} profile within timeout"
+            )
+        ocp_pod = OCP(namespace=config.ENV_DATA["cluster_namespace"], kind="pod")
+        mismatches = []
         for label in label_selector:
+            pod_label = constants.CEPH_DAEMON_LABEL_BY_COMPONENT[label]
             for pod in get_pods_having_label(
-                label=label, namespace=config.ENV_DATA["cluster_namespace"]
+                label=pod_label, namespace=config.ENV_DATA["cluster_namespace"]
             ):
                 pv_pod_obj.append(Pod(**pod))
                 podd = Pod(**pod)
-                log.info(f"Verifying memory and cpu values for pod {podd.name}")
+                log.info(
+                    f"Verifying memory and cpu values for pod {podd.name} ({label})"
+                )
                 log.info(f"RequestCPU{expected_cpu_request_values}")
                 log.info(f"LimitCPU{expected_cpu_limit_values}")
                 log.info(f"RequestMEM{expected_memory_request_values}")
                 log.info(f"LimitMEM{expected_memory_limit_values}")
-                resource_dict = OCP(
-                    namespace=config.ENV_DATA["cluster_namespace"], kind="pod"
-                ).get(resource_name=podd.name)["spec"]["containers"][0]["resources"]
+                resource_dict = ocp_pod.get(resource_name=podd.name)["spec"][
+                    "containers"
+                ][0]["resources"]
                 log.info(
                     f"CPU request and limit values for pod {podd.name} are {resource_dict}"
                 )
-                assert (
-                    resource_dict["limits"]["cpu"] == expected_cpu_limit_values[label]
-                    and resource_dict["limits"]["memory"]
-                    == expected_memory_limit_values[label]
-                    and resource_dict["requests"]["cpu"]
-                    == expected_cpu_request_values[label]
-                    and resource_dict["requests"]["memory"]
-                    == expected_memory_request_values[label]
-                ), f"Resource values arent reflecting actual values for {label} pod "
+                actual_cpu_limit = resource_dict.get("limits", {}).get("cpu")
+                actual_mem_limit = resource_dict.get("limits", {}).get("memory")
+                actual_cpu_req = resource_dict.get("requests", {}).get("cpu")
+                actual_mem_req = resource_dict.get("requests", {}).get("memory")
+                expected_cpu_limit = expected_cpu_limit_values[label]
+                expected_mem_limit = expected_memory_limit_values[label]
+                expected_cpu_req = expected_cpu_request_values[label]
+                expected_mem_req = expected_memory_request_values[label]
+                if (
+                    actual_cpu_limit != expected_cpu_limit
+                    or actual_mem_limit != expected_mem_limit
+                    or actual_cpu_req != expected_cpu_req
+                    or actual_mem_req != expected_mem_req
+                ):
+                    mismatches.append(
+                        f"{label} pod {podd.name}: limits cpu {actual_cpu_limit!r} (expected {expected_cpu_limit!r}),"
+                        f"limits memory {actual_mem_limit!r} (expected {expected_mem_limit!r}), "
+                        f"requests cpu {actual_cpu_req!r} (expected {expected_cpu_req!r}), "
+                        f"requests memory {actual_mem_req!r} (expected {expected_mem_req!r})"
+                    )
+        if mismatches:
+            assert False, (
+                "Resource values are not reflecting actual values for one or more pods:\n"
+                + "\n".join(mismatches)
+            )
         log.info("All the memory and CPU values are matching in the profile")
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
Cherry-pick of #14374 to release-4.19

- Reformats `test_validate_cluster_resource_profile` to collect all mismatches before asserting, giving a full failure report in one go
- Adds polling (every 60s) for pod resources to match expected profile after StorageCluster spec update
- Fixes inconsistent test failures

Fixes: #13645