### PR TITLE
ROSA HCP EC2 confident removal

### DIFF
--- a/ocs_ci/deployment/rosa.py
+++ b/ocs_ci/deployment/rosa.py
@@ -20,13 +20,19 @@ from ocs_ci.framework import config
 from ocs_ci.framework.logger_helper import log_step
 from ocs_ci.ocs.resources.pod import get_operator_pods
 from ocs_ci.utility import openshift_dedicated as ocm, rosa
-from ocs_ci.utility.aws import AWS as AWSUtil, delete_sts_iam_roles, delete_subnet_tags
+from ocs_ci.utility.aws import (
+    AWS as AWSUtil,
+    delete_sts_iam_roles,
+    delete_subnet_tags,
+    terminate_rosa_hcp_worker_instances,
+)
 from ocs_ci.utility.deployment import (
     create_openshift_install_log_file,
     deploy_roks_icsp_daemonset,
 )
 from ocs_ci.utility.rosa import (
     get_associated_oidc_config_id,
+    get_rosa_hcp_infra_id,
     delete_account_roles,
     wait_console_url,
     destroy_rosa_cluster,
@@ -168,8 +174,10 @@ class ROSAOCP(BaseOCPDeployment):
                 raise
             if rosa_hcp:
                 subnet_ids = rosa.get_rosa_hcp_subnet_ids()
+                infra_id = get_rosa_hcp_infra_id(self.cluster_name)
             else:
                 subnet_ids = aws.get_cluster_subnet_ids(cluster_name=self.cluster_name)
+                infra_id = ""
             oidc_endpoint_url = None
             if rosa_hcp:
                 try:
@@ -201,6 +209,8 @@ class ROSAOCP(BaseOCPDeployment):
                 err_msg = f"Failed to delete {self.cluster_name}"
                 logger.error(err_msg)
                 raise TimeoutExpiredError(err_msg)
+            if rosa_hcp and infra_id:
+                terminate_rosa_hcp_worker_instances(infra_id)
             log_step("Deleting ROSA/aws associated resources")
             oproles_prefix = (
                 f"{constants.OPERATOR_ROLE_PREFIX_ROSA_HCP}-{self.cluster_name}"
@@ -249,7 +259,7 @@ class ROSAOCP(BaseOCPDeployment):
         cluster_list = ocm.list_cluster()
         for cluster in cluster_list:
             if cluster[0] == self.cluster_name:
-                logger.info(f"Cluster found: {cluster[0]}")
+                logger.info(f"Cluster found: {cluster[0]}, state: {cluster[1]}")
                 return True
         return False
 

--- a/ocs_ci/utility/aws.py
+++ b/ocs_ci/utility/aws.py
@@ -2776,6 +2776,67 @@ def terminate_rhel_workers(worker_list):
         raise exceptions.FailedToDeleteInstance()
 
 
+def terminate_rosa_hcp_worker_instances(infra_id):
+    """
+    Safety-net: find and terminate EC2 worker instances still tagged with the
+    ROSA HCP cluster infra_id after OCM reports the cluster gone.
+
+    With best_effort=true, OCM may declare deletion complete even when the
+    CAPI NodePool controller failed to terminate worker instances. This function
+    provides an explicit cleanup step to prevent orphaned EC2 instances.
+
+    Args:
+        infra_id (str): The cluster infrastructure name (e.g. 'j041arh13t1')
+    """
+    if not infra_id:
+        logger.warning("No infra_id provided, skipping EC2 worker cleanup")
+        return
+    aws = AWS()
+    filters = [
+        {
+            "Name": f"tag:kubernetes.io/cluster/{infra_id}",
+            "Values": ["owned"],
+        },
+        {
+            "Name": "instance-state-name",
+            "Values": ["pending", "running", "stopping", "stopped"],
+        },
+    ]
+    response = aws.ec2_client.describe_instances(Filters=filters)
+    instance_ids = [
+        inst["InstanceId"]
+        for reservation in response["Reservations"]
+        for inst in reservation["Instances"]
+    ]
+    if not instance_ids:
+        logger.info(f"No leftover EC2 instances found for cluster {infra_id}")
+        return
+    logger.info(
+        f"Terminating {len(instance_ids)} leftover EC2 worker instance(s) "
+        f"for cluster {infra_id}: {instance_ids}"
+    )
+    aws.ec2_client.terminate_instances(InstanceIds=instance_ids)
+    try:
+        waiter = aws.ec2_client.get_waiter("instance_terminated")
+        waiter.wait(
+            InstanceIds=instance_ids,
+            WaiterConfig={"Delay": 15, "MaxAttempts": 40},
+        )
+    except Exception as e:
+        logger.warning(f"EC2 termination waiter failed for {infra_id}: {e}")
+
+    remaining = aws.ec2_client.describe_instances(Filters=filters)
+    remaining_ids = [
+        inst["InstanceId"]
+        for reservation in remaining["Reservations"]
+        for inst in reservation["Instances"]
+    ]
+    assert (
+        not remaining_ids
+    ), f"EC2 instances for cluster {infra_id} were not terminated: {remaining_ids}"
+    logger.info(f"All EC2 instances for cluster {infra_id} terminated successfully")
+
+
 def destroy_volumes(cluster_name):
     """
     Destroy cluster volumes

--- a/ocs_ci/utility/openshift_dedicated.py
+++ b/ocs_ci/utility/openshift_dedicated.py
@@ -80,10 +80,7 @@ def download_ocm_cli():
     Returns:
         str: path to the installer
     """
-    force_download = (
-        config.RUN["cli_params"].get("deploy")
-        and config.DEPLOYMENT["force_download_ocm_cli"]
-    )
+    force_download = config.DEPLOYMENT["force_download_ocm_cli"]
     return utils.get_ocm_cli(
         config.DEPLOYMENT["ocm_cli_version"], force_download=force_download
     )

--- a/ocs_ci/utility/rosa.py
+++ b/ocs_ci/utility/rosa.py
@@ -709,10 +709,7 @@ def download_rosa_cli():
         str: path to the installer
 
     """
-    force_download = (
-        config.RUN["cli_params"].get("deploy")
-        and config.DEPLOYMENT["force_download_rosa_cli"]
-    )
+    force_download = config.DEPLOYMENT["force_download_rosa_cli"]
     return utils.get_rosa_cli(
         config.DEPLOYMENT["rosa_cli_version"], force_download=force_download
     )
@@ -1183,6 +1180,41 @@ def wait_console_url(cluster_name, timeout=600, sleep=10):
         if console_url and "https" in console_url:
             logger.info(f"Console URL: {console_url}")
             return console_url
+
+
+def get_rosa_hcp_infra_id(cluster_name):
+    """
+    Get the infrastructure name (infra_id) of a ROSA HCP cluster.
+    Must be called while the cluster API is still reachable.
+
+    Args:
+        cluster_name (str): The cluster name
+
+    Returns:
+        str: The infra_id (e.g. 'j041arh13t1'), or "" if unavailable
+    """
+    try:
+        infra_id = ocp.OCP().exec_oc_cmd(
+            "get infrastructure cluster " "-o jsonpath='{.status.infrastructureName}'"
+        )
+        if infra_id:
+            logger.info(f"Pre-fetched infra_id from cluster: {infra_id}")
+            return str(infra_id).strip()
+    except Exception as e:
+        logger.warning(f"Could not fetch infra_id from live cluster: {e}")
+
+    cmd = (
+        f"rosa describe cluster --cluster {cluster_name} -o json "
+        "| jq -r '.infra_id // \"\"'"
+    )
+    proc = utils.exec_cmd(cmd, shell=True)
+    if proc.returncode == 0:
+        infra_id = proc.stdout.decode().strip()
+        if infra_id:
+            logger.info(f"Pre-fetched infra_id from rosa CLI: {infra_id}")
+            return infra_id
+    logger.warning(f"Could not determine infra_id for cluster {cluster_name}")
+    return ""
 
 
 def get_associated_oidc_config_id(cluster_name):


### PR DESCRIPTION
This PR is designed to improve EC2 instances removal, in case if `rosa/ocm delete cluster` command has failed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - ROSA HCP cluster cleanup now terminates leftover worker instances after uninstalling a cluster.
  - Improved detection of ROSA HCP infrastructure details, including fallback handling when information is unavailable.
  - Cluster status is now included in relevant cleanup logging.

- **Improvements**
  - Force-download settings for the OCM and ROSA command-line tools now apply consistently, without requiring an additional deployment option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->