### PR TITLE
[release-4.16] Exclude CatalogSource pods from status check (#14542)

### DIFF
--- a/ocs_ci/ocs/resources/pod.py
+++ b/ocs_ci/ocs/resources/pod.py
@@ -2376,6 +2376,9 @@ def check_pods_in_running_state(
     )
     for p in list_of_pods:
         # we don't want to compare osd-prepare and canary pods as they get created freshly when an osd need to be added.
+        # Also skip CatalogSource pods (managed by OLM) — they may be Pending
+        # when nodes are tainted with custom taints that lack matching tolerations
+        # on the CatalogSource resource.
         if (
             "rook-ceph-osd-prepare" not in p.name
             and "rook-ceph-drain-canary" not in p.name
@@ -2386,6 +2389,7 @@ def check_pods_in_running_state(
             and ("rook-ceph-drain-canary" not in p.name)
             and ("debug" not in p.name)
             and (constants.REPORT_STATUS_TO_PROVIDER_POD not in p.name)
+            and not p.get_labels().get("olm.catalogSource")
         ):
             status = ocp_pod_obj.get_resource(p.name, "STATUS")
             if skip_for_status:


### PR DESCRIPTION
## Summary
- Cherry-pick of commit d7d7dcf3c1 from master to release-4.16
- Excludes CatalogSource pods (managed by OLM) from `check_pods_in_running_state` — they may be Pending when nodes are tainted with custom taints that lack matching tolerations on the CatalogSource resource
- Fixes: issues #14541

## Cherry-pick details
- Original PR: #14542
- Original commit: d7d7dcf3c199c916c4bce0cb0187587f20e23ee8
- **Conflict resolution**: the `status-reporter` filter line (added in later releases) does not exist in release-4.16. Resolved by adding only the `olm.catalogSource` label filter after the existing `REPORT_STATUS_TO_PROVIDER_POD` filter

## Test plan
- [ ] Verify CatalogSource pods are excluded from running state checks
- [ ] Verify other pod filters still work correctly