### PR TITLE
Mark test_ceph_health_warning_blocks_upgrade as xfail for DFBUGS-8060

### DIFF
--- a/tests/functional/upgrade/test_upgrade_precheck_ceph_health.py
+++ b/tests/functional/upgrade/test_upgrade_precheck_ceph_health.py
@@ -9,6 +9,7 @@ import pytest
 from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import (
     brown_squad,
+    jira,
     skipif_mcg_only,
     tier2,
     runs_on_provider,
@@ -127,6 +128,7 @@ class TestODFUpgradePrecheckConditions(ManageTest):
     ODF upgrade pre-check conditions not met
     """
 
+    @jira("DFBUGS-8060")
     @pytest.mark.polarion_id("OCS-7422")
     def test_ceph_health_warning_blocks_upgrade(self, mon_pod_down, threading_lock):
         """


### PR DESCRIPTION
## Summary
- Add `@jira("[DFBUGS-8060](https://redhat.atlassian.net/browse/DFBUGS-8060)")` marker to `test_ceph_health_warning_blocks_upgrade` to handle a known product bug in OCS operator
- The OCS operator has a race condition where CephCluster phase transition from "Creating" to "Connected" causes the reconciler to overwrite `Upgradeable=False` (reason: `CephClusterHealthNotOK`) with `Upgradeable=True` (reason: `ReconcileCompleted`), which cascades to ODF operator
- With this marker, the test will be treated as expected failure (xfail) in regression runs until [DFBUGS-8060](https://redhat.atlassian.net/browse/DFBUGS-8060) is fixed

## Test plan
- [ ] Verify the test is collected with xfail marker when [DFBUGS-8060](https://redhat.atlassian.net/browse/DFBUGS-8060) is open
- [ ] Verify the test runs normally when [DFBUGS-8060](https://redhat.atlassian.net/browse/DFBUGS-8060) is resolved/closed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Linked the Ceph health upgrade precheck test to tracking issue [DFBUGS-8060](https://redhat.atlassian.net/browse/DFBUGS-8060) for improved test traceability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->