### PR TITLE
fix: use bool and clear globalnetCIDRRange when globalnet is disabled

### DIFF
--- a/ocs_ci/ocs/acm/acm.py
+++ b/ocs_ci/ocs/acm/acm.py
@@ -688,7 +688,8 @@ class AcmAddClusters(AcmPageNavigator):
             all_documents.append(submariner_addon_yaml)
             all_documents.append(submariner_config_yaml)
         if not globalnet:
-            submariner_broker_yaml["spec"]["globalnetEnabled"] = "false"
+            submariner_broker_yaml["spec"]["globalnetEnabled"] = False
+            submariner_broker_yaml["spec"]["globalnetCIDRRange"] = ""
         submariner_broker_yaml["metadata"]["namespace"] = cluster_set_name + "-broker"
         all_documents.append(submariner_broker_yaml)
 


### PR DESCRIPTION
When globalnet=False, submariner_broker_yaml["spec"]["globalnetEnabled"] was incorrectly set to the string "false" instead of a Python bool False. PyYAML serialises the string as a quoted value rather than a YAML boolean, causing the Broker CR to receive an invalid type.

Also clear globalnetCIDRRange to an empty string when globalnet is disabled, matching the expected Broker CR spec:

  spec:
    globalnetCIDRRange: ''
    globalnetEnabled: false

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected broker configuration when Globalnet is disabled by explicitly disabling Globalnet and clearing its CIDR range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->