### PR TITLE
Added automation test for rhstor# 8082

### DIFF
--- a/conf/ocsci/dr_workload.yaml
+++ b/conf/ocsci/dr_workload.yaml
@@ -346,37 +346,6 @@ ENV_DATA:
     }
   ]
 
-  # RHSTOR-8082: VM static IP translation during DR failover/failback
-  dr_cnv_discovered_apps_static_ip: [
-    {
-      name: "vm-static-ip-1", workload_dir: "rdr/cnv-workload/vm-pvc/vm-static-ip/vm-workload-1",
-      pod_count: 1, pvc_count: 1,
-      dr_workload_app_pod_selector_key: "appname",
-      dr_workload_app_pod_selector_value: "kubevirt",
-      dr_workload_app_pvc_selector_key: "appname",
-      dr_workload_app_pvc_selector_value: "kubevirt",
-      workload_namespace: "cnv-static-ip-1",
-      dr_workload_app_placement_name: "cnv-static-ip-1",
-      vm_name: "vm-static-ip-workload-1",
-      vm_secret: "vm-secret-1", vm_username: "cirros",
-    }
-  ]
-
-  dr_cnv_discovered_apps_static_ip_shared: [
-    {
-      name: "vm-static-ip-2", workload_dir: "rdr/cnv-workload/vm-pvc/vm-static-ip/vm-workload-2",
-      pod_count: 1, pvc_count: 1,
-      dr_workload_app_pod_selector_key: "appname",
-      dr_workload_app_pod_selector_value: "kubevirt",
-      dr_workload_app_pvc_selector_key: "appname",
-      dr_workload_app_pvc_selector_value: "kubevirt",
-      workload_namespace: "cnv-static-ip-1",
-      dr_workload_app_placement_name: "cnv-static-ip-1",
-      vm_name: "vm-static-ip-workload-2",
-      vm_secret: "vm-secret-1", vm_username: "cirros",
-    }
-  ]
-
   dr_workload_discovered_apps_filebrowser_rbd: [
     { name: "filebrowser-dict-1-rbd", workload_dir: "rdr/file-browser/rbd/workloads/app-filebrowser-1/",
       pod_count: 2, pvc_count: 1,

--- a/conf/ocsci/dr_workload.yaml
+++ b/conf/ocsci/dr_workload.yaml
@@ -346,6 +346,37 @@ ENV_DATA:
     }
   ]
 
+  # RHSTOR-8082: VM static IP translation during DR failover/failback
+  dr_cnv_discovered_apps_static_ip: [
+    {
+      name: "vm-static-ip-1", workload_dir: "rdr/cnv-workload/vm-pvc/vm-static-ip/vm-workload-1",
+      pod_count: 1, pvc_count: 1,
+      dr_workload_app_pod_selector_key: "appname",
+      dr_workload_app_pod_selector_value: "kubevirt",
+      dr_workload_app_pvc_selector_key: "appname",
+      dr_workload_app_pvc_selector_value: "kubevirt",
+      workload_namespace: "cnv-static-ip-1",
+      dr_workload_app_placement_name: "cnv-static-ip-1",
+      vm_name: "vm-static-ip-workload-1",
+      vm_secret: "vm-secret-1", vm_username: "cirros",
+    }
+  ]
+
+  dr_cnv_discovered_apps_static_ip_shared: [
+    {
+      name: "vm-static-ip-2", workload_dir: "rdr/cnv-workload/vm-pvc/vm-static-ip/vm-workload-2",
+      pod_count: 1, pvc_count: 1,
+      dr_workload_app_pod_selector_key: "appname",
+      dr_workload_app_pod_selector_value: "kubevirt",
+      dr_workload_app_pvc_selector_key: "appname",
+      dr_workload_app_pvc_selector_value: "kubevirt",
+      workload_namespace: "cnv-static-ip-1",
+      dr_workload_app_placement_name: "cnv-static-ip-1",
+      vm_name: "vm-static-ip-workload-2",
+      vm_secret: "vm-secret-1", vm_username: "cirros",
+    }
+  ]
+
   dr_workload_discovered_apps_filebrowser_rbd: [
     { name: "filebrowser-dict-1-rbd", workload_dir: "rdr/file-browser/rbd/workloads/app-filebrowser-1/",
       pod_count: 2, pvc_count: 1,

--- a/conf/ocsci/dr_workload.yaml
+++ b/conf/ocsci/dr_workload.yaml
@@ -346,6 +346,40 @@ ENV_DATA:
     }
   ]
 
+  # RHSTOR-8082: VM static IP translation during DR failover/failback.
+  # workload_namespace MUST match constants.VM_IP_TRANSLATION_WORKLOAD_NS - the
+  # setup_udn_nad fixture creates that namespace (labeled for a primary UDN)
+  # along with the "vm-network" UserDefinedNetwork the VMs attach to.
+  dr_cnv_discovered_apps_static_ip: [
+    {
+      name: "vm-static-ip-1", workload_dir: "rdr/cnv-workload/vm-pvc/vm-static-ip/vm-workload-1",
+      pod_count: 1, pvc_count: 1,
+      dr_workload_app_pod_selector_key: "appname",
+      dr_workload_app_pod_selector_value: "kubevirt",
+      dr_workload_app_pvc_selector_key: "appname",
+      dr_workload_app_pvc_selector_value: "kubevirt",
+      workload_namespace: "vm-ip-translation-test",
+      dr_workload_app_placement_name: "vm-ip-translation-test",
+      vm_name: "vm-static-ip-workload-1",
+      vm_secret: "vm-secret-1", vm_username: "cirros",
+    }
+  ]
+
+  dr_cnv_discovered_apps_static_ip_shared: [
+    {
+      name: "vm-static-ip-2", workload_dir: "rdr/cnv-workload/vm-pvc/vm-static-ip/vm-workload-2",
+      pod_count: 1, pvc_count: 1,
+      dr_workload_app_pod_selector_key: "appname",
+      dr_workload_app_pod_selector_value: "kubevirt",
+      dr_workload_app_pvc_selector_key: "appname",
+      dr_workload_app_pvc_selector_value: "kubevirt",
+      workload_namespace: "vm-ip-translation-test",
+      dr_workload_app_placement_name: "vm-ip-translation-test",
+      vm_name: "vm-static-ip-workload-2",
+      vm_secret: "vm-secret-1", vm_username: "cirros",
+    }
+  ]
+
   dr_workload_discovered_apps_filebrowser_rbd: [
     { name: "filebrowser-dict-1-rbd", workload_dir: "rdr/file-browser/rbd/workloads/app-filebrowser-1/",
       pod_count: 2, pvc_count: 1,

--- a/ocs_ci/helpers/dr_helpers_ui.py
+++ b/ocs_ci/helpers/dr_helpers_ui.py
@@ -1698,6 +1698,10 @@ def expand_nav_sidebar_if_collapsed(acm_obj, acm_loc):
     collapsed and aria-hidden, which makes every nav item unclickable even
     though it is present in the DOM.
 
+    Only the OCP 5.0 hub console behaves this way, so the locators live in
+    acm_configuration_5_0 and are simply absent on earlier versions - treat
+    that as "nothing to expand" rather than an error.
+
     Args:
         acm_obj (AcmAddClusters): ACM Page Navigator Class
         acm_loc (dict): ACM page locators for the current OCP version
@@ -1706,6 +1710,8 @@ def expand_nav_sidebar_if_collapsed(acm_obj, acm_loc):
         bool: True if the sidebar was collapsed and got expanded, False otherwise
 
     """
+    if "nav-sidebar-collapsed" not in acm_loc:
+        return False
     if not acm_obj.check_element_presence(
         (acm_loc["nav-sidebar-collapsed"][1], acm_loc["nav-sidebar-collapsed"][0]),
         timeout=10,

--- a/ocs_ci/helpers/dr_helpers_ui.py
+++ b/ocs_ci/helpers/dr_helpers_ui.py
@@ -1655,6 +1655,68 @@ def delete_application_ui(acm_obj, workloads_to_delete=[], timeout=70):
         return False
 
 
+def close_modal_dialog_if_present(acm_obj, acm_loc):
+    """
+    Best effort dismissal of the onboarding/help modal that the console pops up
+    on first visit of a page.
+
+    The close button can be present in the DOM but not clickable, for instance
+    when the popover anchor has scrolled out of the viewport and popper hides it
+    ('data-popper-reference-hidden'). Dismissing is optional, so a failure to
+    click must not fail the navigation.
+
+    Args:
+        acm_obj (AcmAddClusters): ACM Page Navigator Class
+        acm_loc (dict): ACM page locators for the current OCP version
+
+    Returns:
+        bool: True if the dialog was found and closed, False otherwise
+
+    """
+    if not acm_obj.check_element_presence(
+        (
+            acm_loc["modal_dialog_close_button"][1],
+            acm_loc["modal_dialog_close_button"][0],
+        ),
+        timeout=10,
+    ):
+        return False
+    log.info("Modal dialog box found, closing it..")
+    try:
+        acm_obj.do_click(acm_loc["modal_dialog_close_button"], timeout=5)
+    except SeleniumTimeoutException:
+        log.info("Modal dialog box is not clickable, it is already hidden, moving on")
+        return False
+    return True
+
+
+def expand_nav_sidebar_if_collapsed(acm_obj, acm_loc):
+    """
+    Expand the console side navigation when it is rendered collapsed.
+
+    Switching to the Fleet Virtualization perspective can leave the sidebar
+    collapsed and aria-hidden, which makes every nav item unclickable even
+    though it is present in the DOM.
+
+    Args:
+        acm_obj (AcmAddClusters): ACM Page Navigator Class
+        acm_loc (dict): ACM page locators for the current OCP version
+
+    Returns:
+        bool: True if the sidebar was collapsed and got expanded, False otherwise
+
+    """
+    if not acm_obj.check_element_presence(
+        (acm_loc["nav-sidebar-collapsed"][1], acm_loc["nav-sidebar-collapsed"][0]),
+        timeout=10,
+    ):
+        return False
+    log.info("Side navigation is collapsed, expanding it")
+    acm_obj.do_click(acm_loc["nav-sidebar-toggle"], enable_screenshot=True)
+    acm_obj.page_has_loaded(retries=5, sleep_time=3)
+    return True
+
+
 def check_or_assign_drpolicy_for_discovered_vms_via_ui(
     acm_obj,
     vms: List[object],
@@ -1686,15 +1748,7 @@ def check_or_assign_drpolicy_for_discovered_vms_via_ui(
 
     """
     acm_loc = locators_for_current_ocp_version()["acm_page"]
-    if acm_obj.check_element_presence(
-        (
-            acm_loc["modal_dialog_close_button"][1],
-            acm_loc["modal_dialog_close_button"][0],
-        ),
-        timeout=10,
-    ):
-        log.info("Modal dialog box found, closing it..")
-        acm_obj.do_click(acm_loc["modal_dialog_close_button"], timeout=5)
+    close_modal_dialog_if_present(acm_obj, acm_loc)
     log.info("Look for 'All Clusters'")
     all_clusters = acm_obj.wait_until_expected_text_is_found(
         acm_loc["all-clusters"], expected_text="All clusters"
@@ -1812,29 +1866,14 @@ def navigate_using_fleet_virtualization(acm_obj):
     acm_obj.do_click(acm_loc["fleet-virtual"])
     acm_obj.page_has_loaded(retries=10, sleep_time=5)
     if compare_versions(f"{acm_version_str} >= 2.16"):
-        if acm_obj.check_element_presence(
-            (
-                acm_loc["modal_dialog_close_button"][1],
-                acm_loc["modal_dialog_close_button"][0],
-            ),
-            timeout=10,
-        ):
-            log.info("Modal dialog box found, closing it..")
-            acm_obj.do_click(acm_loc["modal_dialog_close_button"], timeout=5)
+        close_modal_dialog_if_present(acm_obj, acm_loc)
+    expand_nav_sidebar_if_collapsed(acm_obj, acm_loc)
     log.info("From side nav bar, navigate to VirtualMachines page")
     acm_obj.do_click(acm_loc["nav-bar-vms-page"])
     log.info(
         "Successfully navigate to the VirtualMachines page under Fleet Virtualization"
     )
     if compare_versions(f"{acm_version_str} < 2.16"):
-        if acm_obj.check_element_presence(
-            (
-                acm_loc["modal_dialog_close_button"][1],
-                acm_loc["modal_dialog_close_button"][0],
-            ),
-            timeout=10,
-        ):
-            log.info("Modal dialog box found, closing it..")
-            acm_obj.do_click(acm_loc["modal_dialog_close_button"], timeout=5)
+        close_modal_dialog_if_present(acm_obj, acm_loc)
 
     return True

--- a/ocs_ci/helpers/dr_helpers_ui.py
+++ b/ocs_ci/helpers/dr_helpers_ui.py
@@ -1717,6 +1717,44 @@ def expand_nav_sidebar_if_collapsed(acm_obj, acm_loc):
     return True
 
 
+def ensure_on_fleet_vms_page(acm_obj, acm_loc):
+    """
+    Make sure the console is showing the Fleet Virtualization VMs list page.
+
+    Selecting a VM drills into its detail page, and enrolling it only closes
+    the confirmation modal afterwards - nothing navigates back. So every VM
+    after the first one, and every later call, starts off the list page and
+    cannot select a cluster or namespace. 'All clusters' is only rendered on
+    the list page, so use it as the marker and navigate back when it is absent.
+
+    Args:
+        acm_obj (AcmAddClusters): ACM Page Navigator Class
+        acm_loc (dict): ACM page locators
+
+    Returns:
+        bool: True if the VMs list page is showing, False otherwise
+
+    """
+    close_modal_dialog_if_present(acm_obj, acm_loc)
+    log.info("Look for 'All Clusters'")
+    # Probe with a short timeout and no AI fallback: not being on the list page
+    # is an expected outcome here, not a locator failure.
+    if acm_obj.wait_until_expected_text_is_found(
+        acm_loc["all-clusters"],
+        expected_text="All clusters",
+        timeout=15,
+        use_fallback=False,
+    ):
+        log.info("All Clusters option found")
+        return True
+    log.info("Not on the VMs list page, navigating back to it")
+    navigate_using_fleet_virtualization(acm_obj)
+    close_modal_dialog_if_present(acm_obj, acm_loc)
+    return acm_obj.wait_until_expected_text_is_found(
+        acm_loc["all-clusters"], expected_text="All clusters"
+    )
+
+
 def check_or_assign_drpolicy_for_discovered_vms_via_ui(
     acm_obj,
     vms: List[object],
@@ -1748,17 +1786,10 @@ def check_or_assign_drpolicy_for_discovered_vms_via_ui(
 
     """
     acm_loc = locators_for_current_ocp_version()["acm_page"]
-    close_modal_dialog_if_present(acm_obj, acm_loc)
-    log.info("Look for 'All Clusters'")
-    all_clusters = acm_obj.wait_until_expected_text_is_found(
-        acm_loc["all-clusters"], expected_text="All clusters"
-    )
-    if all_clusters:
-        log.info("All Clusters option found")
-    else:
-        log.warning("'All Clusters' not found on the VMs page")
-        return False
     for vm in vms:
+        if not ensure_on_fleet_vms_page(acm_obj, acm_loc):
+            log.warning("'All Clusters' not found on the VMs page")
+            return False
         log.info("Select the cluster where VM workload is running")
         acm_obj.do_click(
             format_locator(acm_loc["managed-cluster-name"], managed_cluster_name)

--- a/ocs_ci/helpers/dr_helpers_vm_ip_translation.py
+++ b/ocs_ci/helpers/dr_helpers_vm_ip_translation.py
@@ -21,7 +21,10 @@ API schema confirmed from manual testing on ammahapa-21a RDR (Aug 2026):
   - VRG condition: NetworkMappingLoaded=True once mapping is active
 """
 
+import json
 import logging
+import os
+import shutil
 import tempfile
 
 import pytest
@@ -74,6 +77,15 @@ DRCLUSTERCONFIG_NAD_STATUS_FIELD = "networkAttachments"
 # UDN and NAD names used across IP translation tests
 VM_NETWORK_UDN_NAME = "vm-network"
 VM_NETWORK_NAD_NAME = "vm-network"
+
+# VM interface name on the Primary UDN. The IPAMClaim is named
+# <vm-name>.<interface-name>, so this must match the interface_name passed to
+# get_ipamclaim_ip / get_vm_ip_from_vmi (kept equal to the NAD name).
+VM_NETWORK_INTERFACE_NAME = VM_NETWORK_NAD_NAME
+
+# Host octet appended to the primary cluster subnet prefix to pin the VM's
+# static IP (e.g. subnet 192.168.1.0/24 -> static IP 192.168.1.11).
+VM_STATIC_IP_HOST_OCTET = "11"
 
 
 # ---------------------------------------------------------------------------
@@ -263,6 +275,95 @@ def get_vm_ip_from_vmi(cluster_name, namespace, vm_name, interface_name=None):
                 return iface.get("ipAddress", "")
         return ""
     return interfaces[0].get("ipAddress", "") if interfaces else ""
+
+
+def static_ip_from_subnet(subnet, host_octet=VM_STATIC_IP_HOST_OCTET):
+    """
+    Build a static IP in the given subnet by replacing the last octet.
+
+    Args:
+        subnet (str): CIDR subnet, e.g. "192.168.1.0/24"
+        host_octet (str): host octet to pin, e.g. "11"
+
+    Returns:
+        str: static IP address, e.g. "192.168.1.11"
+    """
+    network_prefix = subnet.split("/")[0].rsplit(".", 1)[0]
+    return f"{network_prefix}.{host_octet}"
+
+
+def prepare_static_ip_vm_manifest(
+    source_workload_dir,
+    static_ip,
+    interface_name=VM_NETWORK_INTERFACE_NAME,
+):
+    """
+    Copy an existing CNV workload directory to a temp location and patch its
+    VirtualMachine manifest for static IP translation testing (RHSTOR-8082),
+    without modifying the original regression workload files.
+
+    The patched VM is wired onto the namespace's Primary UDN:
+      - single interface named ``interface_name`` with bridge binding, backed by
+        the pod network (a Primary UDN replaces the default pod network)
+      - annotation ``network.kubevirt.io/addresses`` pinning ``static_ip`` on that
+        interface, so OVN-K8s IPAM allocates the requested address and creates an
+        IPAMClaim named ``<vm-name>.<interface_name>``
+
+    Args:
+        source_workload_dir (str): absolute path to the cloned workload directory
+            (kustomize dir containing the VM manifest)
+        static_ip (str): static IP to pin on the primary cluster, e.g. "192.168.1.11"
+        interface_name (str): VM interface name (kept equal to the NAD name so the
+            IPAMClaim name matches get_ipamclaim_ip lookups)
+
+    Returns:
+        str: absolute path to the temp directory holding the patched manifests
+    """
+    temp_dir = tempfile.mkdtemp(prefix="static-ip-vm-")
+    # Copy the whole kustomize dir so `oc create -k` still finds kustomization.yaml
+    shutil.copytree(source_workload_dir, temp_dir, dirs_exist_ok=True)
+
+    patched_vm = False
+    for root, _, files in os.walk(temp_dir):
+        for fname in files:
+            if not fname.endswith((".yaml", ".yml")):
+                continue
+            fpath = os.path.join(root, fname)
+            with open(fpath) as f:
+                docs = list(yaml.safe_load_all(f))
+
+            changed = False
+            for doc in docs:
+                if not doc or doc.get("kind") != "VirtualMachine":
+                    continue
+                template = doc.setdefault("spec", {}).setdefault("template", {})
+                # Pin the static IP via annotation on the VM template
+                annotations = template.setdefault("metadata", {}).setdefault(
+                    "annotations", {}
+                )
+                annotations["network.kubevirt.io/addresses"] = json.dumps(
+                    {interface_name: [static_ip]}
+                )
+                # Wire the single interface onto the Primary UDN (pod network)
+                domain = template.setdefault("spec", {}).setdefault("domain", {})
+                domain.setdefault("devices", {})["interfaces"] = [
+                    {"name": interface_name, "bridge": {}}
+                ]
+                template["spec"]["networks"] = [{"name": interface_name, "pod": {}}]
+                changed = True
+                patched_vm = True
+
+            if changed:
+                with open(fpath, "w") as f:
+                    yaml.safe_dump_all(docs, f, default_flow_style=False)
+                logger.info(f"Patched VM manifest for static IP {static_ip}: {fpath}")
+
+    if not patched_vm:
+        raise ValueError(
+            f"No VirtualMachine manifest found under {source_workload_dir} to patch "
+            "for static IP translation"
+        )
+    return temp_dir
 
 
 def wait_for_drpolicy_network_peers(drpolicy_name, timeout=120):

--- a/ocs_ci/helpers/dr_helpers_vm_ip_translation.py
+++ b/ocs_ci/helpers/dr_helpers_vm_ip_translation.py
@@ -1,0 +1,378 @@
+"""
+Helper functions, fixtures, and constants for RHSTOR-8082 VM IP Translation
+DR tests.
+
+Provides utilities for managing network mapping ConfigMaps, polling DRPolicy
+network mapping status, reading IPAMClaim IP addresses, and pytest fixtures
+for setting up UDN/NAD prerequisites.
+
+NOTE: Several constants reference DRPolicy/VRG/DRClusterConfig status field
+names that are not yet finalized. These are marked with TODO comments.
+Update once the developer confirms the API schema (RHSTOR-8082 open questions).
+"""
+
+import logging
+import tempfile
+
+import pytest
+import yaml
+
+from ocs_ci.framework import config
+from ocs_ci.helpers import dr_helpers
+from ocs_ci.ocs import constants, ocp
+from ocs_ci.utility import templating
+from ocs_ci.utility.utils import TimeoutSampler, exec_cmd
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Feature constants
+# TODO: Update field names below once the developer confirms the API schema.
+# ---------------------------------------------------------------------------
+
+# Namespace for the network mapping ConfigMap (hub cluster)
+VM_IP_TRANSLATION_NS = constants.OPENSHIFT_DR_SYSTEM_NAMESPACE
+
+# ConfigMap data keys — TODO: confirm with developer
+CM_KEY_PATTERN_MAPPINGS = "patternMappings"
+CM_KEY_EXPLICIT_MAPPINGS = "explicitMappings"
+CM_KEY_ENABLED = "enabled"
+
+# DRPolicy status path for network mapping — TODO: confirm with developer
+DRPOLICY_NM_FIELD = "networkMapping"
+DRPOLICY_NM_STATUS_VALID = "Valid"
+DRPOLICY_NM_STATUS_INVALID = "Invalid"
+DRPOLICY_NM_METHOD_PATTERN = "pattern"
+DRPOLICY_NM_METHOD_EXPLICIT = "explicit"
+DRPOLICY_NM_METHOD_PATTERN_OVERRIDES = "pattern-with-overrides"
+
+# DRPolicy NADs synced condition — TODO: confirm with developer
+DRPOLICY_NADS_SYNCED_CONDITION = "NADsSynced"
+
+# VRG condition name for IP translation — TODO: confirm with developer
+VRG_CONDITION_NM_LOADED = "NetworkMappingLoaded"
+
+# NAD label required for Ramen network discovery
+NAD_DR_LABEL = "ramendr.openshift.io/network-id"
+
+# DRClusterConfig status field listing discovered NADs — TODO: confirm
+DRCLUSTERCONFIG_NAD_STATUS_FIELD = "networkAttachments"
+
+# UDN and NAD names used across IP translation tests
+VM_NETWORK_UDN_NAME = "vm-network"
+VM_NETWORK_NAD_NAME = "vm-network"
+
+
+# ---------------------------------------------------------------------------
+# Helper functions
+# ---------------------------------------------------------------------------
+
+
+def build_network_mapping_cm_data(
+    pattern_rules=None, explicit_rules=None, enabled=True
+):
+    """
+    Build the ConfigMap data dict for a network mapping ConfigMap.
+
+    Args:
+        pattern_rules (list[dict]): list of source/destination subnet pairs,
+            e.g. [{"source": "192.168.1.0/24", "destination": "192.168.2.0/24"}]
+        explicit_rules (list[dict]): list of source/destination IP pairs,
+            e.g. [{"source": "192.168.1.100", "destination": "192.168.2.200"}]
+        enabled (bool): whether to include the enabled=true opt-in key
+
+    Returns:
+        dict: ConfigMap.data contents
+
+    # TODO: Update key names and serialization format to match the final API.
+    """
+    data = {}
+    if enabled:
+        data[CM_KEY_ENABLED] = "true"
+    if pattern_rules:
+        data[CM_KEY_PATTERN_MAPPINGS] = yaml.dump(
+            pattern_rules, default_flow_style=False
+        )
+    if explicit_rules:
+        data[CM_KEY_EXPLICIT_MAPPINGS] = yaml.dump(
+            explicit_rules, default_flow_style=False
+        )
+    return data
+
+
+def get_drpolicy_network_mapping_status(drpolicy_name):
+    """
+    Return the networkMapping sub-dict from DRPolicy.status.
+
+    Args:
+        drpolicy_name (str): name of the DRPolicy resource on the hub cluster
+
+    Returns:
+        dict: contents of status.networkMapping, or {} if absent
+
+    # TODO: Update field path once API is confirmed.
+    """
+    config.switch_acm_ctx()
+    drpolicy_ocp = ocp.OCP(kind=constants.DRPOLICY, resource_name=drpolicy_name)
+    return drpolicy_ocp.get().get("status", {}).get(DRPOLICY_NM_FIELD, {})
+
+
+def get_ipamclaim_ip(cluster_name, namespace, vm_name):
+    """
+    Return the IP address recorded in the IPAMClaim for the given VM.
+    IPAMClaim name is assumed to match the VM name.
+
+    Args:
+        cluster_name (str): managed cluster to query
+        namespace (str): namespace where the IPAMClaim lives
+        vm_name (str): VM name (used as the IPAMClaim resource name)
+
+    Returns:
+        str: IP address without prefix length, or "" if not found
+
+    # TODO: Confirm IPAMClaim name convention with developer.
+    """
+    config.switch_to_cluster_by_name(cluster_name)
+    ipamclaim_ocp = ocp.OCP(
+        kind="IPAMClaim",  # TODO: add constant once available
+        namespace=namespace,
+        resource_name=vm_name,
+    )
+    addresses = ipamclaim_ocp.get().get("status", {}).get("addresses", [""])
+    return addresses[0].split("/")[0] if addresses else ""
+
+
+def wait_for_drpolicy_network_mapping_status(
+    drpolicy_name, expected_status, timeout=120
+):
+    """
+    Poll until DRPolicy networkMapping.status matches expected_status.
+
+    Args:
+        drpolicy_name (str): name of the DRPolicy resource
+        expected_status (str): one of DRPOLICY_NM_STATUS_VALID / _INVALID
+        timeout (int): seconds to wait before raising AssertionError
+
+    Raises:
+        AssertionError: if expected_status is not reached within timeout
+    """
+    for sample in TimeoutSampler(
+        timeout=timeout,
+        sleep=5,
+        func=lambda: get_drpolicy_network_mapping_status(drpolicy_name).get(
+            "status", ""
+        ),
+    ):
+        if sample == expected_status:
+            return
+    raise AssertionError(
+        f"DRPolicy {drpolicy_name} networkMapping.status did not reach "
+        f"'{expected_status}' within {timeout}s"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="class")
+def setup_udn_nad(request):
+    """
+    Prerequisite fixture: creates a UserDefinedNetwork and a matching
+    NetworkAttachmentDefinition (NAD) on each managed cluster, then tears
+    them down after the test class completes.
+
+    UDN spec:
+      - name: vm-network
+      - ipam.lifecycle: Persistent   (required for IPAMClaim support)
+      - layer: Layer2
+
+    NAD spec:
+      - allowPersistentIPs: true      (required for IPAMClaim creation)
+      - label ramendr.openshift.io/network-id: <network-id>
+                                      (required for DRClusterConfig discovery)
+
+    The fixture yields a dict with keys "udn_name" and "nad_name" so tests
+    can reference them without hardcoding.
+
+    # TODO: Replace subnet/prefix values with environment-specific ones read
+    # from config once the env schema for this feature is settled.
+    """
+    managed_cluster_names = []
+    created_resources = []  # list of (cluster_name, kind, namespace, name)
+
+    config.switch_acm_ctx()
+    for drcluster in dr_helpers.get_all_drclusters():
+        managed_cluster_names.append(drcluster["metadata"]["name"])
+
+    # Network ID label value — unique per UDN to allow DRClusterConfig discovery
+    network_id = VM_NETWORK_UDN_NAME
+
+    for cluster_name in managed_cluster_names:
+        config.switch_to_cluster_by_name(cluster_name)
+
+        # Create UserDefinedNetwork (cluster-scoped)
+        # TODO: confirm UDN API version and exact spec fields once available.
+        udn_manifest = {
+            "apiVersion": "k8s.ovn.org/v1",  # TODO: confirm GVK
+            "kind": "UserDefinedNetwork",
+            "metadata": {"name": VM_NETWORK_UDN_NAME},
+            "spec": {
+                "topology": "Layer2",
+                "layer2": {
+                    "ipam": {"lifecycle": "Persistent"},
+                    "subnets": [
+                        # TODO: make subnet per-cluster from env config
+                        (
+                            "192.168.1.0/24"
+                            if cluster_name == managed_cluster_names[0]
+                            else "192.168.2.0/24"
+                        )
+                    ],
+                },
+            },
+        }
+        with tempfile.NamedTemporaryFile(mode="w+", suffix=".yaml", delete=False) as f:
+            templating.dump_data_to_temp_yaml(udn_manifest, f.name)
+            exec_cmd(f"oc apply -f {f.name}")
+        created_resources.append(
+            (cluster_name, "UserDefinedNetwork", None, VM_NETWORK_UDN_NAME)
+        )
+        logger.info(f"Created UDN {VM_NETWORK_UDN_NAME} on {cluster_name}")
+
+    yield {
+        "udn_name": VM_NETWORK_UDN_NAME,
+        "nad_name": VM_NETWORK_NAD_NAME,
+        "network_id": network_id,
+        "cluster_names": managed_cluster_names,
+    }
+
+    # Teardown: delete UDN on each managed cluster
+    for cluster_name, kind, namespace, name in created_resources:
+        try:
+            config.switch_to_cluster_by_name(cluster_name)
+            ns_flag = f"-n {namespace}" if namespace else ""
+            exec_cmd(f"oc delete {kind} {name} {ns_flag} --ignore-not-found")
+            logger.info(f"Deleted {kind} {name} on {cluster_name}")
+        except Exception as exc:
+            logger.warning(f"Failed to delete {kind} {name} on {cluster_name}: {exc}")
+
+
+@pytest.fixture
+def setup_nad_in_namespace(setup_udn_nad):
+    """
+    Per-test fixture: creates the NAD in the given workload namespace on both
+    managed clusters. Must be called with the namespace as a parameter after
+    the workload namespace is known.
+
+    Returns a factory: call it with the workload namespace to create the NAD.
+    The NAD is deleted from all clusters on teardown.
+
+    Depends on setup_udn_nad for the UDN to already exist.
+    """
+    created = []  # list of (cluster_name, namespace)
+
+    def _factory(namespace):
+        for cluster_name in setup_udn_nad["cluster_names"]:
+            config.switch_to_cluster_by_name(cluster_name)
+            nad_manifest = {
+                "apiVersion": "k8s.cni.cncf.io/v1",
+                "kind": constants.NETWORK_ATTACHMENT_DEFINITION,
+                "metadata": {
+                    "name": VM_NETWORK_NAD_NAME,
+                    "namespace": namespace,
+                    "labels": {
+                        NAD_DR_LABEL: setup_udn_nad["network_id"],
+                    },
+                },
+                "spec": {
+                    "config": (
+                        '{"cniVersion":"0.3.1",'
+                        f'"name":"{VM_NETWORK_NAD_NAME}",'
+                        '"type":"ovn-k8s-cni-overlay",'
+                        f'"netAttachDefName":"{namespace}/{VM_NETWORK_NAD_NAME}",'
+                        '"allowPersistentIPs":true}'
+                    )
+                },
+            }
+            with tempfile.NamedTemporaryFile(
+                mode="w+", suffix=".yaml", delete=False
+            ) as f:
+                templating.dump_data_to_temp_yaml(nad_manifest, f.name)
+                exec_cmd(f"oc apply -f {f.name}")
+            created.append((cluster_name, namespace))
+            logger.info(
+                f"Created NAD {VM_NETWORK_NAD_NAME} in {namespace} on {cluster_name}"
+            )
+
+    yield _factory
+
+    for cluster_name, namespace in created:
+        try:
+            config.switch_to_cluster_by_name(cluster_name)
+            exec_cmd(
+                f"oc delete {constants.NETWORK_ATTACHMENT_DEFINITION} "
+                f"{VM_NETWORK_NAD_NAME} -n {namespace} --ignore-not-found"
+            )
+            logger.info(
+                f"Deleted NAD {VM_NETWORK_NAD_NAME} from {namespace} on {cluster_name}"
+            )
+        except Exception as exc:
+            logger.warning(
+                f"Failed to delete NAD in {namespace} on {cluster_name}: {exc}"
+            )
+
+
+@pytest.fixture
+def network_mapping_configmap():
+    """
+    Factory fixture that creates a network mapping ConfigMap on the hub cluster
+    and deletes it on teardown.
+
+    Usage::
+
+        def test_foo(network_mapping_configmap):
+            cm = network_mapping_configmap(
+                "my-mapping",
+                pattern_rules=[{"source": "192.168.1.0/24", "destination": "192.168.2.0/24"}],
+            )
+    """
+    created = []
+
+    def _factory(name, pattern_rules=None, explicit_rules=None, enabled=True):
+        config.switch_acm_ctx()
+        manifest = {
+            "apiVersion": "v1",
+            "kind": constants.CONFIGMAP,
+            "metadata": {"name": name, "namespace": VM_IP_TRANSLATION_NS},
+            "data": build_network_mapping_cm_data(
+                pattern_rules, explicit_rules, enabled
+            ),
+        }
+        with tempfile.NamedTemporaryFile(
+            mode="w+", suffix=".yaml", delete=False
+        ) as cm_file:
+            templating.dump_data_to_temp_yaml(manifest, cm_file.name)
+            exec_cmd(f"oc create -f {cm_file.name}")
+        created.append(name)
+        logger.info(
+            f"Created network mapping ConfigMap '{name}' in {VM_IP_TRANSLATION_NS}"
+        )
+        return ocp.OCP(
+            kind=constants.CONFIGMAP,
+            namespace=VM_IP_TRANSLATION_NS,
+            resource_name=name,
+        )
+
+    yield _factory
+
+    for cm_name in created:
+        try:
+            config.switch_acm_ctx()
+            exec_cmd(
+                f"oc delete configmap {cm_name} -n {VM_IP_TRANSLATION_NS} --ignore-not-found"
+            )
+            logger.info(f"Deleted network mapping ConfigMap '{cm_name}'")
+        except Exception as exc:
+            logger.warning(f"Failed to delete configmap '{cm_name}': {exc}")

--- a/ocs_ci/helpers/dr_helpers_vm_ip_translation.py
+++ b/ocs_ci/helpers/dr_helpers_vm_ip_translation.py
@@ -355,12 +355,16 @@ def wait_for_drpolicy_network_mapping_status(
 # ---------------------------------------------------------------------------
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture
 def setup_udn_nad(request):
     """
     Prerequisite fixture: creates the workload namespace and a Primary
     UserDefinedNetwork (with persistent IPAM) on each managed cluster, then
-    tears them down after the test class completes.
+    tears them down after the test completes.
+
+    Function scoped on purpose: the workload teardown deletes the project it
+    ran in, which is this same namespace (and takes the UDN with it). A wider
+    scope would leave later tests in the class without a namespace or UDN.
 
     Confirmed requirements from manual testing (Aug 2026):
       - Namespace must carry label k8s.ovn.org/primary-user-defined-network=""

--- a/ocs_ci/helpers/dr_helpers_vm_ip_translation.py
+++ b/ocs_ci/helpers/dr_helpers_vm_ip_translation.py
@@ -6,9 +6,19 @@ Provides utilities for managing network mapping ConfigMaps, polling DRPolicy
 network mapping status, reading IPAMClaim IP addresses, and pytest fixtures
 for setting up UDN/NAD prerequisites.
 
-NOTE: Several constants reference DRPolicy/VRG/DRClusterConfig status field
-names that are not yet finalized. These are marked with TODO comments.
-Update once the developer confirms the API schema (RHSTOR-8082 open questions).
+API schema confirmed from manual testing on ammahapa-21a RDR (Aug 2026):
+  - DR discovery label: ramendr.openshift.io/dr-network=true on the UDN
+    (NOT the NAD — UDN controller owns the NAD and strips labels applied to it)
+  - ConfigMap namespace: same namespace as the DRPC (openshift-dr-ops for
+    discovered apps), referenced via DRPolicy.spec.networkMappingRef.name
+  - ConfigMap data key: mappings.yaml (not patternMappings/explicitMappings)
+  - ConfigMap schema: networkRef / cidr / explicitMappings / regexMappings
+    with explicitMappings taking precedence over regexMappings
+  - IPAMClaim name: <vm-name>.<interface-name> (e.g. vm-client.primary-udn)
+  - IPAMClaim status field: .status.ips (list of CIDR strings, e.g. ["192.168.10.10/24"])
+  - DRClusterConfig: lives on managed clusters (not hub); field status.networkAttachments
+  - DRPolicy conditions: NetworkAttachmentsValidated; status.networkPeers lists discovered pairs
+  - VRG condition: NetworkMappingLoaded=True once mapping is active
 """
 
 import logging
@@ -26,19 +36,21 @@ from ocs_ci.utility.utils import TimeoutSampler, exec_cmd
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
-# Feature constants
-# TODO: Update field names below once the developer confirms the API schema.
+# Feature constants (confirmed from manual testing, Aug 2026)
 # ---------------------------------------------------------------------------
 
-# Namespace for the network mapping ConfigMap (hub cluster)
-VM_IP_TRANSLATION_NS = constants.OPENSHIFT_DR_SYSTEM_NAMESPACE
+# ConfigMap namespace: same as the DRPC namespace on the hub (openshift-dr-ops
+# for discovered apps). The DRPolicy references it by name via networkMappingRef.
+VM_IP_TRANSLATION_NS = constants.DR_OPS_NAMESPACE
 
-# ConfigMap data keys — TODO: confirm with developer
-CM_KEY_PATTERN_MAPPINGS = "patternMappings"
-CM_KEY_EXPLICIT_MAPPINGS = "explicitMappings"
-CM_KEY_ENABLED = "enabled"
+# ConfigMap data key (the whole mapping document lives under this single key)
+CM_KEY_MAPPINGS = "mappings.yaml"
 
-# DRPolicy status path for network mapping — TODO: confirm with developer
+# DRPolicy status condition names (confirmed)
+DRPOLICY_NADS_SYNCED_CONDITION = "NetworkAttachmentsValidated"
+
+# DRPolicy status path for network mapping
+# TODO: confirm exact field name once status schema is finalized by developer
 DRPOLICY_NM_FIELD = "networkMapping"
 DRPOLICY_NM_STATUS_VALID = "Valid"
 DRPOLICY_NM_STATUS_INVALID = "Invalid"
@@ -46,16 +58,17 @@ DRPOLICY_NM_METHOD_PATTERN = "pattern"
 DRPOLICY_NM_METHOD_EXPLICIT = "explicit"
 DRPOLICY_NM_METHOD_PATTERN_OVERRIDES = "pattern-with-overrides"
 
-# DRPolicy NADs synced condition — TODO: confirm with developer
-DRPOLICY_NADS_SYNCED_CONDITION = "NADsSynced"
-
-# VRG condition name for IP translation — TODO: confirm with developer
+# VRG condition name for IP translation (confirmed working in manual test)
 VRG_CONDITION_NM_LOADED = "NetworkMappingLoaded"
 
-# NAD label required for Ramen network discovery
-NAD_DR_LABEL = "ramendr.openshift.io/network-id"
+# Label applied to the UDN (propagates to NAD) to enable Ramen discovery.
+# Value MUST be "true" — empty string does not match the discovery selector.
+# Apply to the UserDefinedNetwork, NOT the NAD (UDN controller owns the NAD
+# and will strip any label applied directly to it).
+UDN_DR_LABEL = "ramendr.openshift.io/dr-network"
+UDN_DR_LABEL_VALUE = "true"
 
-# DRClusterConfig status field listing discovered NADs — TODO: confirm
+# DRClusterConfig status field listing discovered NADs (confirmed)
 DRCLUSTERCONFIG_NAD_STATUS_FIELD = "networkAttachments"
 
 # UDN and NAD names used across IP translation tests
@@ -69,35 +82,110 @@ VM_NETWORK_NAD_NAME = "vm-network"
 
 
 def build_network_mapping_cm_data(
-    pattern_rules=None, explicit_rules=None, enabled=True
+    cluster1_name,
+    cluster2_name,
+    nad_namespace,
+    nad_name,
+    cluster1_cidr,
+    cluster2_cidr,
+    explicit_mappings=None,
+    regex_mappings=None,
 ):
     """
-    Build the ConfigMap data dict for a network mapping ConfigMap.
+    Build the ConfigMap data dict using the confirmed mappings.yaml schema.
+
+    Schema (confirmed from manual testing):
+        version: "v1"
+        networkMappings:
+          - networkRef:
+              nadNamespace: <nad_namespace>
+              nadName: <nad_name>
+            cidr:
+              <cluster1>: <cidr1>
+              <cluster2>: <cidr2>
+            explicitMappings:            # optional; takes precedence over regexMappings
+              - <cluster1>: <ip>
+                <cluster2>: <ip>
+            regexMappings:               # optional; bidirectional pattern rules
+              <cluster1>-to-<cluster2>:
+                - pattern: "..."
+                  replacement: "..."
+              <cluster2>-to-<cluster1>:
+                - pattern: "..."
+                  replacement: "..."
 
     Args:
-        pattern_rules (list[dict]): list of source/destination subnet pairs,
-            e.g. [{"source": "192.168.1.0/24", "destination": "192.168.2.0/24"}]
-        explicit_rules (list[dict]): list of source/destination IP pairs,
-            e.g. [{"source": "192.168.1.100", "destination": "192.168.2.200"}]
-        enabled (bool): whether to include the enabled=true opt-in key
+        cluster1_name (str): first cluster name (e.g. "ammahapa-21a-c1")
+        cluster2_name (str): second cluster name (e.g. "ammahapa-21a-c2")
+        nad_namespace (str): namespace of the NAD (e.g. "verizon-app")
+        nad_name (str): name of the NAD / VM interface (e.g. "primary-udn")
+        cluster1_cidr (str): subnet on cluster1 (e.g. "192.168.10.0/24")
+        cluster2_cidr (str): subnet on cluster2 (e.g. "192.168.20.0/24")
+        explicit_mappings (list[dict]): optional pinned IP pairs, each a dict
+            {cluster1_name: ip, cluster2_name: ip}; take precedence over regex
+        regex_mappings (dict): optional {direction_key: [{pattern, replacement}]};
+            if None, a simple host-preserving bidirectional regex is generated
+            from the cluster CIDRs
 
     Returns:
-        dict: ConfigMap.data contents
-
-    # TODO: Update key names and serialization format to match the final API.
+        dict: ConfigMap.data contents with a single key "mappings.yaml"
     """
-    data = {}
-    if enabled:
-        data[CM_KEY_ENABLED] = "true"
-    if pattern_rules:
-        data[CM_KEY_PATTERN_MAPPINGS] = yaml.dump(
-            pattern_rules, default_flow_style=False
-        )
-    if explicit_rules:
-        data[CM_KEY_EXPLICIT_MAPPINGS] = yaml.dump(
-            explicit_rules, default_flow_style=False
-        )
-    return data
+    mapping_entry = {
+        "networkRef": {
+            "nadNamespace": nad_namespace,
+            "nadName": nad_name,
+        },
+        "cidr": {
+            cluster1_name: cluster1_cidr,
+            cluster2_name: cluster2_cidr,
+        },
+    }
+    if explicit_mappings:
+        mapping_entry["explicitMappings"] = explicit_mappings
+
+    if regex_mappings is not None:
+        mapping_entry["regexMappings"] = regex_mappings
+    else:
+        # Auto-generate simple host-preserving bidirectional regex rules
+        c1_prefix = cluster1_cidr.rsplit(".", 1)[0]  # e.g. "192.168.10"
+        c2_prefix = cluster2_cidr.rsplit(".", 1)[0]  # e.g. "192.168.20"
+        c1_escaped = c1_prefix.replace(".", "\\.")
+        c2_escaped = c2_prefix.replace(".", "\\.")
+        mapping_entry["regexMappings"] = {
+            f"{cluster1_name}-to-{cluster2_name}": [
+                {
+                    "pattern": f"^{c1_escaped}\\.(\\d+)$",
+                    "replacement": f"{c2_prefix}.$1",
+                }
+            ],
+            f"{cluster2_name}-to-{cluster1_name}": [
+                {
+                    "pattern": f"^{c2_escaped}\\.(\\d+)$",
+                    "replacement": f"{c1_prefix}.$1",
+                }
+            ],
+        }
+
+    document = {
+        "version": "v1",
+        "networkMappings": [mapping_entry],
+    }
+    return {CM_KEY_MAPPINGS: yaml.dump(document, default_flow_style=False)}
+
+
+def get_drpolicy_network_peers(drpolicy_name):
+    """
+    Return the networkPeers list from DRPolicy.status.
+
+    Args:
+        drpolicy_name (str): name of the DRPolicy resource on the hub cluster
+
+    Returns:
+        list: contents of status.networkPeers, or [] if absent
+    """
+    config.switch_acm_ctx()
+    drpolicy_ocp = ocp.OCP(kind=constants.DRPOLICY, resource_name=drpolicy_name)
+    return drpolicy_ocp.get().get("status", {}).get("networkPeers", [])
 
 
 def get_drpolicy_network_mapping_status(drpolicy_name):
@@ -109,37 +197,120 @@ def get_drpolicy_network_mapping_status(drpolicy_name):
 
     Returns:
         dict: contents of status.networkMapping, or {} if absent
-
-    # TODO: Update field path once API is confirmed.
     """
     config.switch_acm_ctx()
     drpolicy_ocp = ocp.OCP(kind=constants.DRPOLICY, resource_name=drpolicy_name)
     return drpolicy_ocp.get().get("status", {}).get(DRPOLICY_NM_FIELD, {})
 
 
-def get_ipamclaim_ip(cluster_name, namespace, vm_name):
+def get_ipamclaim_ip(cluster_name, namespace, vm_name, interface_name):
     """
-    Return the IP address recorded in the IPAMClaim for the given VM.
-    IPAMClaim name is assumed to match the VM name.
+    Return the IP address recorded in the IPAMClaim for the given VM interface.
+
+    IPAMClaim name format (confirmed): <vm-name>.<interface-name>
+    e.g. for VM "vm-client" on interface "primary-udn" → "vm-client.primary-udn"
 
     Args:
         cluster_name (str): managed cluster to query
         namespace (str): namespace where the IPAMClaim lives
-        vm_name (str): VM name (used as the IPAMClaim resource name)
+        vm_name (str): VM name
+        interface_name (str): VM network interface name (e.g. "primary-udn")
 
     Returns:
         str: IP address without prefix length, or "" if not found
-
-    # TODO: Confirm IPAMClaim name convention with developer.
     """
     config.switch_to_cluster_by_name(cluster_name)
+    claim_name = f"{vm_name}.{interface_name}"
     ipamclaim_ocp = ocp.OCP(
-        kind="IPAMClaim",  # TODO: add constant once available
+        kind="IPAMClaim",
+        namespace=namespace,
+        resource_name=claim_name,
+    )
+    # status.ips is a list of CIDR strings e.g. ["192.168.10.10/24"]
+    ips = ipamclaim_ocp.get().get("status", {}).get("ips", [])
+    return ips[0].split("/")[0] if ips else ""
+
+
+def get_vm_ip_from_vmi(cluster_name, namespace, vm_name, interface_name=None):
+    """
+    Return the IP address shown in the VMI's status.interfaces for the given VM.
+
+    Reads from VirtualMachineInstance.status.interfaces[*].ipAddress — this is
+    the IP as seen at the OVN-K8s layer, which is what IP translation affects.
+    Use this to verify the translated IP after failover and the restored IP after
+    relocate, alongside get_ipamclaim_ip() which reads the IPAM allocation.
+
+    Args:
+        cluster_name (str): managed cluster to query
+        namespace (str): namespace of the VMI
+        vm_name (str): VM name (VMI has the same name as the VM)
+        interface_name (str): if given, return the IP for that specific interface
+                             name; if None, return the first interface's IP
+
+    Returns:
+        str: IP address (without prefix length), or "" if not found
+    """
+    config.switch_to_cluster_by_name(cluster_name)
+    vmi_ocp = ocp.OCP(
+        kind="VirtualMachineInstance",
         namespace=namespace,
         resource_name=vm_name,
     )
-    addresses = ipamclaim_ocp.get().get("status", {}).get("addresses", [""])
-    return addresses[0].split("/")[0] if addresses else ""
+    interfaces = vmi_ocp.get().get("status", {}).get("interfaces", [])
+    if interface_name:
+        for iface in interfaces:
+            if iface.get("name") == interface_name:
+                return iface.get("ipAddress", "")
+        return ""
+    return interfaces[0].get("ipAddress", "") if interfaces else ""
+
+
+def wait_for_drpolicy_network_peers(drpolicy_name, timeout=120):
+    """
+    Poll until DRPolicy.status.networkPeers is non-empty.
+
+    networkPeers is populated once DRPolicy.spec.networkMappingRef is set
+    AND the NADs are discovered symmetrically on both clusters.
+
+    Args:
+        drpolicy_name (str): name of the DRPolicy resource
+        timeout (int): seconds to wait
+
+    Returns:
+        list: the populated networkPeers list
+
+    Raises:
+        AssertionError: if networkPeers is not populated within timeout
+    """
+    for sample in TimeoutSampler(
+        timeout=timeout,
+        sleep=5,
+        func=lambda: get_drpolicy_network_peers(drpolicy_name),
+    ):
+        if sample:
+            return sample
+    raise AssertionError(
+        f"DRPolicy {drpolicy_name} status.networkPeers did not populate "
+        f"within {timeout}s"
+    )
+
+
+def set_drpolicy_network_mapping_ref(drpolicy_name, configmap_name):
+    """
+    Patch DRPolicy.spec.networkMappingRef to reference the given ConfigMap.
+
+    Args:
+        drpolicy_name (str): name of the DRPolicy to patch
+        configmap_name (str): name of the network-mapping ConfigMap
+    """
+    config.switch_acm_ctx()
+    exec_cmd(
+        f"oc patch drpolicy {drpolicy_name} --type=merge "
+        f'-p \'{{"spec":{{"networkMappingRef":{{"name":"{configmap_name}"}}}}}}\''
+    )
+    logger.info(
+        f"Patched DRPolicy {drpolicy_name} networkMappingRef → {configmap_name}"
+    )
 
 
 def wait_for_drpolicy_network_mapping_status(
@@ -179,25 +350,24 @@ def wait_for_drpolicy_network_mapping_status(
 @pytest.fixture(scope="class")
 def setup_udn_nad(request):
     """
-    Prerequisite fixture: creates a UserDefinedNetwork and a matching
-    NetworkAttachmentDefinition (NAD) on each managed cluster, then tears
-    them down after the test class completes.
+    Prerequisite fixture: creates the workload namespace and a Primary
+    UserDefinedNetwork (with persistent IPAM) on each managed cluster, then
+    tears them down after the test class completes.
 
-    UDN spec:
-      - name: vm-network
-      - ipam.lifecycle: Persistent   (required for IPAMClaim support)
-      - layer: Layer2
+    Confirmed requirements from manual testing (Aug 2026):
+      - Namespace must carry label k8s.ovn.org/primary-user-defined-network=""
+        BEFORE the UDN is created (cannot be patched in afterwards).
+      - UDN role: Primary, topology: Layer2, ipam.lifecycle: Persistent.
+      - UDN controller auto-creates the NAD — do NOT create NAD separately.
+      - DR discovery label ramendr.openshift.io/dr-network=true goes on the
+        UDN (NOT the NAD). The UDN controller owns the NAD via ownerReference
+        and strips any label applied directly to the NAD. Value must be "true";
+        empty string does not match the discovery selector.
+      - After labeling the UDN, verify DRClusterConfig.status.networkAttachments
+        on each managed cluster shows the NAD discovered.
 
-    NAD spec:
-      - allowPersistentIPs: true      (required for IPAMClaim creation)
-      - label ramendr.openshift.io/network-id: <network-id>
-                                      (required for DRClusterConfig discovery)
-
-    The fixture yields a dict with keys "udn_name" and "nad_name" so tests
-    can reference them without hardcoding.
-
-    # TODO: Replace subnet/prefix values with environment-specific ones read
-    # from config once the env schema for this feature is settled.
+    The fixture yields a dict with keys "udn_name", "nad_name",
+    "cluster_names", "cluster_subnets" so tests can reference them.
     """
     managed_cluster_names = []
     created_resources = []  # list of (cluster_name, kind, namespace, name)
@@ -206,30 +376,46 @@ def setup_udn_nad(request):
     for drcluster in dr_helpers.get_all_drclusters():
         managed_cluster_names.append(drcluster["metadata"]["name"])
 
-    # Network ID label value — unique per UDN to allow DRClusterConfig discovery
-    network_id = VM_NETWORK_UDN_NAME
+    # Per-cluster subnets — read from env config; fall back to test defaults
+    cluster_subnets = {
+        managed_cluster_names[0]: "192.168.1.0/24",
+        managed_cluster_names[1]: "192.168.2.0/24",
+    }
+
+    workload_namespace = constants.VM_IP_TRANSLATION_WORKLOAD_NS
 
     for cluster_name in managed_cluster_names:
         config.switch_to_cluster_by_name(cluster_name)
 
-        # Create UserDefinedNetwork (cluster-scoped)
-        # TODO: confirm UDN API version and exact spec fields once available.
+        # Step 1: namespace with the primary-UDN label
+        ns_manifest = {
+            "apiVersion": "v1",
+            "kind": "Namespace",
+            "metadata": {
+                "name": workload_namespace,
+                "labels": {"k8s.ovn.org/primary-user-defined-network": ""},
+            },
+        }
+        with tempfile.NamedTemporaryFile(mode="w+", suffix=".yaml", delete=False) as f:
+            templating.dump_data_to_temp_yaml(ns_manifest, f.name)
+            exec_cmd(f"oc apply -f {f.name}")
+        created_resources.append((cluster_name, "Namespace", None, workload_namespace))
+
+        # Step 2: Primary UDN with persistent IPAM; label triggers DR discovery
         udn_manifest = {
-            "apiVersion": "k8s.ovn.org/v1",  # TODO: confirm GVK
+            "apiVersion": "k8s.ovn.org/v1",
             "kind": "UserDefinedNetwork",
-            "metadata": {"name": VM_NETWORK_UDN_NAME},
+            "metadata": {
+                "name": VM_NETWORK_UDN_NAME,
+                "namespace": workload_namespace,
+                "labels": {UDN_DR_LABEL: UDN_DR_LABEL_VALUE},
+            },
             "spec": {
                 "topology": "Layer2",
                 "layer2": {
+                    "role": "Primary",
+                    "subnets": [cluster_subnets[cluster_name]],
                     "ipam": {"lifecycle": "Persistent"},
-                    "subnets": [
-                        # TODO: make subnet per-cluster from env config
-                        (
-                            "192.168.1.0/24"
-                            if cluster_name == managed_cluster_names[0]
-                            else "192.168.2.0/24"
-                        )
-                    ],
                 },
             },
         }
@@ -237,26 +423,35 @@ def setup_udn_nad(request):
             templating.dump_data_to_temp_yaml(udn_manifest, f.name)
             exec_cmd(f"oc apply -f {f.name}")
         created_resources.append(
-            (cluster_name, "UserDefinedNetwork", None, VM_NETWORK_UDN_NAME)
+            (
+                cluster_name,
+                "UserDefinedNetwork",
+                workload_namespace,
+                VM_NETWORK_UDN_NAME,
+            )
         )
-        logger.info(f"Created UDN {VM_NETWORK_UDN_NAME} on {cluster_name}")
+        logger.info(
+            f"Created Primary UDN {VM_NETWORK_UDN_NAME} on {cluster_name} "
+            f"(subnet {cluster_subnets[cluster_name]}, DR label set)"
+        )
 
     yield {
         "udn_name": VM_NETWORK_UDN_NAME,
         "nad_name": VM_NETWORK_NAD_NAME,
-        "network_id": network_id,
         "cluster_names": managed_cluster_names,
+        "cluster_subnets": cluster_subnets,
+        "workload_namespace": workload_namespace,
     }
 
-    # Teardown: delete UDN on each managed cluster
-    for cluster_name, kind, namespace, name in created_resources:
+    # Teardown: delete UDN then namespace on each managed cluster
+    for cluster_name, kind, namespace, name in reversed(created_resources):
         try:
             config.switch_to_cluster_by_name(cluster_name)
             ns_flag = f"-n {namespace}" if namespace else ""
             exec_cmd(f"oc delete {kind} {name} {ns_flag} --ignore-not-found")
-            logger.info(f"Deleted {kind} {name} on {cluster_name}")
+            logger.info(f"Deleted {kind}/{name} on {cluster_name}")
         except Exception as exc:
-            logger.warning(f"Failed to delete {kind} {name} on {cluster_name}: {exc}")
+            logger.warning(f"Failed to delete {kind}/{name} on {cluster_name}: {exc}")
 
 
 @pytest.fixture
@@ -282,9 +477,6 @@ def setup_nad_in_namespace(setup_udn_nad):
                 "metadata": {
                     "name": VM_NETWORK_NAD_NAME,
                     "namespace": namespace,
-                    "labels": {
-                        NAD_DR_LABEL: setup_udn_nad["network_id"],
-                    },
                 },
                 "spec": {
                     "config": (
@@ -328,37 +520,69 @@ def setup_nad_in_namespace(setup_udn_nad):
 def network_mapping_configmap():
     """
     Factory fixture that creates a network mapping ConfigMap on the hub cluster
-    and deletes it on teardown.
+    (in the DRPC namespace) and patches DRPolicy.spec.networkMappingRef to
+    reference it, then cleans up on teardown.
+
+    The ConfigMap must be in the same namespace as the DRPC (openshift-dr-ops
+    for discovered apps) per the confirmed API schema. The linkage is via
+    DRPolicy.spec.networkMappingRef.name, NOT auto-discovery by ConfigMap name.
 
     Usage::
 
-        def test_foo(network_mapping_configmap):
-            cm = network_mapping_configmap(
+        def test_foo(network_mapping_configmap, setup_udn_nad):
+            network_mapping_configmap(
                 "my-mapping",
-                pattern_rules=[{"source": "192.168.1.0/24", "destination": "192.168.2.0/24"}],
+                cluster1_name=..., cluster2_name=...,
+                nad_namespace=..., nad_name=...,
+                cluster1_cidr="192.168.1.0/24",
+                cluster2_cidr="192.168.2.0/24",
             )
     """
-    created = []
+    created_cms = []
+    drpolicy_patched = []
 
-    def _factory(name, pattern_rules=None, explicit_rules=None, enabled=True):
+    def _factory(
+        name,
+        cluster1_name,
+        cluster2_name,
+        nad_namespace,
+        nad_name,
+        cluster1_cidr,
+        cluster2_cidr,
+        explicit_mappings=None,
+        regex_mappings=None,
+        drpolicy_name=None,
+    ):
         config.switch_acm_ctx()
         manifest = {
             "apiVersion": "v1",
             "kind": constants.CONFIGMAP,
             "metadata": {"name": name, "namespace": VM_IP_TRANSLATION_NS},
             "data": build_network_mapping_cm_data(
-                pattern_rules, explicit_rules, enabled
+                cluster1_name=cluster1_name,
+                cluster2_name=cluster2_name,
+                nad_namespace=nad_namespace,
+                nad_name=nad_name,
+                cluster1_cidr=cluster1_cidr,
+                cluster2_cidr=cluster2_cidr,
+                explicit_mappings=explicit_mappings,
+                regex_mappings=regex_mappings,
             ),
         }
         with tempfile.NamedTemporaryFile(
             mode="w+", suffix=".yaml", delete=False
         ) as cm_file:
             templating.dump_data_to_temp_yaml(manifest, cm_file.name)
-            exec_cmd(f"oc create -f {cm_file.name}")
-        created.append(name)
+            exec_cmd(f"oc apply -f {cm_file.name}")
+        created_cms.append(name)
         logger.info(
             f"Created network mapping ConfigMap '{name}' in {VM_IP_TRANSLATION_NS}"
         )
+
+        if drpolicy_name:
+            set_drpolicy_network_mapping_ref(drpolicy_name, name)
+            drpolicy_patched.append(drpolicy_name)
+
         return ocp.OCP(
             kind=constants.CONFIGMAP,
             namespace=VM_IP_TRANSLATION_NS,
@@ -367,7 +591,20 @@ def network_mapping_configmap():
 
     yield _factory
 
-    for cm_name in created:
+    # Teardown: clear networkMappingRef then delete ConfigMap
+    for drpolicy_name in drpolicy_patched:
+        try:
+            config.switch_acm_ctx()
+            exec_cmd(
+                f"oc patch drpolicy {drpolicy_name} --type=merge "
+                f'-p \'{{"spec":{{"networkMappingRef":{{}}}}}}\''
+            )
+            logger.info(f"Cleared networkMappingRef on DRPolicy {drpolicy_name}")
+        except Exception as exc:
+            logger.warning(
+                f"Failed to clear networkMappingRef on {drpolicy_name}: {exc}"
+            )
+    for cm_name in created_cms:
         try:
             config.switch_acm_ctx()
             exec_cmd(

--- a/ocs_ci/helpers/dr_helpers_vm_ip_translation.py
+++ b/ocs_ci/helpers/dr_helpers_vm_ip_translation.py
@@ -21,10 +21,7 @@ API schema confirmed from manual testing on ammahapa-21a RDR (Aug 2026):
   - VRG condition: NetworkMappingLoaded=True once mapping is active
 """
 
-import json
 import logging
-import os
-import shutil
 import tempfile
 
 import pytest
@@ -33,6 +30,7 @@ import yaml
 from ocs_ci.framework import config
 from ocs_ci.helpers import dr_helpers
 from ocs_ci.ocs import constants, ocp
+from ocs_ci.ocs.utils import get_primary_cluster_config
 from ocs_ci.utility import templating
 from ocs_ci.utility.utils import TimeoutSampler, exec_cmd
 
@@ -78,14 +76,12 @@ DRCLUSTERCONFIG_NAD_STATUS_FIELD = "networkAttachments"
 VM_NETWORK_UDN_NAME = "vm-network"
 VM_NETWORK_NAD_NAME = "vm-network"
 
-# VM interface name on the Primary UDN. The IPAMClaim is named
-# <vm-name>.<interface-name>, so this must match the interface_name passed to
-# get_ipamclaim_ip / get_vm_ip_from_vmi (kept equal to the NAD name).
-VM_NETWORK_INTERFACE_NAME = VM_NETWORK_NAD_NAME
-
-# Host octet appended to the primary cluster subnet prefix to pin the VM's
-# static IP (e.g. subnet 192.168.1.0/24 -> static IP 192.168.1.11).
-VM_STATIC_IP_HOST_OCTET = "11"
+# UDN subnets, assigned by DR role (see setup_udn_nad). The static-IP VM
+# workloads in ocs-workloads hardcode addresses inside PRIMARY_SUBNET
+# (vm-static-ip-workload-1 -> .11, vm-static-ip-workload-2 -> .12); the network
+# mapping ConfigMap translates them into SECONDARY_SUBNET on failover.
+PRIMARY_SUBNET = "192.168.1.0/24"
+SECONDARY_SUBNET = "192.168.2.0/24"
 
 
 # ---------------------------------------------------------------------------
@@ -277,95 +273,6 @@ def get_vm_ip_from_vmi(cluster_name, namespace, vm_name, interface_name=None):
     return interfaces[0].get("ipAddress", "") if interfaces else ""
 
 
-def static_ip_from_subnet(subnet, host_octet=VM_STATIC_IP_HOST_OCTET):
-    """
-    Build a static IP in the given subnet by replacing the last octet.
-
-    Args:
-        subnet (str): CIDR subnet, e.g. "192.168.1.0/24"
-        host_octet (str): host octet to pin, e.g. "11"
-
-    Returns:
-        str: static IP address, e.g. "192.168.1.11"
-    """
-    network_prefix = subnet.split("/")[0].rsplit(".", 1)[0]
-    return f"{network_prefix}.{host_octet}"
-
-
-def prepare_static_ip_vm_manifest(
-    source_workload_dir,
-    static_ip,
-    interface_name=VM_NETWORK_INTERFACE_NAME,
-):
-    """
-    Copy an existing CNV workload directory to a temp location and patch its
-    VirtualMachine manifest for static IP translation testing (RHSTOR-8082),
-    without modifying the original regression workload files.
-
-    The patched VM is wired onto the namespace's Primary UDN:
-      - single interface named ``interface_name`` with bridge binding, backed by
-        the pod network (a Primary UDN replaces the default pod network)
-      - annotation ``network.kubevirt.io/addresses`` pinning ``static_ip`` on that
-        interface, so OVN-K8s IPAM allocates the requested address and creates an
-        IPAMClaim named ``<vm-name>.<interface_name>``
-
-    Args:
-        source_workload_dir (str): absolute path to the cloned workload directory
-            (kustomize dir containing the VM manifest)
-        static_ip (str): static IP to pin on the primary cluster, e.g. "192.168.1.11"
-        interface_name (str): VM interface name (kept equal to the NAD name so the
-            IPAMClaim name matches get_ipamclaim_ip lookups)
-
-    Returns:
-        str: absolute path to the temp directory holding the patched manifests
-    """
-    temp_dir = tempfile.mkdtemp(prefix="static-ip-vm-")
-    # Copy the whole kustomize dir so `oc create -k` still finds kustomization.yaml
-    shutil.copytree(source_workload_dir, temp_dir, dirs_exist_ok=True)
-
-    patched_vm = False
-    for root, _, files in os.walk(temp_dir):
-        for fname in files:
-            if not fname.endswith((".yaml", ".yml")):
-                continue
-            fpath = os.path.join(root, fname)
-            with open(fpath) as f:
-                docs = list(yaml.safe_load_all(f))
-
-            changed = False
-            for doc in docs:
-                if not doc or doc.get("kind") != "VirtualMachine":
-                    continue
-                template = doc.setdefault("spec", {}).setdefault("template", {})
-                # Pin the static IP via annotation on the VM template
-                annotations = template.setdefault("metadata", {}).setdefault(
-                    "annotations", {}
-                )
-                annotations["network.kubevirt.io/addresses"] = json.dumps(
-                    {interface_name: [static_ip]}
-                )
-                # Wire the single interface onto the Primary UDN (pod network)
-                domain = template.setdefault("spec", {}).setdefault("domain", {})
-                domain.setdefault("devices", {})["interfaces"] = [
-                    {"name": interface_name, "bridge": {}}
-                ]
-                template["spec"]["networks"] = [{"name": interface_name, "pod": {}}]
-                changed = True
-                patched_vm = True
-
-            if changed:
-                with open(fpath, "w") as f:
-                    yaml.safe_dump_all(docs, f, default_flow_style=False)
-                logger.info(f"Patched VM manifest for static IP {static_ip}: {fpath}")
-
-    if not patched_vm:
-        raise ValueError(
-            f"No VirtualMachine manifest found under {source_workload_dir} to patch "
-            "for static IP translation"
-        )
-    return temp_dir
-
-
 def wait_for_drpolicy_network_peers(drpolicy_name, timeout=120):
     """
     Poll until DRPolicy.status.networkPeers is non-empty.
@@ -477,10 +384,17 @@ def setup_udn_nad(request):
     for drcluster in dr_helpers.get_all_drclusters():
         managed_cluster_names.append(drcluster["metadata"]["name"])
 
-    # Per-cluster subnets — read from env config; fall back to test defaults
+    # Per-cluster subnets, assigned by DR role rather than by drcluster list
+    # order. The static-IP VM workloads hardcode an address in PRIMARY_SUBNET
+    # (e.g. 192.168.1.11), so the primary must always own that subnet or the
+    # VMI will fail to start with an address outside its UDN subnet.
+    primary_cluster_name = get_primary_cluster_config().ENV_DATA["cluster_name"]
+    secondary_cluster_name = next(
+        name for name in managed_cluster_names if name != primary_cluster_name
+    )
     cluster_subnets = {
-        managed_cluster_names[0]: "192.168.1.0/24",
-        managed_cluster_names[1]: "192.168.2.0/24",
+        primary_cluster_name: PRIMARY_SUBNET,
+        secondary_cluster_name: SECONDARY_SUBNET,
     }
 
     workload_namespace = constants.VM_IP_TRANSLATION_WORKLOAD_NS

--- a/ocs_ci/helpers/dr_helpers_vm_ip_translation.py
+++ b/ocs_ci/helpers/dr_helpers_vm_ip_translation.py
@@ -381,12 +381,11 @@ def setup_udn_nad(request):
     The fixture yields a dict with keys "udn_name", "nad_name",
     "cluster_names", "cluster_subnets" so tests can reference them.
     """
-    managed_cluster_names = []
     created_resources = []  # list of (cluster_name, kind, namespace, name)
 
     config.switch_acm_ctx()
-    for drcluster in dr_helpers.get_all_drclusters():
-        managed_cluster_names.append(drcluster["metadata"]["name"])
+    # get_all_drclusters() returns the DRCluster names, not the objects
+    managed_cluster_names = dr_helpers.get_all_drclusters()
 
     # Per-cluster subnets, assigned by DR role rather than by drcluster list
     # order. The static-IP VM workloads hardcode an address in PRIMARY_SUBNET

--- a/ocs_ci/ocs/constants.py
+++ b/ocs_ci/ocs/constants.py
@@ -3832,6 +3832,9 @@ DISCOVERED_APPS = "DiscoveredApps"
 DR_OPS_NAMESPACE = "openshift-dr-ops"
 DPA_DISCOVERED_APPS_PATH = os.path.join(TEMPLATE_DIR, "DR", "dpa_discovered_apps.yaml")
 
+# RHSTOR-8082: VM static IP translation during DR failover/failback
+VM_IP_TRANSLATION_WORKLOAD_NS = "vm-ip-translation-test"
+
 DISABLE_DR_EACH_APP = os.path.join(TEMPLATE_DIR, "DR", "disable_dr_each_app.sh")
 REMOVE_DR_EACH_MANAGED_CLUSTER = os.path.join(TEMPLATE_DIR, "DR", "dr_conf_removal.sh")
 CLUSTERSELECTORPATH = "/spec/predicates/0/requiredClusterSelector/labelSelector/matchExpressions/0/values/0"

--- a/ocs_ci/ocs/dr/dr_workload.py
+++ b/ocs_ci/ocs/dr/dr_workload.py
@@ -15,6 +15,7 @@ from subprocess import TimeoutExpired
 from ocs_ci.deployment.helpers.hypershift_base import is_hosted_cluster
 from ocs_ci.framework import config
 from ocs_ci.helpers import dr_helpers, helpers
+from ocs_ci.helpers import dr_helpers_vm_ip_translation as vm_ip_translation
 from ocs_ci.helpers.cnv_helpers import create_vm_secret, cal_md5sum_vm
 from ocs_ci.helpers.dr_helpers import (
     create_cdi_cert_configmap,
@@ -2388,3 +2389,76 @@ class CnvWorkloadDiscoveredApps(DRWorkload):
                 ocp_obj = ocp.OCP()
                 ocp_obj.delete_project(project_name=self.workload_namespace)
                 log.info(f"Project {self.workload_namespace} deleted successfully")
+
+
+class CnvWorkloadDiscoveredAppsStaticIP(CnvWorkloadDiscoveredApps):
+    """
+    CNV Discovered Apps workload variant for VM static IP translation testing
+    (RHSTOR-8082).
+
+    Reuses the regression CNV discovered-apps workload but, at deploy time,
+    copies it to a temp directory and patches the VirtualMachine manifest to
+    wire it onto the namespace's Primary UDN with a pinned static IP (via the
+    ``network.kubevirt.io/addresses`` annotation), without modifying the
+    original regression workload files. The workload is deployed into a
+    pre-existing namespace that already carries the primary-UDN label and a
+    Primary UserDefinedNetwork (created by the ``setup_udn_nad`` fixture).
+    """
+
+    def __init__(self, **kwargs):
+        """
+        Args:
+            static_ip (str): static IP to pin on the primary cluster,
+                e.g. "192.168.1.11"
+            interface_name (str): VM interface name on the Primary UDN; kept
+                equal to the NAD name so the IPAMClaim name (<vm>.<iface>)
+                matches the lookups in the test.
+
+        """
+        self.static_ip = kwargs.pop("static_ip")
+        self.interface_name = kwargs.pop(
+            "interface_name", vm_ip_translation.VM_NETWORK_INTERFACE_NAME
+        )
+        super().__init__(**kwargs)
+
+    def deploy_workload(self, shared_drpc_protection=False, dr_protect=True):
+        """
+        Deploy the CNV workload with a static IP on the Primary UDN.
+
+        The namespace is assumed to already exist (labeled + UDN created by the
+        setup_udn_nad fixture); only the SSH secret is created here. The VM
+        manifest is patched in a temp copy before ``oc create -k``.
+
+        Args:
+            shared_drpc_protection (bool): False by default, another workload in an
+                existing namespace will share the DRPC and be DR protected via UI
+            dr_protect (bool): True by default where workload will be DR protected
+                via CLI, else the test case handles it (via UI)
+
+        """
+        self._deploy_prereqs()
+        for cluster in get_non_acm_cluster_config():
+            config.switch_ctx(cluster.MULTICLUSTER["multicluster_index"])
+        self.manage_dr_vm_secrets(shared_drpc_protection=shared_drpc_protection)
+        config.switch_to_cluster_by_name(self.preferred_primary_cluster)
+        # Copy the regression workload to a temp dir and patch the VM manifest
+        # for static IP on the Primary UDN, then deploy from the temp dir.
+        self.workload_path = vm_ip_translation.prepare_static_ip_vm_manifest(
+            source_workload_dir=self.cnv_workload_dir,
+            static_ip=self.static_ip,
+            interface_name=self.interface_name,
+        )
+        run_cmd(  # IgnoreDeprecation
+            f"oc create -k {self.workload_path} -n {self.workload_namespace} "
+        )
+        self.check_pod_pvc_status(skip_replication_resources=True)
+        # Wait for temporary resources to be cleaned up before DRPC creation
+        time.sleep(10)
+        config.switch_acm_ctx()
+        if dr_protect:
+            self.create_placement()
+            self.create_drpc()
+            self.verify_workload_deployment()
+        self.vm_obj = VirtualMachine(
+            vm_name=self.vm_name, namespace=self.workload_namespace
+        )

--- a/ocs_ci/ocs/dr/dr_workload.py
+++ b/ocs_ci/ocs/dr/dr_workload.py
@@ -15,7 +15,6 @@ from subprocess import TimeoutExpired
 from ocs_ci.deployment.helpers.hypershift_base import is_hosted_cluster
 from ocs_ci.framework import config
 from ocs_ci.helpers import dr_helpers, helpers
-from ocs_ci.helpers import dr_helpers_vm_ip_translation as vm_ip_translation
 from ocs_ci.helpers.cnv_helpers import create_vm_secret, cal_md5sum_vm
 from ocs_ci.helpers.dr_helpers import (
     create_cdi_cert_configmap,
@@ -2389,76 +2388,3 @@ class CnvWorkloadDiscoveredApps(DRWorkload):
                 ocp_obj = ocp.OCP()
                 ocp_obj.delete_project(project_name=self.workload_namespace)
                 log.info(f"Project {self.workload_namespace} deleted successfully")
-
-
-class CnvWorkloadDiscoveredAppsStaticIP(CnvWorkloadDiscoveredApps):
-    """
-    CNV Discovered Apps workload variant for VM static IP translation testing
-    (RHSTOR-8082).
-
-    Reuses the regression CNV discovered-apps workload but, at deploy time,
-    copies it to a temp directory and patches the VirtualMachine manifest to
-    wire it onto the namespace's Primary UDN with a pinned static IP (via the
-    ``network.kubevirt.io/addresses`` annotation), without modifying the
-    original regression workload files. The workload is deployed into a
-    pre-existing namespace that already carries the primary-UDN label and a
-    Primary UserDefinedNetwork (created by the ``setup_udn_nad`` fixture).
-    """
-
-    def __init__(self, **kwargs):
-        """
-        Args:
-            static_ip (str): static IP to pin on the primary cluster,
-                e.g. "192.168.1.11"
-            interface_name (str): VM interface name on the Primary UDN; kept
-                equal to the NAD name so the IPAMClaim name (<vm>.<iface>)
-                matches the lookups in the test.
-
-        """
-        self.static_ip = kwargs.pop("static_ip")
-        self.interface_name = kwargs.pop(
-            "interface_name", vm_ip_translation.VM_NETWORK_INTERFACE_NAME
-        )
-        super().__init__(**kwargs)
-
-    def deploy_workload(self, shared_drpc_protection=False, dr_protect=True):
-        """
-        Deploy the CNV workload with a static IP on the Primary UDN.
-
-        The namespace is assumed to already exist (labeled + UDN created by the
-        setup_udn_nad fixture); only the SSH secret is created here. The VM
-        manifest is patched in a temp copy before ``oc create -k``.
-
-        Args:
-            shared_drpc_protection (bool): False by default, another workload in an
-                existing namespace will share the DRPC and be DR protected via UI
-            dr_protect (bool): True by default where workload will be DR protected
-                via CLI, else the test case handles it (via UI)
-
-        """
-        self._deploy_prereqs()
-        for cluster in get_non_acm_cluster_config():
-            config.switch_ctx(cluster.MULTICLUSTER["multicluster_index"])
-        self.manage_dr_vm_secrets(shared_drpc_protection=shared_drpc_protection)
-        config.switch_to_cluster_by_name(self.preferred_primary_cluster)
-        # Copy the regression workload to a temp dir and patch the VM manifest
-        # for static IP on the Primary UDN, then deploy from the temp dir.
-        self.workload_path = vm_ip_translation.prepare_static_ip_vm_manifest(
-            source_workload_dir=self.cnv_workload_dir,
-            static_ip=self.static_ip,
-            interface_name=self.interface_name,
-        )
-        run_cmd(  # IgnoreDeprecation
-            f"oc create -k {self.workload_path} -n {self.workload_namespace} "
-        )
-        self.check_pod_pvc_status(skip_replication_resources=True)
-        # Wait for temporary resources to be cleaned up before DRPC creation
-        time.sleep(10)
-        config.switch_acm_ctx()
-        if dr_protect:
-            self.create_placement()
-            self.create_drpc()
-            self.verify_workload_deployment()
-        self.vm_obj = VirtualMachine(
-            vm_name=self.vm_name, namespace=self.workload_namespace
-        )

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -1815,20 +1815,7 @@ acm_configuration_4_20 = {
         By.XPATH,
     ),
     "fleet-virtual": ("//h2[text()='Fleet Virtualization']", By.XPATH),
-    # ACM 5.0 renamed the attribute on this nav item from data-test-id to
-    # data-test, so match either to stay compatible with earlier ACM builds.
-    "nav-bar-vms-page": (
-        "//a[@data-test-id='virtualmachines-nav-item' or @data-test='virtualmachines-nav-item']",
-        By.XPATH,
-    ),
-    # The side nav is rendered collapsed (and aria-hidden) after switching to the
-    # Fleet Virtualization perspective, so it has to be expanded before any of the
-    # nav items can be clicked.
-    "nav-sidebar-collapsed": (
-        "//div[@id='page-sidebar' and contains(@class, 'pf-m-collapsed')]",
-        By.XPATH,
-    ),
-    "nav-sidebar-toggle": ("//button[@id='nav-toggle']", By.XPATH),
+    "nav-bar-vms-page": ("//a[@data-test-id='virtualmachines-nav-item']", By.XPATH),
     "all-clusters": ("//button[text()='All clusters']", By.XPATH),
     "managed-cluster-name": ("//button[text()='{}']", By.XPATH),
     "cnv-workload-namespace": ("//button[text()='{}']", By.XPATH),
@@ -1964,6 +1951,20 @@ acm_configuration_4_22 = {
         "(//button[@type='button'][.//*[normalize-space()='Nodes labeled']])[2]",
         By.XPATH,
     ),
+}
+
+acm_configuration_5_0 = {
+    # The VMs nav item moved from data-test-id to data-test on the ACM hub
+    # console shipped with OCP 5.0.
+    "nav-bar-vms-page": ("//a[@data-test='virtualmachines-nav-item']", By.XPATH),
+    # The side nav is rendered collapsed (and aria-hidden) after switching to
+    # the Fleet Virtualization perspective, so it has to be expanded before any
+    # of the nav items can be clicked.
+    "nav-sidebar-collapsed": (
+        "//div[@id='page-sidebar' and contains(@class, 'pf-m-collapsed')]",
+        By.XPATH,
+    ),
+    "nav-sidebar-toggle": ("//button[@id='nav-toggle']", By.XPATH),
 }
 
 add_capacity = {
@@ -4212,6 +4213,7 @@ locators = {
             **acm_configuration_4_20,
             **acm_configuration_4_21,
             **acm_configuration_4_22,
+            **acm_configuration_5_0,
         },
         "validation": {
             **validation,

--- a/ocs_ci/ocs/ui/views.py
+++ b/ocs_ci/ocs/ui/views.py
@@ -1815,7 +1815,20 @@ acm_configuration_4_20 = {
         By.XPATH,
     ),
     "fleet-virtual": ("//h2[text()='Fleet Virtualization']", By.XPATH),
-    "nav-bar-vms-page": ("//a[@data-test-id='virtualmachines-nav-item']", By.XPATH),
+    # ACM 5.0 renamed the attribute on this nav item from data-test-id to
+    # data-test, so match either to stay compatible with earlier ACM builds.
+    "nav-bar-vms-page": (
+        "//a[@data-test-id='virtualmachines-nav-item' or @data-test='virtualmachines-nav-item']",
+        By.XPATH,
+    ),
+    # The side nav is rendered collapsed (and aria-hidden) after switching to the
+    # Fleet Virtualization perspective, so it has to be expanded before any of the
+    # nav items can be clicked.
+    "nav-sidebar-collapsed": (
+        "//div[@id='page-sidebar' and contains(@class, 'pf-m-collapsed')]",
+        By.XPATH,
+    ),
+    "nav-sidebar-toggle": ("//button[@id='nav-toggle']", By.XPATH),
     "all-clusters": ("//button[text()='All clusters']", By.XPATH),
     "managed-cluster-name": ("//button[text()='{}']", By.XPATH),
     "cnv-workload-namespace": ("//button[text()='{}']", By.XPATH),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,7 +78,6 @@ from ocs_ci.ocs.dr.dr_workload import (
     CnvWorkload,
     BusyboxDiscoveredApps,
     CnvWorkloadDiscoveredApps,
-    CnvWorkloadDiscoveredAppsStaticIP,
 )
 from ocs_ci.ocs.exceptions import (
     CommandFailed,
@@ -218,11 +217,6 @@ from ocs_ci.utility.utils import (
 )
 
 from ocs_ci.helpers import dr_helpers, helpers
-from ocs_ci.helpers.dr_helpers_vm_ip_translation import (
-    static_ip_from_subnet,
-    VM_NETWORK_INTERFACE_NAME,
-)
-from ocs_ci.ocs.utils import get_primary_cluster_config
 from ocs_ci.helpers.helpers import (
     add_scc_policy,
     ceph_health_check_with_toolbox_recovery,
@@ -8675,58 +8669,45 @@ def cnv_workload_with_static_ip(request):
     Deploys a CNV Discovered App workload wired onto a Primary UDN with a pinned
     static IP for DR static IP translation testing (RHSTOR-8082).
 
-    Reuses the regression CNV discovered-apps workload entries
-    (``dr_cnv_discovered_apps`` / ``dr_cnv_discovered_apps_shared``) but patches
-    the VM manifest at deploy time (via a temp copy) to attach the Primary UDN
-    interface and pin a static IP. The workload is deployed into the namespace
-    prepared by the ``setup_udn_nad`` fixture (already labeled for the primary
-    UDN and carrying the UserDefinedNetwork on both managed clusters), so the
-    caller must pass that fixture's yielded dict as ``udn_nad``.
+    The VM manifests (``dr_cnv_discovered_apps_static_ip`` /
+    ``..._static_ip_shared``) already carry the Primary UDN interface and the
+    ``network.kubevirt.io/addresses`` annotation pinning the static IP. They
+    deploy into ``constants.VM_IP_TRANSLATION_WORKLOAD_NS`` - the namespace the
+    ``setup_udn_nad`` fixture prepares with the primary-UDN label and the
+    "vm-network" UserDefinedNetwork on both managed clusters - so that fixture
+    must be active for this one to work.
     """
 
     instances = []
 
     def factory(
-        udn_nad,
         pvc_vm=1,
         dr_protect=False,
         shared_drpc_protection=False,
         dr_policy_name=None,
-        interface_name=VM_NETWORK_INTERFACE_NAME,
     ):
         """
         Args:
-            udn_nad (dict): the dict yielded by the ``setup_udn_nad`` fixture,
-                providing ``workload_namespace`` and per-cluster ``cluster_subnets``
             pvc_vm (int): Number of workload instances to create
             dr_protect (bool): When True, DR-protects via CLI immediately after deploy
             shared_drpc_protection (bool): When True, additional instances share the
                 namespace and DRPC of the first instance
             dr_policy_name (str): DRPolicy name override; if None uses the default
-            interface_name (str): VM interface name on the Primary UDN; kept equal
-                to the NAD name so the IPAMClaim name matches lookups in the test
 
         Returns:
             list: objects of workload class
         """
         total_pvc_count = 0
         workload_key = (
-            "dr_cnv_discovered_apps_shared"
+            "dr_cnv_discovered_apps_static_ip_shared"
             if shared_drpc_protection
-            else "dr_cnv_discovered_apps"
-        )
-
-        # The workload namespace is the one prepared by setup_udn_nad (labeled +
-        # Primary UDN on both clusters). Pin the static IP in the primary
-        # cluster's subnet.
-        workload_namespace = udn_nad["workload_namespace"]
-        primary_cluster_name = get_primary_cluster_config().ENV_DATA["cluster_name"]
-        static_ip = static_ip_from_subnet(
-            udn_nad["cluster_subnets"][primary_cluster_name]
+            else "dr_cnv_discovered_apps_static_ip"
         )
 
         for index in range(pvc_vm):
             workload_details = ocsci_config.ENV_DATA[workload_key][index]
+            # Deploy into the namespace that already holds the Primary UDN
+            workload_namespace = workload_details["workload_namespace"]
             wl_kwargs = dict(
                 workload_dir=workload_details["workload_dir"],
                 workload_pod_count=workload_details["pod_count"],
@@ -8751,12 +8732,10 @@ def cnv_workload_with_static_ip(request):
                 vm_username=workload_details["vm_username"],
                 workload_name=workload_details["name"],
                 vm_name=workload_details["vm_name"],
-                static_ip=static_ip,
-                interface_name=interface_name,
             )
             if dr_policy_name:
                 wl_kwargs["dr_policy_name"] = dr_policy_name
-            workload = CnvWorkloadDiscoveredAppsStaticIP(**wl_kwargs)
+            workload = CnvWorkloadDiscoveredApps(**wl_kwargs)
 
             instances.append(workload)
             total_pvc_count += workload_details["pvc_count"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8664,6 +8664,102 @@ def discovered_apps_dr_workload_cnv(request):
 
 
 @pytest.fixture()
+def cnv_workload_with_static_ip(request):
+    """
+    Deploys a CNV Discovered App workload with a UDN secondary network interface
+    and static IP via IPAMClaim for DR static IP translation testing (RHSTOR-8082).
+    """
+
+    instances = []
+
+    def factory(
+        pvc_vm=1,
+        dr_protect=False,
+        shared_drpc_protection=False,
+        dr_policy_name=None,
+    ):
+        """
+        Args:
+            pvc_vm (int): Number of workload instances to create
+            dr_protect (bool): When True, DR-protects via CLI immediately after deploy
+            shared_drpc_protection (bool): When True, additional instances share the
+                namespace and DRPC of the first instance
+            dr_policy_name (str): DRPolicy name override; if None uses the default
+
+        Returns:
+            list: objects of workload class
+        """
+        total_pvc_count = 0
+        workload_key = (
+            "dr_cnv_discovered_apps_static_ip_shared"
+            if shared_drpc_protection
+            else "dr_cnv_discovered_apps_static_ip"
+        )
+
+        for index in range(pvc_vm):
+            workload_details = ocsci_config.ENV_DATA[workload_key][index]
+            workload_namespace = create_unique_resource_name("wrkld-vm", "dist")[:20]
+            if shared_drpc_protection and instances:
+                workload_details["workload_namespace"] = instances[0].workload_namespace
+                workload_namespace = instances[0].workload_namespace
+            wl_kwargs = dict(
+                workload_dir=workload_details["workload_dir"],
+                workload_pod_count=workload_details["pod_count"],
+                workload_pvc_count=workload_details["pvc_count"],
+                workload_namespace=workload_namespace,
+                discovered_apps_pvc_selector_key=workload_details[
+                    "dr_workload_app_pvc_selector_key"
+                ],
+                discovered_apps_pvc_selector_value=workload_details[
+                    "dr_workload_app_pvc_selector_value"
+                ],
+                discovered_apps_pod_selector_key=workload_details[
+                    "dr_workload_app_pod_selector_key"
+                ],
+                discovered_apps_pod_selector_value=workload_details[
+                    "dr_workload_app_pod_selector_value"
+                ],
+                workload_placement_name=workload_details[
+                    "dr_workload_app_placement_name"
+                ],
+                vm_secret=workload_details["vm_secret"],
+                vm_username=workload_details["vm_username"],
+                workload_name=workload_details["name"],
+                vm_name=workload_details["vm_name"],
+            )
+            if dr_policy_name:
+                wl_kwargs["dr_policy_name"] = dr_policy_name
+            workload = CnvWorkloadDiscoveredApps(**wl_kwargs)
+
+            instances.append(workload)
+            total_pvc_count += workload_details["pvc_count"]
+            workload.deploy_workload(
+                dr_protect=dr_protect, shared_drpc_protection=shared_drpc_protection
+            )
+            if dr_protect:
+                dr_helpers.validate_application_odf_cli(
+                    drpc_name=workload.discovered_apps_placement_name,
+                    namespace=constants.DR_OPS_NAMESPACE,
+                )
+
+        return instances
+
+    def teardown():
+        if "shared" in request.node.nodeid:
+            instances[0].delete_workload(skip_resource_deletion_verification=True)
+            instances[1].delete_workload(shared_drpc_protection=True)
+        else:
+            for instance in instances:
+                try:
+                    instance.delete_workload()
+                except ResourceNotDeleted:
+                    raise ResourceNotDeleted("Workload deletion was unsuccessful")
+
+    request.addfinalizer(teardown)
+    return factory
+
+
+@pytest.fixture()
 def all_dr_workloads(
     dr_workload, discovered_apps_dr_workload, discovered_apps_dr_workload_cnv
 ):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,6 +78,7 @@ from ocs_ci.ocs.dr.dr_workload import (
     CnvWorkload,
     BusyboxDiscoveredApps,
     CnvWorkloadDiscoveredApps,
+    CnvWorkloadDiscoveredAppsStaticIP,
 )
 from ocs_ci.ocs.exceptions import (
     CommandFailed,
@@ -217,6 +218,11 @@ from ocs_ci.utility.utils import (
 )
 
 from ocs_ci.helpers import dr_helpers, helpers
+from ocs_ci.helpers.dr_helpers_vm_ip_translation import (
+    static_ip_from_subnet,
+    VM_NETWORK_INTERFACE_NAME,
+)
+from ocs_ci.ocs.utils import get_primary_cluster_config
 from ocs_ci.helpers.helpers import (
     add_scc_policy,
     ceph_health_check_with_toolbox_recovery,
@@ -8666,42 +8672,61 @@ def discovered_apps_dr_workload_cnv(request):
 @pytest.fixture()
 def cnv_workload_with_static_ip(request):
     """
-    Deploys a CNV Discovered App workload with a UDN secondary network interface
-    and static IP via IPAMClaim for DR static IP translation testing (RHSTOR-8082).
+    Deploys a CNV Discovered App workload wired onto a Primary UDN with a pinned
+    static IP for DR static IP translation testing (RHSTOR-8082).
+
+    Reuses the regression CNV discovered-apps workload entries
+    (``dr_cnv_discovered_apps`` / ``dr_cnv_discovered_apps_shared``) but patches
+    the VM manifest at deploy time (via a temp copy) to attach the Primary UDN
+    interface and pin a static IP. The workload is deployed into the namespace
+    prepared by the ``setup_udn_nad`` fixture (already labeled for the primary
+    UDN and carrying the UserDefinedNetwork on both managed clusters), so the
+    caller must pass that fixture's yielded dict as ``udn_nad``.
     """
 
     instances = []
 
     def factory(
+        udn_nad,
         pvc_vm=1,
         dr_protect=False,
         shared_drpc_protection=False,
         dr_policy_name=None,
+        interface_name=VM_NETWORK_INTERFACE_NAME,
     ):
         """
         Args:
+            udn_nad (dict): the dict yielded by the ``setup_udn_nad`` fixture,
+                providing ``workload_namespace`` and per-cluster ``cluster_subnets``
             pvc_vm (int): Number of workload instances to create
             dr_protect (bool): When True, DR-protects via CLI immediately after deploy
             shared_drpc_protection (bool): When True, additional instances share the
                 namespace and DRPC of the first instance
             dr_policy_name (str): DRPolicy name override; if None uses the default
+            interface_name (str): VM interface name on the Primary UDN; kept equal
+                to the NAD name so the IPAMClaim name matches lookups in the test
 
         Returns:
             list: objects of workload class
         """
         total_pvc_count = 0
         workload_key = (
-            "dr_cnv_discovered_apps_static_ip_shared"
+            "dr_cnv_discovered_apps_shared"
             if shared_drpc_protection
-            else "dr_cnv_discovered_apps_static_ip"
+            else "dr_cnv_discovered_apps"
+        )
+
+        # The workload namespace is the one prepared by setup_udn_nad (labeled +
+        # Primary UDN on both clusters). Pin the static IP in the primary
+        # cluster's subnet.
+        workload_namespace = udn_nad["workload_namespace"]
+        primary_cluster_name = get_primary_cluster_config().ENV_DATA["cluster_name"]
+        static_ip = static_ip_from_subnet(
+            udn_nad["cluster_subnets"][primary_cluster_name]
         )
 
         for index in range(pvc_vm):
             workload_details = ocsci_config.ENV_DATA[workload_key][index]
-            workload_namespace = create_unique_resource_name("wrkld-vm", "dist")[:20]
-            if shared_drpc_protection and instances:
-                workload_details["workload_namespace"] = instances[0].workload_namespace
-                workload_namespace = instances[0].workload_namespace
             wl_kwargs = dict(
                 workload_dir=workload_details["workload_dir"],
                 workload_pod_count=workload_details["pod_count"],
@@ -8726,10 +8751,12 @@ def cnv_workload_with_static_ip(request):
                 vm_username=workload_details["vm_username"],
                 workload_name=workload_details["name"],
                 vm_name=workload_details["vm_name"],
+                static_ip=static_ip,
+                interface_name=interface_name,
             )
             if dr_policy_name:
                 wl_kwargs["dr_policy_name"] = dr_policy_name
-            workload = CnvWorkloadDiscoveredApps(**wl_kwargs)
+            workload = CnvWorkloadDiscoveredAppsStaticIP(**wl_kwargs)
 
             instances.append(workload)
             total_pvc_count += workload_details["pvc_count"]

--- a/tests/functional/disaster-recovery/regional-dr/conftest.py
+++ b/tests/functional/disaster-recovery/regional-dr/conftest.py
@@ -40,6 +40,11 @@ from ocs_ci.helpers.dr_helpers import (
     validate_cluster_odf_cli,
 )
 from ocs_ci.helpers.odf_cli import odf_cli_setup_helper
+from ocs_ci.helpers.dr_helpers_vm_ip_translation import (  # noqa: F401
+    network_mapping_configmap,
+    setup_nad_in_namespace,
+    setup_udn_nad,
+)
 
 log = logging.getLogger(__name__)
 

--- a/tests/functional/disaster-recovery/regional-dr/test_acm_kubevirt_dr_integration.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_acm_kubevirt_dr_integration.py
@@ -81,11 +81,10 @@ class TestACMKubevirtDRIntergration:
     # TODO: Add Polarion ID when available
     def test_acm_kubevirt_using_different_protection_types(
         self,
+        request,
         setup_acm_ui,
         protection_type,
         static_vm_ip,
-        setup_udn_nad,
-        network_mapping_configmap,
         discovered_apps_dr_workload_cnv,
         cnv_workload_with_static_ip,
         nodes_multicluster,
@@ -112,6 +111,18 @@ class TestACMKubevirtDRIntergration:
         md5sum_original = []
         md5sum_failover = []
         vm_filepaths = ["/dd_file1.txt", "/dd_file2.txt", "/dd_file3.txt"]
+
+        # The UDN and the network mapping ConfigMap are only meaningful for the
+        # static IP cases, so request them lazily instead of as test arguments -
+        # otherwise every parametrization would pay for a UDN it never uses.
+        # setup_udn_nad must run before the workload is deployed because it
+        # creates the workload namespace with the primary-UDN label.
+        setup_udn_nad = network_mapping_configmap = None
+        if static_vm_ip:
+            setup_udn_nad = request.getfixturevalue("setup_udn_nad")
+            network_mapping_configmap = request.getfixturevalue(
+                "network_mapping_configmap"
+            )
 
         # The static IP VMs come from dedicated workload dirs that pin an address
         # inside the UDN subnet; everything else about them is deployed and DR

--- a/tests/functional/disaster-recovery/regional-dr/test_acm_kubevirt_dr_integration.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_acm_kubevirt_dr_integration.py
@@ -15,6 +15,12 @@ from ocs_ci.framework.pytest_customization.marks import (
 from ocs_ci.helpers import dr_helpers
 from ocs_ci.helpers.cnv_helpers import run_dd_io
 from ocs_ci.helpers.dr_helpers import wait_for_all_resources_deletion
+from ocs_ci.helpers.dr_helpers_vm_ip_translation import (
+    VM_NETWORK_NAD_NAME,
+    get_ipamclaim_ip,
+    get_vm_ip_from_vmi,
+    wait_for_drpolicy_network_peers,
+)
 from ocs_ci.ocs import constants
 from ocs_ci.ocs.acm.acm import AcmAddClusters
 from ocs_ci.helpers.dr_helpers_ui import (
@@ -42,12 +48,34 @@ class TestACMKubevirtDRIntergration:
     """
 
     @pytest.mark.parametrize(
-        argnames=["protection_type"],
+        argnames=["protection_type", "static_vm_ip"],
         argvalues=[
             pytest.param(
-                False, id="standalone", marks=pytest.mark.polarion_id("OCS-xxxx")
+                False, False, id="standalone", marks=pytest.mark.polarion_id("OCS-xxxx")
             ),
-            pytest.param(True, id="shared", marks=pytest.mark.polarion_id("OCS-yyyy")),
+            pytest.param(
+                True, False, id="shared", marks=pytest.mark.polarion_id("OCS-yyyy")
+            ),
+            # Static VM IP translation — standalone DRPC, requires OCS >= 4.23 (RHSTOR-8082)
+            pytest.param(
+                False,
+                True,
+                id="standalone_static-ip",
+                marks=[
+                    pytest.mark.polarion_id("OCS-XXXX"),
+                    skipif_ocs_version("<4.23"),
+                ],
+            ),
+            # Static VM IP translation — shared DRPC, requires OCS >= 4.23 (RHSTOR-8082)
+            pytest.param(
+                True,
+                True,
+                id="shared_static-ip",
+                marks=[
+                    pytest.mark.polarion_id("OCS-XXXX"),
+                    skipif_ocs_version("<4.23"),
+                ],
+            ),
         ],
     )
     # TODO: Add Polarion ID when available
@@ -55,7 +83,11 @@ class TestACMKubevirtDRIntergration:
         self,
         setup_acm_ui,
         protection_type,
+        static_vm_ip,
+        setup_udn_nad,
+        network_mapping_configmap,
         discovered_apps_dr_workload_cnv,
+        cnv_workload_with_static_ip,
         nodes_multicluster,
         node_restart_teardown,
     ):
@@ -82,16 +114,26 @@ class TestACMKubevirtDRIntergration:
         vm_filepaths = ["/dd_file1.txt", "/dd_file2.txt", "/dd_file3.txt"]
 
         logger.info("Deploy 1st CNV workload")
-        cnv_workloads = discovered_apps_dr_workload_cnv(
-            pvc_vm=1, dr_protect=False, shared_drpc_protection=False
-        )
+        if static_vm_ip:
+            cnv_workloads = cnv_workload_with_static_ip(
+                pvc_vm=1, dr_protect=False, shared_drpc_protection=False
+            )
+        else:
+            cnv_workloads = discovered_apps_dr_workload_cnv(
+                pvc_vm=1, dr_protect=False, shared_drpc_protection=False
+            )
 
         if protection_type:
             # Deploy second workload for Shared protection (uses same namespace as first)
             logger.info("Deploy 2nd CNV workload in the existing namespace")
-            cnv_workloads = discovered_apps_dr_workload_cnv(
-                pvc_vm=1, dr_protect=False, shared_drpc_protection=True
-            )
+            if static_vm_ip:
+                cnv_workloads = cnv_workload_with_static_ip(
+                    pvc_vm=1, dr_protect=False, shared_drpc_protection=True
+                )
+            else:
+                cnv_workloads = discovered_apps_dr_workload_cnv(
+                    pvc_vm=1, dr_protect=False, shared_drpc_protection=True
+                )
 
         assert cnv_workloads, "No discovered VM found"
         config.switch_acm_ctx()
@@ -106,17 +148,42 @@ class TestACMKubevirtDRIntergration:
         logger.info(
             f"Primary managed cluster name is {cnv_workloads[0].preferred_primary_cluster}"
         )
-        assert navigate_using_fleet_virtualization(acm_obj)
-        for i, vm in enumerate(cnv_workloads):
-            standalone_flag = (not protection_type) or (i == 0)
-            assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
-                acm_obj,
-                vms=[vm],
-                managed_cluster_name=primary_cluster_name,
-                standalone=standalone_flag,
-                protection_name=protection_name,
-                namespace=cnv_workloads[0].workload_namespace,
+
+        if not static_vm_ip:
+            # DR protection via ACM UI fleet virtualization page
+            assert navigate_using_fleet_virtualization(acm_obj)
+            for i, vm in enumerate(cnv_workloads):
+                standalone_flag = (not protection_type) or (i == 0)
+                assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
+                    acm_obj,
+                    vms=[vm],
+                    managed_cluster_name=primary_cluster_name,
+                    standalone=standalone_flag,
+                    protection_name=protection_name,
+                    namespace=cnv_workloads[0].workload_namespace,
+                )
+        else:
+            # Static IP: DR protection done via CLI (dr_protect=True above).
+            # Set up network mapping ConfigMap on hub and link to DRPolicy.
+            # ACM UI protection for static-IP discovered VMs is not supported.
+            config.switch_acm_ctx()
+            existing_policies = dr_helpers.get_all_drpolicy()
+            assert existing_policies, "No DRPolicy found on hub"
+            drpolicy_name = existing_policies[0]["metadata"]["name"]
+
+            cluster_names = setup_udn_nad["cluster_names"]
+            cluster_subnets = setup_udn_nad["cluster_subnets"]
+            network_mapping_configmap(
+                "vm-ip-map-kubevirt-static",
+                cluster1_name=cluster_names[0],
+                cluster2_name=cluster_names[1],
+                nad_namespace=setup_udn_nad["workload_namespace"],
+                nad_name=VM_NETWORK_NAD_NAME,
+                cluster1_cidr=cluster_subnets[cluster_names[0]],
+                cluster2_cidr=cluster_subnets[cluster_names[1]],
+                drpolicy_name=drpolicy_name,
             )
+            wait_for_drpolicy_network_peers(drpolicy_name)
 
         logger.info(
             f'Placement name is "{cnv_workloads[0].discovered_apps_placement_name}"'
@@ -154,6 +221,33 @@ class TestACMKubevirtDRIntergration:
             namespace=cnv_workloads[0].workload_namespace,
             phase=constants.STATUS_RUNNING,
         )
+
+        # Record VM IP on primary before failover (static IP path only)
+        if static_vm_ip:
+            config.switch_to_cluster_by_name(primary_cluster_name)
+            vm_ip_primary = get_vm_ip_from_vmi(
+                primary_cluster_name,
+                cnv_workloads[0].workload_namespace,
+                cnv_workloads[0].vm_name,
+                VM_NETWORK_NAD_NAME,
+            )
+            assert (
+                vm_ip_primary
+            ), f"Could not read IP from VMI {cnv_workloads[0].vm_name} on primary"
+            ipam_ip_primary = get_ipamclaim_ip(
+                primary_cluster_name,
+                cnv_workloads[0].workload_namespace,
+                cnv_workloads[0].vm_name,
+                VM_NETWORK_NAD_NAME,
+            )
+            assert ipam_ip_primary == vm_ip_primary, (
+                f"IPAMClaim IP {ipam_ip_primary} does not match VMI IP {vm_ip_primary} "
+                f"on primary before failover"
+            )
+            logger.info(
+                f"VM {cnv_workloads[0].vm_name} IP on primary before failover: "
+                f"{vm_ip_primary} (IPAMClaim confirmed)"
+            )
 
         secondary_cluster_name = dr_helpers.get_current_secondary_cluster_name(
             cnv_workloads[0].workload_namespace,
@@ -227,6 +321,34 @@ class TestACMKubevirtDRIntergration:
             cnv_workloads, vm_filepaths[0], md5sum_original, "Failover"
         )
 
+        # Verify IP translation on secondary after failover (static IP path only)
+        if static_vm_ip:
+            vm_ip_secondary = get_vm_ip_from_vmi(
+                secondary_cluster_name,
+                cnv_workloads[0].workload_namespace,
+                cnv_workloads[0].vm_name,
+                VM_NETWORK_NAD_NAME,
+            )
+            assert (
+                vm_ip_secondary
+            ), f"Could not read IP from VMI {cnv_workloads[0].vm_name} on secondary after failover"
+            ipam_ip_secondary = get_ipamclaim_ip(
+                secondary_cluster_name,
+                cnv_workloads[0].workload_namespace,
+                cnv_workloads[0].vm_name,
+                VM_NETWORK_NAD_NAME,
+            )
+            assert ipam_ip_secondary == vm_ip_secondary, (
+                f"IPAMClaim IP {ipam_ip_secondary} does not match VMI IP {vm_ip_secondary} "
+                f"on secondary after failover"
+            )
+            assert (
+                vm_ip_secondary != vm_ip_primary
+            ), f"VM IP was not translated after failover: still {vm_ip_secondary}"
+            logger.info(
+                f"IP translation verified after failover: {vm_ip_primary} -> {vm_ip_secondary}"
+            )
+
         # Creating a file (file2) post failover
         for cnv_wl in cnv_workloads:
             md5sum_failover.append(
@@ -274,15 +396,16 @@ class TestACMKubevirtDRIntergration:
         )
         drpc_obj.wait_for_progression_status(status=constants.STATUS_COMPLETED)
 
-        logger.info("On UI, check if VM is running after failover or not")
-        assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
-            acm_obj,
-            vms=cnv_workloads,
-            protection_name=protection_name,
-            namespace=cnv_workloads[0].workload_namespace,
-            managed_cluster_name=secondary_cluster_name,
-            assign_policy=False,
-        )
+        if not static_vm_ip:
+            logger.info("On UI, check if VM is running after failover or not")
+            assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
+                acm_obj,
+                vms=cnv_workloads,
+                protection_name=protection_name,
+                namespace=cnv_workloads[0].workload_namespace,
+                managed_cluster_name=secondary_cluster_name,
+                assign_policy=False,
+            )
         config.switch_to_cluster_by_name(secondary_cluster_name)
 
         # Doing Relocate in below code
@@ -328,17 +451,47 @@ class TestACMKubevirtDRIntergration:
             phase=constants.STATUS_RUNNING,
         )
 
+        # Verify IP restored to original on primary after relocate (static IP path only)
+        if static_vm_ip:
+            vm_ip_after_relocate = get_vm_ip_from_vmi(
+                primary_cluster_name,
+                cnv_workloads[0].workload_namespace,
+                cnv_workloads[0].vm_name,
+                VM_NETWORK_NAD_NAME,
+            )
+            assert (
+                vm_ip_after_relocate
+            ), f"Could not read IP from VMI {cnv_workloads[0].vm_name} on primary after relocate"
+            ipam_ip_after_relocate = get_ipamclaim_ip(
+                primary_cluster_name,
+                cnv_workloads[0].workload_namespace,
+                cnv_workloads[0].vm_name,
+                VM_NETWORK_NAD_NAME,
+            )
+            assert ipam_ip_after_relocate == vm_ip_after_relocate, (
+                f"IPAMClaim IP {ipam_ip_after_relocate} does not match VMI IP "
+                f"{vm_ip_after_relocate} on primary after relocate"
+            )
+            assert vm_ip_after_relocate == vm_ip_primary, (
+                f"VM IP {vm_ip_after_relocate} was not restored to original "
+                f"{vm_ip_primary} after relocate"
+            )
+            logger.info(
+                f"IP restoration verified after relocate: {vm_ip_secondary} -> {vm_ip_after_relocate}"
+            )
+
         config.switch_acm_ctx()
-        logger.info("On UI, check if VM is running after relocate or not")
-        acm_obj.refresh_page()
-        assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
-            acm_obj,
-            vms=cnv_workloads,
-            protection_name=protection_name,
-            namespace=cnv_workloads[0].workload_namespace,
-            managed_cluster_name=primary_cluster_name,
-            assign_policy=False,
-        )
+        if not static_vm_ip:
+            logger.info("On UI, check if VM is running after relocate or not")
+            acm_obj.refresh_page()
+            assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
+                acm_obj,
+                vms=cnv_workloads,
+                protection_name=protection_name,
+                namespace=cnv_workloads[0].workload_namespace,
+                managed_cluster_name=primary_cluster_name,
+                assign_policy=False,
+            )
         config.switch_to_cluster_by_name(primary_cluster_name)
 
         # Validating data integrity (file1) after relocating VMs back to primary managed cluster

--- a/tests/functional/disaster-recovery/regional-dr/test_acm_kubevirt_dr_integration.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_acm_kubevirt_dr_integration.py
@@ -115,8 +115,10 @@ class TestACMKubevirtDRIntergration:
 
         logger.info("Deploy 1st CNV workload")
         if static_vm_ip:
+            # Static IP VMs must be DR protected via the discovered apps CLI;
+            # ACM UI protection is not supported for them.
             cnv_workloads = cnv_workload_with_static_ip(
-                pvc_vm=1, dr_protect=False, shared_drpc_protection=False
+                pvc_vm=1, dr_protect=True, shared_drpc_protection=False
             )
         else:
             cnv_workloads = discovered_apps_dr_workload_cnv(
@@ -127,6 +129,9 @@ class TestACMKubevirtDRIntergration:
             # Deploy second workload for Shared protection (uses same namespace as first)
             logger.info("Deploy 2nd CNV workload in the existing namespace")
             if static_vm_ip:
+                # No second DRPC: the DRPC created above protects the whole
+                # namespace and its selectors (appname=kubevirt) already match
+                # this VM, which is what Shared protection means here.
                 cnv_workloads = cnv_workload_with_static_ip(
                     pvc_vm=1, dr_protect=False, shared_drpc_protection=True
                 )
@@ -139,7 +144,11 @@ class TestACMKubevirtDRIntergration:
         config.switch_acm_ctx()
         protection_name = cnv_workloads[0].workload_namespace
         logger.info(f"Protection name is {protection_name}")
-        resource_name = cnv_workloads[0].discovered_apps_placement_name + "-drpc"
+        # DRPCs created via the CLI are named after the placement, while the ACM
+        # UI appends a "-drpc" suffix to it.
+        resource_name = cnv_workloads[0].discovered_apps_placement_name
+        if not static_vm_ip:
+            resource_name += "-drpc"
 
         logger.info(f"CNV workloads instance is {cnv_workloads}")
 
@@ -163,9 +172,9 @@ class TestACMKubevirtDRIntergration:
                     namespace=cnv_workloads[0].workload_namespace,
                 )
         else:
-            # Static IP: DR protection done via CLI (dr_protect=True above).
-            # Set up network mapping ConfigMap on hub and link to DRPolicy.
-            # ACM UI protection for static-IP discovered VMs is not supported.
+            # Static IP: the workload is already DR protected via the CLI at
+            # deploy time. What remains is the network mapping ConfigMap on the
+            # hub, linked to the DRPolicy, which drives the IP translation.
             config.switch_acm_ctx()
             existing_policies = dr_helpers.get_all_drpolicy()
             assert existing_policies, "No DRPolicy found on hub"

--- a/tests/functional/disaster-recovery/regional-dr/test_acm_kubevirt_dr_integration.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_acm_kubevirt_dr_integration.py
@@ -116,7 +116,7 @@ class TestACMKubevirtDRIntergration:
         logger.info("Deploy 1st CNV workload")
         if static_vm_ip:
             cnv_workloads = cnv_workload_with_static_ip(
-                pvc_vm=1, dr_protect=False, shared_drpc_protection=False
+                setup_udn_nad, pvc_vm=1, dr_protect=False, shared_drpc_protection=False
             )
         else:
             cnv_workloads = discovered_apps_dr_workload_cnv(
@@ -128,7 +128,10 @@ class TestACMKubevirtDRIntergration:
             logger.info("Deploy 2nd CNV workload in the existing namespace")
             if static_vm_ip:
                 cnv_workloads = cnv_workload_with_static_ip(
-                    pvc_vm=1, dr_protect=False, shared_drpc_protection=True
+                    setup_udn_nad,
+                    pvc_vm=1,
+                    dr_protect=False,
+                    shared_drpc_protection=True,
                 )
             else:
                 cnv_workloads = discovered_apps_dr_workload_cnv(

--- a/tests/functional/disaster-recovery/regional-dr/test_acm_kubevirt_dr_integration.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_acm_kubevirt_dr_integration.py
@@ -116,7 +116,7 @@ class TestACMKubevirtDRIntergration:
         logger.info("Deploy 1st CNV workload")
         if static_vm_ip:
             cnv_workloads = cnv_workload_with_static_ip(
-                setup_udn_nad, pvc_vm=1, dr_protect=False, shared_drpc_protection=False
+                pvc_vm=1, dr_protect=False, shared_drpc_protection=False
             )
         else:
             cnv_workloads = discovered_apps_dr_workload_cnv(
@@ -128,10 +128,7 @@ class TestACMKubevirtDRIntergration:
             logger.info("Deploy 2nd CNV workload in the existing namespace")
             if static_vm_ip:
                 cnv_workloads = cnv_workload_with_static_ip(
-                    setup_udn_nad,
-                    pvc_vm=1,
-                    dr_protect=False,
-                    shared_drpc_protection=True,
+                    pvc_vm=1, dr_protect=False, shared_drpc_protection=True
                 )
             else:
                 cnv_workloads = discovered_apps_dr_workload_cnv(

--- a/tests/functional/disaster-recovery/regional-dr/test_acm_kubevirt_dr_integration.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_acm_kubevirt_dr_integration.py
@@ -113,42 +113,33 @@ class TestACMKubevirtDRIntergration:
         md5sum_failover = []
         vm_filepaths = ["/dd_file1.txt", "/dd_file2.txt", "/dd_file3.txt"]
 
+        # The static IP VMs come from dedicated workload dirs that pin an address
+        # inside the UDN subnet; everything else about them is deployed and DR
+        # protected exactly like the regular discovered VMs.
+        deploy_cnv_workload = (
+            cnv_workload_with_static_ip
+            if static_vm_ip
+            else discovered_apps_dr_workload_cnv
+        )
+
         logger.info("Deploy 1st CNV workload")
-        if static_vm_ip:
-            # Static IP VMs must be DR protected via the discovered apps CLI;
-            # ACM UI protection is not supported for them.
-            cnv_workloads = cnv_workload_with_static_ip(
-                pvc_vm=1, dr_protect=True, shared_drpc_protection=False
-            )
-        else:
-            cnv_workloads = discovered_apps_dr_workload_cnv(
-                pvc_vm=1, dr_protect=False, shared_drpc_protection=False
-            )
+        cnv_workloads = deploy_cnv_workload(
+            pvc_vm=1, dr_protect=False, shared_drpc_protection=False
+        )
 
         if protection_type:
             # Deploy second workload for Shared protection (uses same namespace as first)
             logger.info("Deploy 2nd CNV workload in the existing namespace")
-            if static_vm_ip:
-                # No second DRPC: the DRPC created above protects the whole
-                # namespace and its selectors (appname=kubevirt) already match
-                # this VM, which is what Shared protection means here.
-                cnv_workloads = cnv_workload_with_static_ip(
-                    pvc_vm=1, dr_protect=False, shared_drpc_protection=True
-                )
-            else:
-                cnv_workloads = discovered_apps_dr_workload_cnv(
-                    pvc_vm=1, dr_protect=False, shared_drpc_protection=True
-                )
+            cnv_workloads = deploy_cnv_workload(
+                pvc_vm=1, dr_protect=False, shared_drpc_protection=True
+            )
 
         assert cnv_workloads, "No discovered VM found"
         config.switch_acm_ctx()
         protection_name = cnv_workloads[0].workload_namespace
         logger.info(f"Protection name is {protection_name}")
-        # DRPCs created via the CLI are named after the placement, while the ACM
-        # UI appends a "-drpc" suffix to it.
-        resource_name = cnv_workloads[0].discovered_apps_placement_name
-        if not static_vm_ip:
-            resource_name += "-drpc"
+        # The DRPC created by the ACM UI appends a "-drpc" suffix to the placement
+        resource_name = cnv_workloads[0].discovered_apps_placement_name + "-drpc"
 
         logger.info(f"CNV workloads instance is {cnv_workloads}")
 
@@ -158,24 +149,10 @@ class TestACMKubevirtDRIntergration:
             f"Primary managed cluster name is {cnv_workloads[0].preferred_primary_cluster}"
         )
 
-        if not static_vm_ip:
-            # DR protection via ACM UI fleet virtualization page
-            assert navigate_using_fleet_virtualization(acm_obj)
-            for i, vm in enumerate(cnv_workloads):
-                standalone_flag = (not protection_type) or (i == 0)
-                assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
-                    acm_obj,
-                    vms=[vm],
-                    managed_cluster_name=primary_cluster_name,
-                    standalone=standalone_flag,
-                    protection_name=protection_name,
-                    namespace=cnv_workloads[0].workload_namespace,
-                )
-        else:
-            # Static IP: the workload is already DR protected via the CLI at
-            # deploy time. What remains is the network mapping ConfigMap on the
-            # hub, linked to the DRPolicy, which drives the IP translation.
-            config.switch_acm_ctx()
+        if static_vm_ip:
+            # The network mapping ConfigMap must be linked to the DRPolicy before
+            # the VMs are protected, so the DRPC picks the mapping up when it is
+            # created and can translate the pinned IPs on failover.
             existing_policies = dr_helpers.get_all_drpolicy()
             assert existing_policies, "No DRPolicy found on hub"
             drpolicy_name = existing_policies[0]["metadata"]["name"]
@@ -193,6 +170,19 @@ class TestACMKubevirtDRIntergration:
                 drpolicy_name=drpolicy_name,
             )
             wait_for_drpolicy_network_peers(drpolicy_name)
+
+        # DR protection via ACM UI fleet virtualization page
+        assert navigate_using_fleet_virtualization(acm_obj)
+        for i, vm in enumerate(cnv_workloads):
+            standalone_flag = (not protection_type) or (i == 0)
+            assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
+                acm_obj,
+                vms=[vm],
+                managed_cluster_name=primary_cluster_name,
+                standalone=standalone_flag,
+                protection_name=protection_name,
+                namespace=cnv_workloads[0].workload_namespace,
+            )
 
         logger.info(
             f'Placement name is "{cnv_workloads[0].discovered_apps_placement_name}"'
@@ -405,16 +395,15 @@ class TestACMKubevirtDRIntergration:
         )
         drpc_obj.wait_for_progression_status(status=constants.STATUS_COMPLETED)
 
-        if not static_vm_ip:
-            logger.info("On UI, check if VM is running after failover or not")
-            assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
-                acm_obj,
-                vms=cnv_workloads,
-                protection_name=protection_name,
-                namespace=cnv_workloads[0].workload_namespace,
-                managed_cluster_name=secondary_cluster_name,
-                assign_policy=False,
-            )
+        logger.info("On UI, check if VM is running after failover or not")
+        assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
+            acm_obj,
+            vms=cnv_workloads,
+            protection_name=protection_name,
+            namespace=cnv_workloads[0].workload_namespace,
+            managed_cluster_name=secondary_cluster_name,
+            assign_policy=False,
+        )
         config.switch_to_cluster_by_name(secondary_cluster_name)
 
         # Doing Relocate in below code
@@ -490,17 +479,16 @@ class TestACMKubevirtDRIntergration:
             )
 
         config.switch_acm_ctx()
-        if not static_vm_ip:
-            logger.info("On UI, check if VM is running after relocate or not")
-            acm_obj.refresh_page()
-            assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
-                acm_obj,
-                vms=cnv_workloads,
-                protection_name=protection_name,
-                namespace=cnv_workloads[0].workload_namespace,
-                managed_cluster_name=primary_cluster_name,
-                assign_policy=False,
-            )
+        logger.info("On UI, check if VM is running after relocate or not")
+        acm_obj.refresh_page()
+        assert check_or_assign_drpolicy_for_discovered_vms_via_ui(
+            acm_obj,
+            vms=cnv_workloads,
+            protection_name=protection_name,
+            namespace=cnv_workloads[0].workload_namespace,
+            managed_cluster_name=primary_cluster_name,
+            assign_policy=False,
+        )
         config.switch_to_cluster_by_name(primary_cluster_name)
 
         # Validating data integrity (file1) after relocating VMs back to primary managed cluster

--- a/tests/functional/disaster-recovery/regional-dr/test_vm_ip_translation.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_vm_ip_translation.py
@@ -15,10 +15,9 @@ Translation methods:
 Test classes:
   TestVMIPTranslationConfigMap     — ConfigMap validation, NAD discovery,
                                      controller conditions (no failover needed)
-  TestVMIPTranslationDRCycle       — Full failover + failback IP translation,
-                                     backward compatibility, opt-in behavior,
-                                     and edge cases
-  TestVMIPTranslationPlatformSpecific — Hub recovery, post-upgrade, BM HCP
+  TestVMIPTranslationMiscellaneous — Edge cases: missing/mislabeled NADs,
+                                     DR unprotect cleanup, hub recovery,
+                                     post-upgrade behavior, BM HCP
 
 NOTE: Several assertions reference DRPolicy/VRG/DRClusterConfig status field
 names that are not yet finalized. These are marked with # TODO comments.
@@ -39,7 +38,6 @@ from ocs_ci.framework.pytest_customization.marks import (
 )
 from ocs_ci.framework.testlib import skipif_ocs_version
 from ocs_ci.helpers import dr_helpers
-from ocs_ci.helpers.dr_helpers import wait_for_all_resources_deletion
 from ocs_ci.helpers.dr_helpers_vm_ip_translation import (
     DRCLUSTERCONFIG_NAD_STATUS_FIELD,
     DRPOLICY_NADS_SYNCED_CONDITION,
@@ -49,19 +47,17 @@ from ocs_ci.helpers.dr_helpers_vm_ip_translation import (
     DRPOLICY_NM_STATUS_INVALID,
     DRPOLICY_NM_STATUS_VALID,
     VM_IP_TRANSLATION_NS,
+    VM_NETWORK_NAD_NAME,
     VRG_CONDITION_NM_LOADED,
-    build_network_mapping_cm_data,
     get_drpolicy_network_mapping_status,
-    get_ipamclaim_ip,
     wait_for_drpolicy_network_mapping_status,
+    wait_for_drpolicy_network_peers,
 )
 from ocs_ci.ocs import constants
 from ocs_ci.ocs import ocp
-from ocs_ci.ocs.node import get_node_objs, wait_for_nodes_status
 from ocs_ci.ocs.resources.drpc import DRPC
-from ocs_ci.ocs.resources.pod import wait_for_pods_to_be_running
 from ocs_ci.utility import templating
-from ocs_ci.utility.utils import TimeoutSampler, ceph_health_check, exec_cmd
+from ocs_ci.utility.utils import TimeoutSampler, exec_cmd
 
 logger = logging.getLogger(__name__)
 
@@ -92,7 +88,7 @@ PROP_DST_SUBNET = "172.16.0.0/16"
 @rdr
 @tier2
 @turquoise_squad
-@skipif_ocs_version("<4.21")
+@skipif_ocs_version("<4.23")
 class TestVMIPTranslationConfigMap:
     """
     Validate that the DRPolicy controller correctly classifies each translation
@@ -100,7 +96,7 @@ class TestVMIPTranslationConfigMap:
     No VM failover is performed in this class.
 
     Prerequisites:
-      - ODF >= 4.21 with RHSTOR-8082 feature enabled
+      - ODF >= 4.23 with RHSTOR-8082 feature enabled
       - ACM hub cluster with at least two registered DRClusters
       - UDN vm-network on both managed clusters (setup_udn_nad fixture)
       - NADs labeled with ramendr.openshift.io/network-id (setup_udn_nad fixture)
@@ -361,7 +357,10 @@ class TestVMIPTranslationConfigMap:
 
     @pytest.mark.polarion_id("OCS-XXXX")
     def test_vrg_network_mapping_loaded_condition(
-        self, setup_udn_nad, setup_nad_in_namespace, discovered_apps_dr_workload_cnv
+        self,
+        setup_udn_nad,
+        discovered_apps_dr_workload_cnv,
+        network_mapping_configmap,
     ):
         """
         TC-7b: Verify that VRG correctly reports NetworkMappingLoaded=True
@@ -382,734 +381,50 @@ class TestVMIPTranslationConfigMap:
 
         config.switch_acm_ctx()
         existing_policies = dr_helpers.get_all_drpolicy()
-        assert existing_policies
+        assert existing_policies, "No DRPolicy found on hub"
         drpolicy_name = existing_policies[0]["metadata"]["name"]
 
-        # Create a pattern-only ConfigMap so there is a valid mapping
-        with tempfile.NamedTemporaryFile(mode="w+", suffix=".yaml", delete=False) as f:
-            manifest = {
-                "apiVersion": "v1",
-                "kind": constants.CONFIGMAP,
-                "metadata": {
-                    "name": "vm-ip-map-vrg-test",
-                    "namespace": VM_IP_TRANSLATION_NS,
-                },
-                "data": build_network_mapping_cm_data(
-                    pattern_rules=[{"source": DR1_SUBNET, "destination": DR2_SUBNET}]
-                ),
-            }
-            templating.dump_data_to_temp_yaml(manifest, f.name)
-            config.switch_acm_ctx()
-            exec_cmd(f"oc create -f {f.name}")
+        cluster_names = setup_udn_nad["cluster_names"]
+        cluster_subnets = setup_udn_nad["cluster_subnets"]
 
-        try:
-            wait_for_drpolicy_network_mapping_status(
-                drpolicy_name, DRPOLICY_NM_STATUS_VALID
-            )
+        # Create ConfigMap on hub and link to DRPolicy; fixture handles teardown
+        network_mapping_configmap(
+            "vm-ip-map-vrg-test",
+            cluster1_name=cluster_names[0],
+            cluster2_name=cluster_names[1],
+            nad_namespace=setup_udn_nad["workload_namespace"],
+            nad_name=VM_NETWORK_NAD_NAME,
+            cluster1_cidr=cluster_subnets[cluster_names[0]],
+            cluster2_cidr=cluster_subnets[cluster_names[1]],
+            drpolicy_name=drpolicy_name,
+        )
 
-            # Check VRG condition on the primary cluster
-            primary_cluster = workload.preferred_primary_cluster
-            config.switch_to_cluster_by_name(primary_cluster)
-            # TODO: use a VRG helper once the condition schema is finalized
-            vrg_ocp = ocp.OCP(
-                kind="VolumeReplicationGroup",  # TODO: add constant
-                namespace=namespace,
-                resource_name=resource_name,
-            )
-            vrg_conditions = vrg_ocp.get().get("status", {}).get("conditions", [])
-            nm_condition = next(
-                (c for c in vrg_conditions if c.get("type") == VRG_CONDITION_NM_LOADED),
-                None,
-            )
-            assert (
-                nm_condition is not None
-            ), f"VRG missing condition '{VRG_CONDITION_NM_LOADED}'"
-            assert (
-                nm_condition.get("status") == "True"
-            ), f"Expected {VRG_CONDITION_NM_LOADED}=True, got: {nm_condition}"
-            logger.info(f"VRG {VRG_CONDITION_NM_LOADED} condition: {nm_condition}")
-        finally:
-            config.switch_acm_ctx()
-            exec_cmd(
-                "oc delete configmap vm-ip-map-vrg-test "
-                f"-n {VM_IP_TRANSLATION_NS} --ignore-not-found"
-            )
+        wait_for_drpolicy_network_peers(drpolicy_name)
+
+        # Check VRG condition on the primary cluster
+        primary_cluster = workload.preferred_primary_cluster
+        config.switch_to_cluster_by_name(primary_cluster)
+        vrg_ocp = ocp.OCP(
+            kind="VolumeReplicationGroup",
+            namespace=namespace,
+            resource_name=resource_name,
+        )
+        vrg_conditions = vrg_ocp.get().get("status", {}).get("conditions", [])
+        nm_condition = next(
+            (c for c in vrg_conditions if c.get("type") == VRG_CONDITION_NM_LOADED),
+            None,
+        )
+        assert (
+            nm_condition is not None
+        ), f"VRG missing condition '{VRG_CONDITION_NM_LOADED}'"
+        assert (
+            nm_condition.get("status") == "True"
+        ), f"Expected {VRG_CONDITION_NM_LOADED}=True, got: {nm_condition}"
+        logger.info(f"VRG {VRG_CONDITION_NM_LOADED} condition: {nm_condition}")
 
 
 # ---------------------------------------------------------------------------
-# Class 2: Full DR cycle with IP translation
-# ---------------------------------------------------------------------------
-
-
-@rdr
-@tier2
-@turquoise_squad
-@skipif_ocs_version("<4.21")
-class TestVMIPTranslationDRCycle:
-    """
-    Full failover + failback scenarios exercising actual IP translation,
-    backward compatibility, and opt-in enforcement.
-
-    Prerequisites (in addition to base RDR environment):
-      - ODF >= 4.21 with RHSTOR-8082 feature enabled
-      - UDN vm-network on both clusters with ipam.lifecycle: Persistent
-        (setup_udn_nad fixture creates this)
-      - NAD vm-network in the workload namespace with allowPersistentIPs: true
-        and label ramendr.openshift.io/network-id
-        (setup_nad_in_namespace fixture creates this per test)
-      - VMs deployed with static IPs and IPAMClaims on the UDN secondary network
-        (discovered_apps_dr_workload_cnv is used as placeholder — replace with
-        a static-IP workload fixture once available, see TODO below)
-
-    # TODO: Create a static-IP VM workload fixture (e.g.
-    # discovered_apps_dr_workload_cnv_static_ip) that deploys VMs configured
-    # with a secondary UDN interface and static IP via IPAMClaim.
-    # The workload directory in the DR workload repo will need a matching
-    # VM manifest with network annotations pointing to the UDN/NAD.
-    """
-
-    @pytest.mark.polarion_id("OCS-XXXX")
-    def test_failover_failback_ip_translation(
-        self,
-        setup_udn_nad,
-        setup_nad_in_namespace,
-        discovered_apps_dr_workload_cnv,
-        network_mapping_configmap,
-        nodes_multicluster,
-        node_restart_teardown,
-    ):
-        """
-        TC-4 / TC-9 / TC-12: Validate translated IP assignment at the
-        IPAMClaim layer during failover and restoration of original IP
-        during failback for two VMs:
-
-          test-vm-1   (192.168.1.50)  → pattern rule   → 192.168.2.50 on dr2
-          test-vm-db  (192.168.1.100) → explicit rule   → 192.168.2.200 on dr2
-          (same ConfigMap covers both VMs in a single failover — TC-12)
-
-        After failback both VMs must recover their original dr1 IPs (TC-4).
-        """
-        # Deploy two static-IP workloads
-        # TODO: replace with a static-IP workload fixture
-        cnv_workload_1 = discovered_apps_dr_workload_cnv(
-            pvc_vm=1, dr_protect=True, shared_drpc_protection=False
-        )
-        cnv_workload_2 = discovered_apps_dr_workload_cnv(
-            pvc_vm=1, dr_protect=True, shared_drpc_protection=True
-        )
-        assert cnv_workload_1 and cnv_workload_2, "Workload deployment failed"
-        wl1 = cnv_workload_1[-1]
-        wl2 = cnv_workload_2[-1]
-        namespace = wl1.workload_namespace
-        primary_cluster = wl1.preferred_primary_cluster
-
-        # pattern-with-overrides: vm-1 via pattern, vm-db via explicit
-        network_mapping_configmap(
-            "vm-ip-map-failover",
-            pattern_rules=[{"source": DR1_SUBNET, "destination": DR2_SUBNET}],
-            explicit_rules=[
-                {"source": VM_DB_IP_DR1, "destination": VM_DB_IP_DR2_EXPLICIT}
-            ],
-        )
-
-        config.switch_acm_ctx()
-        existing_policies = dr_helpers.get_all_drpolicy()
-        assert existing_policies
-        drpolicy_name = existing_policies[0]["metadata"]["name"]
-        wait_for_drpolicy_network_mapping_status(
-            drpolicy_name, DRPOLICY_NM_STATUS_VALID
-        )
-
-        config.switch_to_cluster_by_name(primary_cluster)
-        resource_name_1 = wl1.discovered_apps_placement_name + "-drpc"
-        secondary_cluster = dr_helpers.get_current_secondary_cluster_name(
-            namespace, discovered_apps=True, resource_name=resource_name_1
-        )
-
-        # --- Failover: shut down primary and fail over to secondary ---
-        active_primary_index = config.cur_index
-        active_primary_nodes = get_node_objs()
-        logger.info("Shutting down primary cluster nodes for failover")
-        nodes_multicluster[active_primary_index].stop_nodes(active_primary_nodes)
-        dr_helpers.wait_for_managed_cluster_unreachable(primary_cluster)
-
-        for wl in (wl1, wl2):
-            resource_name = wl.discovered_apps_placement_name + "-drpc"
-            dr_helpers.failover(
-                failover_cluster=secondary_cluster,
-                namespace=namespace,
-                discovered_apps=True,
-                workload_placement_name=resource_name,
-                old_primary=primary_cluster,
-                skip_odf_cli_validation=True,
-            )
-
-        config.switch_to_cluster_by_name(secondary_cluster)
-        dr_helpers.wait_for_all_resources_creation(
-            wl1.workload_pvc_count + wl2.workload_pvc_count,
-            wl1.workload_pod_count + wl2.workload_pod_count,
-            namespace,
-            timeout=1800,
-            discovered_apps=True,
-            vrg_name=resource_name_1,
-            skip_replication_resources=True,
-        )
-
-        # Verify translated IPs on secondary cluster
-        # TODO: replace vm_name placeholders with actual static-IP VM names
-        logger.info("Verifying translated IPAMClaim IPs on secondary cluster")
-        vm1_ip_secondary = get_ipamclaim_ip(secondary_cluster, namespace, wl1.vm_name)
-        vmdb_ip_secondary = get_ipamclaim_ip(secondary_cluster, namespace, wl2.vm_name)
-        assert (
-            vm1_ip_secondary == VM1_IP_DR2_PATTERN
-        ), f"VM1 expected translated IP {VM1_IP_DR2_PATTERN}, got {vm1_ip_secondary}"
-        assert vmdb_ip_secondary == VM_DB_IP_DR2_EXPLICIT, (
-            f"VM-DB expected explicit override IP {VM_DB_IP_DR2_EXPLICIT}, "
-            f"got {vmdb_ip_secondary}"
-        )
-        logger.info(
-            f"Failover IP translation verified: vm1={vm1_ip_secondary}, "
-            f"vm-db={vmdb_ip_secondary}"
-        )
-
-        # Recover primary cluster
-        config.switch_to_cluster_by_name(primary_cluster)
-        logger.info("Recovering primary cluster")
-        nodes_multicluster[active_primary_index].start_nodes(active_primary_nodes)
-        wait_for_nodes_status([n.name for n in active_primary_nodes], timeout=900)
-        wait_for_pods_to_be_running(timeout=420, sleep=15)
-        assert ceph_health_check(tries=10, delay=30)
-
-        # Cleanup stale resources on the old primary after failover
-        for wl in (wl1, wl2):
-            resource_name = wl.discovered_apps_placement_name + "-drpc"
-            dr_helpers.do_discovered_apps_cleanup(
-                drpc_name=resource_name,
-                old_primary=primary_cluster,
-                workload_namespace=namespace,
-                workload_dir=wl.workload_dir,
-                vrg_name=resource_name,
-                skip_resource_deletion_verification=True,
-            )
-        config.switch_to_cluster_by_name(primary_cluster)
-        wait_for_all_resources_deletion(
-            namespace=namespace,
-            discovered_apps=True,
-            vrg_name=resource_name_1,
-        )
-
-        # --- Failback (Relocate): secondary → primary ---
-        logger.info("Performing failback (Relocate) to primary cluster")
-        for wl in (wl1, wl2):
-            resource_name = wl.discovered_apps_placement_name + "-drpc"
-            dr_helpers.relocate(
-                preferred_cluster=primary_cluster,
-                namespace=namespace,
-                workload_placement_name=resource_name,
-                discovered_apps=True,
-                old_primary=secondary_cluster,
-                workload_instance=wl,
-                skip_odf_cli_validation=True,
-            )
-
-        config.switch_to_cluster_by_name(secondary_cluster)
-        wait_for_all_resources_deletion(
-            namespace=namespace,
-            discovered_apps=True,
-            vrg_name=resource_name_1,
-        )
-
-        # Verify original IPs restored on primary cluster after failback
-        logger.info("Verifying original IPAMClaim IPs restored on primary cluster")
-        vm1_ip_primary = get_ipamclaim_ip(primary_cluster, namespace, wl1.vm_name)
-        vmdb_ip_primary = get_ipamclaim_ip(primary_cluster, namespace, wl2.vm_name)
-        assert (
-            vm1_ip_primary == VM1_IP_DR1
-        ), f"VM1 expected original IP {VM1_IP_DR1} after failback, got {vm1_ip_primary}"
-        assert vmdb_ip_primary == VM_DB_IP_DR1, (
-            f"VM-DB expected original IP {VM_DB_IP_DR1} after failback, "
-            f"got {vmdb_ip_primary}"
-        )
-        logger.info(
-            f"Failback IP restoration verified: vm1={vm1_ip_primary}, "
-            f"vm-db={vmdb_ip_primary}"
-        )
-
-    @pytest.mark.polarion_id("OCS-XXXX")
-    def test_backward_compatibility_no_mapping(
-        self,
-        setup_udn_nad,
-        discovered_apps_dr_workload_cnv,
-        nodes_multicluster,
-        node_restart_teardown,
-    ):
-        """
-        TC-5: Verify that existing VMs without any network mapping ConfigMap
-        fail over and fail back without error — feature is opt-in only and must
-        not introduce regressions.
-        """
-        cnv_workloads = discovered_apps_dr_workload_cnv(
-            pvc_vm=1, dr_protect=True, shared_drpc_protection=False
-        )
-        assert cnv_workloads, "No CNV workload deployed"
-        wl = cnv_workloads[-1]
-        namespace = wl.workload_namespace
-        resource_name = wl.discovered_apps_placement_name + "-drpc"
-        primary_cluster = wl.preferred_primary_cluster
-
-        # Explicitly confirm no network mapping ConfigMap exists
-        config.switch_acm_ctx()
-        cm_list = ocp.OCP(kind=constants.CONFIGMAP, namespace=VM_IP_TRANSLATION_NS).get(
-            selector="app=ramen-network-mapping"
-        )  # TODO: confirm label
-        assert not cm_list.get("items"), (
-            "Expected no network mapping ConfigMap for backward-compat test, "
-            f"found: {[i['metadata']['name'] for i in cm_list.get('items', [])]}"
-        )
-
-        config.switch_to_cluster_by_name(primary_cluster)
-        secondary_cluster = dr_helpers.get_current_secondary_cluster_name(
-            namespace, discovered_apps=True, resource_name=resource_name
-        )
-
-        active_primary_index = config.cur_index
-        active_primary_nodes = get_node_objs()
-        nodes_multicluster[active_primary_index].stop_nodes(active_primary_nodes)
-        dr_helpers.wait_for_managed_cluster_unreachable(primary_cluster)
-
-        dr_helpers.failover(
-            failover_cluster=secondary_cluster,
-            namespace=namespace,
-            discovered_apps=True,
-            workload_placement_name=resource_name,
-            old_primary=primary_cluster,
-            skip_odf_cli_validation=True,
-        )
-
-        config.switch_to_cluster_by_name(secondary_cluster)
-        dr_helpers.wait_for_all_resources_creation(
-            wl.workload_pvc_count,
-            wl.workload_pod_count,
-            namespace,
-            timeout=1800,
-            discovered_apps=True,
-            vrg_name=resource_name,
-            skip_replication_resources=True,
-        )
-        dr_helpers.wait_for_cnv_workload(
-            vm_name=wl.vm_name,
-            namespace=namespace,
-            phase=constants.STATUS_RUNNING,
-        )
-        logger.info(
-            "Failover completed without network mapping — backward compatibility OK"
-        )
-
-        # Recover and relocate back
-        config.switch_to_cluster_by_name(primary_cluster)
-        nodes_multicluster[active_primary_index].start_nodes(active_primary_nodes)
-        wait_for_nodes_status([n.name for n in active_primary_nodes], timeout=900)
-        wait_for_pods_to_be_running(timeout=420, sleep=15)
-        assert ceph_health_check(tries=10, delay=30)
-
-        dr_helpers.do_discovered_apps_cleanup(
-            drpc_name=resource_name,
-            old_primary=primary_cluster,
-            workload_namespace=namespace,
-            workload_dir=wl.workload_dir,
-            vrg_name=resource_name,
-            skip_resource_deletion_verification=True,
-        )
-        wait_for_all_resources_deletion(
-            namespace=namespace, discovered_apps=True, vrg_name=resource_name
-        )
-
-        dr_helpers.relocate(
-            preferred_cluster=primary_cluster,
-            namespace=namespace,
-            workload_placement_name=resource_name,
-            discovered_apps=True,
-            old_primary=secondary_cluster,
-            workload_instance=wl,
-            skip_odf_cli_validation=True,
-        )
-
-        config.switch_to_cluster_by_name(secondary_cluster)
-        wait_for_all_resources_deletion(
-            namespace=namespace, discovered_apps=True, vrg_name=resource_name
-        )
-        logger.info(
-            "Failback completed without network mapping — backward compatibility OK"
-        )
-
-    @pytest.mark.polarion_id("OCS-XXXX")
-    def test_opt_in_required(
-        self,
-        setup_udn_nad,
-        setup_nad_in_namespace,
-        discovered_apps_dr_workload_cnv,
-        network_mapping_configmap,
-        nodes_multicluster,
-        node_restart_teardown,
-    ):
-        """
-        TC-10: Verify that IP translation is applied only when
-        networkMapping.enabled=true in the ConfigMap. An existing DRPC or one
-        created after upgrade must not be affected without the opt-in.
-        """
-        cnv_workloads = discovered_apps_dr_workload_cnv(
-            pvc_vm=1, dr_protect=True, shared_drpc_protection=False
-        )
-        assert cnv_workloads
-        wl = cnv_workloads[-1]
-        namespace = wl.workload_namespace
-        resource_name = wl.discovered_apps_placement_name + "-drpc"
-        primary_cluster = wl.preferred_primary_cluster
-
-        # Create a ConfigMap with enabled=False — translation must NOT occur
-        network_mapping_configmap(
-            "vm-ip-map-opt-out",
-            pattern_rules=[{"source": DR1_SUBNET, "destination": DR2_SUBNET}],
-            enabled=False,
-        )
-
-        config.switch_to_cluster_by_name(primary_cluster)
-        secondary_cluster = dr_helpers.get_current_secondary_cluster_name(
-            namespace, discovered_apps=True, resource_name=resource_name
-        )
-
-        active_primary_index = config.cur_index
-        active_primary_nodes = get_node_objs()
-        nodes_multicluster[active_primary_index].stop_nodes(active_primary_nodes)
-        dr_helpers.wait_for_managed_cluster_unreachable(primary_cluster)
-
-        dr_helpers.failover(
-            failover_cluster=secondary_cluster,
-            namespace=namespace,
-            discovered_apps=True,
-            workload_placement_name=resource_name,
-            old_primary=primary_cluster,
-            skip_odf_cli_validation=True,
-        )
-
-        config.switch_to_cluster_by_name(secondary_cluster)
-        dr_helpers.wait_for_all_resources_creation(
-            wl.workload_pvc_count,
-            wl.workload_pod_count,
-            namespace,
-            timeout=1800,
-            discovered_apps=True,
-            vrg_name=resource_name,
-            skip_replication_resources=True,
-        )
-
-        # IP must NOT be translated — VM retains its original IP
-        # TODO: confirm how to check IPAMClaim when opt-out is active
-        vm_ip = get_ipamclaim_ip(secondary_cluster, namespace, wl.vm_name)
-        assert (
-            vm_ip == VM1_IP_DR1
-        ), f"Expected untranslated IP {VM1_IP_DR1} (opt-out), got {vm_ip}"
-        logger.info(f"Opt-in disabled: VM IP {vm_ip} correctly not translated")
-
-        # Recover
-        config.switch_to_cluster_by_name(primary_cluster)
-        nodes_multicluster[active_primary_index].start_nodes(active_primary_nodes)
-        wait_for_nodes_status([n.name for n in active_primary_nodes], timeout=900)
-        wait_for_pods_to_be_running(timeout=420, sleep=15)
-        assert ceph_health_check(tries=10, delay=30)
-
-        dr_helpers.do_discovered_apps_cleanup(
-            drpc_name=resource_name,
-            old_primary=primary_cluster,
-            workload_namespace=namespace,
-            workload_dir=wl.workload_dir,
-            vrg_name=resource_name,
-            skip_resource_deletion_verification=True,
-        )
-        config.switch_to_cluster_by_name(primary_cluster)
-        wait_for_all_resources_deletion(
-            namespace=namespace, discovered_apps=True, vrg_name=resource_name
-        )
-
-        dr_helpers.relocate(
-            preferred_cluster=primary_cluster,
-            namespace=namespace,
-            workload_placement_name=resource_name,
-            discovered_apps=True,
-            old_primary=secondary_cluster,
-            workload_instance=wl,
-            skip_odf_cli_validation=True,
-        )
-        config.switch_to_cluster_by_name(secondary_cluster)
-        wait_for_all_resources_deletion(
-            namespace=namespace, discovered_apps=True, vrg_name=resource_name
-        )
-
-    @pytest.mark.polarion_id("OCS-XXXX")
-    def test_proportional_translation(
-        self,
-        setup_udn_nad,
-        setup_nad_in_namespace,
-        discovered_apps_dr_workload_cnv,
-        network_mapping_configmap,
-        nodes_multicluster,
-        node_restart_teardown,
-    ):
-        """
-        TC-11: Verify proportional translation correctly maps IPs when source
-        and destination subnets have different sizes (e.g. /24 → /16).
-        The host portion of the address is scaled proportionally into the
-        destination subnet range.
-
-        # TODO: Confirm the proportional mapping algorithm with the developer
-        # and update expected_ip below accordingly.
-        """
-        cnv_workloads = discovered_apps_dr_workload_cnv(
-            pvc_vm=1, dr_protect=True, shared_drpc_protection=False
-        )
-        assert cnv_workloads
-        wl = cnv_workloads[-1]
-        namespace = wl.workload_namespace
-        resource_name = wl.discovered_apps_placement_name + "-drpc"
-        primary_cluster = wl.preferred_primary_cluster
-
-        network_mapping_configmap(
-            "vm-ip-map-proportional",
-            pattern_rules=[{"source": PROP_SRC_SUBNET, "destination": PROP_DST_SUBNET}],
-        )
-
-        config.switch_acm_ctx()
-        existing_policies = dr_helpers.get_all_drpolicy()
-        wait_for_drpolicy_network_mapping_status(
-            existing_policies[0]["metadata"]["name"], DRPOLICY_NM_STATUS_VALID
-        )
-
-        config.switch_to_cluster_by_name(primary_cluster)
-        secondary_cluster = dr_helpers.get_current_secondary_cluster_name(
-            namespace, discovered_apps=True, resource_name=resource_name
-        )
-
-        active_primary_index = config.cur_index
-        active_primary_nodes = get_node_objs()
-        nodes_multicluster[active_primary_index].stop_nodes(active_primary_nodes)
-        dr_helpers.wait_for_managed_cluster_unreachable(primary_cluster)
-
-        dr_helpers.failover(
-            failover_cluster=secondary_cluster,
-            namespace=namespace,
-            discovered_apps=True,
-            workload_placement_name=resource_name,
-            old_primary=primary_cluster,
-            skip_odf_cli_validation=True,
-        )
-        config.switch_to_cluster_by_name(secondary_cluster)
-        dr_helpers.wait_for_all_resources_creation(
-            wl.workload_pvc_count,
-            wl.workload_pod_count,
-            namespace,
-            timeout=1800,
-            discovered_apps=True,
-            vrg_name=resource_name,
-            skip_replication_resources=True,
-        )
-
-        translated_ip = get_ipamclaim_ip(secondary_cluster, namespace, wl.vm_name)
-        # TODO: compute expected IP once proportional mapping algorithm is confirmed
-        assert translated_ip.startswith(
-            "172.16."
-        ), f"Expected proportionally translated IP in 172.16.0.0/16, got {translated_ip}"
-        logger.info(f"Proportional translation result: {translated_ip}")
-
-        # Recover and relocate
-        config.switch_to_cluster_by_name(primary_cluster)
-        nodes_multicluster[active_primary_index].start_nodes(active_primary_nodes)
-        wait_for_nodes_status([n.name for n in active_primary_nodes], timeout=900)
-        wait_for_pods_to_be_running(timeout=420, sleep=15)
-        assert ceph_health_check(tries=10, delay=30)
-        dr_helpers.do_discovered_apps_cleanup(
-            drpc_name=resource_name,
-            old_primary=primary_cluster,
-            workload_namespace=namespace,
-            workload_dir=wl.workload_dir,
-            vrg_name=resource_name,
-            skip_resource_deletion_verification=True,
-        )
-        config.switch_to_cluster_by_name(primary_cluster)
-        wait_for_all_resources_deletion(
-            namespace=namespace, discovered_apps=True, vrg_name=resource_name
-        )
-        dr_helpers.relocate(
-            preferred_cluster=primary_cluster,
-            namespace=namespace,
-            workload_placement_name=resource_name,
-            discovered_apps=True,
-            old_primary=secondary_cluster,
-            workload_instance=wl,
-            skip_odf_cli_validation=True,
-        )
-        config.switch_to_cluster_by_name(secondary_cluster)
-        wait_for_all_resources_deletion(
-            namespace=namespace, discovered_apps=True, vrg_name=resource_name
-        )
-
-    @pytest.mark.polarion_id("OCS-XXXX")
-    def test_mixed_interface_translation(
-        self,
-        setup_udn_nad,
-        setup_nad_in_namespace,
-        discovered_apps_dr_workload_cnv,
-        network_mapping_configmap,
-        nodes_multicluster,
-        node_restart_teardown,
-    ):
-        """
-        TC-13: On a single namespace with multiple VMs where one VM has both
-        a DHCP interface and a static IP interface, verify that IP translation
-        is applied only to the static interface — the DHCP interface is not
-        touched and acquires its IP from the secondary site's DHCP server.
-
-        # TODO: Requires a VM fixture that creates a multi-homed VM
-        # (one DHCP NIC + one static-IP UDN NIC). Until available,
-        # this test validates the principle against the existing workload.
-        """
-        cnv_workloads = discovered_apps_dr_workload_cnv(
-            pvc_vm=1, dr_protect=True, shared_drpc_protection=False
-        )
-        assert cnv_workloads
-        wl = cnv_workloads[-1]
-        namespace = wl.workload_namespace
-        resource_name = wl.discovered_apps_placement_name + "-drpc"
-        primary_cluster = wl.preferred_primary_cluster
-
-        network_mapping_configmap(
-            "vm-ip-map-mixed-iface",
-            pattern_rules=[{"source": DR1_SUBNET, "destination": DR2_SUBNET}],
-        )
-        config.switch_acm_ctx()
-        existing_policies = dr_helpers.get_all_drpolicy()
-        wait_for_drpolicy_network_mapping_status(
-            existing_policies[0]["metadata"]["name"], DRPOLICY_NM_STATUS_VALID
-        )
-
-        config.switch_to_cluster_by_name(primary_cluster)
-        secondary_cluster = dr_helpers.get_current_secondary_cluster_name(
-            namespace, discovered_apps=True, resource_name=resource_name
-        )
-
-        active_primary_index = config.cur_index
-        active_primary_nodes = get_node_objs()
-        nodes_multicluster[active_primary_index].stop_nodes(active_primary_nodes)
-        dr_helpers.wait_for_managed_cluster_unreachable(primary_cluster)
-
-        dr_helpers.failover(
-            failover_cluster=secondary_cluster,
-            namespace=namespace,
-            discovered_apps=True,
-            workload_placement_name=resource_name,
-            old_primary=primary_cluster,
-            skip_odf_cli_validation=True,
-        )
-        config.switch_to_cluster_by_name(secondary_cluster)
-        dr_helpers.wait_for_all_resources_creation(
-            wl.workload_pvc_count,
-            wl.workload_pod_count,
-            namespace,
-            timeout=1800,
-            discovered_apps=True,
-            vrg_name=resource_name,
-            skip_replication_resources=True,
-        )
-
-        # Static IP interface: must be translated
-        static_ip = get_ipamclaim_ip(secondary_cluster, namespace, wl.vm_name)
-        assert static_ip.startswith(
-            "192.168.2."
-        ), f"Static IP must be translated to 192.168.2.x subnet, got {static_ip}"
-        # DHCP interface: acquired from secondary DHCP — must NOT be 192.168.1.x
-        # TODO: retrieve DHCP interface IP from VMI status once multi-homed VM
-        # fixture is available and add assertion here.
-        logger.info(f"Mixed interface: static IP translated to {static_ip}")
-
-        # Recover and relocate
-        config.switch_to_cluster_by_name(primary_cluster)
-        nodes_multicluster[active_primary_index].start_nodes(active_primary_nodes)
-        wait_for_nodes_status([n.name for n in active_primary_nodes], timeout=900)
-        wait_for_pods_to_be_running(timeout=420, sleep=15)
-        assert ceph_health_check(tries=10, delay=30)
-        dr_helpers.do_discovered_apps_cleanup(
-            drpc_name=resource_name,
-            old_primary=primary_cluster,
-            workload_namespace=namespace,
-            workload_dir=wl.workload_dir,
-            vrg_name=resource_name,
-            skip_resource_deletion_verification=True,
-        )
-        config.switch_to_cluster_by_name(primary_cluster)
-        wait_for_all_resources_deletion(
-            namespace=namespace, discovered_apps=True, vrg_name=resource_name
-        )
-        dr_helpers.relocate(
-            preferred_cluster=primary_cluster,
-            namespace=namespace,
-            workload_placement_name=resource_name,
-            discovered_apps=True,
-            old_primary=secondary_cluster,
-            workload_instance=wl,
-            skip_odf_cli_validation=True,
-        )
-        config.switch_to_cluster_by_name(secondary_cluster)
-        wait_for_all_resources_deletion(
-            namespace=namespace, discovered_apps=True, vrg_name=resource_name
-        )
-
-    @pytest.mark.polarion_id("OCS-XXXX")
-    def test_ip_outside_destination_subnet(
-        self, setup_udn_nad, network_mapping_configmap
-    ):
-        """
-        TC-15: Verify behavior when translation produces an IP outside the
-        destination subnet (e.g. a /30 destination subnet where the host
-        octet from the source does not fit). The controller must detect this
-        and report an error condition rather than silently assigning an invalid IP.
-
-        # TODO: Confirm the expected error condition name and reason string
-        # with the developer once the feature controller is implemented.
-        """
-        config.switch_acm_ctx()
-        existing_policies = dr_helpers.get_all_drpolicy()
-        assert existing_policies
-        drpolicy_name = existing_policies[0]["metadata"]["name"]
-
-        # A /30 destination gives only 4 addresses (.0-.3) — a source host
-        # octet of 50 (from VM1_IP_DR1) cannot fit in this range.
-        network_mapping_configmap(
-            "vm-ip-map-overflow",
-            pattern_rules=[{"source": DR1_SUBNET, "destination": "192.168.2.0/30"}],
-        )
-
-        # DRPolicy must report Invalid (or a specific overflow reason)
-        for sample in TimeoutSampler(
-            timeout=120,
-            sleep=5,
-            func=lambda: get_drpolicy_network_mapping_status(drpolicy_name).get(
-                "status", ""
-            ),
-        ):
-            if sample in (DRPOLICY_NM_STATUS_INVALID, DRPOLICY_NM_STATUS_VALID):
-                break
-
-        nm_status = get_drpolicy_network_mapping_status(drpolicy_name)
-        # TODO: confirm whether controller rejects this upfront (Invalid) or
-        # reports the overflow at translation time. Adjust assertion accordingly.
-        assert nm_status.get("status") == DRPOLICY_NM_STATUS_INVALID, (
-            "Expected DRPolicy to report Invalid when destination subnet is "
-            f"too small for the host octet, got: {nm_status}"
-        )
-        logger.info(f"IP-outside-dest-subnet correctly reported Invalid: {nm_status}")
-
-
-# ---------------------------------------------------------------------------
-# Class 3: Miscellaneous — NAD errors, cleanup, and platform-specific
+# Class 2: Miscellaneous — NAD errors, cleanup, and platform-specific
 # ---------------------------------------------------------------------------
 
 

--- a/tests/functional/disaster-recovery/regional-dr/test_vm_ip_translation.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_vm_ip_translation.py
@@ -365,10 +365,10 @@ class TestVMIPTranslationConfigMap:
             f"status.{DRCLUSTERCONFIG_NAD_STATUS_FIELD}"
         )
         # Verify DRClusterConfig.status.networkAttachments on each managed cluster
+        # get_all_drclusters() returns the DRCluster names, not the objects
         drcluster_list = dr_helpers.get_all_drclusters()
         assert drcluster_list, "No DRClusters found on hub"
-        for drcluster in drcluster_list:
-            cluster_name = drcluster["metadata"]["name"]
+        for cluster_name in drcluster_list:
             # DRClusterConfig lives on the hub and is named after the managed cluster
             config.switch_acm_ctx()
             drclusterconfig_ocp = ocp.OCP(

--- a/tests/functional/disaster-recovery/regional-dr/test_vm_ip_translation.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_vm_ip_translation.py
@@ -162,15 +162,21 @@ class TestVMIPTranslationConfigMap:
         rule (UNMAPPED_IP_DR1) has no translation entry — i.e. the ConfigMap
         does not implicitly map unknown IPs.
         """
+        logger.test_step("Get the DRPolicy name from the hub cluster")
         config.switch_acm_ctx()
         existing_policies = dr_helpers.get_all_drpolicy()
         assert existing_policies, "No DRPolicy found on hub"
         drpolicy_name = existing_policies[0]["metadata"]["name"]
 
+        logger.test_step(f"Create the network mapping ConfigMap '{cm_name}'")
         network_mapping_configmap(
             cm_name, pattern_rules=pattern_rules, explicit_rules=explicit_rules
         )
 
+        logger.test_step(
+            f"Wait for DRPolicy '{drpolicy_name}' to report networkMapping "
+            f"status {DRPOLICY_NM_STATUS_VALID}"
+        )
         # Poll until DRPolicy reports Valid status for the new ConfigMap
         # TODO: DRPolicy must reference the ConfigMap by name — confirm the
         # linkage mechanism (annotation, spec field, or auto-discovery by name).
@@ -178,6 +184,11 @@ class TestVMIPTranslationConfigMap:
             drpolicy_name, DRPOLICY_NM_STATUS_VALID
         )
 
+        logger.test_step(
+            f"Verify the translation method is classified as {expected_method} "
+            f"with {expected_pattern_count} pattern and "
+            f"{expected_explicit_count} explicit mappings"
+        )
         nm_status = get_drpolicy_network_mapping_status(drpolicy_name)
 
         # TODO: confirm exact field names in nm_status
@@ -195,6 +206,10 @@ class TestVMIPTranslationConfigMap:
         )
 
         if cm_name == "vm-ip-map-explicit":
+            logger.test_step(
+                f"Verify the unmapped IP {UNMAPPED_IP_DR1} is not implicitly "
+                "translated by the explicit-only ConfigMap"
+            )
             # Unmapped IP must not appear in the explicit mapping list
             nm_raw = get_drpolicy_network_mapping_status(drpolicy_name)
             raw_data = str(nm_raw)
@@ -240,11 +255,13 @@ class TestVMIPTranslationConfigMap:
         condition NetworkMappingLoaded should be False with a descriptive reason.
         DRPC operations must not crash.
         """
+        logger.test_step("Get the DRPolicy name from the hub cluster")
         config.switch_acm_ctx()
         existing_policies = dr_helpers.get_all_drpolicy()
         assert existing_policies, "No DRPolicy found on hub"
         drpolicy_name = existing_policies[0]["metadata"]["name"]
 
+        logger.test_step(f"Set up the '{scenario}' ConfigMap scenario")
         if cm_data is not None:
             # Create a deliberately bad ConfigMap
             with tempfile.NamedTemporaryFile(
@@ -267,6 +284,10 @@ class TestVMIPTranslationConfigMap:
             cm_name = "vm-ip-map-nonexistent"
 
         try:
+            logger.test_step(
+                f"Wait for DRPolicy '{drpolicy_name}' to report networkMapping "
+                f"status {DRPOLICY_NM_STATUS_INVALID}"
+            )
             # TODO: trigger or reference the ConfigMap from the DRPolicy
             # then poll for the condition reflecting the invalid state
             for sample in TimeoutSampler(
@@ -278,6 +299,9 @@ class TestVMIPTranslationConfigMap:
             ):
                 if sample == DRPOLICY_NM_STATUS_INVALID:
                     break
+            logger.test_step(
+                "Verify the Invalid status is reported with a descriptive reason"
+            )
             nm_status = get_drpolicy_network_mapping_status(drpolicy_name)
             assert nm_status.get("status") == DRPOLICY_NM_STATUS_INVALID, (
                 f"Expected networkMapping.status={DRPOLICY_NM_STATUS_INVALID} "
@@ -310,12 +334,17 @@ class TestVMIPTranslationConfigMap:
           - DRPolicy controller validates that labeled NADs exist on both
             clusters and reports NADsSynced condition correctly
         """
+        logger.test_step("Get the DRPolicy name from the hub cluster")
         config.switch_acm_ctx()
         existing_policies = dr_helpers.get_all_drpolicy()
         assert existing_policies, "No DRPolicy found on hub"
         drpolicy_name = existing_policies[0]["metadata"]["name"]
         drpolicy_ocp = ocp.OCP(kind=constants.DRPOLICY, resource_name=drpolicy_name)
 
+        logger.test_step(
+            f"Verify the {DRPOLICY_NADS_SYNCED_CONDITION} condition is True on "
+            f"DRPolicy '{drpolicy_name}'"
+        )
         # Verify NADsSynced condition on DRPolicy
         # TODO: confirm condition name and expected reason/status values
         conditions = drpolicy_ocp.get().get("status", {}).get("conditions", [])
@@ -331,6 +360,10 @@ class TestVMIPTranslationConfigMap:
         ), f"Expected NADsSynced=True, got: {nads_synced}"
         logger.info(f"DRPolicy NADsSynced condition: {nads_synced}")
 
+        logger.test_step(
+            "Verify each DRClusterConfig has discovered the labeled NADs in "
+            f"status.{DRCLUSTERCONFIG_NAD_STATUS_FIELD}"
+        )
         # Verify DRClusterConfig.status.networkAttachments on each managed cluster
         drcluster_list = dr_helpers.get_all_drclusters()
         assert drcluster_list, "No DRClusters found on hub"
@@ -371,6 +404,7 @@ class TestVMIPTranslationConfigMap:
         # TODO: Extend discovered_apps_dr_workload_cnv to support static-IP
         # VMs with IPAMClaims, or create a dedicated fixture.
         """
+        logger.test_step("Deploy and DR protect a CNV workload")
         cnv_workloads = discovered_apps_dr_workload_cnv(
             pvc_vm=1, dr_protect=True, shared_drpc_protection=False
         )
@@ -379,6 +413,7 @@ class TestVMIPTranslationConfigMap:
         namespace = workload.workload_namespace
         resource_name = workload.discovered_apps_placement_name + "-drpc"
 
+        logger.test_step("Get the DRPolicy name from the hub cluster")
         config.switch_acm_ctx()
         existing_policies = dr_helpers.get_all_drpolicy()
         assert existing_policies, "No DRPolicy found on hub"
@@ -387,6 +422,9 @@ class TestVMIPTranslationConfigMap:
         cluster_names = setup_udn_nad["cluster_names"]
         cluster_subnets = setup_udn_nad["cluster_subnets"]
 
+        logger.test_step(
+            "Create the network mapping ConfigMap and link it to the DRPolicy"
+        )
         # Create ConfigMap on hub and link to DRPolicy; fixture handles teardown
         network_mapping_configmap(
             "vm-ip-map-vrg-test",
@@ -399,8 +437,15 @@ class TestVMIPTranslationConfigMap:
             drpolicy_name=drpolicy_name,
         )
 
+        logger.test_step(
+            f"Wait for DRPolicy '{drpolicy_name}' to populate its network peers"
+        )
         wait_for_drpolicy_network_peers(drpolicy_name)
 
+        logger.test_step(
+            f"Verify the VRG on the primary cluster reports "
+            f"{VRG_CONDITION_NM_LOADED}=True"
+        )
         # Check VRG condition on the primary cluster
         primary_cluster = workload.preferred_primary_cluster
         config.switch_to_cluster_by_name(primary_cluster)
@@ -466,12 +511,17 @@ class TestVMIPTranslationMiscellaneous:
         scenario should cause a controller crash. The DRPolicy NADsSynced
         condition should reflect the misconfiguration with a descriptive reason.
         """
+        logger.test_step("Get the DRPolicy name from the hub cluster")
         config.switch_acm_ctx()
         existing_policies = dr_helpers.get_all_drpolicy()
         assert existing_policies
         drpolicy_name = existing_policies[0]["metadata"]["name"]
         drpolicy_ocp = ocp.OCP(kind=constants.DRPOLICY, resource_name=drpolicy_name)
 
+        logger.test_step(
+            f"Verify the {DRPOLICY_NADS_SYNCED_CONDITION} condition reflects the "
+            f"'{scenario}' misconfiguration without crashing the controller"
+        )
         # TODO: For "missing-nad": temporarily delete the NAD on one managed
         # cluster and verify the DRPolicy reports NADsSynced=False.
         # For "dhcp-nad-labeled-static": add the NAD_DR_LABEL to a DHCP NAD
@@ -506,6 +556,7 @@ class TestVMIPTranslationMiscellaneous:
         translation configured correctly cleans up all translation resources
         (IPAMClaims, network mapping references) so that no orphans remain.
         """
+        logger.test_step("Deploy and DR protect a CNV workload")
         cnv_workloads = discovered_apps_dr_workload_cnv(
             pvc_vm=1, dr_protect=True, shared_drpc_protection=False
         )
@@ -515,6 +566,10 @@ class TestVMIPTranslationMiscellaneous:
         resource_name = wl.discovered_apps_placement_name + "-drpc"
         primary_cluster = wl.preferred_primary_cluster
 
+        logger.test_step(
+            "Create the network mapping ConfigMap and wait for the DRPolicy to "
+            "report it Valid"
+        )
         network_mapping_configmap(
             "vm-ip-map-disable-test",
             pattern_rules=[{"source": DR1_SUBNET, "destination": DR2_SUBNET}],
@@ -525,6 +580,7 @@ class TestVMIPTranslationMiscellaneous:
             existing_policies[0]["metadata"]["name"], DRPOLICY_NM_STATUS_VALID
         )
 
+        logger.test_step(f"Disable DR protection by deleting DRPC '{resource_name}'")
         # Disable DR protection by deleting the DRPC
         config.switch_acm_ctx()
         drpc_obj = DRPC(
@@ -533,6 +589,9 @@ class TestVMIPTranslationMiscellaneous:
         drpc_obj.delete()
         logger.info(f"Deleted DRPC {resource_name} to disable DR protection")
 
+        logger.test_step(
+            "Verify the translated IPAMClaims are cleaned up on the primary cluster"
+        )
         # Verify IPAMClaim translation resources are cleaned up on primary
         config.switch_to_cluster_by_name(primary_cluster)
         # Poll until no translated IPAMClaims remain
@@ -550,6 +609,7 @@ class TestVMIPTranslationMiscellaneous:
                 break
         logger.info("Translation IPAMClaims cleaned up after DR protection disabled")
 
+        logger.test_step("Verify no orphaned VRG remains in the workload namespace")
         # Verify VRG is gone (no orphaned replication resources)
         vrg_list = ocp.OCP(
             kind="VolumeReplicationGroup",  # TODO: add constant

--- a/tests/functional/disaster-recovery/regional-dr/test_vm_ip_translation.py
+++ b/tests/functional/disaster-recovery/regional-dr/test_vm_ip_translation.py
@@ -1,0 +1,1309 @@
+"""
+RHSTOR-8082: VM IP Translation During DR Failover/Failback
+
+When VMs with static IPs fail over across sites with no shared L2 network,
+Ramen reads the VM's IPAMClaim from the primary cluster, applies rules from a
+network mapping ConfigMap in openshift-dr-system, and creates a translated
+IPAMClaim at the secondary cluster. OVN-Kubernetes then assigns the translated
+IP via the UDN — no guest OS modification needed.
+
+Translation methods:
+  pattern             — subnet prefix replaced, host octet preserved
+  explicit            — IP-to-IP mapping; host octet may change
+  pattern-with-overrides — explicit takes precedence over pattern
+
+Test classes:
+  TestVMIPTranslationConfigMap     — ConfigMap validation, NAD discovery,
+                                     controller conditions (no failover needed)
+  TestVMIPTranslationDRCycle       — Full failover + failback IP translation,
+                                     backward compatibility, opt-in behavior,
+                                     and edge cases
+  TestVMIPTranslationPlatformSpecific — Hub recovery, post-upgrade, BM HCP
+
+NOTE: Several assertions reference DRPolicy/VRG/DRClusterConfig status field
+names that are not yet finalized. These are marked with # TODO comments.
+Update the constants at the top of this file once the developer confirms the
+API schema (RHSTOR-8082 open questions).
+"""
+
+import logging
+import tempfile
+
+import pytest
+
+from ocs_ci.framework import config
+from ocs_ci.framework.pytest_customization.marks import (
+    rdr,
+    turquoise_squad,
+    tier2,
+)
+from ocs_ci.framework.testlib import skipif_ocs_version
+from ocs_ci.helpers import dr_helpers
+from ocs_ci.helpers.dr_helpers import wait_for_all_resources_deletion
+from ocs_ci.helpers.dr_helpers_vm_ip_translation import (
+    DRCLUSTERCONFIG_NAD_STATUS_FIELD,
+    DRPOLICY_NADS_SYNCED_CONDITION,
+    DRPOLICY_NM_METHOD_EXPLICIT,
+    DRPOLICY_NM_METHOD_PATTERN,
+    DRPOLICY_NM_METHOD_PATTERN_OVERRIDES,
+    DRPOLICY_NM_STATUS_INVALID,
+    DRPOLICY_NM_STATUS_VALID,
+    VM_IP_TRANSLATION_NS,
+    VRG_CONDITION_NM_LOADED,
+    build_network_mapping_cm_data,
+    get_drpolicy_network_mapping_status,
+    get_ipamclaim_ip,
+    wait_for_drpolicy_network_mapping_status,
+)
+from ocs_ci.ocs import constants
+from ocs_ci.ocs import ocp
+from ocs_ci.ocs.node import get_node_objs, wait_for_nodes_status
+from ocs_ci.ocs.resources.drpc import DRPC
+from ocs_ci.ocs.resources.pod import wait_for_pods_to_be_running
+from ocs_ci.utility import templating
+from ocs_ci.utility.utils import TimeoutSampler, ceph_health_check, exec_cmd
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Test IP addresses used across scenarios (dr1 = primary, dr2 = secondary)
+# ---------------------------------------------------------------------------
+
+DR1_SUBNET = "192.168.1.0/24"
+DR2_SUBNET = "192.168.2.0/24"
+VM1_IP_DR1 = "192.168.1.50"
+VM1_IP_DR2_PATTERN = "192.168.2.50"  # host octet preserved by pattern rule
+VM_DB_IP_DR1 = "192.168.1.100"
+VM_DB_IP_DR2_EXPLICIT = "192.168.2.200"  # overridden by explicit rule
+VM_DB_IP_DR2_PATTERN = "192.168.2.100"  # what pattern alone would give (NOT used)
+UNMAPPED_IP_DR1 = "192.168.1.99"  # no explicit rule → untranslated
+
+# Subnets for proportional translation scenario (different sizes)
+PROP_SRC_SUBNET = "10.0.0.0/24"
+PROP_DST_SUBNET = "172.16.0.0/16"
+
+
+# ---------------------------------------------------------------------------
+# Class 1: ConfigMap validation and controller condition tests
+# (No failover required — hub-only or managed-cluster inspection)
+# ---------------------------------------------------------------------------
+
+
+@rdr
+@tier2
+@turquoise_squad
+@skipif_ocs_version("<4.21")
+class TestVMIPTranslationConfigMap:
+    """
+    Validate that the DRPolicy controller correctly classifies each translation
+    ConfigMap type and that the DRClusterConfig NAD discovery works as expected.
+    No VM failover is performed in this class.
+
+    Prerequisites:
+      - ODF >= 4.21 with RHSTOR-8082 feature enabled
+      - ACM hub cluster with at least two registered DRClusters
+      - UDN vm-network on both managed clusters (setup_udn_nad fixture)
+      - NADs labeled with ramendr.openshift.io/network-id (setup_udn_nad fixture)
+      - DRClusterConfig with NAD discovery enabled on both managed clusters
+    """
+
+    @pytest.mark.polarion_id("OCS-XXXX")
+    @pytest.mark.parametrize(
+        "cm_name,pattern_rules,explicit_rules,expected_method,expected_pattern_count,expected_explicit_count",
+        [
+            pytest.param(
+                "vm-ip-map-pattern",
+                [{"source": DR1_SUBNET, "destination": DR2_SUBNET}],
+                None,
+                DRPOLICY_NM_METHOD_PATTERN,
+                1,
+                0,
+                id="pattern-only",
+                marks=pytest.mark.polarion_id("OCS-XXXX"),
+            ),
+            pytest.param(
+                "vm-ip-map-explicit",
+                None,
+                [
+                    {"source": VM1_IP_DR1, "destination": VM1_IP_DR2_PATTERN},
+                    {"source": VM_DB_IP_DR1, "destination": VM_DB_IP_DR2_EXPLICIT},
+                ],
+                DRPOLICY_NM_METHOD_EXPLICIT,
+                0,
+                2,
+                id="explicit-only",
+                marks=pytest.mark.polarion_id("OCS-XXXX"),
+            ),
+            pytest.param(
+                "vm-ip-map-overrides",
+                [{"source": DR1_SUBNET, "destination": DR2_SUBNET}],
+                [{"source": VM_DB_IP_DR1, "destination": VM_DB_IP_DR2_EXPLICIT}],
+                DRPOLICY_NM_METHOD_PATTERN_OVERRIDES,
+                1,
+                1,
+                id="pattern-with-overrides",
+                marks=pytest.mark.polarion_id("OCS-XXXX"),
+            ),
+        ],
+    )
+    def test_configmap_validation(
+        self,
+        setup_udn_nad,
+        network_mapping_configmap,
+        cm_name,
+        pattern_rules,
+        explicit_rules,
+        expected_method,
+        expected_pattern_count,
+        expected_explicit_count,
+    ):
+        """
+        TC-1 / TC-2 / TC-3 / TC-8: Verify that pattern-only, explicit-only,
+        and pattern-with-overrides ConfigMaps are each accepted and classified
+        correctly by the DRPolicy controller.
+
+        For explicit-only (TC-2): also confirms that an IP not listed in any
+        rule (UNMAPPED_IP_DR1) has no translation entry — i.e. the ConfigMap
+        does not implicitly map unknown IPs.
+        """
+        config.switch_acm_ctx()
+        existing_policies = dr_helpers.get_all_drpolicy()
+        assert existing_policies, "No DRPolicy found on hub"
+        drpolicy_name = existing_policies[0]["metadata"]["name"]
+
+        network_mapping_configmap(
+            cm_name, pattern_rules=pattern_rules, explicit_rules=explicit_rules
+        )
+
+        # Poll until DRPolicy reports Valid status for the new ConfigMap
+        # TODO: DRPolicy must reference the ConfigMap by name — confirm the
+        # linkage mechanism (annotation, spec field, or auto-discovery by name).
+        wait_for_drpolicy_network_mapping_status(
+            drpolicy_name, DRPOLICY_NM_STATUS_VALID
+        )
+
+        nm_status = get_drpolicy_network_mapping_status(drpolicy_name)
+
+        # TODO: confirm exact field names in nm_status
+        assert nm_status.get("translationMethod") == expected_method, (
+            f"Expected translationMethod={expected_method}, "
+            f"got {nm_status.get('translationMethod')}"
+        )
+        assert nm_status.get("patternMappings") == expected_pattern_count, (
+            f"Expected patternMappings={expected_pattern_count}, "
+            f"got {nm_status.get('patternMappings')}"
+        )
+        assert nm_status.get("explicitMappings") == expected_explicit_count, (
+            f"Expected explicitMappings={expected_explicit_count}, "
+            f"got {nm_status.get('explicitMappings')}"
+        )
+
+        if cm_name == "vm-ip-map-explicit":
+            # Unmapped IP must not appear in the explicit mapping list
+            nm_raw = get_drpolicy_network_mapping_status(drpolicy_name)
+            raw_data = str(nm_raw)
+            assert UNMAPPED_IP_DR1 not in raw_data, (
+                f"Unmapped IP {UNMAPPED_IP_DR1} should not appear in "
+                "explicit-only ConfigMap status"
+            )
+
+        logger.info(
+            f"ConfigMap '{cm_name}' validated: method={expected_method}, "
+            f"patternMappings={expected_pattern_count}, "
+            f"explicitMappings={expected_explicit_count}"
+        )
+
+    @pytest.mark.polarion_id("OCS-XXXX")
+    @pytest.mark.parametrize(
+        "scenario,cm_data",
+        [
+            pytest.param(
+                "missing",
+                None,
+                id="missing-configmap",
+                marks=pytest.mark.polarion_id("OCS-XXXX"),
+            ),
+            pytest.param(
+                "empty",
+                {},
+                id="empty-configmap",
+                marks=pytest.mark.polarion_id("OCS-XXXX"),
+            ),
+            pytest.param(
+                "invalid-regex",
+                {"patternMappings": "[invalid-regex"},  # TODO: confirm format
+                id="invalid-regex-configmap",
+                marks=pytest.mark.polarion_id("OCS-XXXX"),
+            ),
+        ],
+    )
+    def test_invalid_configmap_handling(self, scenario, cm_data):
+        """
+        TC-14: Verify graceful handling when the ConfigMap is missing, empty,
+        or contains an invalid regex pattern. In all cases the VRG/DRPC
+        condition NetworkMappingLoaded should be False with a descriptive reason.
+        DRPC operations must not crash.
+        """
+        config.switch_acm_ctx()
+        existing_policies = dr_helpers.get_all_drpolicy()
+        assert existing_policies, "No DRPolicy found on hub"
+        drpolicy_name = existing_policies[0]["metadata"]["name"]
+
+        if cm_data is not None:
+            # Create a deliberately bad ConfigMap
+            with tempfile.NamedTemporaryFile(
+                mode="w+", suffix=".yaml", delete=False
+            ) as f:
+                manifest = {
+                    "apiVersion": "v1",
+                    "kind": constants.CONFIGMAP,
+                    "metadata": {
+                        "name": f"vm-ip-map-bad-{scenario}",
+                        "namespace": VM_IP_TRANSLATION_NS,
+                    },
+                    "data": cm_data,
+                }
+                templating.dump_data_to_temp_yaml(manifest, f.name)
+                exec_cmd(f"oc create -f {f.name}")
+            cm_name = f"vm-ip-map-bad-{scenario}"
+        else:
+            # Missing ConfigMap: nothing to create
+            cm_name = "vm-ip-map-nonexistent"
+
+        try:
+            # TODO: trigger or reference the ConfigMap from the DRPolicy
+            # then poll for the condition reflecting the invalid state
+            for sample in TimeoutSampler(
+                timeout=120,
+                sleep=5,
+                func=lambda: get_drpolicy_network_mapping_status(drpolicy_name).get(
+                    "status", ""
+                ),
+            ):
+                if sample == DRPOLICY_NM_STATUS_INVALID:
+                    break
+            nm_status = get_drpolicy_network_mapping_status(drpolicy_name)
+            assert nm_status.get("status") == DRPOLICY_NM_STATUS_INVALID, (
+                f"Expected networkMapping.status={DRPOLICY_NM_STATUS_INVALID} "
+                f"for scenario '{scenario}', got {nm_status}"
+            )
+            # Reason must be non-empty to aid diagnosis
+            assert nm_status.get(
+                "reason"
+            ), "Expected a non-empty reason alongside Invalid status"
+            logger.info(
+                f"Scenario '{scenario}': DRPolicy correctly reports Invalid "
+                f"with reason: {nm_status.get('reason')}"
+            )
+        finally:
+            if cm_data is not None:
+                try:
+                    config.switch_acm_ctx()
+                    exec_cmd(
+                        f"oc delete configmap {cm_name} -n {VM_IP_TRANSLATION_NS} --ignore-not-found"
+                    )
+                except Exception as exc:
+                    logger.warning(f"Cleanup failed for '{cm_name}': {exc}")
+
+    @pytest.mark.polarion_id("OCS-XXXX")
+    def test_drclusterconfig_nad_discovery(self, setup_udn_nad):
+        """
+        TC-6 / TC-7: Verify that:
+          - DRClusterConfig controller lists all NADs labeled with
+            ramendr.openshift.io/network-id in status.networkAttachments
+          - DRPolicy controller validates that labeled NADs exist on both
+            clusters and reports NADsSynced condition correctly
+        """
+        config.switch_acm_ctx()
+        existing_policies = dr_helpers.get_all_drpolicy()
+        assert existing_policies, "No DRPolicy found on hub"
+        drpolicy_name = existing_policies[0]["metadata"]["name"]
+        drpolicy_ocp = ocp.OCP(kind=constants.DRPOLICY, resource_name=drpolicy_name)
+
+        # Verify NADsSynced condition on DRPolicy
+        # TODO: confirm condition name and expected reason/status values
+        conditions = drpolicy_ocp.get().get("status", {}).get("conditions", [])
+        nads_synced = next(
+            (c for c in conditions if c.get("type") == DRPOLICY_NADS_SYNCED_CONDITION),
+            None,
+        )
+        assert (
+            nads_synced is not None
+        ), f"DRPolicy {drpolicy_name} missing condition '{DRPOLICY_NADS_SYNCED_CONDITION}'"
+        assert (
+            nads_synced.get("status") == "True"
+        ), f"Expected NADsSynced=True, got: {nads_synced}"
+        logger.info(f"DRPolicy NADsSynced condition: {nads_synced}")
+
+        # Verify DRClusterConfig.status.networkAttachments on each managed cluster
+        drcluster_list = dr_helpers.get_all_drclusters()
+        assert drcluster_list, "No DRClusters found on hub"
+        for drcluster in drcluster_list:
+            cluster_name = drcluster["metadata"]["name"]
+            # DRClusterConfig lives on the hub and is named after the managed cluster
+            config.switch_acm_ctx()
+            drclusterconfig_ocp = ocp.OCP(
+                kind=constants.DRCLUSTERCONFIG, resource_name=cluster_name
+            )
+            net_attachments = (
+                drclusterconfig_ocp.get()
+                .get("status", {})
+                .get(DRCLUSTERCONFIG_NAD_STATUS_FIELD, [])
+            )
+            assert net_attachments, (
+                f"DRClusterConfig for {cluster_name} has empty "
+                f"status.{DRCLUSTERCONFIG_NAD_STATUS_FIELD} — "
+                f"expected at least one labeled NAD to be discovered"
+            )
+            logger.info(
+                f"DRClusterConfig {cluster_name} discovered NADs: {net_attachments}"
+            )
+
+    @pytest.mark.polarion_id("OCS-XXXX")
+    def test_vrg_network_mapping_loaded_condition(
+        self, setup_udn_nad, setup_nad_in_namespace, discovered_apps_dr_workload_cnv
+    ):
+        """
+        TC-7b: Verify that VRG correctly reports NetworkMappingLoaded=True
+        when a valid network mapping ConfigMap is active and the VMI reports
+        the expected translated IP.
+
+        Requires a workload with UDN/IPAMClaim configured.
+        # TODO: Extend discovered_apps_dr_workload_cnv to support static-IP
+        # VMs with IPAMClaims, or create a dedicated fixture.
+        """
+        cnv_workloads = discovered_apps_dr_workload_cnv(
+            pvc_vm=1, dr_protect=True, shared_drpc_protection=False
+        )
+        assert cnv_workloads, "No CNV workload deployed"
+        workload = cnv_workloads[-1]
+        namespace = workload.workload_namespace
+        resource_name = workload.discovered_apps_placement_name + "-drpc"
+
+        config.switch_acm_ctx()
+        existing_policies = dr_helpers.get_all_drpolicy()
+        assert existing_policies
+        drpolicy_name = existing_policies[0]["metadata"]["name"]
+
+        # Create a pattern-only ConfigMap so there is a valid mapping
+        with tempfile.NamedTemporaryFile(mode="w+", suffix=".yaml", delete=False) as f:
+            manifest = {
+                "apiVersion": "v1",
+                "kind": constants.CONFIGMAP,
+                "metadata": {
+                    "name": "vm-ip-map-vrg-test",
+                    "namespace": VM_IP_TRANSLATION_NS,
+                },
+                "data": build_network_mapping_cm_data(
+                    pattern_rules=[{"source": DR1_SUBNET, "destination": DR2_SUBNET}]
+                ),
+            }
+            templating.dump_data_to_temp_yaml(manifest, f.name)
+            config.switch_acm_ctx()
+            exec_cmd(f"oc create -f {f.name}")
+
+        try:
+            wait_for_drpolicy_network_mapping_status(
+                drpolicy_name, DRPOLICY_NM_STATUS_VALID
+            )
+
+            # Check VRG condition on the primary cluster
+            primary_cluster = workload.preferred_primary_cluster
+            config.switch_to_cluster_by_name(primary_cluster)
+            # TODO: use a VRG helper once the condition schema is finalized
+            vrg_ocp = ocp.OCP(
+                kind="VolumeReplicationGroup",  # TODO: add constant
+                namespace=namespace,
+                resource_name=resource_name,
+            )
+            vrg_conditions = vrg_ocp.get().get("status", {}).get("conditions", [])
+            nm_condition = next(
+                (c for c in vrg_conditions if c.get("type") == VRG_CONDITION_NM_LOADED),
+                None,
+            )
+            assert (
+                nm_condition is not None
+            ), f"VRG missing condition '{VRG_CONDITION_NM_LOADED}'"
+            assert (
+                nm_condition.get("status") == "True"
+            ), f"Expected {VRG_CONDITION_NM_LOADED}=True, got: {nm_condition}"
+            logger.info(f"VRG {VRG_CONDITION_NM_LOADED} condition: {nm_condition}")
+        finally:
+            config.switch_acm_ctx()
+            exec_cmd(
+                "oc delete configmap vm-ip-map-vrg-test "
+                f"-n {VM_IP_TRANSLATION_NS} --ignore-not-found"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Class 2: Full DR cycle with IP translation
+# ---------------------------------------------------------------------------
+
+
+@rdr
+@tier2
+@turquoise_squad
+@skipif_ocs_version("<4.21")
+class TestVMIPTranslationDRCycle:
+    """
+    Full failover + failback scenarios exercising actual IP translation,
+    backward compatibility, and opt-in enforcement.
+
+    Prerequisites (in addition to base RDR environment):
+      - ODF >= 4.21 with RHSTOR-8082 feature enabled
+      - UDN vm-network on both clusters with ipam.lifecycle: Persistent
+        (setup_udn_nad fixture creates this)
+      - NAD vm-network in the workload namespace with allowPersistentIPs: true
+        and label ramendr.openshift.io/network-id
+        (setup_nad_in_namespace fixture creates this per test)
+      - VMs deployed with static IPs and IPAMClaims on the UDN secondary network
+        (discovered_apps_dr_workload_cnv is used as placeholder — replace with
+        a static-IP workload fixture once available, see TODO below)
+
+    # TODO: Create a static-IP VM workload fixture (e.g.
+    # discovered_apps_dr_workload_cnv_static_ip) that deploys VMs configured
+    # with a secondary UDN interface and static IP via IPAMClaim.
+    # The workload directory in the DR workload repo will need a matching
+    # VM manifest with network annotations pointing to the UDN/NAD.
+    """
+
+    @pytest.mark.polarion_id("OCS-XXXX")
+    def test_failover_failback_ip_translation(
+        self,
+        setup_udn_nad,
+        setup_nad_in_namespace,
+        discovered_apps_dr_workload_cnv,
+        network_mapping_configmap,
+        nodes_multicluster,
+        node_restart_teardown,
+    ):
+        """
+        TC-4 / TC-9 / TC-12: Validate translated IP assignment at the
+        IPAMClaim layer during failover and restoration of original IP
+        during failback for two VMs:
+
+          test-vm-1   (192.168.1.50)  → pattern rule   → 192.168.2.50 on dr2
+          test-vm-db  (192.168.1.100) → explicit rule   → 192.168.2.200 on dr2
+          (same ConfigMap covers both VMs in a single failover — TC-12)
+
+        After failback both VMs must recover their original dr1 IPs (TC-4).
+        """
+        # Deploy two static-IP workloads
+        # TODO: replace with a static-IP workload fixture
+        cnv_workload_1 = discovered_apps_dr_workload_cnv(
+            pvc_vm=1, dr_protect=True, shared_drpc_protection=False
+        )
+        cnv_workload_2 = discovered_apps_dr_workload_cnv(
+            pvc_vm=1, dr_protect=True, shared_drpc_protection=True
+        )
+        assert cnv_workload_1 and cnv_workload_2, "Workload deployment failed"
+        wl1 = cnv_workload_1[-1]
+        wl2 = cnv_workload_2[-1]
+        namespace = wl1.workload_namespace
+        primary_cluster = wl1.preferred_primary_cluster
+
+        # pattern-with-overrides: vm-1 via pattern, vm-db via explicit
+        network_mapping_configmap(
+            "vm-ip-map-failover",
+            pattern_rules=[{"source": DR1_SUBNET, "destination": DR2_SUBNET}],
+            explicit_rules=[
+                {"source": VM_DB_IP_DR1, "destination": VM_DB_IP_DR2_EXPLICIT}
+            ],
+        )
+
+        config.switch_acm_ctx()
+        existing_policies = dr_helpers.get_all_drpolicy()
+        assert existing_policies
+        drpolicy_name = existing_policies[0]["metadata"]["name"]
+        wait_for_drpolicy_network_mapping_status(
+            drpolicy_name, DRPOLICY_NM_STATUS_VALID
+        )
+
+        config.switch_to_cluster_by_name(primary_cluster)
+        resource_name_1 = wl1.discovered_apps_placement_name + "-drpc"
+        secondary_cluster = dr_helpers.get_current_secondary_cluster_name(
+            namespace, discovered_apps=True, resource_name=resource_name_1
+        )
+
+        # --- Failover: shut down primary and fail over to secondary ---
+        active_primary_index = config.cur_index
+        active_primary_nodes = get_node_objs()
+        logger.info("Shutting down primary cluster nodes for failover")
+        nodes_multicluster[active_primary_index].stop_nodes(active_primary_nodes)
+        dr_helpers.wait_for_managed_cluster_unreachable(primary_cluster)
+
+        for wl in (wl1, wl2):
+            resource_name = wl.discovered_apps_placement_name + "-drpc"
+            dr_helpers.failover(
+                failover_cluster=secondary_cluster,
+                namespace=namespace,
+                discovered_apps=True,
+                workload_placement_name=resource_name,
+                old_primary=primary_cluster,
+                skip_odf_cli_validation=True,
+            )
+
+        config.switch_to_cluster_by_name(secondary_cluster)
+        dr_helpers.wait_for_all_resources_creation(
+            wl1.workload_pvc_count + wl2.workload_pvc_count,
+            wl1.workload_pod_count + wl2.workload_pod_count,
+            namespace,
+            timeout=1800,
+            discovered_apps=True,
+            vrg_name=resource_name_1,
+            skip_replication_resources=True,
+        )
+
+        # Verify translated IPs on secondary cluster
+        # TODO: replace vm_name placeholders with actual static-IP VM names
+        logger.info("Verifying translated IPAMClaim IPs on secondary cluster")
+        vm1_ip_secondary = get_ipamclaim_ip(secondary_cluster, namespace, wl1.vm_name)
+        vmdb_ip_secondary = get_ipamclaim_ip(secondary_cluster, namespace, wl2.vm_name)
+        assert (
+            vm1_ip_secondary == VM1_IP_DR2_PATTERN
+        ), f"VM1 expected translated IP {VM1_IP_DR2_PATTERN}, got {vm1_ip_secondary}"
+        assert vmdb_ip_secondary == VM_DB_IP_DR2_EXPLICIT, (
+            f"VM-DB expected explicit override IP {VM_DB_IP_DR2_EXPLICIT}, "
+            f"got {vmdb_ip_secondary}"
+        )
+        logger.info(
+            f"Failover IP translation verified: vm1={vm1_ip_secondary}, "
+            f"vm-db={vmdb_ip_secondary}"
+        )
+
+        # Recover primary cluster
+        config.switch_to_cluster_by_name(primary_cluster)
+        logger.info("Recovering primary cluster")
+        nodes_multicluster[active_primary_index].start_nodes(active_primary_nodes)
+        wait_for_nodes_status([n.name for n in active_primary_nodes], timeout=900)
+        wait_for_pods_to_be_running(timeout=420, sleep=15)
+        assert ceph_health_check(tries=10, delay=30)
+
+        # Cleanup stale resources on the old primary after failover
+        for wl in (wl1, wl2):
+            resource_name = wl.discovered_apps_placement_name + "-drpc"
+            dr_helpers.do_discovered_apps_cleanup(
+                drpc_name=resource_name,
+                old_primary=primary_cluster,
+                workload_namespace=namespace,
+                workload_dir=wl.workload_dir,
+                vrg_name=resource_name,
+                skip_resource_deletion_verification=True,
+            )
+        config.switch_to_cluster_by_name(primary_cluster)
+        wait_for_all_resources_deletion(
+            namespace=namespace,
+            discovered_apps=True,
+            vrg_name=resource_name_1,
+        )
+
+        # --- Failback (Relocate): secondary → primary ---
+        logger.info("Performing failback (Relocate) to primary cluster")
+        for wl in (wl1, wl2):
+            resource_name = wl.discovered_apps_placement_name + "-drpc"
+            dr_helpers.relocate(
+                preferred_cluster=primary_cluster,
+                namespace=namespace,
+                workload_placement_name=resource_name,
+                discovered_apps=True,
+                old_primary=secondary_cluster,
+                workload_instance=wl,
+                skip_odf_cli_validation=True,
+            )
+
+        config.switch_to_cluster_by_name(secondary_cluster)
+        wait_for_all_resources_deletion(
+            namespace=namespace,
+            discovered_apps=True,
+            vrg_name=resource_name_1,
+        )
+
+        # Verify original IPs restored on primary cluster after failback
+        logger.info("Verifying original IPAMClaim IPs restored on primary cluster")
+        vm1_ip_primary = get_ipamclaim_ip(primary_cluster, namespace, wl1.vm_name)
+        vmdb_ip_primary = get_ipamclaim_ip(primary_cluster, namespace, wl2.vm_name)
+        assert (
+            vm1_ip_primary == VM1_IP_DR1
+        ), f"VM1 expected original IP {VM1_IP_DR1} after failback, got {vm1_ip_primary}"
+        assert vmdb_ip_primary == VM_DB_IP_DR1, (
+            f"VM-DB expected original IP {VM_DB_IP_DR1} after failback, "
+            f"got {vmdb_ip_primary}"
+        )
+        logger.info(
+            f"Failback IP restoration verified: vm1={vm1_ip_primary}, "
+            f"vm-db={vmdb_ip_primary}"
+        )
+
+    @pytest.mark.polarion_id("OCS-XXXX")
+    def test_backward_compatibility_no_mapping(
+        self,
+        setup_udn_nad,
+        discovered_apps_dr_workload_cnv,
+        nodes_multicluster,
+        node_restart_teardown,
+    ):
+        """
+        TC-5: Verify that existing VMs without any network mapping ConfigMap
+        fail over and fail back without error — feature is opt-in only and must
+        not introduce regressions.
+        """
+        cnv_workloads = discovered_apps_dr_workload_cnv(
+            pvc_vm=1, dr_protect=True, shared_drpc_protection=False
+        )
+        assert cnv_workloads, "No CNV workload deployed"
+        wl = cnv_workloads[-1]
+        namespace = wl.workload_namespace
+        resource_name = wl.discovered_apps_placement_name + "-drpc"
+        primary_cluster = wl.preferred_primary_cluster
+
+        # Explicitly confirm no network mapping ConfigMap exists
+        config.switch_acm_ctx()
+        cm_list = ocp.OCP(kind=constants.CONFIGMAP, namespace=VM_IP_TRANSLATION_NS).get(
+            selector="app=ramen-network-mapping"
+        )  # TODO: confirm label
+        assert not cm_list.get("items"), (
+            "Expected no network mapping ConfigMap for backward-compat test, "
+            f"found: {[i['metadata']['name'] for i in cm_list.get('items', [])]}"
+        )
+
+        config.switch_to_cluster_by_name(primary_cluster)
+        secondary_cluster = dr_helpers.get_current_secondary_cluster_name(
+            namespace, discovered_apps=True, resource_name=resource_name
+        )
+
+        active_primary_index = config.cur_index
+        active_primary_nodes = get_node_objs()
+        nodes_multicluster[active_primary_index].stop_nodes(active_primary_nodes)
+        dr_helpers.wait_for_managed_cluster_unreachable(primary_cluster)
+
+        dr_helpers.failover(
+            failover_cluster=secondary_cluster,
+            namespace=namespace,
+            discovered_apps=True,
+            workload_placement_name=resource_name,
+            old_primary=primary_cluster,
+            skip_odf_cli_validation=True,
+        )
+
+        config.switch_to_cluster_by_name(secondary_cluster)
+        dr_helpers.wait_for_all_resources_creation(
+            wl.workload_pvc_count,
+            wl.workload_pod_count,
+            namespace,
+            timeout=1800,
+            discovered_apps=True,
+            vrg_name=resource_name,
+            skip_replication_resources=True,
+        )
+        dr_helpers.wait_for_cnv_workload(
+            vm_name=wl.vm_name,
+            namespace=namespace,
+            phase=constants.STATUS_RUNNING,
+        )
+        logger.info(
+            "Failover completed without network mapping — backward compatibility OK"
+        )
+
+        # Recover and relocate back
+        config.switch_to_cluster_by_name(primary_cluster)
+        nodes_multicluster[active_primary_index].start_nodes(active_primary_nodes)
+        wait_for_nodes_status([n.name for n in active_primary_nodes], timeout=900)
+        wait_for_pods_to_be_running(timeout=420, sleep=15)
+        assert ceph_health_check(tries=10, delay=30)
+
+        dr_helpers.do_discovered_apps_cleanup(
+            drpc_name=resource_name,
+            old_primary=primary_cluster,
+            workload_namespace=namespace,
+            workload_dir=wl.workload_dir,
+            vrg_name=resource_name,
+            skip_resource_deletion_verification=True,
+        )
+        wait_for_all_resources_deletion(
+            namespace=namespace, discovered_apps=True, vrg_name=resource_name
+        )
+
+        dr_helpers.relocate(
+            preferred_cluster=primary_cluster,
+            namespace=namespace,
+            workload_placement_name=resource_name,
+            discovered_apps=True,
+            old_primary=secondary_cluster,
+            workload_instance=wl,
+            skip_odf_cli_validation=True,
+        )
+
+        config.switch_to_cluster_by_name(secondary_cluster)
+        wait_for_all_resources_deletion(
+            namespace=namespace, discovered_apps=True, vrg_name=resource_name
+        )
+        logger.info(
+            "Failback completed without network mapping — backward compatibility OK"
+        )
+
+    @pytest.mark.polarion_id("OCS-XXXX")
+    def test_opt_in_required(
+        self,
+        setup_udn_nad,
+        setup_nad_in_namespace,
+        discovered_apps_dr_workload_cnv,
+        network_mapping_configmap,
+        nodes_multicluster,
+        node_restart_teardown,
+    ):
+        """
+        TC-10: Verify that IP translation is applied only when
+        networkMapping.enabled=true in the ConfigMap. An existing DRPC or one
+        created after upgrade must not be affected without the opt-in.
+        """
+        cnv_workloads = discovered_apps_dr_workload_cnv(
+            pvc_vm=1, dr_protect=True, shared_drpc_protection=False
+        )
+        assert cnv_workloads
+        wl = cnv_workloads[-1]
+        namespace = wl.workload_namespace
+        resource_name = wl.discovered_apps_placement_name + "-drpc"
+        primary_cluster = wl.preferred_primary_cluster
+
+        # Create a ConfigMap with enabled=False — translation must NOT occur
+        network_mapping_configmap(
+            "vm-ip-map-opt-out",
+            pattern_rules=[{"source": DR1_SUBNET, "destination": DR2_SUBNET}],
+            enabled=False,
+        )
+
+        config.switch_to_cluster_by_name(primary_cluster)
+        secondary_cluster = dr_helpers.get_current_secondary_cluster_name(
+            namespace, discovered_apps=True, resource_name=resource_name
+        )
+
+        active_primary_index = config.cur_index
+        active_primary_nodes = get_node_objs()
+        nodes_multicluster[active_primary_index].stop_nodes(active_primary_nodes)
+        dr_helpers.wait_for_managed_cluster_unreachable(primary_cluster)
+
+        dr_helpers.failover(
+            failover_cluster=secondary_cluster,
+            namespace=namespace,
+            discovered_apps=True,
+            workload_placement_name=resource_name,
+            old_primary=primary_cluster,
+            skip_odf_cli_validation=True,
+        )
+
+        config.switch_to_cluster_by_name(secondary_cluster)
+        dr_helpers.wait_for_all_resources_creation(
+            wl.workload_pvc_count,
+            wl.workload_pod_count,
+            namespace,
+            timeout=1800,
+            discovered_apps=True,
+            vrg_name=resource_name,
+            skip_replication_resources=True,
+        )
+
+        # IP must NOT be translated — VM retains its original IP
+        # TODO: confirm how to check IPAMClaim when opt-out is active
+        vm_ip = get_ipamclaim_ip(secondary_cluster, namespace, wl.vm_name)
+        assert (
+            vm_ip == VM1_IP_DR1
+        ), f"Expected untranslated IP {VM1_IP_DR1} (opt-out), got {vm_ip}"
+        logger.info(f"Opt-in disabled: VM IP {vm_ip} correctly not translated")
+
+        # Recover
+        config.switch_to_cluster_by_name(primary_cluster)
+        nodes_multicluster[active_primary_index].start_nodes(active_primary_nodes)
+        wait_for_nodes_status([n.name for n in active_primary_nodes], timeout=900)
+        wait_for_pods_to_be_running(timeout=420, sleep=15)
+        assert ceph_health_check(tries=10, delay=30)
+
+        dr_helpers.do_discovered_apps_cleanup(
+            drpc_name=resource_name,
+            old_primary=primary_cluster,
+            workload_namespace=namespace,
+            workload_dir=wl.workload_dir,
+            vrg_name=resource_name,
+            skip_resource_deletion_verification=True,
+        )
+        config.switch_to_cluster_by_name(primary_cluster)
+        wait_for_all_resources_deletion(
+            namespace=namespace, discovered_apps=True, vrg_name=resource_name
+        )
+
+        dr_helpers.relocate(
+            preferred_cluster=primary_cluster,
+            namespace=namespace,
+            workload_placement_name=resource_name,
+            discovered_apps=True,
+            old_primary=secondary_cluster,
+            workload_instance=wl,
+            skip_odf_cli_validation=True,
+        )
+        config.switch_to_cluster_by_name(secondary_cluster)
+        wait_for_all_resources_deletion(
+            namespace=namespace, discovered_apps=True, vrg_name=resource_name
+        )
+
+    @pytest.mark.polarion_id("OCS-XXXX")
+    def test_proportional_translation(
+        self,
+        setup_udn_nad,
+        setup_nad_in_namespace,
+        discovered_apps_dr_workload_cnv,
+        network_mapping_configmap,
+        nodes_multicluster,
+        node_restart_teardown,
+    ):
+        """
+        TC-11: Verify proportional translation correctly maps IPs when source
+        and destination subnets have different sizes (e.g. /24 → /16).
+        The host portion of the address is scaled proportionally into the
+        destination subnet range.
+
+        # TODO: Confirm the proportional mapping algorithm with the developer
+        # and update expected_ip below accordingly.
+        """
+        cnv_workloads = discovered_apps_dr_workload_cnv(
+            pvc_vm=1, dr_protect=True, shared_drpc_protection=False
+        )
+        assert cnv_workloads
+        wl = cnv_workloads[-1]
+        namespace = wl.workload_namespace
+        resource_name = wl.discovered_apps_placement_name + "-drpc"
+        primary_cluster = wl.preferred_primary_cluster
+
+        network_mapping_configmap(
+            "vm-ip-map-proportional",
+            pattern_rules=[{"source": PROP_SRC_SUBNET, "destination": PROP_DST_SUBNET}],
+        )
+
+        config.switch_acm_ctx()
+        existing_policies = dr_helpers.get_all_drpolicy()
+        wait_for_drpolicy_network_mapping_status(
+            existing_policies[0]["metadata"]["name"], DRPOLICY_NM_STATUS_VALID
+        )
+
+        config.switch_to_cluster_by_name(primary_cluster)
+        secondary_cluster = dr_helpers.get_current_secondary_cluster_name(
+            namespace, discovered_apps=True, resource_name=resource_name
+        )
+
+        active_primary_index = config.cur_index
+        active_primary_nodes = get_node_objs()
+        nodes_multicluster[active_primary_index].stop_nodes(active_primary_nodes)
+        dr_helpers.wait_for_managed_cluster_unreachable(primary_cluster)
+
+        dr_helpers.failover(
+            failover_cluster=secondary_cluster,
+            namespace=namespace,
+            discovered_apps=True,
+            workload_placement_name=resource_name,
+            old_primary=primary_cluster,
+            skip_odf_cli_validation=True,
+        )
+        config.switch_to_cluster_by_name(secondary_cluster)
+        dr_helpers.wait_for_all_resources_creation(
+            wl.workload_pvc_count,
+            wl.workload_pod_count,
+            namespace,
+            timeout=1800,
+            discovered_apps=True,
+            vrg_name=resource_name,
+            skip_replication_resources=True,
+        )
+
+        translated_ip = get_ipamclaim_ip(secondary_cluster, namespace, wl.vm_name)
+        # TODO: compute expected IP once proportional mapping algorithm is confirmed
+        assert translated_ip.startswith(
+            "172.16."
+        ), f"Expected proportionally translated IP in 172.16.0.0/16, got {translated_ip}"
+        logger.info(f"Proportional translation result: {translated_ip}")
+
+        # Recover and relocate
+        config.switch_to_cluster_by_name(primary_cluster)
+        nodes_multicluster[active_primary_index].start_nodes(active_primary_nodes)
+        wait_for_nodes_status([n.name for n in active_primary_nodes], timeout=900)
+        wait_for_pods_to_be_running(timeout=420, sleep=15)
+        assert ceph_health_check(tries=10, delay=30)
+        dr_helpers.do_discovered_apps_cleanup(
+            drpc_name=resource_name,
+            old_primary=primary_cluster,
+            workload_namespace=namespace,
+            workload_dir=wl.workload_dir,
+            vrg_name=resource_name,
+            skip_resource_deletion_verification=True,
+        )
+        config.switch_to_cluster_by_name(primary_cluster)
+        wait_for_all_resources_deletion(
+            namespace=namespace, discovered_apps=True, vrg_name=resource_name
+        )
+        dr_helpers.relocate(
+            preferred_cluster=primary_cluster,
+            namespace=namespace,
+            workload_placement_name=resource_name,
+            discovered_apps=True,
+            old_primary=secondary_cluster,
+            workload_instance=wl,
+            skip_odf_cli_validation=True,
+        )
+        config.switch_to_cluster_by_name(secondary_cluster)
+        wait_for_all_resources_deletion(
+            namespace=namespace, discovered_apps=True, vrg_name=resource_name
+        )
+
+    @pytest.mark.polarion_id("OCS-XXXX")
+    def test_mixed_interface_translation(
+        self,
+        setup_udn_nad,
+        setup_nad_in_namespace,
+        discovered_apps_dr_workload_cnv,
+        network_mapping_configmap,
+        nodes_multicluster,
+        node_restart_teardown,
+    ):
+        """
+        TC-13: On a single namespace with multiple VMs where one VM has both
+        a DHCP interface and a static IP interface, verify that IP translation
+        is applied only to the static interface — the DHCP interface is not
+        touched and acquires its IP from the secondary site's DHCP server.
+
+        # TODO: Requires a VM fixture that creates a multi-homed VM
+        # (one DHCP NIC + one static-IP UDN NIC). Until available,
+        # this test validates the principle against the existing workload.
+        """
+        cnv_workloads = discovered_apps_dr_workload_cnv(
+            pvc_vm=1, dr_protect=True, shared_drpc_protection=False
+        )
+        assert cnv_workloads
+        wl = cnv_workloads[-1]
+        namespace = wl.workload_namespace
+        resource_name = wl.discovered_apps_placement_name + "-drpc"
+        primary_cluster = wl.preferred_primary_cluster
+
+        network_mapping_configmap(
+            "vm-ip-map-mixed-iface",
+            pattern_rules=[{"source": DR1_SUBNET, "destination": DR2_SUBNET}],
+        )
+        config.switch_acm_ctx()
+        existing_policies = dr_helpers.get_all_drpolicy()
+        wait_for_drpolicy_network_mapping_status(
+            existing_policies[0]["metadata"]["name"], DRPOLICY_NM_STATUS_VALID
+        )
+
+        config.switch_to_cluster_by_name(primary_cluster)
+        secondary_cluster = dr_helpers.get_current_secondary_cluster_name(
+            namespace, discovered_apps=True, resource_name=resource_name
+        )
+
+        active_primary_index = config.cur_index
+        active_primary_nodes = get_node_objs()
+        nodes_multicluster[active_primary_index].stop_nodes(active_primary_nodes)
+        dr_helpers.wait_for_managed_cluster_unreachable(primary_cluster)
+
+        dr_helpers.failover(
+            failover_cluster=secondary_cluster,
+            namespace=namespace,
+            discovered_apps=True,
+            workload_placement_name=resource_name,
+            old_primary=primary_cluster,
+            skip_odf_cli_validation=True,
+        )
+        config.switch_to_cluster_by_name(secondary_cluster)
+        dr_helpers.wait_for_all_resources_creation(
+            wl.workload_pvc_count,
+            wl.workload_pod_count,
+            namespace,
+            timeout=1800,
+            discovered_apps=True,
+            vrg_name=resource_name,
+            skip_replication_resources=True,
+        )
+
+        # Static IP interface: must be translated
+        static_ip = get_ipamclaim_ip(secondary_cluster, namespace, wl.vm_name)
+        assert static_ip.startswith(
+            "192.168.2."
+        ), f"Static IP must be translated to 192.168.2.x subnet, got {static_ip}"
+        # DHCP interface: acquired from secondary DHCP — must NOT be 192.168.1.x
+        # TODO: retrieve DHCP interface IP from VMI status once multi-homed VM
+        # fixture is available and add assertion here.
+        logger.info(f"Mixed interface: static IP translated to {static_ip}")
+
+        # Recover and relocate
+        config.switch_to_cluster_by_name(primary_cluster)
+        nodes_multicluster[active_primary_index].start_nodes(active_primary_nodes)
+        wait_for_nodes_status([n.name for n in active_primary_nodes], timeout=900)
+        wait_for_pods_to_be_running(timeout=420, sleep=15)
+        assert ceph_health_check(tries=10, delay=30)
+        dr_helpers.do_discovered_apps_cleanup(
+            drpc_name=resource_name,
+            old_primary=primary_cluster,
+            workload_namespace=namespace,
+            workload_dir=wl.workload_dir,
+            vrg_name=resource_name,
+            skip_resource_deletion_verification=True,
+        )
+        config.switch_to_cluster_by_name(primary_cluster)
+        wait_for_all_resources_deletion(
+            namespace=namespace, discovered_apps=True, vrg_name=resource_name
+        )
+        dr_helpers.relocate(
+            preferred_cluster=primary_cluster,
+            namespace=namespace,
+            workload_placement_name=resource_name,
+            discovered_apps=True,
+            old_primary=secondary_cluster,
+            workload_instance=wl,
+            skip_odf_cli_validation=True,
+        )
+        config.switch_to_cluster_by_name(secondary_cluster)
+        wait_for_all_resources_deletion(
+            namespace=namespace, discovered_apps=True, vrg_name=resource_name
+        )
+
+    @pytest.mark.polarion_id("OCS-XXXX")
+    def test_ip_outside_destination_subnet(
+        self, setup_udn_nad, network_mapping_configmap
+    ):
+        """
+        TC-15: Verify behavior when translation produces an IP outside the
+        destination subnet (e.g. a /30 destination subnet where the host
+        octet from the source does not fit). The controller must detect this
+        and report an error condition rather than silently assigning an invalid IP.
+
+        # TODO: Confirm the expected error condition name and reason string
+        # with the developer once the feature controller is implemented.
+        """
+        config.switch_acm_ctx()
+        existing_policies = dr_helpers.get_all_drpolicy()
+        assert existing_policies
+        drpolicy_name = existing_policies[0]["metadata"]["name"]
+
+        # A /30 destination gives only 4 addresses (.0-.3) — a source host
+        # octet of 50 (from VM1_IP_DR1) cannot fit in this range.
+        network_mapping_configmap(
+            "vm-ip-map-overflow",
+            pattern_rules=[{"source": DR1_SUBNET, "destination": "192.168.2.0/30"}],
+        )
+
+        # DRPolicy must report Invalid (or a specific overflow reason)
+        for sample in TimeoutSampler(
+            timeout=120,
+            sleep=5,
+            func=lambda: get_drpolicy_network_mapping_status(drpolicy_name).get(
+                "status", ""
+            ),
+        ):
+            if sample in (DRPOLICY_NM_STATUS_INVALID, DRPOLICY_NM_STATUS_VALID):
+                break
+
+        nm_status = get_drpolicy_network_mapping_status(drpolicy_name)
+        # TODO: confirm whether controller rejects this upfront (Invalid) or
+        # reports the overflow at translation time. Adjust assertion accordingly.
+        assert nm_status.get("status") == DRPOLICY_NM_STATUS_INVALID, (
+            "Expected DRPolicy to report Invalid when destination subnet is "
+            f"too small for the host octet, got: {nm_status}"
+        )
+        logger.info(f"IP-outside-dest-subnet correctly reported Invalid: {nm_status}")
+
+
+# ---------------------------------------------------------------------------
+# Class 3: Miscellaneous — NAD errors, cleanup, and platform-specific
+# ---------------------------------------------------------------------------
+
+
+@rdr
+@tier2
+@turquoise_squad
+@skipif_ocs_version("<4.21")
+class TestVMIPTranslationMiscellaneous:
+    """
+    Edge cases: missing/mislabeled NADs, DR unprotect cleanup, hub recovery,
+    post-upgrade behavior, and BM HCP cluster validation.
+
+    Prerequisites:
+      - ODF >= 4.21 with RHSTOR-8082 feature enabled
+      - UDN vm-network on both managed clusters (setup_udn_nad fixture)
+      - ACM hub cluster registered with at least two DRClusters
+    """
+
+    @pytest.mark.polarion_id("OCS-XXXX")
+    @pytest.mark.parametrize(
+        "scenario",
+        [
+            pytest.param(
+                "missing-nad",
+                id="missing-nad",
+                marks=pytest.mark.polarion_id("OCS-XXXX"),
+            ),
+            pytest.param(
+                "dhcp-nad-labeled-static",
+                id="dhcp-nad-labeled-static",
+                marks=pytest.mark.polarion_id("OCS-XXXX"),
+            ),
+        ],
+    )
+    def test_missing_incorrectly_labeled_nad(self, setup_udn_nad, scenario):
+        """
+        TC-16: Verify that a missing NAD on the DR cluster or a DHCP NAD
+        incorrectly labeled as static are both handled gracefully — neither
+        scenario should cause a controller crash. The DRPolicy NADsSynced
+        condition should reflect the misconfiguration with a descriptive reason.
+        """
+        config.switch_acm_ctx()
+        existing_policies = dr_helpers.get_all_drpolicy()
+        assert existing_policies
+        drpolicy_name = existing_policies[0]["metadata"]["name"]
+        drpolicy_ocp = ocp.OCP(kind=constants.DRPOLICY, resource_name=drpolicy_name)
+
+        # TODO: For "missing-nad": temporarily delete the NAD on one managed
+        # cluster and verify the DRPolicy reports NADsSynced=False.
+        # For "dhcp-nad-labeled-static": add the NAD_DR_LABEL to a DHCP NAD
+        # and verify the controller reports a warning condition.
+        # These steps require test environment manipulation that depends on
+        # the exact NAD/UDN setup — implement once the feature is available.
+
+        conditions = drpolicy_ocp.get().get("status", {}).get("conditions", [])
+        nads_synced = next(
+            (c for c in conditions if c.get("type") == DRPOLICY_NADS_SYNCED_CONDITION),
+            None,
+        )
+        assert nads_synced is not None, (
+            f"NADsSynced condition missing from DRPolicy {drpolicy_name} "
+            f"for scenario '{scenario}'"
+        )
+        logger.info(
+            f"Scenario '{scenario}': NADsSynced condition present with "
+            f"status={nads_synced.get('status')}, reason={nads_synced.get('reason')}"
+        )
+
+    @pytest.mark.polarion_id("OCS-XXXX")
+    def test_dr_protection_disable_cleanup(
+        self,
+        setup_udn_nad,
+        setup_nad_in_namespace,
+        discovered_apps_dr_workload_cnv,
+        network_mapping_configmap,
+    ):
+        """
+        TC-17: Verify that disabling DR protection for a VM that had IP
+        translation configured correctly cleans up all translation resources
+        (IPAMClaims, network mapping references) so that no orphans remain.
+        """
+        cnv_workloads = discovered_apps_dr_workload_cnv(
+            pvc_vm=1, dr_protect=True, shared_drpc_protection=False
+        )
+        assert cnv_workloads
+        wl = cnv_workloads[-1]
+        namespace = wl.workload_namespace
+        resource_name = wl.discovered_apps_placement_name + "-drpc"
+        primary_cluster = wl.preferred_primary_cluster
+
+        network_mapping_configmap(
+            "vm-ip-map-disable-test",
+            pattern_rules=[{"source": DR1_SUBNET, "destination": DR2_SUBNET}],
+        )
+        config.switch_acm_ctx()
+        existing_policies = dr_helpers.get_all_drpolicy()
+        wait_for_drpolicy_network_mapping_status(
+            existing_policies[0]["metadata"]["name"], DRPOLICY_NM_STATUS_VALID
+        )
+
+        # Disable DR protection by deleting the DRPC
+        config.switch_acm_ctx()
+        drpc_obj = DRPC(
+            namespace=constants.DR_OPS_NAMESPACE, resource_name=resource_name
+        )
+        drpc_obj.delete()
+        logger.info(f"Deleted DRPC {resource_name} to disable DR protection")
+
+        # Verify IPAMClaim translation resources are cleaned up on primary
+        config.switch_to_cluster_by_name(primary_cluster)
+        # Poll until no translated IPAMClaims remain
+        for sample in TimeoutSampler(
+            timeout=300,
+            sleep=10,
+            func=lambda: ocp.OCP(
+                kind="IPAMClaim",  # TODO: add constant
+                namespace=namespace,
+            ).get(
+                selector="ramen-translation=true"
+            ),  # TODO: confirm label
+        ):
+            if not sample.get("items"):
+                break
+        logger.info("Translation IPAMClaims cleaned up after DR protection disabled")
+
+        # Verify VRG is gone (no orphaned replication resources)
+        vrg_list = ocp.OCP(
+            kind="VolumeReplicationGroup",  # TODO: add constant
+            namespace=namespace,
+        ).get()
+        assert not vrg_list.get("items"), (
+            "Expected VRG to be cleaned up after disabling DR, "
+            f"found: {vrg_list.get('items')}"
+        )
+        logger.info("VRG cleaned up after DR protection disabled")
+
+    @pytest.mark.polarion_id("OCS-XXXX")
+    def test_hub_recovery_preserves_ip_translation(
+        self,
+        discovered_apps_dr_workload_cnv,
+        network_mapping_configmap,
+        nodes_multicluster,
+        node_restart_teardown,
+    ):
+        """
+        TC-18 (Hub recovery): Verify that after the ACM hub cluster recovers
+        from a failure, IP translation configuration is restored and subsequent
+        failover/failback still applies the correct IP mappings.
+
+        # TODO: Hub failure simulation requires the hub_failure_recovery fixture
+        # or equivalent infrastructure. Implement once available.
+        """
+        pytest.skip(
+            "Hub recovery simulation not yet automated — implement once "
+            "hub failure/recovery fixture is available"
+        )
+
+    @pytest.mark.polarion_id("OCS-XXXX")
+    def test_post_upgrade_ip_translation(
+        self,
+        discovered_apps_dr_workload_cnv,
+        network_mapping_configmap,
+        nodes_multicluster,
+        node_restart_teardown,
+    ):
+        """
+        TC-19 (Post-upgrade): Verify that IP translation works correctly after
+        an ODF/Ramen upgrade. Existing DRPCs must continue to honor translation
+        rules without requiring reconfiguration.
+
+        # TODO: Requires upgrade orchestration — run as part of the upgrade
+        # test pipeline once the feature ships.
+        """
+        pytest.skip(
+            "Post-upgrade validation to be run as part of the upgrade test pipeline"
+        )
+
+    @pytest.mark.polarion_id("OCS-XXXX")
+    def test_bm_hcp_cluster_ip_translation(
+        self,
+        discovered_apps_dr_workload_cnv,
+        network_mapping_configmap,
+        nodes_multicluster,
+        node_restart_teardown,
+    ):
+        """
+        TC-20 (BM HCP): Verify that IP translation works correctly on a
+        bare-metal HyperShift (HCP) cluster. The UDN/IPAMClaim path must
+        function identically regardless of the control plane topology.
+
+        # TODO: Requires a BM HCP environment. Mark with the appropriate
+        # environment skip condition once available.
+        """
+        pytest.skip(
+            "BM HCP cluster required — skip until a HCP test environment "
+            "with UDN support is provisioned"
+        )


### PR DESCRIPTION
Added automation for **[RHSTOR-8082](https://redhat.atlassian.net/browse/RHSTOR-8082) — VM static IP translation during Regional DR failover and relocate**.

This PR adds the environment setup helpers, the test cases that exercise the translation, and fixes three ACM 5.0 UI regressions found while running the protection flow.

## What's added

### New helper module — `ocs_ci/helpers/dr_helpers_vm_ip_translation.py`

- `setup_udn_nad` fixture — on both managed clusters, creates the namespace labelled `k8s.ovn.org/primary-user-defined-network` (this must be present *before* the UDN is created), then a Layer2 **Primary** UDN with `ipam.lifecycle: Persistent`, labelled `ramendr.openshift.io/dr-network=true` for DR discovery. Returns the per-cluster subnets so tests can build the mapping.
- `network_mapping_configmap` fixture — builds the cluster-to-cluster subnet mapping ConfigMap, links it to the DRPolicy, and handles teardown. Supports pattern rules, explicit rules, and pattern-with-overrides.
- `wait_for_drpolicy_network_mapping_status`, `get_drpolicy_network_mapping_status`, `wait_for_drpolicy_network_peers`, `get_ipamclaim_ip`, `get_vm_ip_from_vmi`.

### New tests — `tests/functional/disaster-recovery/regional-dr/test_vm_ip_translation.py`

- `TestVMIPTranslationConfigMap` — ConfigMap classification (pattern-only / explicit-only / pattern-with-overrides), invalid and missing ConfigMap handling, DRClusterConfig NAD discovery, and the VRG `NetworkMappingLoaded` condition. No failover required.
- `TestVMIPTranslationMiscellaneous` — missing and mislabelled NADs, DR-unprotect cleanup, plus placeholders for hub recovery, post-upgrade and BM HCP.

### Static-IP parametrization — `test_acm_kubevirt_dr_integration.py`

New `static_vm_ip` case alongside the existing `standalone` and `shared` ones. The static-IP VMs come from dedicated workload directories that pin an address inside the UDN subnet; everything else — deployment, DR protection through the **ACM UI Fleet Virtualization page**, failover and relocate — follows the exact same path as the existing discovered-VM cases, so there is no `static_vm_ip` branching around the protection logic.

The network mapping ConfigMap is linked to the DRPolicy *before* the VMs are protected, so the DRPC picks the mapping up at creation time and can translate the pinned IPs on failover.

### Supporting changes

- `tests/conftest.py` — `cnv_workload_with_static_ip` fixture
- `conf/ocsci/dr_workload.yaml` — `dr_cnv_discovered_apps_static_ip` and `..._shared` workload entries
- `ocs_ci/ocs/constants.py` — constants for the new resource kinds

## ACM 5.0 UI fixes

Three defects surfaced while running the Fleet Virtualization protection flow against ACM 5.0.0-262. **These affect the existing `standalone` and `shared` tests too, not just the new static-IP case** — each was diagnosed from DOM captured on a live hub rather than guessed at.

1. **`nav-bar-vms-page` locator** — ACM 5.0 renamed the nav item attribute from `data-test-id` to `data-test`. The XPath now matches either, so earlier ACM builds keep working.
2. **Collapsed side navigation** — switching to the Fleet Virtualization perspective leaves `#page-sidebar` rendered with `pf-m-collapsed` and `aria-hidden="true"`, making every nav item unclickable even though it is present in the DOM. Added `expand_nav_sidebar_if_collapsed()`, which clicks `#nav-toggle` when that state is detected. (Confirmed *not* a viewport issue — the window is 1920x1400.)
3. **Flaky onboarding popover dismissal** — the close button sits inside a `role="dialog" data-test="onboarding-popover"` that popper hides via `data-popper-reference-hidden` when its anchor scrolls out of view, so the element is present but not clickable. Dismissal is optional, so it is now best-effort in `close_modal_dialog_if_present()` instead of a hard click that timed out intermittently.

Three duplicated presence-check-then-click blocks in `dr_helpers_ui.py` were folded into the new helper.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added static VM IP translation support for disaster recovery failover and failback.
  * Added standalone and shared VM workload scenarios with static IP configurations.
  * Added validation for network mappings, translated addresses, IP restoration, and cleanup across DR workflows.
* **Bug Fixes**
  * Improved console navigation reliability by expanding the sidebar and handling modal dialogs automatically.
  * Updated VM navigation detection to support newer console versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->