### PR TITLE
retry node platform-type labeling for vSphere UPI

### DIFF
--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -214,6 +214,7 @@ from ocs_ci.utility.utils import (
     get_infra_id,
     apply_oadp_workaround,
     mute_mon_netsplit,
+    label_nodes_platform_type,
 )
 from ocs_ci.utility.vsphere_nodes import update_ntp_compute_nodes
 from ocs_ci.helpers import helpers
@@ -1142,11 +1143,7 @@ class Deployment(object):
             and version.get_semantic_ocp_version_from_config() >= version.VERSION_4_22
         ):
             logger.info("Labeling all nodes with platform-type=vsphere for vSphere UPI")
-            ocp = OCP()
-            ocp.exec_oc_cmd(
-                "label node --all node.openshift.io/platform-type=vsphere"
-                " --overwrite"
-            )
+            label_nodes_platform_type(platform_type="vsphere")
         # configure Ingress Node Firewall and restrict SSH access to nodes
         if config.ENV_DATA.get("restrict_ssh_access_to_nodes", False):
             try:

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -3022,6 +3022,38 @@ def get_cluster_version_info():
     return cluster_version_info
 
 
+@retry(
+    CommandFailed,
+    tries=10,
+    delay=30,
+    backoff=1,
+)
+def label_nodes_platform_type(platform_type="vsphere"):
+    """
+    Label all nodes with the given platform-type.
+
+    Retries the command on failure to handle transient errors (e.g. "infra
+    config cache not synchronized") that can occur shortly after the nodes join
+    the cluster (OCPBUGS-100052).
+
+    Args:
+        platform_type (str): Platform type value to set on the
+            node.openshift.io/platform-type label (default: "vsphere").
+
+    Raises:
+        CommandFailed: If labeling the nodes keeps failing after all retries.
+
+    """
+    # importing here to avoid circular imports
+    from ocs_ci.ocs.ocp import OCP
+
+    ocp = OCP()
+    ocp.exec_oc_cmd(
+        f"label node --all node.openshift.io/platform-type={platform_type}"
+        " --overwrite"
+    )
+
+
 def get_ocs_build_number():
     """
     Gets the build number for ocs operator


### PR DESCRIPTION
Fixes: #16197 

Signed-off-by: vavuthu [vavuthu@redhat.com](mailto:vavuthu@redhat.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when applying platform labels to cluster nodes during vSphere deployments.
  * Added automatic retries to handle temporary synchronization issues, reducing deployment failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->