### PR TITLE
Add temporary submariner 0.24.1 lighthouse import-namespace-deny-list…

### DIFF
--- a/ocs_ci/deployment/deployment.py
+++ b/ocs_ci/deployment/deployment.py
@@ -61,6 +61,7 @@ from ocs_ci.utility.iscsi_config import iscsi_setup
 from ocs_ci.framework.logger_helper import log_step
 from ocs_ci.helpers.dr_helpers import (
     configure_drcluster_for_fencing,
+    configure_submariner_lighthouse_import_namespace_deny_list,
     get_cluster_set_name,
     create_service_exporter,
     is_cg_enabled,
@@ -639,6 +640,11 @@ class Deployment(object):
                                 timeout=2000,
                                 ocs_registry_image=ocs_registry_image,
                             )
+                        # Temporary workaround for submariner 0.24.1: after the
+                        # multicluster service is enabled on both managed
+                        # clusters, create the submariner-lighthouse-agent
+                        # configmap and restart ocs-operator pods
+                        configure_submariner_lighthouse_import_namespace_deny_list()
                     config.reset_ctx()
                 if config.REPORTING["collect_logs_on_success_run"]:
                     try:

--- a/ocs_ci/helpers/dr_helpers.py
+++ b/ocs_ci/helpers/dr_helpers.py
@@ -4771,3 +4771,61 @@ def validate_cluster_odf_cli(retries=5, retry_interval=60):
         f"ODF DR validate clusters did not report success after {retries} attempts. "
         f"Output:\n{last_stdout}"
     )
+
+
+def configure_submariner_lighthouse_import_namespace_deny_list():
+    """
+    Temporary workaround required only for submariner version 0.24.1 in a
+    globalnet RDR setup, to be run after the multicluster service is enabled on
+    both managed clusters.
+
+    On each managed cluster, if the deployed submariner version is 0.24.1,
+    create the submariner-lighthouse-agent configmap with the
+    import-namespace-deny-list set to "kube-" and restart the ocs-operator pods
+    so that the change takes effect.
+
+    """
+    # Local imports to keep this temporary workaround self-contained
+    from ocs_ci.utility import version
+    from ocs_ci.ocs.resources.pod import get_operator_pods, delete_pods
+
+    target_version = version.get_semantic_version("0.24.1")
+    restore_index = config.cur_index
+    try:
+        for cluster in get_non_acm_cluster_config():
+            # Skip hosted/client clusters, apply only on managed clusters
+            if cluster.ENV_DATA.get("cluster_type", "").lower() == constants.HCI_CLIENT:
+                continue
+            config.switch_ctx(cluster.MULTICLUSTER["multicluster_index"])
+            cluster_name = cluster.ENV_DATA["cluster_name"]
+
+            submariner_version = version.get_submariner_operator_version()
+            if (
+                not submariner_version
+                or version.get_semantic_version(submariner_version) != target_version
+            ):
+                logger.info(
+                    f"Submariner version on cluster {cluster_name} is "
+                    f"{submariner_version}, skipping the submariner-lighthouse-agent "
+                    "import-namespace-deny-list configmap workaround "
+                    f"(only applicable for {target_version})"
+                )
+                continue
+
+            logger.info(
+                f"Submariner version on cluster {cluster_name} is {target_version}, "
+                "creating the submariner-lighthouse-agent configmap"
+            )
+            exec_cmd(
+                "oc create configmap submariner-lighthouse-agent "
+                '--from-literal=import-namespace-deny-list="kube-" '
+                f"-n {constants.SUBMARINER_OPERATOR_NAMESPACE}"
+            )
+            logger.info(f"Restarting ocs-operator pods on cluster {cluster_name}")
+            ocs_operator_pods = get_operator_pods(
+                operator_label=constants.OCS_OPERATOR_LABEL,
+                namespace=config.ENV_DATA["cluster_namespace"],
+            )
+            delete_pods(ocs_operator_pods)
+    finally:
+        config.switch_ctx(restore_index)


### PR DESCRIPTION
Temp fix for service export's restriction issue.
… workaround

For globalnet RDR with submariner 0.24.1, create the submariner-lighthouse-agent configmap with import-namespace-deny-list set to "kube-" and restart the ocs-operator pods on both managed clusters after the multicluster service is enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multicluster disaster recovery deployment compatibility with Submariner 0.24.1 in globalnet environments.
  * Automatically applies the required namespace import configuration during applicable deployments.
  * Refreshes OCS operator pods so the updated settings take effect immediately.
  * Deployments using other Submariner versions remain unaffected.
  * Clusters that do not use the applicable Submariner version are skipped without changing their existing configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->