### PR TITLE
[release-4.22] deployment/acm: revert submariner routeagent image override WA (#16026)

### DIFF
--- a/ocs_ci/deployment/acm.py
+++ b/ocs_ci/deployment/acm.py
@@ -3,10 +3,8 @@ All ACM related deployment classes and functions should go here.
 
 """
 
-import json
 import os
 import logging
-import subprocess
 import tempfile
 import shutil
 import requests
@@ -32,15 +30,11 @@ from ocs_ci.utility.ibmcloud import (
     is_ibm_platform,
 )
 from ocs_ci.utility.retry import retry
-from ocs_ci.ocs.ocp import OCP
 from ocs_ci.utility.utils import (
-    exec_cmd,
     run_cmd,
     run_cmd_interactive,
-    TimeoutSampler,
     wait_for_machineconfigpool_status,
 )
-from ocs_ci.deployment.helpers.hypershift_base import is_hosted_cluster
 from ocs_ci.ocs.node import get_typed_worker_nodes, label_nodes, get_worker_nodes
 
 logger = logging.getLogger(__name__)
@@ -194,137 +188,7 @@ class Submariner(object):
         else:
             acm_obj.install_submariner_ui(globalnet=global_net)
 
-        # TODO  Remove after submariner 0.24.1
-        self.override_submariner_routeagent_image()
-
         acm_obj.submariner_validation_ui()
-
-    def override_submariner_routeagent_image(self):
-        """
-        Workaround for submariner issue #4124: override the routeagent image on
-        each managed cluster via the SubmarinerConfig on the hub.
-
-        For every non-ACM cluster:
-          1. Switch to the hub context and patch the SubmarinerConfig
-             (namespace = cluster_name, resource_name = "submariner") with the
-             routeagent image override.
-          2. Switch to the managed cluster context and wait for the
-             routeagent DaemonSet rollout to complete.
-
-        TODO: Remove after submariner 0.24.1
-        """
-        routeagent_image = "quay.io/yboaron/submariner-route-agent:dev-20260811"
-        logger.info(
-            f"[submariner#4124 WA] Overriding routeagent image to {routeagent_image}"
-        )
-        restore_index = config.cur_index
-
-        try:
-            for cluster in get_non_acm_cluster_config():
-                cluster_name = cluster.ENV_DATA["cluster_name"]
-                if is_hosted_cluster(cluster_name):
-                    cluster_name = (
-                        f"{constants.HYPERSHIFT_ADDON_DISCOVERYPREFIX}-{cluster_name}"
-                    )
-                cluster_index = cluster.MULTICLUSTER["multicluster_index"]
-
-                # 1. Switch to hub and patch the SubmarinerConfig for this cluster
-                config.switch_acm_ctx()
-                submariner_config = OCP(
-                    kind=constants.SUBMARINERCONFIG,
-                    namespace=cluster_name,
-                    resource_name="submariner",
-                )
-                if not submariner_config.check_resource_existence(
-                    timeout=10, should_exist=True
-                ):
-                    logger.warning(
-                        f"SubmarinerConfig 'submariner' not found in namespace '{cluster_name}' "
-                        f"on hub; skipping routeagent override for cluster '{cluster_name}'"
-                    )
-                    continue
-
-                patch_params = (
-                    f'{{"spec":{{"imagePullSpecs":{{"submarinerRouteAgentImagePullSpec":'
-                    f'"{routeagent_image}"}}}}}}'
-                )
-                submariner_config.patch(
-                    params=patch_params,
-                    format_type="merge",
-                )
-                logger.info(
-                    f"Patched SubmarinerConfig for cluster '{cluster_name}' "
-                    f"with routeagent image '{routeagent_image}'"
-                )
-                # 2. Switch to the managed cluster, wait for DaemonSet image update, then rollout
-                config.switch_ctx(cluster_index)
-                kubeconfig = cluster.RUN["kubeconfig"]
-
-                # Wait for ACM to reconcile the image into the DaemonSet spec.
-                # sleep=30 means the first poll happens after 30s (giving ACM time to start
-                # reconciling) and repeats every 30s if the image is not yet updated.
-                # (both main container and init container must reflect the new image)
-                logger.info(
-                    f"Waiting for submariner-routeagent DaemonSet on cluster '{cluster_name}' "
-                    f"to reflect image '{routeagent_image}'"
-                )
-                image_updated = False
-                for ds_data in TimeoutSampler(
-                    timeout=300,
-                    sleep=30,
-                    func=exec_cmd,
-                    cmd=(
-                        f"oc --kubeconfig {kubeconfig} get daemonset submariner-routeagent "
-                        f"-n {constants.SUBMARINER_OPERATOR_NAMESPACE} -o json"
-                    ),
-                ):
-                    if ds_data is None:
-                        continue
-                    ds = json.loads(ds_data.stdout)
-                    containers = ds["spec"]["template"]["spec"].get("containers", [])
-                    init_containers = ds["spec"]["template"]["spec"].get(
-                        "initContainers", []
-                    )
-                    all_images = [c["image"] for c in containers + init_containers]
-                    if all(img == routeagent_image for img in all_images):
-                        logger.info(
-                            f"DaemonSet image updated on cluster '{cluster_name}'"
-                        )
-                        image_updated = True
-                        break
-
-                if not image_updated:
-                    logger.warning(
-                        f"DaemonSet image not updated within timeout on cluster '{cluster_name}'; "
-                        "skipping rollout check"
-                    )
-                    continue
-
-                # Wait for rollout to complete with retry (tries=3, 30s initial delay, backoff=2)
-                rollout_cmd = (
-                    f"oc --kubeconfig {kubeconfig} rollout status "
-                    f"daemonset/submariner-routeagent "
-                    f"-n {constants.SUBMARINER_OPERATOR_NAMESPACE} --timeout=120s"
-                )
-
-                @retry(
-                    (CommandFailed, subprocess.TimeoutExpired),
-                    tries=3,
-                    delay=30,
-                    backoff=2,
-                )
-                def _run_rollout():
-                    exec_cmd(rollout_cmd)
-
-                try:
-                    _run_rollout()
-                except (CommandFailed, subprocess.TimeoutExpired) as e:
-                    logger.warning(
-                        f"Routeagent rollout did not complete after retries on cluster "
-                        f"'{cluster_name}': {e}; continuing"
-                    )
-        finally:
-            config.switch_ctx(restore_index)
 
     def create_acm_brew_idms(self):
         """


### PR DESCRIPTION
## Summary

Cherry-pick of PR #16092 to `release-4.22`.

Removes the workaround added in #16028 (cherry-pick of #16026) for submariner issue [#4124](https://github.com/submariner-io/submariner/issues/4124).
Submariner 0.24.1 ships the fix, so the WA is no longer needed.

## Changes

Removes from `ocs_ci/deployment/acm.py`:
- `override_submariner_routeagent_image()` method from `Submariner` class
- Call site in `deploy_downstream()` after submariner install
- WA-only imports: `json`, `subprocess`, `exec_cmd`, `TimeoutSampler`, `OCP`, `is_hosted_cluster`

## Related
- Original WA added: #16028 (cherry-pick of #16026 to release-4.22)
- Revert on master: #16092

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the Submariner deployment flow to proceed directly to validation after installing the Submariner CLI or UI.
  - Removed a workaround that could affect the deployment process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->