### PR TITLE
Cherry-pick #14374 to release-4.20: Fixes 13645: test enhancement to resolve flakyness

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,1311 @@
+{
+  "exclude": {
+    "files": "^.secrets.baseline$",
+    "lines": null
+  },
+  "plugins_used": [
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "base64_limit": 4.5,
+      "name": "Base64HighEntropyString"
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "BoxDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "ghe_instance": "github.ibm.com",
+      "name": "GheDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "hex_limit": 3,
+      "name": "HexHighEntropyString"
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "keyword_exclude": null,
+      "name": "KeywordDetector"
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "results": {
+    "conf/deployment/ibmcloud/ibm_cloud_managed_3az_0m_3w_vpc_cluster.yaml": [
+      {
+        "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 25,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster.yaml": [
+      {
+        "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 23,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_hpcs_external.yaml": [
+      {
+        "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 25,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_stage.yaml": [
+      {
+        "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 22,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_without_cos.yaml": [
+      {
+        "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 21,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_without_cos_stage.yaml": [
+      {
+        "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 23,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_zone_eu_de_1.yaml": [
+      {
+        "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 23,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_zone_eu_de_2.yaml": [
+      {
+        "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 23,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_zone_eu_de_3.yaml": [
+      {
+        "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 23,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_zone_jp_tok_1.yaml": [
+      {
+        "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 23,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_zone_jp_tok_2.yaml": [
+      {
+        "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 23,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_zone_jp_tok_3.yaml": [
+      {
+        "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 23,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_zone_us_east_1.yaml": [
+      {
+        "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 23,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_zone_us_east_2.yaml": [
+      {
+        "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 23,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "conf/deployment/ibmcloud/ibm_cloud_vpc_cluster_zone_us_east_3.yaml": [
+      {
+        "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 23,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "conf/deployment/ibmcloud/ipi_1az_us_east1_rhcos_3m_3w.yaml": [
+      {
+        "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 25,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "conf/deployment/ibmcloud/ipi_1az_us_east1_rhcos_custom_vpc_3m_3w.yaml": [
+      {
+        "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 28,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "conf/deployment/ibmcloud/ipi_1az_us_east2_rhcos_3m_3w.yaml": [
+      {
+        "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 25,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "conf/deployment/ibmcloud/ipi_1az_us_east3_rhcos_3m_3w.yaml": [
+      {
+        "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 25,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "conf/deployment/ibmcloud/ipi_1az_us_south1_rhcos_custom_vpc_3m_3w.yaml": [
+      {
+        "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 28,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "conf/deployment/ibmcloud/ipi_3az_rhcos_3m_3w.yaml": [
+      {
+        "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 29,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "conf/deployment/ibmcloud/ipi_3az_rhcos_3m_6w.yaml": [
+      {
+        "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 30,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "conf/deployment/ibmcloud/ipi_3az_rhcos_compactmode_3m_0w.yaml": [
+      {
+        "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 29,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "conf/deployment/ibmcloud/ipi_3az_rhcos_lowerreq_3m_3w.yaml": [
+      {
+        "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 29,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "conf/deployment/rhv/ipi_1az_rhcos_3m_3w.yaml": [
+      {
+        "hashed_secret": "ff55435345834a3fe224936776c2aa15f6ed5358",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 21,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "conf/deployment/rhv/ipi_1az_rhcos_lso_3m_3w.yaml": [
+      {
+        "hashed_secret": "ff55435345834a3fe224936776c2aa15f6ed5358",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 30,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "conf/deployment/vsphere/upi_1az_rhcos_vsan_3m_3w_disconnected_flexy.yaml": [
+      {
+        "hashed_secret": "66a1db0d75c1b2302b441a31b75b4d5a9f291d22",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 21,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "conf/deployment/vsphere/upi_1az_rhcos_vsan_lso_vmdk_3m_3w_disconnected_flexy.yaml": [
+      {
+        "hashed_secret": "66a1db0d75c1b2302b441a31b75b4d5a9f291d22",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 24,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "conf/examples/hpcs_external_standalone_mode.yaml": [
+      {
+        "hashed_secret": "fc4a8593743fd8a94fce1b137d964432bb1a9e91",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 13,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "conf/ocsci/disconnected_cluster.yaml.example": [
+      {
+        "hashed_secret": "1dee91010328c9606757a6ddb538d608b6d89d1c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 6,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 9,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "conf/ocsci/dr_workload.yaml": [
+      {
+        "hashed_secret": "3bb712fd293d3816c7c111dffc96dffc5c873602",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 294,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "conf/ocsci/hpcs_external_standalone_mode.yaml": [
+      {
+        "hashed_secret": "fc4a8593743fd8a94fce1b137d964432bb1a9e91",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 12,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "conf/ocsci/mdr_workload.yaml": [
+      {
+        "hashed_secret": "3bb712fd293d3816c7c111dffc96dffc5c873602",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 119,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "conf/ocsci/noobaa_external_pgsql.yaml": [
+      {
+        "hashed_secret": "6cb6eb9fabad447f4ec9965879927661143bdfed",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 12,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "conf/ocsci/openshift_dedicated.yaml": [
+      {
+        "hashed_secret": "66b2fcbc520c25a8087712aa85e95516a2b6c79b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 14,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "conf/ocsci/vsphere_upi_vars.yaml.example": [
+      {
+        "hashed_secret": "e894b36b7cdd92461cad391cf01f52c9e53c41ad",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 26,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "conf/ocsci/vsphere_upi_vars.yaml.skeleton": [
+      {
+        "hashed_secret": "d63f8d34ad75f338f5b42b331e2fd883576a29bd",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 10,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "e894b36b7cdd92461cad391cf01f52c9e53c41ad",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 27,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "docs/getting_started.md": [
+      {
+        "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 174,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "docs/supported_platforms.md": [
+      {
+        "hashed_secret": "6eae3a5b062c6d0d79f070c26e6d62486b40cb46",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 30,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d3ac7a4ef1a838b4134f2f6e7f3c0d249d74b674",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 171,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "docs/usage.md": [
+      {
+        "hashed_secret": "89a519cc7786f3290ad671412d92f325f9ef2a57",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 98,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "cfcafdd35cb253bd1a95060758e671abe510920a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 347,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "ocs_ci/deployment/aws.py": [
+      {
+        "hashed_secret": "134f379c01b1cf36e5ee172c37ffeca5c679a5ee",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 802,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "ocs_ci/deployment/flexy.py": [
+      {
+        "hashed_secret": "bea1af2a15561a266eda3472673d24cb4f2020d4",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 241,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "ocs_ci/deployment/hub_spoke.py": [
+      {
+        "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2319,
+        "type": "Private Key",
+        "verified_result": null
+      }
+    ],
+    "ocs_ci/framework/conf/default_config.yaml": [
+      {
+        "hashed_secret": "613fb9979a1ab677719426dd2e81a60fad637cf2",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 28,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "eea97d7f2f305e7afdc0b9bf64859b660cd09232",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 31,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 325,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "de19c40310ad831a71524cd279e6f5f0577fb09a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 370,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "ocs_ci/helpers/cluster_exp_helpers.py": [
+      {
+        "hashed_secret": "fa3798e69b10954419dfdcf70da00dce77b1416e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 57,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "ocs_ci/helpers/helpers.py": [
+      {
+        "hashed_secret": "66a36e77fd002579809717841f998f4d21cd5913",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2812,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "ocs_ci/krkn_chaos/template/krkn_global_config.yaml.j2": [
+      {
+        "hashed_secret": "d2e2ab0f407e4ee3cf2ab87d61c31b25a74085e5",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 50,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "ocs_ci/ocs/clients.py": [
+      {
+        "hashed_secret": "a8c1dc105c415cc7ccb286ecdb1156ebd9f957fb",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 14,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "ocs_ci/ocs/constants.py": [
+      {
+        "hashed_secret": "b7e9a6e2e04ed3edbf8b4e21def4beccbb6eb6b1",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 229,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a12337323b638ab044b1166bff4b1a1f83162819",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 823,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "fb947972c92f052c0a08866d182be0075a2b601b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 832,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "03e227627ab8681281fdb8aa3d799b03f782d672",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1988,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ef5f3d909f23bd0aa02b4253f98350384f709c86",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2094,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "cb1ae2b504c4615841d8144267a131231d2bd677",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2095,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "1a1e70e87dd0452c42f33ce9bf74aa28134dba6b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2096,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "7b1ba2f04f2f1604dc4e3caffcadf9fcbce7df5b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2097,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "0fa3b21ced80146d752888f2b60ec80e0d4b8925",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2102,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f084f2068494b8d1cd06811dd97d02c3d85f40ee",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2117,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "adfa401a3b0a733d8f00519ac8c6b3893a2e7e8e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2118,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "898e46bbadc12f87120548bd445eb4210c8407c8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2126,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f57ccec6b8f7b12b635ab53d26c3bf7300247341",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2127,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "77b044ea736f8cbe568d1954424186d901f89db9",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2128,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d64368f12ca17c69568c6a132f17d44d56e60660",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2129,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "8f9ca35156c02cb6ba58c5b51230b9bedc38de4f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2130,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ee977806d7286510da8b9a7492ba58e2484c0ecc",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2861,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "adc1f5c8707f7d7aba3aabe13c15e5ef1151872e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2862,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ee46262b2df945e46ea310b925ad087465dbd3f2",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 3583,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f678cad4ab874d71b559a069d5e34a95fe38a480",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 3584,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "ocs_ci/ocs/defaults.py": [
+      {
+        "hashed_secret": "ca4dbbee191f1e04318439e30e4e9f55134e4513",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 123,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "9125b9994805d74d9545e381b9d5a90e65e2d63e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 124,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "637138e061a7c9dc22f301dfcf7a43b638a2e1d8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 125,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "ocs_ci/ocs/external_ceph.py": [
+      {
+        "hashed_secret": "d2137e76c2c4f75fe37e8c0a03670d3715849389",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 473,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "30274c47903bd1bac7633bbf09743149ebab805f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 474,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "ocs_ci/ocs/fusion.py": [
+      {
+        "hashed_secret": "6eae3a5b062c6d0d79f070c26e6d62486b40cb46",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 97,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "ocs_ci/ocs/platform_nodes.py": [
+      {
+        "hashed_secret": "134f379c01b1cf36e5ee172c37ffeca5c679a5ee",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1262,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "ocs_ci/ocs/resources/ocsconfigmaps.py": [
+      {
+        "hashed_secret": "347cd9c53ff77d41a7b22aa56c7b4efaf54658e3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 404,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "ocs_ci/ocs/utils.py": [
+      {
+        "hashed_secret": "f2dde9105675b76e1f542230a642933ccffd8a8e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 329,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "8f57c0c672ec244816d827f57ea488c2d609efc9",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 641,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "30274c47903bd1bac7633bbf09743149ebab805f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 642,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "ocs_ci/templates/CSI/rbd/csi-kms-connection-details.yaml": [
+      {
+        "hashed_secret": "214d02537c8b2382bd599e97b100b78d1f9614aa",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 4,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "ocs_ci/templates/ocs-deployment/external-pgsql-noobaa-secret.yaml": [
+      {
+        "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 9,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "ocs_ci/templates/ocs-deployment/multicluster/odr_s3_secret.yaml": [
+      {
+        "hashed_secret": "d3045fb7f8faed786bb7694d7d4ca06e357eea24",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 5,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "ocs_ci/templates/openshift-infra/hpcs/ibm-kp-kms-secret.yaml": [
+      {
+        "hashed_secret": "021b53ce46b72837170446bee4e579c4801bc67a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 8,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "ocs_ci/templates/workloads/couchbase/server/couchbase-worker-secret.yaml": [
+      {
+        "hashed_secret": "7cf7ed86e8f660ade5996a1072d74cd35def47af",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 9,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "ocs_ci/templates/workloads/couchbase/server/couchbase-worker.yaml": [
+      {
+        "hashed_secret": "8d6478f5d35b469b1568d41c393b3e08d30e7a2e",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 27,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "ocs_ci/templates/workloads/hsbench/hsbench_obj.yaml": [
+      {
+        "hashed_secret": "7a9a4af7de5c6536e46cbee0856f11b46cdde7c9",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 5,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "ocs_ci/templates/workloads/quay/quay_registry.yaml": [
+      {
+        "hashed_secret": "83f7cd4240b0182d4e26f6f5aa845d3d29e4adfb",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 7,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "ocs_ci/utility/managedservice.py": [
+      {
+        "hashed_secret": "6eae3a5b062c6d0d79f070c26e6d62486b40cb46",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 95,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "be4fc4886bd949b369d5e092eb87494f12e57e5b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 169,
+        "type": "Private Key",
+        "verified_result": null
+      }
+    ],
+    "ocs_ci/utility/rosa.py": [
+      {
+        "hashed_secret": "6eae3a5b062c6d0d79f070c26e6d62486b40cb46",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 686,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "ocs_ci/utility/storage_cluster_setup.py": [
+      {
+        "hashed_secret": "f0e2d8610edefa0c02b673dcac7964b02ce3e890",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 607,
+        "type": "Basic Auth Credentials",
+        "verified_result": null
+      }
+    ],
+    "terraform/ai/vsphere/terraform.tfvars.example": [
+      {
+        "hashed_secret": "42a818da3bb789755a56f06412ebba442bf41edf",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 12,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/cross_functional/kcs/test_noobaadb_pw_reset.py": [
+      {
+        "hashed_secret": "95b0665e64fa24c375f1db3797739dc833a01be1",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 87,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "tests/functional/ui/test_alert_text.py": [
+      {
+        "hashed_secret": "deed437581abf6a8a8c3f908a00739ec66bd1907",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 25,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d3c7cf8a52f042f5ad10e7e04c6efa9b3edfc091",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 26,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "0e47f8d47cf71626c411322d5cc46463bb9ee63a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 27,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "def6a0eb64808cbdf3e3985b380d06019ccaf15c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 28,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "1eb02d1de1c583c352016b765c4470f14688c27f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 29,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "beb03c56370648a8018847b7eb6f0ff17e2ec17d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 30,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c8a3e4b73af4fc164a18209fa3248cace0376de6",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 31,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "3b793d3c8f6140791030db45900185a24bc0f8d6",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 32,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "5e10a523088617ee53c02a050ecb4f3c02ff36a6",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 33,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "67cec59154e2b4dbc161ab590ea9836833a03879",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 34,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a7051bbf0cbb04fbd58fea9202861924cf476965",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 35,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "711167a9e39213a023177fb6f8726eed4ae87724",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 36,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "62f46554adcad52e1b59156746059e8fe2b68114",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 37,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "6b6660ec37abef577585e08fbadd66a1daa126ad",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 38,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ba9fdcab8f3a1c05e545c90657adeeca92457819",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 39,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d92508b7e8714361d780028189182ccc838905fd",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 40,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "5d831603558fae694509e52443867d9d0fe15dab",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 41,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "70444c50c0b30525a518f749e570c2b5ab2ea159",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 42,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b3a6d9ed97f183a3ed70fe50f8f5a1ab84eccfb5",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 43,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d94d7c9ec8c812df775f85cf53d44fe0dacb153c",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 44,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "7fbab5f66d94793e754adf5eec572dd69895add7",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 45,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d5164d922808f83e1bb2fb7ef4ae43a8fdc2d63a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 46,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "474e5f07c32a4837e6685a64fb86c3b80ed14ef5",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 47,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "aee98b1d4cdc9ea965426edfff3e89413d648f28",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 48,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "cb44fa15b838b5bd5bb7cf855c8b65b83575b049",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 49,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "bfcb7bd33a4d476579e23a6ab6bef8270fd359a6",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 50,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "9109e09e3881791c6e7245a3e4dc3e9dd23305ec",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 51,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "44ac318f0525c62193986773a822397d9cd65220",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 52,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a34ddb5f6561f1c681ea9d6369f2bf5ea5435bbf",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 53,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a0f8bc5793f4cc0b1173b8e65c824e80bba32ec3",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 54,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "11b02033ace8079c90a25fe5dfef319b19363e56",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 55,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c3bce19887dde7c21edbcc997f70e2d9b67a7845",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 56,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "918b8462281c3884363c68bd466e90e34bcb7b4f",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 57,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "5d279aca1022ec52d2f595199e74490d75bf3940",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 58,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "8308b864c9c12f694be52639f16fc312929c268a",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 61,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "64d5413c9629cf6c976224d145450a839f213b96",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 62,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ]
+  },
+  "version": "0.13.1+ibm.64.dss",
+  "word_list": {
+    "file": null,
+    "hash": null
+  }
+}

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -704,6 +704,14 @@ MGR_APP_LABEL = "app=rook-ceph-mgr"
 OSD_APP_LABEL = "app=rook-ceph-osd"
 OSD_PREPARE_APP_LABEL = "app=rook-ceph-osd-prepare"
 RGW_APP_LABEL = "app=rook-ceph-rgw"
+# Map performance profile component name to pod label selector for Ceph daemons
+CEPH_DAEMON_LABEL_BY_COMPONENT = {
+    "mgr": MGR_APP_LABEL,
+    "mon": MON_APP_LABEL,
+    "osd": OSD_APP_LABEL,
+    "mds": MDS_APP_LABEL,
+    "rgw": RGW_APP_LABEL,
+}
 EXPORTER_APP_LABEL = "app=rook-ceph-exporter"
 OPERATOR_LABEL = "app=rook-ceph-operator"
 ODF_CONSOLE = "app=odf-console"

--- a/tests/functional/z_cluster/test_performance_profile_validation.py
+++ b/tests/functional/z_cluster/test_performance_profile_validation.py
@@ -88,7 +88,7 @@ class TestProfileDefaultValuesCheck(ManageTest):
             # Wait up to 600 seconds for performance changes to reflect
             sample = TimeoutSampler(
                 timeout=600,
-                sleep=300,
+                sleep=60,
                 func=verify_performance_profile_change,
                 perf_profile=self.perf_profile,
             )
@@ -129,32 +129,108 @@ class TestProfileDefaultValuesCheck(ManageTest):
 
         label_selector = list(expected_cpu_limit_values.keys())
 
+        def _all_pods_match_profile():
+            """Return True only when all Ceph daemon pods have expected resources."""
+
+            for label in label_selector:
+                pod_label = constants.CEPH_DAEMON_LABEL_BY_COMPONENT[label]
+                pods = get_pods_having_label(
+                    label=pod_label, namespace=config.ENV_DATA["cluster_namespace"]
+                )
+                if not pods:
+                    log.info(f"No pods yet for {label} (selector {pod_label})")
+                    return False
+                ocp_pod = OCP(
+                    namespace=config.ENV_DATA["cluster_namespace"], kind="pod"
+                )
+                for pod in pods:
+                    name = pod["metadata"]["name"]
+                    try:
+                        resource_dict = ocp_pod.get(resource_name=name)["spec"][
+                            "containers"
+                        ][0]["resources"]
+                    except (KeyError, TypeError):
+                        return False
+                    for key in ("limits", "requests"):
+                        if key not in resource_dict:
+                            return False
+                    if (
+                        resource_dict["limits"].get("cpu")
+                        != expected_cpu_limit_values[label]
+                        or resource_dict["limits"].get("memory")
+                        != expected_memory_limit_values[label]
+                        or resource_dict["requests"].get("cpu")
+                        != expected_cpu_request_values[label]
+                        or resource_dict["requests"].get("memory")
+                        != expected_memory_request_values[label]
+                    ):
+                        log.info(
+                            f"Pod {name} ({label}) resources not yet updated: "
+                            f"limits={resource_dict.get('limits')}, "
+                            f"requests={resource_dict.get('requests')}"
+                        )
+                        return False
+            return True
+
+        # Wait for operator to roll out daemon pods with new profile (up to 600s).
+        # verify_performance_profile_change only checks StorageCluster spec; pod
+        # resources can lag until deployments are updated and pods recreated.
+        sample = TimeoutSampler(
+            timeout=600,
+            sleep=30,
+            func=_all_pods_match_profile,
+        )
+        if not sample.wait_for_func_status(True):
+            log.warning(
+                f"Pod resources did not match {self.perf_profile} profile within timeout"
+            )
+        ocp_pod = OCP(namespace=config.ENV_DATA["cluster_namespace"], kind="pod")
+        mismatches = []
         for label in label_selector:
+            pod_label = constants.CEPH_DAEMON_LABEL_BY_COMPONENT[label]
             for pod in get_pods_having_label(
-                label=label, namespace=config.ENV_DATA["cluster_namespace"]
+                label=pod_label, namespace=config.ENV_DATA["cluster_namespace"]
             ):
                 pv_pod_obj.append(Pod(**pod))
                 podd = Pod(**pod)
-                log.info(f"Verifying memory and cpu values for pod {podd.name}")
+                log.info(
+                    f"Verifying memory and cpu values for pod {podd.name} ({label})"
+                )
                 log.info(f"RequestCPU{expected_cpu_request_values}")
                 log.info(f"LimitCPU{expected_cpu_limit_values}")
                 log.info(f"RequestMEM{expected_memory_request_values}")
                 log.info(f"LimitMEM{expected_memory_limit_values}")
-                resource_dict = OCP(
-                    namespace=config.ENV_DATA["cluster_namespace"], kind="pod"
-                ).get(resource_name=podd.name)["spec"]["containers"][0]["resources"]
+                resource_dict = ocp_pod.get(resource_name=podd.name)["spec"][
+                    "containers"
+                ][0]["resources"]
                 log.info(
                     f"CPU request and limit values for pod {podd.name} are {resource_dict}"
                 )
-                assert (
-                    resource_dict["limits"]["cpu"] == expected_cpu_limit_values[label]
-                    and resource_dict["limits"]["memory"]
-                    == expected_memory_limit_values[label]
-                    and resource_dict["requests"]["cpu"]
-                    == expected_cpu_request_values[label]
-                    and resource_dict["requests"]["memory"]
-                    == expected_memory_request_values[label]
-                ), f"Resource values arent reflecting actual values for {label} pod "
+                actual_cpu_limit = resource_dict.get("limits", {}).get("cpu")
+                actual_mem_limit = resource_dict.get("limits", {}).get("memory")
+                actual_cpu_req = resource_dict.get("requests", {}).get("cpu")
+                actual_mem_req = resource_dict.get("requests", {}).get("memory")
+                expected_cpu_limit = expected_cpu_limit_values[label]
+                expected_mem_limit = expected_memory_limit_values[label]
+                expected_cpu_req = expected_cpu_request_values[label]
+                expected_mem_req = expected_memory_request_values[label]
+                if (
+                    actual_cpu_limit != expected_cpu_limit
+                    or actual_mem_limit != expected_mem_limit
+                    or actual_cpu_req != expected_cpu_req
+                    or actual_mem_req != expected_mem_req
+                ):
+                    mismatches.append(
+                        f"{label} pod {podd.name}: limits cpu {actual_cpu_limit!r} (expected {expected_cpu_limit!r}),"
+                        f"limits memory {actual_mem_limit!r} (expected {expected_mem_limit!r}), "
+                        f"requests cpu {actual_cpu_req!r} (expected {expected_cpu_req!r}), "
+                        f"requests memory {actual_mem_req!r} (expected {expected_mem_req!r})"
+                    )
+        if mismatches:
+            assert False, (
+                "Resource values are not reflecting actual values for one or more pods:\n"
+                + "\n".join(mismatches)
+            )
         log.info("All the memory and CPU values are matching in the profile")
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
Cherry-pick of #14374 to release-4.20

- Reformats `test_validate_cluster_resource_profile` to collect all mismatches before asserting, giving a full failure report in one go
- Adds polling (every 60s) for pod resources to match expected profile after StorageCluster spec update
- Fixes inconsistent test failures

Fixes: #13645
