### PR TITLE
Enhance retry logic to handle multiple exception text patterns

### DIFF
--- a/ocs_ci/utility/aws.py
+++ b/ocs_ci/utility/aws.py
@@ -13,6 +13,7 @@ from botocore.exceptions import (
     NoCredentialsError,
     WaiterError,
     EndpointConnectionError,
+    ProxyConnectionError,
 )
 
 from ocs_ci.utility.retry import retry
@@ -2814,6 +2815,13 @@ def check_root_volume(volume):
     return True if volume["attachments"][0]["DeleteOnTermination"] else False
 
 
+@retry(
+    ProxyConnectionError,
+    tries=4,
+    delay=5,
+    backoff=2,
+    text_in_exception="Tunnel connection failed",
+)
 def update_config_from_s3(
     bucket_name=constants.OCSCI_DATA_BUCKET, filename=constants.AUTHYAML
 ):
@@ -2845,6 +2853,11 @@ def update_config_from_s3(
         return None
     except EndpointConnectionError:
         logger.warning("Failed to fetch auth.yaml from ocs-ci-data")
+        return None
+    except ProxyConnectionError:
+        logger.warning(
+            "Proxy connection error while fetching auth.yaml from ocs-ci-data"
+        )
         return None
 
 

--- a/ocs_ci/utility/retry.py
+++ b/ocs_ci/utility/retry.py
@@ -53,6 +53,8 @@ def retry(
         backoff: Backoff multiplier e.g., value of 2 will double the delay each retry. If the delay
             is greater than max_delay after multiplier, than max_delay is used as delay
         text_in_exception: Retry only when text_in_exception is in the text of exception.
+            Can be a single string or a tuple/list of strings. If a list/tuple is provided,
+            retry will happen if ANY of the strings are found in the exception.
         func: Function for garbage collector.
         max_timeout: Maximum total time for retries in seconds (default: 4 hours).
         max_delay: Maximum delay between retries in seconds (default: 600 seconds or 10 minutes).
@@ -79,9 +81,22 @@ def retry(
                     return f(*args, **kwargs)
                 except exception_to_check as e:
                     if text_in_exception:
-                        if text_in_exception in str(e):
+                        # Convert single string to list for uniform handling
+                        texts_to_check = (
+                            [text_in_exception]
+                            if isinstance(text_in_exception, str)
+                            else text_in_exception
+                        )
+                        exception_str = str(e)
+                        matching_text = None
+                        for text in texts_to_check:
+                            if text in exception_str:
+                                matching_text = text
+                                break
+
+                        if matching_text:
                             logger.debug(
-                                f"Text: {text_in_exception} found in exception: {e}"
+                                f"Text: {matching_text} found in exception: {e}"
                             )
                         else:
                             raise
@@ -138,7 +153,9 @@ def retry_until_exception(
         delay: initial delay between retries in seconds
         backoff: Backoff multiplier e.g., value of 2 will double the delay each retry. If the delay
             is greater than max_delay after multiplier, than max_delay is used as delay
-        text_in_exception: Retry only when text_in_exception is in the text of exception
+        text_in_exception: Retry only when text_in_exception is in the text of exception.
+            Can be a single string or a tuple/list of strings. If a list/tuple is provided,
+            retry will happen if ANY of the strings are found in the exception.
         func: function for garbage collector
     """
 
@@ -153,9 +170,22 @@ def retry_until_exception(
                     f(*args, **kwargs)
                 except exception_to_check as e:
                     if text_in_exception:
-                        if text_in_exception in str(e):
+                        # Convert single string to list for uniform handling
+                        texts_to_check = (
+                            [text_in_exception]
+                            if isinstance(text_in_exception, str)
+                            else text_in_exception
+                        )
+                        exception_str = str(e)
+                        matching_text = None
+                        for text in texts_to_check:
+                            if text in exception_str:
+                                matching_text = text
+                                break
+
+                        if matching_text:
                             logger.debug(
-                                f"Text: {text_in_exception} found in exception: {e}"
+                                f"Text: {matching_text} found in exception: {e}"
                             )
                             return True
                         else:

--- a/ocs_ci/utility/utils.py
+++ b/ocs_ci/utility/utils.py
@@ -745,7 +745,12 @@ def run_cmd_multicluster(
     tries=6,
     delay=10,
     backoff=1,
-    text_in_exception="client connection lost",
+    text_in_exception=(
+        "client connection lost",
+        "proxyconnect tcp",
+        "i/o timeout",
+        "websocket: close 1006",
+    ),
 )
 def exec_cmd(
     cmd,


### PR DESCRIPTION
The retry decorator's text_in_exception parameter now accepts either a single string or a tuple/list of strings, allowing retry on multiple error patterns. This addresses intermittent proxy timeout failures in containerized environments.

In containerized CI environments using proxies, we encounter multiple connection error patterns beyond "client connection lost":
- "proxyconnect tcp: dial tcp <ip>:<port>"
- "i/o timeout"

Updated exec_cmd decorator to retry on all three patterns, reducing test flakiness from transient network issues.

The enhancement maintains backward compatibility - existing code using a single string continues to work unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Retry handling now supports matching one or multiple exception messages.
  * Command execution retries automatically for additional transient connection and network timeout errors, helping recover from temporary failures without manual intervention.
  * Retry logs identify the specific exception text that triggered the retry, making retry activity clearer.
  * Retry behavior consistently checks all configured messages and proceeds when any matching error text is detected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->