### PR TITLE
Add Nvmeof to  existing pvc tests

### DIFF
--- a/tests/functional/pv/add_metadata_feature/test_metadata.py
+++ b/tests/functional/pv/add_metadata_feature/test_metadata.py
@@ -8,6 +8,7 @@ from ocs_ci.framework import config
 from ocs_ci.framework.pytest_customization.marks import (
     green_squad,
     skipif_cephfs_disabled,
+    skipif_no_nvmeof,
 )
 from ocs_ci.ocs.resources import pod
 from ocs_ci.framework.testlib import (
@@ -209,6 +210,15 @@ class TestMetadata(ManageTest):
                 marks=[
                     tier2,
                     pytest.mark.polarion_id("OCS-4679"),
+                ],
+            ),
+            pytest.param(
+                # NVMe-oF StorageClass is RBD-backed on the default block pool
+                "ocs-storagecluster-cephblockpool",
+                constants.CEPH_NVMEOF_SC,
+                marks=[
+                    tier2,
+                    skipif_no_nvmeof,
                 ],
             ),
         ],
@@ -434,6 +444,12 @@ class TestMetadata(ManageTest):
         argvalues=[
             pytest.param(
                 "ocs-storagecluster-cephblockpool", constants.DEFAULT_STORAGECLASS_RBD
+            ),
+            pytest.param(
+                # NVMe-oF StorageClass is RBD-backed on the default block pool
+                "ocs-storagecluster-cephblockpool",
+                constants.CEPH_NVMEOF_SC,
+                marks=skipif_no_nvmeof,
             ),
         ],
     )

--- a/tests/functional/pv/conftest.py
+++ b/tests/functional/pv/conftest.py
@@ -1,10 +1,46 @@
 import logging
 
+import pytest
+
 from ocs_ci.ocs import constants
+from ocs_ci.ocs.ocp import OCP
+from ocs_ci.ocs.resources.ocs import OCS
 from ocs_ci.framework import config
 from ocs_ci.utility import version
 
 log = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def block_storageclass(request):
+    """
+    Resolve the block-backed StorageClass to use for a PVC test.
+
+    This enables the same block-device PVC test to run against different
+    block-backed StorageClasses (e.g. the default Ceph RBD SC and the
+    NVMe-oF SC) via indirect parametrization.
+
+    ``request.param`` is expected to be either:
+        * ``None`` - use the test/factory default (Ceph RBD) StorageClass, or
+        * a StorageClass name (str), e.g. ``constants.CEPH_NVMEOF_SC``.
+
+    Guard the NVMe-oF parametrization with the ``skipif_no_nvmeof`` marker so
+    it is only collected on clusters where NVMe-oF is enabled.
+
+    Returns:
+        OCS: StorageClass OCS instance for the requested name, or ``None`` to
+            let the test/factory use its default RBD StorageClass.
+
+    """
+    sc_name = getattr(request, "param", None)
+    if not sc_name:
+        return None
+    sc_ocp_obj = OCP(
+        kind=constants.STORAGECLASS,
+        namespace=config.ENV_DATA["cluster_namespace"],
+        resource_name=sc_name,
+    )
+    return OCS(**sc_ocp_obj.get())
 
 
 def pytest_collection_modifyitems(items):

--- a/tests/functional/pv/pv_services/test_rbd_image_metadata.py
+++ b/tests/functional/pv/pv_services/test_rbd_image_metadata.py
@@ -1,5 +1,7 @@
 import logging
 
+import pytest
+
 from ocs_ci.framework import config
 from ocs_ci.ocs import constants
 from ocs_ci.helpers.helpers import create_unique_resource_name, get_snapshot_content_obj
@@ -9,6 +11,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     tier2,
     polarion_id,
     green_squad,
+    skipif_no_nvmeof,
 )
 
 log = logging.getLogger(__name__)
@@ -19,8 +22,20 @@ class TestRbdImageMetadata:
     @tier2
     @polarion_id("OCS-4465")
     @polarion_id("OCS-4675")
+    @pytest.mark.parametrize(
+        argnames=["block_storageclass"],
+        argvalues=[
+            pytest.param(None),
+            pytest.param(constants.CEPH_NVMEOF_SC, marks=skipif_no_nvmeof),
+        ],
+        indirect=True,
+    )
     def test_rbd_image_metadata(
-        self, pvc_factory, pvc_clone_factory, snapshot_restore_factory
+        self,
+        pvc_factory,
+        pvc_clone_factory,
+        snapshot_restore_factory,
+        block_storageclass,
     ):
         """
         Test by default the rbd images doesnot have metdata details for,
@@ -29,12 +44,18 @@ class TestRbdImageMetadata:
         3. volume snapshot
         4. Restore volume from snapshot
 
+        Runs against both the default Ceph RBD StorageClass and, when NVMe-oF
+        is enabled on the cluster, the NVMe-oF (block-backed) StorageClass. The
+        NVMe-oF StorageClass is RBD-backed on the default cephblockpool, so the
+        image metadata assertions below apply unchanged.
+
         """
 
         rbd_images = []
-        # create a pvc with ceph-rbd sc
+        # create a pvc with ceph-rbd sc (or the NVMe-oF SC when parametrized)
         pvc_obj = pvc_factory(
             interface=constants.CEPHBLOCKPOOL,
+            storageclass=block_storageclass,
             status=constants.STATUS_BOUND,
             volume_mode="Block",
         )

--- a/tests/functional/pv/pv_services/test_rbd_rwx_pvc.py
+++ b/tests/functional/pv/pv_services/test_rbd_rwx_pvc.py
@@ -2,7 +2,7 @@ import logging
 import pytest
 
 from ocs_ci.ocs import constants, node
-from ocs_ci.framework.pytest_customization.marks import green_squad
+from ocs_ci.framework.pytest_customization.marks import green_squad, skipif_no_nvmeof
 from ocs_ci.framework.testlib import ManageTest, tier2
 
 log = logging.getLogger(__name__)
@@ -17,15 +17,21 @@ class TestRbdBlockPvc(ManageTest):
     """
 
     @pytest.fixture(autouse=True)
-    def setup(self, project_factory, pvc_factory, pod_factory):
+    def setup(self, project_factory, pvc_factory, pod_factory, block_storageclass):
         """
         Create PVC and pods
+
+        Args:
+            block_storageclass (OCS): Block-backed StorageClass to use for the
+                PVC. ``None`` selects the pvc_factory default (Ceph RBD); the
+                NVMe-oF StorageClass is passed for the NVMe-oF variant.
 
         """
         self.pvc_size = 10
 
         self.pvc_obj = pvc_factory(
             interface=constants.CEPHBLOCKPOOL,
+            storageclass=block_storageclass,
             size=self.pvc_size,
             access_mode=constants.ACCESS_MODE_RWX,
             status=constants.STATUS_BOUND,
@@ -47,9 +53,20 @@ class TestRbdBlockPvc(ManageTest):
             )
             self.pod_objs.append(pod_obj)
 
+    @pytest.mark.parametrize(
+        argnames=["block_storageclass"],
+        argvalues=[
+            pytest.param(None),
+            pytest.param(constants.CEPH_NVMEOF_SC, marks=skipif_no_nvmeof),
+        ],
+        indirect=True,
+    )
     def test_rbd_block_rwx_pvc(self, pod_factory):
         """
         Test RBD Block volume mode RWX PVC
+
+        Runs against both the default Ceph RBD StorageClass and, when NVMe-oF
+        is enabled on the cluster, the NVMe-oF (block-backed) StorageClass.
 
         """
         # Find initial md5sum value

--- a/tests/functional/pv/pvc_clone/test_clone_with_different_access_mode.py
+++ b/tests/functional/pv/pvc_clone/test_clone_with_different_access_mode.py
@@ -3,7 +3,7 @@ import pytest
 from itertools import cycle
 
 from ocs_ci.ocs import constants, node
-from ocs_ci.framework.pytest_customization.marks import green_squad
+from ocs_ci.framework.pytest_customization.marks import green_squad, skipif_no_nvmeof
 from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     ManageTest,
@@ -29,16 +29,51 @@ class TestCloneWithDifferentAccessMode(ManageTest):
     """
 
     @pytest.fixture(autouse=True)
-    def setup(self, project_factory, pvc_clone_factory, create_pvcs_and_pods):
+    def setup(
+        self,
+        project_factory,
+        pvc_clone_factory,
+        create_pvcs_and_pods,
+        block_storageclass,
+    ):
         """
         Create PVCs and pods
 
-        """
-        self.pvcs, self.pods = create_pvcs_and_pods(pvc_size=3)
+        Args:
+            block_storageclass (OCS): Block-backed StorageClass to use for the
+                RBD PVCs. ``None`` selects the create_pvcs_and_pods default
+                (Ceph RBD, plus CephFS PVCs). When the NVMe-oF StorageClass is
+                passed, only block-mode PVCs on that StorageClass are created.
 
+        """
+        if block_storageclass is None:
+            self.pvcs, self.pods = create_pvcs_and_pods(pvc_size=3)
+        else:
+            # NVMe-oF variant: block-only PVCs on the NVMe-oF StorageClass
+            self.pvcs, self.pods = create_pvcs_and_pods(
+                pvc_size=3,
+                sc_rbd=block_storageclass,
+                num_of_cephfs_pvc=0,
+                access_modes_rbd=[
+                    f"{constants.ACCESS_MODE_RWO}-Block",
+                    f"{constants.ACCESS_MODE_RWX}-Block",
+                ],
+            )
+
+    @pytest.mark.parametrize(
+        argnames=["block_storageclass"],
+        argvalues=[
+            pytest.param(None),
+            pytest.param(constants.CEPH_NVMEOF_SC, marks=skipif_no_nvmeof),
+        ],
+        indirect=True,
+    )
     def test_clone_with_different_access_mode(self, pvc_clone_factory, pod_factory):
         """
         Create clone of a PVC with an access mode different than parent PVC
+
+        Runs against the default Ceph RBD/CephFS StorageClasses and, when
+        NVMe-oF is enabled, against block-mode PVCs on the NVMe-oF StorageClass.
 
         """
         file_name = "fio_test"

--- a/tests/functional/pv/pvc_snapshot/test_restore_snapshot_when_parent_pvc_deleted.py
+++ b/tests/functional/pv/pvc_snapshot/test_restore_snapshot_when_parent_pvc_deleted.py
@@ -2,7 +2,7 @@ import logging
 import pytest
 
 from ocs_ci.ocs import constants
-from ocs_ci.framework.pytest_customization.marks import green_squad
+from ocs_ci.framework.pytest_customization.marks import green_squad, skipif_no_nvmeof
 from ocs_ci.framework.testlib import (
     skipif_ocs_version,
     ManageTest,
@@ -34,19 +34,50 @@ class TestRestoreSnapshotWhenParentPVCDeleted(ManageTest):
         snapshot_restore_factory,
         pvc_clone_factory,
         create_pvcs_and_pods,
+        block_storageclass,
     ):
         """
         Create PVCs and pods
 
+        Args:
+            block_storageclass (OCS): Block-backed StorageClass to use for the
+                RBD PVCs. ``None`` selects the create_pvcs_and_pods default
+                (Ceph RBD, plus CephFS PVCs). When the NVMe-oF StorageClass is
+                passed, only block-mode PVCs on that StorageClass are created.
+
         """
-        self.pvcs, self.pods = create_pvcs_and_pods(pvc_size=3, pods_for_rwx=1)
+        if block_storageclass is None:
+            self.pvcs, self.pods = create_pvcs_and_pods(pvc_size=3, pods_for_rwx=1)
+        else:
+            # NVMe-oF variant: block-only PVCs on the NVMe-oF StorageClass
+            self.pvcs, self.pods = create_pvcs_and_pods(
+                pvc_size=3,
+                pods_for_rwx=1,
+                sc_rbd=block_storageclass,
+                num_of_cephfs_pvc=0,
+                access_modes_rbd=[
+                    f"{constants.ACCESS_MODE_RWO}-Block",
+                    f"{constants.ACCESS_MODE_RWX}-Block",
+                ],
+            )
 
     @tier2
+    @pytest.mark.parametrize(
+        argnames=["block_storageclass"],
+        argvalues=[
+            pytest.param(None),
+            pytest.param(constants.CEPH_NVMEOF_SC, marks=skipif_no_nvmeof),
+        ],
+        indirect=True,
+    )
     def test_restore_snapshot_when_parent_pvc_deleted(
         self, snapshot_factory, snapshot_restore_factory, pvc_clone_factory
     ):
         """
         Restore a pvc from snapshot when the parent PVC is deleted
+
+        Runs against the default Ceph RBD/CephFS StorageClasses and, when
+        NVMe-oF is enabled, against block-mode PVCs on the NVMe-oF StorageClass.
 
         """
         file_name = "fio_test"

--- a/tests/functional/pv/pvc_snapshot/test_snapshot_restore_with_different_access_mode.py
+++ b/tests/functional/pv/pvc_snapshot/test_snapshot_restore_with_different_access_mode.py
@@ -7,6 +7,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     green_squad,
     provider_mode,
     run_on_all_clients_push_missing_configs,
+    skipif_no_nvmeof,
 )
 from ocs_ci.framework.testlib import (
     skipif_ocs_version,
@@ -35,19 +36,55 @@ class TestSnapshotRestoreWithDifferentAccessMode(ManageTest):
     """
 
     @pytest.fixture(autouse=True)
-    def setup(self, project_factory, snapshot_restore_factory, create_pvcs_and_pods):
+    def setup(
+        self,
+        project_factory,
+        snapshot_restore_factory,
+        create_pvcs_and_pods,
+        block_storageclass,
+    ):
         """
         Create PVCs and pods
 
-        """
-        self.pvcs, self.pods = create_pvcs_and_pods(pvc_size=3, pods_for_rwx=1)
+        Args:
+            block_storageclass (OCS): Block-backed StorageClass to use for the
+                RBD PVCs. ``None`` selects the create_pvcs_and_pods default
+                (Ceph RBD, plus CephFS PVCs). When the NVMe-oF StorageClass is
+                passed, only block-mode PVCs on that StorageClass are created.
 
+        """
+        if block_storageclass is None:
+            self.pvcs, self.pods = create_pvcs_and_pods(pvc_size=3, pods_for_rwx=1)
+        else:
+            # NVMe-oF variant: block-only PVCs on the NVMe-oF StorageClass
+            self.pvcs, self.pods = create_pvcs_and_pods(
+                pvc_size=3,
+                pods_for_rwx=1,
+                sc_rbd=block_storageclass,
+                num_of_cephfs_pvc=0,
+                access_modes_rbd=[
+                    f"{constants.ACCESS_MODE_RWO}-Block",
+                    f"{constants.ACCESS_MODE_RWX}-Block",
+                ],
+            )
+
+    @pytest.mark.parametrize(
+        argnames=["block_storageclass"],
+        argvalues=[
+            pytest.param(None),
+            pytest.param(constants.CEPH_NVMEOF_SC, marks=skipif_no_nvmeof),
+        ],
+        indirect=True,
+    )
     @run_on_all_clients_push_missing_configs
     def test_snapshot_restore_with_different_access_mode(
         self, pod_factory, snapshot_factory, snapshot_restore_factory, cluster_index
     ):
         """
         Restore snapshot with an access mode different than parent PVC
+
+        Runs against the default Ceph RBD/CephFS StorageClasses and, when
+        NVMe-oF is enabled, against block-mode PVCs on the NVMe-oF StorageClass.
 
         """
         file_name = "fio_test"

--- a/tests/functional/ui/test_pvc_ui.py
+++ b/tests/functional/ui/test_pvc_ui.py
@@ -8,6 +8,7 @@ from ocs_ci.framework.pytest_customization.marks import (
     green_squad,
     runs_on_provider,
     skipif_cephfs_disabled,
+    skipif_no_nvmeof,
 )
 from ocs_ci.ocs.resources.pvc import get_all_pvc_objs, get_pvc_objs
 from ocs_ci.ocs.ocp import OCP
@@ -67,6 +68,13 @@ class TestPvcUserInterface(object):
                 "13",
                 "Filesystem",
                 marks=pytest.mark.polarion_id("OCS-5207"),
+            ),
+            pytest.param(
+                constants.CEPH_NVMEOF_SC,
+                "ReadWriteOnce",
+                "11",
+                "Block",
+                marks=skipif_no_nvmeof,
             ),
         ],
     )
@@ -147,7 +155,11 @@ class TestPvcUserInterface(object):
 
         # Creating Pod via CLI
         logger.info("Creating Pod")
-        if sc_name in constants.DEFAULT_STORAGECLASS_RBD:
+        if (
+            sc_name in constants.DEFAULT_STORAGECLASS_RBD
+            or sc_name == constants.CEPH_NVMEOF_SC
+        ):
+            # NVMe-oF StorageClass is RBD (block) backed
             interface_type = constants.CEPHBLOCKPOOL
         elif sc_name in constants.DEFAULT_EXTERNAL_MODE_STORAGECLASS_RBD:
             interface_type = constants.CEPHBLOCKPOOL
@@ -244,6 +256,12 @@ class TestPvcUserInterface(object):
                 constants.ACCESS_MODE_RWX,
                 constants.ACCESS_MODE_RWO,
                 marks=[pytest.mark.polarion_id("OCS-5209"), skipif_cephfs_disabled],
+            ),
+            pytest.param(
+                constants.CEPH_NVMEOF_SC,
+                constants.ACCESS_MODE_RWO,
+                constants.ACCESS_MODE_RWO,
+                marks=skipif_no_nvmeof,
             ),
         ],
     )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded persistent volume coverage for NVMe-oF block-backed storage classes.
  * Added NVMe-oF scenarios for metadata updates, RBD image metadata, RWX volumes, cloning, snapshots, restores, and access modes.
  * Extended PVC UI coverage to include creating, resizing, deleting, and cloning NVMe-oF-backed PVCs.
  * NVMe-oF-specific scenarios are skipped when the capability is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->